### PR TITLE
Bring geospatial filtering to the command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## Development
+- Bring geospatial filtering to the command line.
+
 ## 0.1.0
 - initial release
 - update README.md


### PR DESCRIPTION
Hi there,

both `wetterdienst stations|readings` now accept `--latitude` and `--longitude` parameters. Optionally, `--count` can be added to adjust the number of nearby stations. Default: 1.

### Synopsis
```
# Acquire stations and readings by geoposition.
wetterdienst stations --resolution=daily --parameter=kl --period=recent --lat=50.2 --lon=10.3 --count=10
wetterdienst readings --resolution=daily --parameter=kl --period=recent --lat=50.2 --lon=10.3 --count=10 --date=2020-06-30
```

Cheers,
Andreas.