### PR TITLE
Add GeoJSON output format for station data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Development
 - [cli] Add geospatial filtering by distance.
 - [cli] Filter stations by station identifiers.
+- [cli] Add GeoJSON output format for station data.
 
 ## 0.1.1 (05.07.2020)
 - [cli] Add geospatial filtering by number of nearby stations.


### PR DESCRIPTION
Hi again,

this is another feature from [dwdweather2](https://github.com/panodata/dwdweather2/). With these updates, the user will be able to output station information in [GeoJSON format](https://tools.ietf.org/html/rfc7946), which is useful for a bunch of Web-GIS stuff [like within Leaflet](https://leafletjs.com/examples/geojson/).

Cheers,
Andreas.