### PR TITLE
Add DWD MOSMIX client and parser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,4 @@
+*********
 Changelog
 *********
 
@@ -10,6 +11,7 @@ Development
 - Query results with SQL, based on in-memory DuckDB
 - split get_nearby_stations into two functions, get_nearby_stations_by_number and
   get_nearby_stations_by_distance
+- Add MOSMIX client and parser. Thanks, @jlewis91!
 
 0.7.0 (16.09.2020)
 ==================
@@ -20,6 +22,9 @@ Development
 - Make the CLI work again and add software tests to prevent future havocs
 - Use Sphinx Material theme for documentation
 - Fix typo in enumeration for TimeResolution.MINUTES_10
+- Add test for Jupyter notebook
+- Add function to discover available climate observations
+  (time resolution, parameter, period type)
 
 0.6.0 (07.09.2020)
 ==================

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1,3 +1,5 @@
+.. wetterdienst-api:
+
 ###
 API
 ###
@@ -5,6 +7,7 @@ API
 .. contents::
     :local:
     :depth: 1
+
 
 ************
 Introduction
@@ -222,8 +225,28 @@ Examples:
 ******
 MOSMIX
 ******
+::
 
-Yet to be implemented...
+    from wetterdienst.mosmix import MOSMIXReader
+
+    # MOSMIX-L, all parameters
+    mosmix = MOSMIXReader(station_ids=["01001", "01008"])
+    response = mosmix.read_mosmix_l_latest()
+
+    print(response.metadata)
+    print(response.stations)
+    print(response.forecasts)
+
+Other variants::
+
+    # MOSMIX-L, specific parameters
+    mosmix = MOSMIXReader(station_ids=["01001", "01008"], parameters=["DD", "ww"])
+    response = mosmix.read_mosmix_l_latest()
+
+    # MOSMIX-S, all parameters
+    mosmix = MOSMIXReader(station_ids=["01028", "01092"])
+    response = mosmix.read_mosmix_s_latest()
+
 
 *******
 RADOLAN

--- a/example/mosmix.py
+++ b/example/mosmix.py
@@ -1,0 +1,56 @@
+"""
+=====
+About
+=====
+Example for DWD MOSMIX acquisition.
+
+This program will request latest MOSMIX-L data for
+stations 01001 and 01008 and parameters DD and ww.
+
+Other MOSMIX variants are also listed and can be
+enabled on demand.
+"""
+from wetterdienst.additionals.util import setup_logging
+from wetterdienst.mosmix import MOSMIXReader
+
+
+def mosmix_example():
+
+    # A. MOSMIX-L -- Specific stations
+    # mosmix = MOSMIXReader(station_ids=['01001', '01008'], parameters=['DD', 'ww'])
+    mosmix = MOSMIXReader(station_ids=["01001", "01008"])
+    response = mosmix.read_mosmix_l_latest()
+
+    # B. MOSMIX-S -- All stations.
+    # Remark: This will take **some** time for downloading and parsing ~40MB worth of XML.
+    # mosmix = MOSMIXReader(station_ids=['01028', '01092'])
+    # mosmix = MOSMIXReader(station_ids=['01028', '01092'], parameters=['DD', 'ww'])
+    # response = mosmix.read_mosmix_s_latest()
+
+    # C. MOSMIX-L -- All stations.
+    # Remark: This will take **ages** for downloading and parsing ~80MB worth of XML.
+    # mosmix = MOSMIXReader()
+    # response = mosmix.read_mosmix_l_latest()
+
+    response.forecasts = response.forecasts.dropna(axis='columns', how='all')
+
+    output_section("Metadata", response.metadata)
+    output_section("Stations", response.stations)
+    output_section("Forecasts", response.forecasts)
+
+
+def output_section(title, data):  # pragma: no cover
+    print("-" * len(title))
+    print(title)
+    print("-" * len(title))
+    print(data)
+    print()
+
+
+def main():
+    setup_logging()
+    mosmix_example()
+
+
+if __name__ == "__main__":
+    main()

--- a/poetry.lock
+++ b/poetry.lock
@@ -288,13 +288,13 @@ version = "0.10.0"
 six = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "A backport of the dataclasses module for Python 3.6"
-marker = "python_version < \"3.7\""
+marker = "python_version >= \"3.6\" and python_version < \"3.7\" or python_version < \"3.7\""
 name = "dataclasses"
 optional = false
-python-versions = "*"
-version = "0.6"
+python-versions = ">=3.6, <3.7"
+version = "0.7"
 
 [[package]]
 category = "main"
@@ -750,7 +750,7 @@ version = "1.2.0"
 category = "main"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 name = "lxml"
-optional = true
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
 version = "4.5.2"
 
@@ -1698,6 +1698,17 @@ version = "6.0.4"
 
 [[package]]
 category = "main"
+description = "Fast, Extensible Progress Meter"
+name = "tqdm"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+version = "4.49.0"
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
+
+[[package]]
+category = "main"
 description = "Traitlets Python config system"
 name = "traitlets"
 optional = false
@@ -1827,7 +1838,7 @@ postgresql = ["psycopg2"]
 sql = ["duckdb"]
 
 [metadata]
-content-hash = "9aa7deb8d40d27f93e13c32f26c54a4729afd3acc82940ed1c1b385b0a688d4d"
+content-hash = "b2e2c2c33035a6a72ceaca6d63de293ae8b6ae50ce027d2c8f21b50fb4395ecb"
 lock-version = "1.0"
 python-versions = "^3.6.1"
 
@@ -2008,8 +2019,8 @@ cycler = [
     {file = "cycler-0.10.0.tar.gz", hash = "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"},
 ]
 dataclasses = [
-    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
-    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
+    {file = "dataclasses-0.7-py3-none-any.whl", hash = "sha256:3459118f7ede7c8bea0fe795bff7c6c2ce287d01dd226202f7c9ebc0610a7836"},
+    {file = "dataclasses-0.7.tar.gz", hash = "sha256:494a6dcae3b8bcf80848eea2ef64c0cc5cd307ffc263e17cdf42f3e5420808e6"},
 ]
 dateparser = [
     {file = "dateparser-0.7.6-py2.py3-none-any.whl", hash = "sha256:7552c994f893b5cb8fcf103b4cd2ff7f57aab9bfd2619fdf0cf571c0740fd90b"},
@@ -2856,6 +2867,10 @@ tornado = [
     {file = "tornado-6.0.4-cp38-cp38-win32.whl", hash = "sha256:22aed82c2ea340c3771e3babc5ef220272f6fd06b5108a53b4976d0d722bcd52"},
     {file = "tornado-6.0.4-cp38-cp38-win_amd64.whl", hash = "sha256:c58d56003daf1b616336781b26d184023ea4af13ae143d9dda65e31e534940b9"},
     {file = "tornado-6.0.4.tar.gz", hash = "sha256:0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc"},
+]
+tqdm = [
+    {file = "tqdm-4.49.0-py2.py3-none-any.whl", hash = "sha256:8f3c5815e3b5e20bc40463fa6b42a352178859692a68ffaa469706e6d38342a5"},
+    {file = "tqdm-4.49.0.tar.gz", hash = "sha256:faf9c671bd3fad5ebaeee366949d969dca2b2be32c872a7092a1e1a9048d105b"},
 ]
 traitlets = [
     {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,8 +80,11 @@ python-dateutil = "^2.8.0"
 "dogpile.cache" = "^1.0.2"
 appdirs = "^1.4.4"
 lxml = "^4.5.2"
+tqdm = "^4.47.0"
 
-importlib_metadata = {version = "1.7.0", python = "<3.8"}
+# Conditionally installed for backward compatibility with older Python versions
+importlib_metadata              = {version = "1.7.0", python = "<3.8"}
+dataclasses                     = {version = "0.7", python = "^3.6,<3.7"}
 
 # Optional dependencies aka. "extras"
 ipython                         = { version = "^7.10.1", optional = true }

--- a/tests/file_path_handling/test_path_handling.py
+++ b/tests/file_path_handling/test_path_handling.py
@@ -6,7 +6,7 @@ from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
 from wetterdienst.file_path_handling.path_handling import (
     build_local_filepath_for_station_data,
     build_path_to_parameter,
-    list_files_of_dwd_server,
+    list_remote_files,
 )
 
 
@@ -28,7 +28,7 @@ def test_build_index_path():
 
 @pytest.mark.remote
 def test_list_files_of_climate_observations():
-    files_server = list_files_of_dwd_server(
+    files_server = list_remote_files(
         "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/"
         "annual/kl/recent",
         recursive=False,

--- a/tests/test_mosmix.py
+++ b/tests/test_mosmix.py
@@ -1,0 +1,241 @@
+import pytest
+from wetterdienst.mosmix import MOSMIXReader
+
+
+@pytest.mark.remote
+def test_mosmix_l():
+    """
+    Test some details of a typical MOSMIX-L response.
+    """
+
+    mosmix = MOSMIXReader(station_ids=["01001", "01008"])
+    response = mosmix.read_mosmix_l_latest()
+
+    # Verify metadata.
+    assert response.metadata.loc[0].issuer == "Deutscher Wetterdienst"
+    assert response.metadata.loc[0].product_id == "MOSMIX"
+
+    # Verify list of stations.
+    station_names = list(response.stations["station_name"].unique())
+    assert station_names == ["JAN MAYEN", "SVALBARD"]
+
+    # Verify forecast data.
+    station_ids = list(response.forecasts["station_id"].unique())
+    assert station_ids == ["01001", "01008"]
+    assert len(response.forecasts) > 200
+
+    assert len(response.forecasts.columns) == 116
+    assert list(response.forecasts.columns) == [
+        "station_id",
+        "datetime",
+        "PPPP",
+        "E_PPP",
+        "TX",
+        "TTT",
+        "E_TTT",
+        "Td",
+        "E_Td",
+        "TN",
+        "TG",
+        "TM",
+        "T5cm",
+        "DD",
+        "E_DD",
+        "FF",
+        "E_FF",
+        "FX1",
+        "FX3",
+        "FX625",
+        "FX640",
+        "FX655",
+        "FXh",
+        "FXh25",
+        "FXh40",
+        "FXh55",
+        "N",
+        "Neff",
+        "Nlm",
+        "Nh",
+        "Nm",
+        "Nl",
+        "N05",
+        "VV",
+        "VV10",
+        "wwM",
+        "wwM6",
+        "wwMh",
+        "wwMd",
+        "ww",
+        "ww3",
+        "W1W2",
+        "wwP",
+        "wwP6",
+        "wwPh",
+        "wwPd",
+        "wwZ",
+        "wwZ6",
+        "wwZh",
+        "wwD",
+        "wwD6",
+        "wwDh",
+        "wwC",
+        "wwC6",
+        "wwCh",
+        "wwT",
+        "wwT6",
+        "wwTh",
+        "wwTd",
+        "wwS",
+        "wwS6",
+        "wwSh",
+        "wwL",
+        "wwL6",
+        "wwLh",
+        "wwF",
+        "wwF6",
+        "wwFh",
+        "DRR1",
+        "RR6c",
+        "RRhc",
+        "RRdc",
+        "RR1c",
+        "RRS1c",
+        "RRL1c",
+        "RR3c",
+        "RRS3c",
+        "R101",
+        "R102",
+        "R103",
+        "R105",
+        "R107",
+        "R110",
+        "R120",
+        "R130",
+        "R150",
+        "RR1o1",
+        "RR1w1",
+        "RR1u1",
+        "R600",
+        "R602",
+        "R610",
+        "R650",
+        "Rh00",
+        "Rh02",
+        "Rh10",
+        "Rh50",
+        "Rd00",
+        "Rd02",
+        "Rd10",
+        "Rd50",
+        "SunD",
+        "RSunD",
+        "PSd00",
+        "PSd30",
+        "PSd60",
+        "RRad1",
+        "Rad1h",
+        "SunD1",
+        "SunD3",
+        "PEvap",
+        "WPc11",
+        "WPc31",
+        "WPc61",
+        "WPch1",
+        "WPcd1",
+    ]
+
+
+@pytest.mark.remote
+@pytest.mark.slow
+def test_mosmix_s():
+    """
+    Test some details of a typical MOSMIX-S response.
+    """
+
+    mosmix = MOSMIXReader(station_ids=["01028", "01092"])
+    response = mosmix.read_mosmix_s_latest()
+
+    # Verify metadata.
+    assert response.metadata.loc[0].issuer == "Deutscher Wetterdienst"
+    assert response.metadata.loc[0].product_id == "MOSMIX"
+
+    # Verify list of stations.
+    station_names = list(response.stations["station_name"].unique())
+    assert station_names == ["BJORNOYA", "MAKKAUR FYR"]
+
+    # Verify forecast data.
+    station_ids = list(response.forecasts["station_id"].unique())
+    assert station_ids == ["01028", "01092"]
+    assert len(response.forecasts) > 200
+
+    assert len(response.forecasts.columns) == 42
+    assert list(response.forecasts.columns) == [
+        "station_id",
+        "datetime",
+        "PPPP",
+        "TX",
+        "TTT",
+        "Td",
+        "TN",
+        "T5cm",
+        "DD",
+        "FF",
+        "FX1",
+        "FX3",
+        "FXh",
+        "FXh25",
+        "FXh40",
+        "FXh55",
+        "N",
+        "Neff",
+        "Nh",
+        "Nm",
+        "Nl",
+        "N05",
+        "VV",
+        "wwM",
+        "wwM6",
+        "wwMh",
+        "ww",
+        "W1W2",
+        "RR1c",
+        "RRS1c",
+        "RR3c",
+        "RRS3c",
+        "R602",
+        "R650",
+        "Rh00",
+        "Rh02",
+        "Rh10",
+        "Rh50",
+        "Rd02",
+        "Rd50",
+        "Rad1h",
+        "SunD1",
+    ]
+
+
+@pytest.mark.remote
+def test_mosmix_l_parameters():
+    """
+    Test some details of a MOSMIX-L response when queried for specific parameters.
+    """
+
+    mosmix = MOSMIXReader(station_ids=["01001", "01008"], parameters=["DD", "ww"])
+    response = mosmix.read_mosmix_l_latest()
+
+    # Verify forecast data.
+    station_ids = list(response.forecasts["station_id"].unique())
+    assert station_ids == ["01001", "01008"]
+    assert len(response.forecasts) > 200
+
+    assert len(response.forecasts.columns) == 4
+    assert list(response.forecasts.columns) == ["station_id", "datetime", "DD", "ww"]
+
+
+def test_mosmix_get_url_latest_fails():
+    mosmix = MOSMIXReader()
+    with pytest.raises(KeyError) as ex:
+        mosmix.get_url_latest("http://example.net")
+
+    assert "Unable to find LATEST file within http://example.net" in str(ex.value)

--- a/wetterdienst/constants/access_credentials.py
+++ b/wetterdienst/constants/access_credentials.py
@@ -4,6 +4,10 @@ from enum import Enum
 DWD_SERVER = "https://opendata.dwd.de"
 DWD_CDC_PATH = "climate_environment/CDC/"
 
+DWD_MOSMIX_S_PATH = "weather/local_forecasts/mos/MOSMIX_S/all_stations/kml/"
+DWD_MOSMIX_L_PATH = "weather/local_forecasts/mos/MOSMIX_L/all_stations/kml/"
+DWD_MOSMIX_L_SINGLE_PATH = "weather/local_forecasts/mos/MOSMIX_L/single_stations/{station_id}/kml/"  # noqa:E501,B950
+
 
 class DWDCDCBase(Enum):
     CLIMATE_OBSERVATIONS = "observations_germany/climate/"

--- a/wetterdienst/file_path_handling/path_handling.py
+++ b/wetterdienst/file_path_handling/path_handling.py
@@ -42,7 +42,7 @@ def build_path_to_parameter(
     return f"{time_resolution.value}/{parameter.value}/{period_type.value}/"
 
 
-def list_files_of_dwd_server(url: str, recursive: bool) -> List[str]:
+def list_remote_files(url: str, recursive: bool) -> List[str]:
     """
     A function used to create a listing of all files of a given path on the server
 
@@ -78,9 +78,7 @@ def list_files_of_dwd_server(url: str, recursive: bool) -> List[str]:
             folders.append(urljoin(url, f))
 
     if recursive:
-        files_in_folders = [
-            list_files_of_dwd_server(folder, recursive) for folder in folders
-        ]
+        files_in_folders = [list_remote_files(folder, recursive) for folder in folders]
 
         for files_in_folder in files_in_folders:
             files.extend(files_in_folder)

--- a/wetterdienst/indexing/file_index_creation.py
+++ b/wetterdienst/indexing/file_index_creation.py
@@ -29,7 +29,7 @@ from wetterdienst.enumerations.period_type_enumeration import PeriodType
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
 from wetterdienst.file_path_handling.path_handling import (
     build_path_to_parameter,
-    list_files_of_dwd_server,
+    list_remote_files,
 )
 
 
@@ -148,7 +148,7 @@ def _create_file_index_for_dwd_server(
 
     url = reduce(urljoin, [DWD_SERVER, DWD_CDC_PATH, cdc_base.value, parameter_path])
 
-    files_server = list_files_of_dwd_server(url, recursive=True)
+    files_server = list_remote_files(url, recursive=True)
 
     files_server = pd.DataFrame(
         files_server, columns=[DWDMetaColumns.FILENAME.value], dtype="str"

--- a/wetterdienst/indexing/meta_index_creation.py
+++ b/wetterdienst/indexing/meta_index_creation.py
@@ -33,7 +33,7 @@ from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
 from wetterdienst.exceptions import MetaFileNotFound
 from wetterdienst.file_path_handling.path_handling import (
     build_path_to_parameter,
-    list_files_of_dwd_server,
+    list_remote_files,
 )
 
 METADATA_COLUMNS = [
@@ -151,7 +151,7 @@ def _create_meta_index_for_climate_observations(
         ],
     )
 
-    files_server = list_files_of_dwd_server(url, recursive=True)
+    files_server = list_remote_files(url, recursive=True)
 
     # Find the one meta file from the files listed on the server
     meta_file = _find_meta_file(files_server, url)
@@ -226,7 +226,7 @@ def _create_meta_index_for_1minute_historical_precipitation() -> pd.DataFrame:
         ],
     )
 
-    metadata_file_paths = list_files_of_dwd_server(url, recursive=False)
+    metadata_file_paths = list_remote_files(url, recursive=False)
 
     station_ids = [
         re.findall(STATION_ID_REGEX, file).pop(0) for file in metadata_file_paths

--- a/wetterdienst/mosmix.py
+++ b/wetterdienst/mosmix.py
@@ -1,0 +1,292 @@
+# Source:
+# https://github.com/jlewis91/dwdbulk/blob/master/dwdbulk/api/forecasts.py
+import logging
+from io import BytesIO
+from typing import List
+from zipfile import ZipFile
+from os.path import basename
+
+from lxml import etree  # noqa:S410
+from pandas import DatetimeIndex
+from tqdm import tqdm
+from urllib.parse import urljoin
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+
+from wetterdienst.constants.access_credentials import (
+    DWD_SERVER,
+    DWD_MOSMIX_S_PATH,
+    DWD_MOSMIX_L_PATH,
+    DWD_MOSMIX_L_SINGLE_PATH,
+)
+from wetterdienst.download.https_handling import create_dwd_session
+from wetterdienst.file_path_handling.path_handling import list_remote_files
+
+log = logging.getLogger(__name__)
+
+
+class KMLReader:
+    def __init__(self, station_ids: List = None, parameters: List = None):
+
+        self.station_ids = station_ids
+        self.parameters = parameters
+
+        self.metadata = {}
+        self.root = None
+        self.timesteps = []
+        self.items = []
+
+        self.dwd_session = create_dwd_session()
+
+    def download(self, url: str):
+        # https://stackoverflow.com/questions/37573483/progress-bar-while-download-file-over-http-with-requests  # noqa:E501,B950
+
+        response = self.dwd_session.get(url, stream=True)
+        response.raise_for_status()
+
+        total = int(response.headers.get("content-length", 0))
+
+        buffer = BytesIO()
+        with tqdm(
+            desc=url,
+            total=total,
+            unit="iB",
+            unit_scale=True,
+            unit_divisor=1024,
+        ) as bar:
+            for data in response.iter_content(chunk_size=1024):
+                size = buffer.write(data)
+                bar.update(size)
+
+        return buffer
+
+    def fetch(self, url) -> str:
+        """
+        Fetch weather forecast file (zipped xml).
+        """
+        buffer = self.download(url)
+        kmz = ZipFile(buffer, "r")
+        kml = kmz.open(kmz.namelist()[0], "r").read()
+        return kml
+
+    def read(self, url: str):
+        """
+        Download and read DWD XML Weather Forecast File of Type KML.
+        """
+
+        log.info(f"Downloading KMZ file {basename(url)}")
+        kml = self.fetch(url)
+
+        log.info("Parsing KML data")
+        # TODO: Check if XML parsing performance can be improved by using libxml2.
+        tree = etree.parse(BytesIO(kml))  # noqa:S320
+        self.root = root = tree.getroot()
+
+        prod_items = {
+            "issuer": "Issuer",
+            "product_id": "ProductID",
+            "generating_process": "GeneratingProcess",
+            "issue_time": "IssueTime",
+        }
+
+        # Get Basic Metadata
+        prod_definition = root.findall(
+            "kml:Document/kml:ExtendedData/dwd:ProductDefinition", root.nsmap
+        )[0]
+
+        self.metadata = {
+            k: prod_definition.find(f"{{{root.nsmap['dwd']}}}{v}").text
+            for k, v in prod_items.items()
+        }
+        self.metadata["issue_time"] = pd.Timestamp(self.metadata["issue_time"])
+
+        # Get time steps.
+        timesteps = root.findall(
+            "kml:Document/kml:ExtendedData/dwd:ProductDefinition/dwd:ForecastTimeSteps",
+            root.nsmap,
+        )[0]
+        self.timesteps = DatetimeIndex(
+            [pd.Timestamp(i.text) for i in timesteps.getchildren()]
+        )
+
+        # Find all kml:Placemark items.
+        self.items += root.findall("kml:Document/kml:Placemark", root.nsmap)
+
+    def iter_items(self):
+        for item in self.items:
+            station_id = item.find("kml:name", self.root.nsmap).text
+
+            if (self.station_ids is None) or station_id in self.station_ids:
+                yield item
+
+    def get_metadata(self):
+        return pd.DataFrame([self.metadata])
+
+    def get_stations(self):
+        stations = []
+        for station_forecast in self.iter_items():
+            station = {
+                "station_id": station_forecast.find("kml:name", self.root.nsmap).text,
+                "station_name": station_forecast.find(
+                    "kml:description", self.root.nsmap
+                ).text,
+            }
+
+            coordinates = station_forecast.find(
+                "kml:Point/kml:coordinates", self.root.nsmap
+            ).text.split(",")
+
+            station["longitude"] = float(coordinates[0])
+            station["latitude"] = float(coordinates[1])
+            station["height"] = float(coordinates[2])
+
+            stations.append(station)
+
+        return pd.DataFrame(stations)
+
+    def get_forecasts(self):
+        df_list = []
+        for station_forecast in self.iter_items():
+            station_ids = station_forecast.find("kml:name", self.root.nsmap).text
+
+            measurement_list = station_forecast.findall(
+                "kml:ExtendedData/dwd:Forecast", self.root.nsmap
+            )
+            df = pd.DataFrame({"station_id": station_ids, "datetime": self.timesteps})
+
+            for measurement_item in measurement_list:
+
+                measurement_parameter = measurement_item.get(
+                    f"{{{self.root.nsmap['dwd']}}}elementName"
+                )
+
+                if self.parameters is None or measurement_parameter in self.parameters:
+                    measurement_string = measurement_item.getchildren()[0].text
+
+                    measurement_values = " ".join(measurement_string.split()).split(" ")
+                    measurement_values = [
+                        np.nan if i == "-" else float(i) for i in measurement_values
+                    ]
+
+                    assert len(measurement_values) == len(  # noqa:S101
+                        self.timesteps
+                    ), "Number of timesteps does not match number of measurement values"
+
+                    df[measurement_parameter] = measurement_values
+
+                df_list.append(df)
+
+        df = pd.concat(df_list, axis=0)
+
+        self.coerce_columns(df)
+
+        return df
+
+    def coerce_columns(self, df):
+        for column in df.columns:
+            if column == "W1W2" or column.startswith("WPc") or column in ["ww", "ww3"]:
+                df[column] = df[column].astype("Int64")
+
+
+@dataclass
+class MOSMIXResult:
+    """
+    Result object encapsulating metadata, station information and forecast data.
+    """
+
+    metadata: pd.DataFrame
+    stations: pd.DataFrame
+    forecasts: pd.DataFrame
+
+
+class MOSMIXReader:
+    """
+
+    Fetch weather forecast data (KML/MOSMIX_S dataset).
+
+    Parameters
+    ----------
+    station_ids : List
+        - If None, data for all stations is returned.
+        - If not None, station_ids are a list of station ids for which data is desired.
+
+    parameters: List
+        - If None, data for all parameters is returned.
+        - If not None, list of parameters, per MOSMIX definition, see
+          https://www.dwd.de/DE/leistungen/opendata/help/schluessel_datenformate/kml/mosmix_elemente_pdf.pdf?__blob=publicationFile&v=2  # noqa:E501,B950
+    """
+
+    def __init__(self, station_ids: List = None, parameters: List = None):
+
+        self.station_ids = None
+        self.parameters = None
+
+        if station_ids:
+            assert isinstance(  # noqa:S101
+                station_ids, list
+            ), "station_ids must be None or a list"
+            self.station_ids = [str(station_id) for station_id in station_ids]
+
+        if parameters:
+            assert isinstance(  # noqa:S101
+                parameters, list
+            ), "parameters must be None or a list"
+            self.parameters = [str(param) for param in parameters]
+
+        self.kml = KMLReader(station_ids=self.station_ids, parameters=self.parameters)
+
+    def read_mosmix_s_latest(self) -> MOSMIXResult:
+        """
+        Fetch weather forecast data (KML/MOSMIX_S dataset).
+        """
+        url = urljoin(DWD_SERVER, DWD_MOSMIX_S_PATH)
+
+        return self.read_mosmix_single(url)
+
+    def read_mosmix_l_latest(self) -> MOSMIXResult:
+        """
+        Fetch weather forecast data (KML/MOSMIX_L dataset).
+        """
+        if self.station_ids is None:  # pragma: no cover
+            url = urljoin(DWD_SERVER, DWD_MOSMIX_L_PATH)
+            return self.read_mosmix_single(url)
+        else:
+            url = urljoin(DWD_SERVER, DWD_MOSMIX_L_SINGLE_PATH)
+            return self.read_mosmix_multi(url)
+
+    def read_mosmix_single(self, url) -> MOSMIXResult:
+
+        url = self.get_url_latest(url)
+        self.kml.read(url)
+
+        result = MOSMIXResult(
+            metadata=self.kml.get_metadata(),
+            stations=self.kml.get_stations(),
+            forecasts=self.kml.get_forecasts(),
+        )
+
+        return result
+
+    def read_mosmix_multi(self, url) -> MOSMIXResult:
+        for station_id in self.station_ids:
+            station_url = url.format(station_id=station_id)
+            station_url = self.get_url_latest(station_url)
+            self.kml.read(station_url)
+
+        result = MOSMIXResult(
+            metadata=self.kml.get_metadata(),
+            stations=self.kml.get_stations(),
+            forecasts=self.kml.get_forecasts(),
+        )
+
+        return result
+
+    def get_url_latest(self, url):
+        urls = list_remote_files(url, False)
+        try:
+            url = list(filter(lambda url: "LATEST" in url, urls))[0]
+            return url
+        except:  # noqa:E722,B001
+            raise KeyError(f"Unable to find LATEST file within {url}")


### PR DESCRIPTION
Hi there,

## About
This is a first shot at #70 and has been derived from the [`dwdbulk::forecasts`](https://github.com/jlewis91/dwdbulk/blob/master/dwdbulk/api/forecasts.py) implementation by @jlewis91. Thanks a bunch!

## Synopsis
```
poetry update
poetry shell
python wetterdienst/mosmix.py
```

## Backlog
- Column names and such have not been integrated into the Enum-based knowledgebase yet.
- As outlined within https://github.com/earthobservations/wetterdienst/issues/70#issuecomment-653690214, it would be cool to reuse additional code from @FL550's [`dwdforecast.py`](https://github.com/FL550/simple_dwd_weatherforecast/blob/master/simple_dwd_weatherforecast/dwdforecast.py) implementation.
  > I like that it already maps the technical meteorological element names to more meaningful field names (see #54). Also, it features a mapping to resolve the weather condition codes to meaningful textual labels.
- Add software tests.
- Integrate with `cli.py`.

With kind regards,
Andreas.