### PR TITLE
Extend request class to be able to request multiple parameters at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Development
-...
+- extend DWDStationRequest to take multiple parameters as request
 
 ## 0.3.0 (26.07.2020)
 - establish code style black

--- a/tests/test_dwd_station_request.py
+++ b/tests/test_dwd_station_request.py
@@ -1,4 +1,6 @@
 import pytest
+import pandas as pd
+
 from wetterdienst.dwd_station_request import DWDStationRequest
 from wetterdienst.exceptions.start_date_end_date_exception import StartDateEndDateError
 from wetterdienst.enumerations.parameter_enumeration import Parameter
@@ -6,20 +8,15 @@ from wetterdienst.enumerations.period_type_enumeration import PeriodType
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
 
 
-def test_parse_station_id_to_list_of_integers():
-    # @todo
-    assert True
-
-
 def test_dwd_station_request():
     assert DWDStationRequest(
         station_ids=[1],
-        time_resolution="daily",
         parameter="kl",
+        time_resolution="daily",
         period_type="historical",
     ) == [
         [1],
-        Parameter.CLIMATE_SUMMARY,
+        [Parameter.CLIMATE_SUMMARY],
         TimeResolution.DAILY,
         [PeriodType.HISTORICAL],
         None,
@@ -29,24 +26,16 @@ def test_dwd_station_request():
     assert DWDStationRequest(
         station_ids=[1],
         parameter=Parameter.CLIMATE_SUMMARY,
-        period_type=PeriodType.HISTORICAL,
         time_resolution=TimeResolution.DAILY,
+        period_type=PeriodType.HISTORICAL,
     ) == [
         [1],
-        Parameter.CLIMATE_SUMMARY,
+        [Parameter.CLIMATE_SUMMARY],
         TimeResolution.DAILY,
         [PeriodType.HISTORICAL],
         None,
         None,
     ]
-
-    with pytest.raises(ValueError):
-        DWDStationRequest(
-            station_ids=[1],
-            parameter=Parameter.CLIMATE_SUMMARY,
-            period_type=PeriodType.HISTORICAL,
-            time_resolution=TimeResolution.MINUTE_1,
-        )
 
 
 def test_station_id():
@@ -59,30 +48,49 @@ def test_station_id():
         )
 
 
-def test_parameter_enumerations():
-    with pytest.raises(ValueError):
-        DWDStationRequest(
-            station_ids=[1], parameter="kl", period_type="now", time_resolution="daily"
-        )
-
-
 def test_time_input():
-    with pytest.raises(ValueError):
-        DWDStationRequest(
+    assert DWDStationRequest(
             station_ids=[1],
             parameter=Parameter.CLIMATE_SUMMARY,
             time_resolution=TimeResolution.DAILY,
             start_date="1971-01-01",
-        )
+    ) == [
+        [1],
+        [Parameter.CLIMATE_SUMMARY],
+        TimeResolution.DAILY,
+        [PeriodType.HISTORICAL, PeriodType.RECENT, PeriodType.NOW],
+        pd.Timestamp("1971-01-01"),
+        pd.Timestamp("1971-01-01"),
+    ]
 
-        with pytest.raises(ValueError):
-            DWDStationRequest(
+    assert DWDStationRequest(
+        station_ids=[1],
+        parameter=Parameter.CLIMATE_SUMMARY,
+        time_resolution=TimeResolution.DAILY,
+        end_date="1971-01-01",
+    ) == [
+               [1],
+               [Parameter.CLIMATE_SUMMARY],
+               TimeResolution.DAILY,
+               [PeriodType.HISTORICAL, PeriodType.RECENT, PeriodType.NOW],
+               pd.Timestamp("1971-01-01"),
+               pd.Timestamp("1971-01-01"),
+           ]
+
+    assert DWDStationRequest(
                 station_ids=[1],
                 parameter=Parameter.CLIMATE_SUMMARY,
                 time_resolution=TimeResolution.DAILY,
                 period_type=PeriodType.HISTORICAL,
                 start_date="1971-01-01",
-            )
+    ) == [
+        [1],
+        [Parameter.CLIMATE_SUMMARY],
+        TimeResolution.DAILY,
+        [PeriodType.HISTORICAL],
+        None,
+        None
+    ]
 
     with pytest.raises(StartDateEndDateError):
         DWDStationRequest(

--- a/tests/test_dwd_station_request.py
+++ b/tests/test_dwd_station_request.py
@@ -50,10 +50,10 @@ def test_station_id():
 
 def test_time_input():
     assert DWDStationRequest(
-            station_ids=[1],
-            parameter=Parameter.CLIMATE_SUMMARY,
-            time_resolution=TimeResolution.DAILY,
-            start_date="1971-01-01",
+        station_ids=[1],
+        parameter=Parameter.CLIMATE_SUMMARY,
+        time_resolution=TimeResolution.DAILY,
+        start_date="1971-01-01",
     ) == [
         [1],
         [Parameter.CLIMATE_SUMMARY],
@@ -69,27 +69,27 @@ def test_time_input():
         time_resolution=TimeResolution.DAILY,
         end_date="1971-01-01",
     ) == [
-               [1],
-               [Parameter.CLIMATE_SUMMARY],
-               TimeResolution.DAILY,
-               [PeriodType.HISTORICAL, PeriodType.RECENT, PeriodType.NOW],
-               pd.Timestamp("1971-01-01"),
-               pd.Timestamp("1971-01-01"),
-           ]
+        [1],
+        [Parameter.CLIMATE_SUMMARY],
+        TimeResolution.DAILY,
+        [PeriodType.HISTORICAL, PeriodType.RECENT, PeriodType.NOW],
+        pd.Timestamp("1971-01-01"),
+        pd.Timestamp("1971-01-01"),
+    ]
 
     assert DWDStationRequest(
-                station_ids=[1],
-                parameter=Parameter.CLIMATE_SUMMARY,
-                time_resolution=TimeResolution.DAILY,
-                period_type=PeriodType.HISTORICAL,
-                start_date="1971-01-01",
+        station_ids=[1],
+        parameter=Parameter.CLIMATE_SUMMARY,
+        time_resolution=TimeResolution.DAILY,
+        period_type=PeriodType.HISTORICAL,
+        start_date="1971-01-01",
     ) == [
         [1],
         [Parameter.CLIMATE_SUMMARY],
         TimeResolution.DAILY,
         [PeriodType.HISTORICAL],
         None,
-        None
+        None,
     ]
 
     with pytest.raises(StartDateEndDateError):

--- a/wetterdienst/data_collection.py
+++ b/wetterdienst/data_collection.py
@@ -194,8 +194,8 @@ def _tidy_up_data(df: pd.DataFrame, parameter: Parameter) -> pd.DataFrame:
 
     # Extract quality
     # Set empty quality for first columns until first QN column
-    quality = pd.Series()
-    column_quality = pd.Series()
+    quality = pd.Series(dtype=int)
+    column_quality = pd.Series(dtype=int)
 
     for column in df:
         # If is quality column, overwrite current "column quality"

--- a/wetterdienst/dwd_station_request.py
+++ b/wetterdienst/dwd_station_request.py
@@ -125,7 +125,8 @@ class DWDStationRequest:
         self.prefer_local = prefer_local
         self.write_file = write_file
         self.folder = folder
-        self.tidy_data = tidy_data
+        # If more then one parameter requested, automatically tidy data
+        self.tidy_data = len(self.parameter) == 2 or tidy_data
         self.humanize_column_names = humanize_column_names
         self.create_new_file_index = create_new_file_index
 

--- a/wetterdienst/dwd_station_request.py
+++ b/wetterdienst/dwd_station_request.py
@@ -10,11 +10,12 @@ from wetterdienst.enumerations.parameter_enumeration import Parameter
 from wetterdienst.enumerations.period_type_enumeration import PeriodType
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
 from wetterdienst.additionals.functions import (
-    check_parameters,
     cast_to_list,
     parse_enumeration_from_template,
 )
-from wetterdienst.exceptions.invalid_parameter_exception import InvalidParameterCombination
+from wetterdienst.exceptions.invalid_parameter_exception import (
+    InvalidParameterCombination,
+)
 from wetterdienst.exceptions.start_date_end_date_exception import StartDateEndDateError
 from wetterdienst.constants.metadata import DWD_FOLDER_MAIN
 from wetterdienst.enumerations.column_names_enumeration import DWDMetaColumns
@@ -34,7 +35,9 @@ class DWDStationRequest:
         station_ids: Union[str, int, List[Union[int, str]]],
         parameter: Union[str, Parameter, List[Union[str, Parameter]]],
         time_resolution: Union[str, TimeResolution],
-        period_type: Union[Union[None, str, PeriodType], List[Union[None, str, PeriodType]]] = None,
+        period_type: Union[
+            Union[None, str, PeriodType], List[Union[None, str, PeriodType]]
+        ] = None,
         start_date: Union[None, str, Timestamp] = None,
         end_date: Union[None, str, Timestamp] = None,
         prefer_local: bool = False,
@@ -100,10 +103,12 @@ class DWDStationRequest:
                 if pt is None:
                     self.period_type.append(None)
                 else:
-                    self.period_type.append(parse_enumeration_from_template(pt, PeriodType))
+                    self.period_type.append(
+                        parse_enumeration_from_template(pt, PeriodType)
+                    )
 
-            # Additional sorting required for self.period_type to ensure that for multiple
-            # periods the data is first sourced from historical
+            # Additional sorting required for self.period_type to ensure that for
+            # multiple periods the data is first sourced from historical
             self.period_type = sorted(self.period_type)
 
         else:
@@ -219,7 +224,9 @@ class DWDStationRequest:
                     except KeyError:
                         pass
 
-                    df_parameter_period = df_parameter_period.append(df_period, ignore_index=True)
+                    df_parameter_period = df_parameter_period.append(
+                        df_period, ignore_index=True
+                    )
 
                 df_station = df_station.append(df_parameter_period, ignore_index=True)
 


### PR DESCRIPTION
I extended the DWDStationRequest class and simplified the init process a bit. Now we are able to request multiple parameters at once. The **collect_data** method will now return one DataFrame per station including multiple parameters (this may change in the future, should we see any performance problems with this). 

With this change, we will be able to fullfill #106. @amotl please have a look at the changes I've set to make this work!