### PR TITLE
Update get_nearby_stations

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -18,8 +18,8 @@ The API for the historical weather data mainly consists of the following functio
     - calculates the close weather stations based on the coordinates for the requested
       data
     - either selected by rank (n stations) or by distance in km
-    - it returns a list of station ids that can be used to download the data plus the
-      distances
+    - it returns a DataFrame with meta data, distances [in km] and station ids that can be used to download the
+      data plus the
 
 - **DWDStationRequest:**
     - a class that can combine multiple periods/date ranges for any number of stations
@@ -97,18 +97,21 @@ Now, we know an approximate location, where we cant to get data for the temperat
 
 .. code-block:: Python
 
+    from datetime import datetime
     from wetterdienst import Parameter, PeriodType, TimeResolution
     from wetterdienst import get_nearby_stations
 
     get_nearby_stations(
-        [50., 51.4], [8.9, 9.3],
+        50., 8.9,
+        datetime(2020, 1, 1),
+        datetime(2020, 1, 20),
         Parameter.TEMPERATURE_AIR,
         TimeResolution.HOURLY,
         PeriodType.RECENT,
         num_stations_nearby=1
     )
 
-The function returns us the station ids (and distances), that we can use to get our
+The function returns a meta data DataFrame, where we can find weather station ids and distances to get our
 observation data.
 
 .. code-block:: Python

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -43,7 +43,7 @@ def test_get_nearby_stations():
         pd.DataFrame(
             [
                 [
-                    4411,
+                    np.int64(4411),
                     np.datetime64("2002-01-24", dtype="np.datetime64[ns]"),
                     155.0,
                     49.9195,
@@ -85,7 +85,7 @@ def test_get_nearby_stations():
         pd.DataFrame(
             [
                 [
-                    4411,
+                    np.int64(4411),
                     np.datetime64("2002-01-24 00:00:00", dtype="datetime64[ns]"),
                     155.0,
                     49.9195,
@@ -96,7 +96,7 @@ def test_get_nearby_stations():
                     11.653026716750542,
                 ],
                 [
-                    2480,
+                    np.int64(2480),
                     np.datetime64("2004-09-01 00:00:00", dtype="datetime64[ns]"),
                     108.0,
                     50.0643,
@@ -107,7 +107,7 @@ def test_get_nearby_stations():
                     12.572153957087247,
                 ],
                 [
-                    7341,
+                    np.int64(7341),
                     np.datetime64("2005-07-16 00:00:00", dtype="datetime64[ns]"),
                     119.0,
                     50.09,

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -170,6 +170,7 @@ def test_get_nearby_stations():
             num_stations_nearby=1,
         )
 
+
 def test_get_nearby_stations_out_of_distance():
     nearest_station = get_nearby_stations(
         [50.0],

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -27,8 +27,8 @@ fixtures_dir = f"{os.path.dirname(__file__)}/../fixtures/"
 def test_get_nearby_stations():
     # Test for one nearest station
     nearest_station = get_nearby_stations(
-        [50.0, 51.4],
-        [8.9, 9.3],
+        50.0,
+        8.9,
         datetime(2020, 1, 1),
         datetime(2020, 1, 20),
         Parameter.TEMPERATURE_AIR,
@@ -36,10 +36,10 @@ def test_get_nearby_stations():
         PeriodType.RECENT,
         num_stations_nearby=1,
     )
-    nearest_station[0] = nearest_station[0].drop("TO_DATE", axis="columns")
+    nearest_station = nearest_station.drop("TO_DATE", axis="columns")
 
     pd.testing.assert_frame_equal(
-        nearest_station[0],
+        nearest_station,
         pd.DataFrame(
             [
                 [
@@ -70,8 +70,8 @@ def test_get_nearby_stations():
     )
 
     nearest_station = get_nearby_stations(
-        [50.0, 51.4],
-        [8.9, 9.3],
+        50.0,
+        8.9,
         datetime(2020, 1, 1),
         datetime(2020, 1, 20),
         Parameter.TEMPERATURE_AIR,
@@ -79,9 +79,9 @@ def test_get_nearby_stations():
         PeriodType.RECENT,
         max_distance_in_km=20,
     )
-    nearest_station[0] = nearest_station[0].drop("TO_DATE", axis="columns")
+    nearest_station = nearest_station.drop("TO_DATE", axis="columns")
     pd.testing.assert_frame_equal(
-        nearest_station[0],
+        nearest_station,
         pd.DataFrame(
             [
                 [
@@ -135,8 +135,8 @@ def test_get_nearby_stations():
 
     with pytest.raises(ValueError):
         get_nearby_stations(
-            [50.0, 51.4],
-            [8.9, 9.3],
+            50.0,
+            8.9,
             datetime(2020, 1, 1),
             datetime(2020, 1, 20),
             Parameter.TEMPERATURE_AIR,
@@ -148,8 +148,8 @@ def test_get_nearby_stations():
 
     with pytest.raises(ValueError):
         get_nearby_stations(
-            [50.0, 51.4],
-            [8.9, 9.3],
+            51.4,
+            9.3,
             datetime(2020, 1, 1),
             datetime(2020, 1, 20),
             Parameter.TEMPERATURE_AIR,
@@ -160,8 +160,8 @@ def test_get_nearby_stations():
 
     with pytest.raises(InvalidParameterCombination):
         get_nearby_stations(
-            [50.0, 51.4],
-            [8.9, 9.3],
+            51.4,
+            9.3,
             datetime(2020, 1, 1),
             datetime(2020, 1, 20),
             Parameter.SOIL,

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -37,6 +37,7 @@ def test_get_nearby_stations():
         num_stations_nearby=1,
     )
     nearby_station = nearby_station.drop("TO_DATE", axis="columns")
+    nearby_station.STATION_ID = nearby_station.STATION_ID.astype(np.int64)
 
     pd.testing.assert_frame_equal(
         nearby_station,
@@ -80,6 +81,8 @@ def test_get_nearby_stations():
         max_distance_in_km=20,
     )
     nearby_station = nearby_station.drop("TO_DATE", axis="columns")
+    nearby_station.STATION_ID = nearby_station.STATION_ID.astype(np.int64)
+
     pd.testing.assert_frame_equal(
         nearby_station,
         pd.DataFrame(

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -26,7 +26,7 @@ fixtures_dir = f"{os.path.dirname(__file__)}/../fixtures/"
 )
 def test_get_nearby_stations():
     # Test for one nearest station
-    nearest_station = get_nearby_stations(
+    nearby_station = get_nearby_stations(
         50.0,
         8.9,
         datetime(2020, 1, 1),
@@ -36,10 +36,10 @@ def test_get_nearby_stations():
         PeriodType.RECENT,
         num_stations_nearby=1,
     )
-    nearest_station = nearest_station.drop("TO_DATE", axis="columns")
+    nearby_station = nearby_station.drop("TO_DATE", axis="columns")
 
     pd.testing.assert_frame_equal(
-        nearest_station,
+        nearby_station,
         pd.DataFrame(
             [
                 [
@@ -69,7 +69,7 @@ def test_get_nearby_stations():
         ),
     )
 
-    nearest_station = get_nearby_stations(
+    nearby_station = get_nearby_stations(
         50.0,
         8.9,
         datetime(2020, 1, 1),
@@ -79,9 +79,9 @@ def test_get_nearby_stations():
         PeriodType.RECENT,
         max_distance_in_km=20,
     )
-    nearest_station = nearest_station.drop("TO_DATE", axis="columns")
+    nearby_station = nearby_station.drop("TO_DATE", axis="columns")
     pd.testing.assert_frame_equal(
-        nearest_station,
+        nearby_station,
         pd.DataFrame(
             [
                 [
@@ -172,9 +172,9 @@ def test_get_nearby_stations():
 
 
 def test_get_nearby_stations_out_of_distance():
-    nearest_station = get_nearby_stations(
-        [50.0],
-        [8.9],
+    nearby_station = get_nearby_stations(
+        50.0,
+        8.9,
         datetime(2020, 1, 1),
         datetime(2020, 1, 20),
         Parameter.TEMPERATURE_AIR,
@@ -182,7 +182,7 @@ def test_get_nearby_stations_out_of_distance():
         PeriodType.RECENT,
         max_distance_in_km=10,
     )
-    assert nearest_station[0].empty is True
+    assert nearby_station.empty is True
 
 
 def test_derive_nearest_neighbours():

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -34,29 +34,39 @@ def test_get_nearby_stations():
         PeriodType.RECENT,
         num_stations_nearby=1,
     )
-    nearest_station[0] = nearest_station[0].drop('TO_DATE', axis='columns')
+    nearest_station[0] = nearest_station[0].drop("TO_DATE", axis="columns")
 
     pd.testing.assert_frame_equal(
         nearest_station[0],
-        pd.DataFrame([[4411,
-                       np.datetime64('2002-01-24', dtype='np.datetime64[ns]'),
-                       155.,
-                       49.9195,
-                       8.9671,
-                       'Schaafheim-Schlierbach',
-                       'Hessen',
-                       True,
-                       11.65302672]],
-                     columns=['STATION_ID', 'FROM_DATE', 'STATION_HEIGHT', 'LAT', 'LON',
-                              'STATION_NAME', 'STATE', 'HAS_FILE', 'DISTANCE_TO_LOCATION'],
-                     index=[321])
+        pd.DataFrame(
+            [
+                [
+                    4411,
+                    np.datetime64("2002-01-24", dtype="np.datetime64[ns]"),
+                    155.0,
+                    49.9195,
+                    8.9671,
+                    "Schaafheim-Schlierbach",
+                    "Hessen",
+                    True,
+                    11.65302672,
+                ]
+            ],
+            columns=[
+                "STATION_ID",
+                "FROM_DATE",
+                "STATION_HEIGHT",
+                "LAT",
+                "LON",
+                "STATION_NAME",
+                "STATE",
+                "HAS_FILE",
+                "DISTANCE_TO_LOCATION",
+            ],
+            index=[321],
+        ),
     )
 
-    # np.testing.assert_array_almost_equal(
-    #     np.array(distances), np.array([[11.653026716750542, 14.520733407578632]])
-    # )
-
-    # Test for maximum distance (take same station
     nearest_station = get_nearby_stations(
         [50.0, 51.4],
         [8.9, 9.3],
@@ -67,39 +77,58 @@ def test_get_nearby_stations():
         PeriodType.RECENT,
         max_distance_in_km=20,
     )
-    nearest_station[0] = nearest_station[0].drop('TO_DATE', axis='columns')
+    nearest_station[0] = nearest_station[0].drop("TO_DATE", axis="columns")
     pd.testing.assert_frame_equal(
         nearest_station[0],
-        pd.DataFrame([[4411,
-                       np.datetime64('2002-01-24 00:00:00', dtype='datetime64[ns]'),
-                       155.0,
-                       49.9195,
-                       8.9671,
-                       'Schaafheim-Schlierbach',
-                       'Hessen',
-                       True,
-                       11.653026716750542],
-                      [2480,
-                       np.datetime64('2004-09-01 00:00:00', dtype='datetime64[ns]'),
-                       108.0,
-                       50.0643,
-                       8.993,
-                       'Kahl/Main',
-                       'Bayern',
-                       True,
-                       12.572153957087247],
-                      [7341,
-                       np.datetime64('2005-07-16 00:00:00', dtype='datetime64[ns]'),
-                       119.0,
-                       50.09,
-                       8.7862,
-                       'Offenbach-Wetterpark',
-                       'Hessen',
-                       True,
-                       16.13301589362613]],
-                     columns=['STATION_ID', 'FROM_DATE', 'STATION_HEIGHT', 'LAT', 'LON',
-                              'STATION_NAME', 'STATE', 'HAS_FILE', 'DISTANCE_TO_LOCATION'],
-                     index=[321, 170, 465])
+        pd.DataFrame(
+            [
+                [
+                    4411,
+                    np.datetime64("2002-01-24 00:00:00", dtype="datetime64[ns]"),
+                    155.0,
+                    49.9195,
+                    8.9671,
+                    "Schaafheim-Schlierbach",
+                    "Hessen",
+                    True,
+                    11.653026716750542,
+                ],
+                [
+                    2480,
+                    np.datetime64("2004-09-01 00:00:00", dtype="datetime64[ns]"),
+                    108.0,
+                    50.0643,
+                    8.993,
+                    "Kahl/Main",
+                    "Bayern",
+                    True,
+                    12.572153957087247,
+                ],
+                [
+                    7341,
+                    np.datetime64("2005-07-16 00:00:00", dtype="datetime64[ns]"),
+                    119.0,
+                    50.09,
+                    8.7862,
+                    "Offenbach-Wetterpark",
+                    "Hessen",
+                    True,
+                    16.13301589362613,
+                ],
+            ],
+            columns=[
+                "STATION_ID",
+                "FROM_DATE",
+                "STATION_HEIGHT",
+                "LAT",
+                "LON",
+                "STATION_NAME",
+                "STATE",
+                "HAS_FILE",
+                "DISTANCE_TO_LOCATION",
+            ],
+            index=[321, 170, 465],
+        ),
     )
 
     with pytest.raises(ValueError):
@@ -128,7 +157,18 @@ def test_get_nearby_stations():
         )
 
 
-test_get_nearby_stations()
+def test_get_nearby_stations_out_of_distance():
+    nearest_station = get_nearby_stations(
+        [50.0],
+        [8.9],
+        datetime(2020, 1, 1),
+        datetime(2020, 1, 20),
+        Parameter.TEMPERATURE_AIR,
+        TimeResolution.HOURLY,
+        PeriodType.RECENT,
+        max_distance_in_km=10,
+    )
+    assert nearest_station[0].empty is True
 
 
 def test_derive_nearest_neighbours():

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -14,6 +14,8 @@ from wetterdienst.enumerations.parameter_enumeration import Parameter
 from wetterdienst.enumerations.period_type_enumeration import PeriodType
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
 from wetterdienst.data_models.coordinates import Coordinates
+from wetterdienst.exceptions import InvalidParameterCombination
+
 
 fixtures_dir = f"{os.path.dirname(__file__)}/../fixtures/"
 
@@ -156,6 +158,17 @@ def test_get_nearby_stations():
             num_stations_nearby=0,
         )
 
+    with pytest.raises(InvalidParameterCombination):
+        get_nearby_stations(
+            [50.0, 51.4],
+            [8.9, 9.3],
+            datetime(2020, 1, 1),
+            datetime(2020, 1, 20),
+            Parameter.SOIL,
+            TimeResolution.MINUTE_10,
+            PeriodType.RECENT,
+            num_stations_nearby=1,
+        )
 
 def test_get_nearby_stations_out_of_distance():
     nearest_station = get_nearby_stations(

--- a/wetterdienst/additionals/geo_location.py
+++ b/wetterdienst/additionals/geo_location.py
@@ -1,37 +1,38 @@
 """ calculates the nearest weather station to a requested location"""
-from typing import List, Union, Tuple, Optional
 from _datetime import datetime
+from typing import List, Union, Tuple, Optional
+
 import numpy as np
 import pandas as pd
 from scipy.spatial import cKDTree
 
-from wetterdienst.enumerations.column_names_enumeration import DWDMetaColumns
-from wetterdienst.exceptions import InvalidParameterCombination
-from wetterdienst.parse_metadata import metadata_for_climate_observations
 from wetterdienst.additionals.functions import (
     check_parameters,
     parse_enumeration_from_template,
     cast_to_list,
 )
+from wetterdienst.additionals.time_handling import parse_datetime
 from wetterdienst.data_models.coordinates import Coordinates
+from wetterdienst.enumerations.column_names_enumeration import DWDMetaColumns
 from wetterdienst.enumerations.parameter_enumeration import Parameter
 from wetterdienst.enumerations.period_type_enumeration import PeriodType
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
-from wetterdienst.additionals.time_handling import parse_datetime
+from wetterdienst.exceptions import InvalidParameterCombination
+from wetterdienst.parse_metadata import metadata_for_climate_observations
 
 KM_EARTH_RADIUS = 6371
 
 
 def get_nearby_stations(
-    latitudes: Union[List[float], np.array],
-    longitudes: Union[List[float], np.array],
-    minimal_available_date: Union[datetime, str],
-    maximal_available_date: Union[datetime, str],
-    parameter: Union[Parameter, str],
-    time_resolution: Union[TimeResolution, str],
-    period_type: Union[PeriodType, str],
-    num_stations_nearby: Optional[int] = None,
-    max_distance_in_km: Optional[float] = None,
+        latitudes: Union[List[float], np.array],
+        longitudes: Union[List[float], np.array],
+        minimal_available_date: Union[datetime, str],
+        maximal_available_date: Union[datetime, str],
+        parameter: Union[Parameter, str],
+        time_resolution: Union[TimeResolution, str],
+        period_type: Union[PeriodType, str],
+        num_stations_nearby: Optional[int] = None,
+        max_distance_in_km: Optional[float] = None,
 ) -> List[pd.DataFrame]:
     """
     Provides a list of weather station ids for the requested data
@@ -56,7 +57,7 @@ def get_nearby_stations(
 
     """
     if (num_stations_nearby and max_distance_in_km) and (
-        num_stations_nearby and max_distance_in_km
+            num_stations_nearby and max_distance_in_km
     ):
         raise ValueError("Either set 'num_stations_nearby' or 'max_distance_in_km'.")
 
@@ -67,9 +68,11 @@ def get_nearby_stations(
     time_resolution = parse_enumeration_from_template(time_resolution, TimeResolution)
     period_type = parse_enumeration_from_template(period_type, PeriodType)
     minimal_available_date = \
-        minimal_available_date if isinstance(minimal_available_date, datetime) else parse_datetime(minimal_available_date)
+        minimal_available_date if isinstance(minimal_available_date, datetime) else parse_datetime(
+            minimal_available_date)
     maximal_available_date = \
-        maximal_available_date if isinstance(maximal_available_date, datetime) else parse_datetime(maximal_available_date)
+        maximal_available_date if isinstance(maximal_available_date, datetime) else parse_datetime(
+            maximal_available_date)
 
     if not check_parameters(parameter, time_resolution, period_type):
         raise InvalidParameterCombination(
@@ -124,10 +127,10 @@ def get_nearby_stations(
 
 
 def _derive_nearest_neighbours(
-    latitudes_stations: np.array,
-    longitudes_stations: np.array,
-    coordinates: Coordinates,
-    num_stations_nearby: int = 1,
+        latitudes_stations: np.array,
+        longitudes_stations: np.array,
+        coordinates: Coordinates,
+        num_stations_nearby: int = 1,
 ) -> Tuple[Union[float, np.ndarray], np.ndarray]:
     """
     A function that uses a k-d tree algorithm to obtain the nearest

--- a/wetterdienst/additionals/geo_location.py
+++ b/wetterdienst/additionals/geo_location.py
@@ -127,7 +127,7 @@ def get_nearby_stations(
     ]
     metadata_location["DISTANCE_TO_LOCATION"] = distances_km
 
-    if metadata_location:
+    if metadata_location.empty:
         logger.warning(
             f"No weather station was found for coordinate "
             f"{latitude}°N and {longitude}°E "

--- a/wetterdienst/additionals/geo_location.py
+++ b/wetterdienst/additionals/geo_location.py
@@ -1,6 +1,6 @@
 """ calculates the nearest weather station to a requested location"""
 from _datetime import datetime
-from typing import List, Union, Tuple, Optional
+from typing import Union, Tuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -113,8 +113,7 @@ def get_nearby_stations(
 
     # Filter for distance based on calculated distances
     if max_distance_in_km:
-        _in_max_distance_indices = np.where(
-            distances_km <= max_distance_in_km)[0]
+        _in_max_distance_indices = np.where(distances_km <= max_distance_in_km)[0]
         indices_nearest_neighbours = indices_nearest_neighbours[
             _in_max_distance_indices
         ]
@@ -123,11 +122,16 @@ def get_nearby_stations(
     metadata_location = metadata.loc[
         indices_nearest_neighbours
         if isinstance(indices_nearest_neighbours, (list, np.ndarray))
-        else [indices_nearest_neighbours], :]
+        else [indices_nearest_neighbours],
+        :,
+    ]
     metadata_location["DISTANCE_TO_LOCATION"] = distances_km
 
     if metadata_location:
-        logger.warning(f"No weather station was found for {_idx+1}. location")
+        logger.warning(
+            f"No weather station was found for coordinate "
+            f"{latitude}°N and {longitude}°E "
+        )
 
     return metadata_location
 

--- a/wetterdienst/additionals/geo_location.py
+++ b/wetterdienst/additionals/geo_location.py
@@ -1,5 +1,6 @@
 """ calculates the nearest weather station to a requested location"""
 from typing import List, Union, Tuple, Optional
+from _datetime import datetime
 import numpy as np
 import pandas as pd
 from scipy.spatial import cKDTree
@@ -16,6 +17,7 @@ from wetterdienst.data_models.coordinates import Coordinates
 from wetterdienst.enumerations.parameter_enumeration import Parameter
 from wetterdienst.enumerations.period_type_enumeration import PeriodType
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
+from wetterdienst.additionals.time_handling import parse_datetime
 
 KM_EARTH_RADIUS = 6371
 
@@ -23,12 +25,14 @@ KM_EARTH_RADIUS = 6371
 def get_nearby_stations(
     latitudes: Union[List[float], np.array],
     longitudes: Union[List[float], np.array],
+    minimal_available_date: Union[datetime, str],
+    maximal_available_date: Union[datetime, str],
     parameter: Union[Parameter, str],
     time_resolution: Union[TimeResolution, str],
     period_type: Union[PeriodType, str],
     num_stations_nearby: Optional[int] = None,
     max_distance_in_km: Optional[float] = None,
-) -> Tuple[List[int], List[List[float]]]:
+) -> List[pd.DataFrame]:
     """
     Provides a list of weather station ids for the requested data
     Args:
@@ -36,6 +40,10 @@ def get_nearby_stations(
             weather station
         longitudes: longitudes of locations to search for nearest
             weather station
+        minimal_available_date: Start date of timespan where measurements
+            should be available
+        maximal_available_date: End date of timespan where measurements
+            should be available
         parameter: observation measure
         time_resolution: frequency/granularity of measurement interval
         period_type: recent or historical files
@@ -44,8 +52,7 @@ def get_nearby_stations(
             distance to location in km
 
     Returns:
-        list of stations ids for the given locations/coordinate pairs and
-        a list of distances in kilometer to the weather station
+        List of DataFrames with valid Stations in radius per requested location
 
     """
     if (num_stations_nearby and max_distance_in_km) and (
@@ -59,6 +66,10 @@ def get_nearby_stations(
     parameter = parse_enumeration_from_template(parameter, Parameter)
     time_resolution = parse_enumeration_from_template(time_resolution, TimeResolution)
     period_type = parse_enumeration_from_template(period_type, PeriodType)
+    minimal_available_date = \
+        minimal_available_date if isinstance(minimal_available_date, datetime) else parse_datetime(minimal_available_date)
+    maximal_available_date = \
+        maximal_available_date if isinstance(maximal_available_date, datetime) else parse_datetime(maximal_available_date)
 
     if not check_parameters(parameter, time_resolution, period_type):
         raise InvalidParameterCombination(
@@ -78,6 +89,10 @@ def get_nearby_stations(
         parameter, time_resolution, period_type
     )
 
+    metadata = \
+        metadata[(metadata[DWDMetaColumns.FROM_DATE.value] <= minimal_available_date) &
+                 (metadata[DWDMetaColumns.TO_DATE.value] >= maximal_available_date)].reset_index(drop=True)
+
     # For distance filtering make normal query including all stations
     if max_distance_in_km:
         num_stations_nearby = metadata.shape[0]
@@ -86,39 +101,26 @@ def get_nearby_stations(
         metadata.LAT.values, metadata.LON.values, coords, num_stations_nearby
     )
 
-    # Make sure go get list of lists [[dist1_1, dist1_2], [dist2_1, dist2_2]]
-    if num_stations_nearby == 1:
-        distances = np.array([distances])
-    else:
-        distances = distances.T
-
-    if np.max(indices_nearest_neighbours.shape) > 1:
-        indices_nearest_neighbours = indices_nearest_neighbours[0]
-
     # Require list of indices for consistency
     # Cast to np.array required for subset
     indices_nearest_neighbours = np.array(cast_to_list(indices_nearest_neighbours))
-
     distances_km = np.array(distances * KM_EARTH_RADIUS)
+    nearest_station_list = []
 
-    # Filter for distance based on calculated distances
-    if max_distance_in_km:
-        indices_stations_in_distance = (
-            np.max(distances_km, axis=1) <= max_distance_in_km
-        )
+    for distances_km_location, indices_nearest_neighbours_location in zip(distances_km, indices_nearest_neighbours):
+        # Filter for distance based on calculated distances
+        if max_distance_in_km:
+            _in_max_distance_indices = np.where(distances_km_location <= max_distance_in_km)[0]
+            indices_nearest_neighbours_location = \
+                indices_nearest_neighbours_location[_in_max_distance_indices]
+            distances_km_location = distances_km_location[_in_max_distance_indices]
 
-        # Reduce stations to those in distance
-        distances_km = distances_km[indices_stations_in_distance]
-        indices_nearest_neighbours = indices_nearest_neighbours[
-            indices_stations_in_distance
-        ]
-
-    return (
-        metadata.loc[
-            indices_nearest_neighbours, DWDMetaColumns.STATION_ID.value
-        ].values.tolist(),
-        distances_km.tolist(),
-    )
+        metadata_location = metadata.loc[indices_nearest_neighbours_location
+                                         if isinstance(indices_nearest_neighbours_location, (list, np.ndarray))
+                                         else [indices_nearest_neighbours_location], :]
+        metadata_location['DISTANCE_TO_LOCATION'] = distances_km_location
+        nearest_station_list.append(metadata_location)
+    return nearest_station_list
 
 
 def _derive_nearest_neighbours(
@@ -154,10 +156,12 @@ def stations_to_geojson(df: pd.DataFrame) -> dict:
     """
     Convert DWD station information into GeoJSON format.
 
-    :param df: Input DataFrame containing station information.
-    :return: Dictionary in GeoJSON FeatureCollection format.
-    """
+    Args:
+        df: Input DataFrame containing station information.
 
+    Return:
+         Dictionary in GeoJSON FeatureCollection format.
+    """
     df = df.rename(columns=str.lower)
 
     features = []
@@ -188,9 +192,7 @@ def stations_to_geojson(df: pd.DataFrame) -> dict:
             }
         )
 
-    data = {
+    return {
         "type": "FeatureCollection",
         "features": features,
     }
-
-    return data


### PR DESCRIPTION
Adapt get_nearby_stations by selecting only weather stations covering  the requested period with measurements and provide the whole meta information.

Fixes #134 #133 #132 