### PR TITLE
Slightly improve tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,11 +102,10 @@ and also
 For the whole functionality, check out the
 `API <https://wetterdienst.readthedocs.io/en/latest/pages/api.html>`_
 section of our documentation, which will be constantly updated. Also don't miss out our
-`examples <https://github.com/earthobservations/wetterdienst/tree/master/example>`_
-.
+`examples <https://github.com/earthobservations/wetterdienst/tree/master/example>`_.
 
 Contribution
-***************
+************
 
 Check out our contribution section in the documentation! For a successful PR passing
 all tests, you have to run

--- a/docs/pages/development.rst
+++ b/docs/pages/development.rst
@@ -33,4 +33,10 @@ Before committing, run black code formatter and lint to test for format.
     nox -s black
     nox -s lint
 
+In order to run the tests more **quickly**::
+
+    poetry install --extras=excel
+    poetry shell
+    pytest -vvvv -m "not (remote or slow)
+
 .. include:: ../../CHANGELOG.rst

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 markers =
     remote: Tests accessing the internet.
+    slow: Slow tests.

--- a/tests/additionals/test_geo_location.py
+++ b/tests/additionals/test_geo_location.py
@@ -174,6 +174,10 @@ def test_get_nearby_stations():
         )
 
 
+@patch(
+    "wetterdienst.parse_metadata.metadata_for_climate_observations",
+    MagicMock(return_value=pd.read_json(f"{fixtures_dir}FIXED_METADATA.JSON")),
+)
 def test_get_nearby_stations_out_of_distance():
     nearby_station = get_nearby_stations(
         50.0,

--- a/tests/example/test_notebooks.py
+++ b/tests/example/test_notebooks.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from pytest_notebook.nb_regression import NBRegressionFixture
 
 EXAMPLE_DIR = Path(__file__).parent.parent.parent / "example"
@@ -13,6 +14,7 @@ FIXTURE = NBRegressionFixture(
 )
 
 
+@pytest.mark.slow
 def test_simple_example():
     """ Test for simple_example jupyter notebook """
     FIXTURE.check(EXAMPLE_DIR / "simple_example.ipynb")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -107,6 +107,7 @@ def test_dwd_station_request():
         )
 
 
+@pytest.mark.remote
 def test_dwd_radolan_request():
     with pytest.raises(ValueError):
         DWDRadolanRequest(

--- a/tests/test_data_collection.py
+++ b/tests/test_data_collection.py
@@ -244,6 +244,7 @@ def test_tidy_up_data():
     assert _tidy_up_data(df, Parameter.CLIMATE_SUMMARY).equals(df_tidy)
 
 
+@pytest.mark.remote
 def test_collect_radolan_data():
     with Path(FIXTURES_DIR, "radolan_hourly_201908080050").open("rb") as f:
         radolan_hourly = BytesIO(f.read())

--- a/tests/test_parse_metadata.py
+++ b/tests/test_parse_metadata.py
@@ -11,6 +11,7 @@ from wetterdienst.enumerations.period_type_enumeration import PeriodType
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
 
 
+@pytest.mark.remote
 def test_metadata_for_climate_observations():
     reset_meta_index_cache()
 
@@ -52,6 +53,7 @@ def test_metadata_for_climate_observations():
         )
 
 
+@pytest.mark.remote
 def test_metadata_geojson():
     reset_meta_index_cache()
 


### PR DESCRIPTION
Hi there,

this is just a small fixup.

It adds the `FIXED_METADATA.json` mock to another test function and decorates some other test functions with `@pytest.mark.remote` and `@pytest.mark.slow`. The marks significantly help in order to speed up the test cycle.

When invoked using `time pytest -vvvv -m "not (remote or slow)"`:
```
real	0m3.800s
user	0m2.786s
sys	0m0.488s
```

When invoked using `time pytest -vvvv`:
```
real	2m15.609s
user	0m59.317s
sys	0m18.932s
```

With kind regards,
Andreas.
