### PR TITLE
[docs] Add sphinx-autodoc-typehints

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ master_doc = 'index'
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx_autodoc_typehints",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.autosectionlabel",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx_rtd_theme==0.5.0
 sphinx-material==0.0.30
 importlib_metadata==1.6.1
 tomlkit==0.7.0
+sphinx-autodoc-typehints==1.11.0

--- a/wetterdienst/additionals/functions.py
+++ b/wetterdienst/additionals/functions.py
@@ -349,14 +349,10 @@ def discover_climate_observations(
     combinations.
 
     :param parameter:               Observation measure
-    :type parameter:                Parameter
     :param time_resolution:         Frequency/granularity of measurement interval
-    :type time_resolution:          TimeResolution
     :param period_type:             Recent or historical files
-    :type period_type:              PeriodType
 
-    :return: JSON string of available combinations
-    :rtype: str
+    :return:                        Result of available combinations in JSON.
     """
     if not time_resolution:
         time_resolution = [*TimeResolution]

--- a/wetterdienst/additionals/geo_location.py
+++ b/wetterdienst/additionals/geo_location.py
@@ -48,17 +48,14 @@ def get_nearby_stations(
     :param maximal_available_date:  End date of timespan where measurements
                                     should be available
     :param parameter:               Observation measure
-    :type parameter:                Parameter
     :param time_resolution:         Frequency/granularity of measurement interval
-    :type time_resolution:          TimeResolution
     :param period_type:             Recent or historical files
-    :type period_type:              PeriodType
     :param num_stations_nearby:     Number of stations that should be nearby
     :param max_distance_in_km:      Alternative filtering criteria, maximum
                                     distance to location in km
 
-    :return: DataFrames with valid stations in radius per requested location
-    :rtype: pandas.DataFrame
+    :return:                        DataFrames with valid stations in radius per
+                                    requested location
 
     """
     if num_stations_nearby and max_distance_in_km:

--- a/wetterdienst/api.py
+++ b/wetterdienst/api.py
@@ -61,11 +61,8 @@ class DWDStationRequest:
         :param station_ids: definition of stations by str, int or list of str/int,
                             will be parsed to list of int
         :param parameter:           Observation measure
-        :type parameter:            Union[Parameter, str]
         :param time_resolution:     Frequency/granularity of measurement interval
-        :type time_resolution:      Union[TimeResolution, str]
         :param period_type:         Recent or historical files
-        :type period_type:          Union[PeriodType, str]
         :param start_date:          Replacement for period type to define exact time
                                     of requested data
         :param end_date:            Replacement for period type to define exact time
@@ -244,7 +241,7 @@ class DWDStationRequest:
 
 class DWDRadolanRequest:
     """
-    API for DWD RADOLAN data requests
+    API for DWD RADOLAN data requests.
     """
 
     def __init__(
@@ -267,10 +264,10 @@ class DWDRadolanRequest:
         :param end_date:        Alternative to datetimes, giving a start and end date
         :param prefer_local:    RADOLAN should rather be loaded from disk, for
                                 processing purposes
-        :type prefer_local:     bool
         :param write_file:      File should be stored on drive
-        :type write_file:       bool
         :param folder:          Folder where to store RADOLAN data
+
+        :return:                Nothing for now.
         """
         time_resolution = parse_enumeration_from_template(
             time_resolution, TimeResolution

--- a/wetterdienst/data_collection.py
+++ b/wetterdienst/data_collection.py
@@ -76,32 +76,20 @@ def collect_climate_observations_data(
     it will try to store the data in a hdf file.
 
     :param station_ids:             station ids that are trying to be loaded
-    :type station_ids:              List[int]
     :param parameter:               Parameter as enumeration
-    :type parameter:                Parameter
     :param time_resolution:         Time resolution as enumeration
-    :type time_resolution:          TimeResolution
     :param period_type:             Period type as enumeration
-    :type period_type:              PeriodType
     :param folder:                  Folder for local file interaction
-    :type folder:                   str
     :param prefer_local:            Local data should be preferred
-    :type prefer_local:             bool
     :param write_file:              Write data to local storage
-    :type write_file:               bool
     :param tidy_data:               Tidy up data so that there's only one set of values
                                     for a datetime in a row, e.g. station_id, parameter,
                                     element, datetime, value, quality.
-    :type tidy_data:                bool
     :param humanize_column_names:   Yield column names for human consumption
-    :type humanize_column_names:    bool
     :param run_download_only:       Run only the download and storing process
-    :type run_download_only:        bool
     :param create_new_file_index:   Create a new file index for the data selection
-    :type create_new_file_index:    bool
 
-    :return: All the data given by the station ids.
-    :rtype: pandas.DataFrame
+    :return:                        All the data given by the station ids.
     """
     parameter = parse_enumeration_from_template(parameter, Parameter)
     time_resolution = parse_enumeration_from_template(time_resolution, TimeResolution)
@@ -258,19 +246,13 @@ def collect_radolan_data(
     Function used to collect RADOLAN data for given datetimes and a time resolution.
     Additionally the file can be written to a local folder and read from there as well.
 
-    :param date_times: List of datetime objects for which RADOLAN shall be acquired
-    :type date_times: List[datetime]
+    :param date_times:      List of datetime objects for which RADOLAN shall be acquired
     :param time_resolution: Time resolution for requested data, either hourly or daily
-    :type time_resolution: TimeResolution
-    :param prefer_local: File should be read from local store instead
-    :type prefer_local: bool
-    :param write_file: File should be stored on the drive
-    :type write_file: bool
-    :param folder: Path for storage
-    :type folder: str
+    :param prefer_local:    File should be read from local store instead
+    :param write_file:      File should be stored on the drive
+    :param folder:          Path for storage
 
-    :return: List of tuples of a datetime and the corresponding file in bytes
-    :rtype: List[Tuple[datetime, BytesIO]]
+    :return:                List of tuples: datetime and the corresponding file in bytes
     """
     if time_resolution not in (TimeResolution.HOURLY, TimeResolution.DAILY):
         raise ValueError("RADOLAN is only offered in hourly and daily resolution.")

--- a/wetterdienst/data_storing.py
+++ b/wetterdienst/data_storing.py
@@ -29,19 +29,14 @@ def store_climate_observations(
     hdf file and another folder argument for the place where the file is stored.
 
     :param station_data:            The pandas DataFrame with the obtained data
-    :type station_data:             pandas.DataFrame
     :param station_id:              The station id of the station to store
-    :type station_id:               int
     :param parameter:               Observation measure
-    :type parameter:                Parameter
     :param time_resolution:         Frequency/granularity of measurement interval
-    :type time_resolution:          TimeResolution
     :param period_type:             Recent or historical files
-    :type period_type:              PeriodType
     :param folder:                  The folder where the hdf is stored
-    :type folder:                   str
 
-    :return: None, prints information if data was not stored
+    :return:                        Nothing, only prints information if data was
+                                    not stored.
     """
     # Make sure that there is data that can be stored
     if station_data.empty:
@@ -70,18 +65,12 @@ def restore_climate_observations(
     the file is stored and parameters that define the request in particular.
 
     :param station_id:              Station id of which data should be restored
-    :type station_id:               int
     :param parameter:               Observation measure
-    :type parameter:                Parameter
     :param time_resolution:         Frequency/granularity of measurement interval
-    :type time_resolution:          TimeResolution
     :param period_type:             Recent or historical files
-    :type period_type:              PeriodType
     :param folder:                  The folder where the hdf is stored
-    :type folder:                   str
 
-    :return: All the data
-    :rtype: pandas.DataFrame
+    :return:                        All the data.
     """
     request_string = _build_local_store_key(
         station_id, parameter, time_resolution, period_type
@@ -112,16 +101,11 @@ def _build_local_store_key(
     station id
 
     :param station_id:              Station id of data
-    :type station_id:               int
     :param parameter:               Observation measure
-    :type parameter:                Parameter
     :param time_resolution:         Frequency/granularity of measurement interval
-    :type time_resolution:          TimeResolution
     :param period_type:             Recent or historical files
-    :type period_type:              PeriodType
 
     :return: A string building a key that is used to identify the request
-    :rtype:  str
     """
     request_string = (
         f"{parameter.value}/{time_resolution.value}/"

--- a/wetterdienst/download/download.py
+++ b/wetterdienst/download/download.py
@@ -24,7 +24,12 @@ PRODUCT_FILE_IDENTIFIER = "produkt"
 def download_climate_observations_data_parallel(
     remote_files: List[str],
 ) -> List[Tuple[str, BytesIO]]:
-    """ wrapper for _download_dwd_data to provide a multiprocessing feature"""
+    """
+    Wrapper for ``_download_dwd_data`` to provide a multiprocessing feature.
+
+    :param remote_files:    List of requested files
+    :return:                List of downloaded files
+    """
 
     with ThreadPoolExecutor() as executor:
         files_in_bytes = executor.map(
@@ -93,15 +98,15 @@ def download_radolan_data(
     a separate download function that is cached for reuse which is especially used for
     historical data that comes packaged for multiple datetimes in one archive.
 
-    Args:
-        date_time: the datetime for the requested RADOLAN file, required for recognition
-        of the returned binary, which has no obvious name tag
-        remote_radolan_file_path: the remote filepath to the file that has the data
+    :param date_time:   The datetime for the requested RADOLAN file.
+                        This is required for the recognition of the returned binary,
+                        which has no obvious name tag.
+
+    :param remote_radolan_file_path: The remote filepath to the file that has the data
         for the requested datetime, either an archive of multiple files for a datetime
         in historical time or an archive with one file for the recent RADOLAN file
 
-    Returns:
-        string of requested datetime and binary file
+    :return: String of requested datetime and binary file
     """
     archive_in_bytes = _download_radolan_data(remote_radolan_file_path)
 

--- a/wetterdienst/download/download_services.py
+++ b/wetterdienst/download/download_services.py
@@ -14,15 +14,13 @@ def download_file_from_dwd(
     filepath: Union[PurePosixPath, str], cdc_base: DWDCDCBase
 ) -> BytesIO:
     """
-    A function used to download a specified file from the server
+    A function used to download a specified file from the server.
 
-    Args:
-        filepath: the path that defines the file relative to
-        observations_germany/climate/
-        cdc_base:
+    :param filepath:    The path that defines the file relative to
+                        ``observations_germany/climate/``.
+    :param cdc_base:    Foobar.
 
-    Returns:
-        bytes of the file
+    :return:            Bytes of the file.
     """
     dwd_session = create_dwd_session()
 

--- a/wetterdienst/parse_metadata.py
+++ b/wetterdienst/parse_metadata.py
@@ -35,18 +35,12 @@ def metadata_for_climate_observations(
     - daily precipitation data is the most common data served by the DWD
 
     :param parameter:               Observation measure
-    :type parameter:                Parameter
     :param time_resolution:         Frequency/granularity of measurement interval
-    :type time_resolution:          TimeResolution
     :param period_type:             Recent or historical files
-    :type period_type:              PeriodType
     :param create_new_meta_index:   Create a new meta index for metadata
-    :type create_new_meta_index:    bool
     :param create_new_file_index:   Create a new file index
-    :type create_new_file_index:    bool
 
     :return: List of stations for selected parameters
-    :rtype: pandas.DataFrame
     """
     if create_new_meta_index:
         reset_meta_index_cache()


### PR DESCRIPTION
Hi there,

this adds [sphinx-autodoc-typehints](https://github.com/agronholm/sphinx-autodoc-typehints) as suggested by @larsrinn (thanks!) within #136. Now, there's no need for manually annotating these with `:type` and `:rtype` docstrings any more.

With kind regards,
Andreas.
