### PR TITLE
Emit data to different data sinks and query interactively using SQL

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,7 +7,5 @@ source =
 show_missing = true
 fail_under = 0
 omit =
-    wetterdienst/cli.py
-    wetterdienst/run.py
     tests/*
     noxfile.py

--- a/.flake8
+++ b/.flake8
@@ -2,4 +2,4 @@
 select = B,B9,BLK,C,E,F,W,S
 ignore = E203,W503
 max-line-length = 88
-per-file-ignores = tests/*:S101, wetterdienst/__init__.py:F401, wetterdienst/cli.py:E501,B950
+per-file-ignores = tests/*:S101, wetterdienst/__init__.py:F401, wetterdienst/cli.py:E501,B950, wetterdienst/io.py:E501,B950

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ htmlcov
 .nox/
 .pytest_cache/
 docs/_build/
+dist/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Development
 
 - Add TTL-based persistent caching using dogpile.cache
 - Add ``example/radolan.py`` and adjust documentation
+- Export dataframe to different data sinks like SQLite, DuckDB, InfluxDB and CrateDB
+- Query results with SQL, based on in-memory DuckDB
 
 0.7.0 (16.09.2020)
 ==================

--- a/README.rst
+++ b/README.rst
@@ -64,13 +64,15 @@ Details
 - Get metadata for a set of Parameter, PeriodType and TimeResolution.
 - Get station(s) nearby a selected location for a given set.
 - Store/recover collected data.
-- Docker image to run the library dockerized.
-- Client to run the library from command line.
+- Command line interface.
+- Run SQL queries on the results.
+- Export results to databases and other data sinks.
+- Public Docker image on ghcr.io.
 
 
 Setup
 *****
-Run the following to make ``wetterdienst`` available in your current environment:
+Run this to make ``wetterdienst`` available in your current environment:
 
 .. code-block:: bash
 
@@ -115,7 +117,7 @@ Documentation
 We strongly recommend reading the full documentation, which will be updated continuously
 as we make progress with this library:
 
-    - https://wetterdienst.readthedocs.io/
+- https://wetterdienst.readthedocs.io/
 
 For the whole functionality, check out the `Wetterdienst API`_ section of our
 documentation, which will be constantly updated. To stay up to date with the
@@ -132,7 +134,7 @@ copyright owner. Please take a look at the `Open Data Strategy at the DWD`_ and 
 .. _rdwd: https://github.com/brry/rdwd
 .. _Wetterdienst API: https://wetterdienst.readthedocs.io/en/latest/pages/api.html
 .. _data coverage: https://wetterdienst.readthedocs.io/en/latest/pages/data_coverage.html
-.. _changelog: https://wetterdienst.readthedocs.io/en/latest/pages/api.html
+.. _changelog: https://wetterdienst.readthedocs.io/en/latest/pages/changelog.html
 .. _examples: https://github.com/earthobservations/wetterdienst/tree/master/example
 .. _Open Data Strategy at the DWD: https://www.dwd.de/EN/ourservices/opendata/opendata.html
 .. _Official Copyright: https://www.dwd.de/EN/service/copyright/copyright_artikel.html?nn=495490&lsbId=627548

--- a/docs/pages/development.rst
+++ b/docs/pages/development.rst
@@ -54,7 +54,7 @@ This will inform you in case of problems with tests and your code format.
 
 In order to run the tests more **quickly**::
 
-    poetry install --extras=excel
+    poetry install --extras=sql --extras=excel
     poetry shell
     pytest -vvvv -m "not (remote or slow)"
 

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -16,13 +16,27 @@ PyPI
 
 .. code-block:: bash
 
-  pip install wetterdienst
+    pip install wetterdienst
 
 GitHub
 
 .. code-block:: bash
 
-  pip install git+https://github.com/earthobservations/wetterdienst
+    pip install git+https://github.com/earthobservations/wetterdienst
+
+There are some extras available for ``wetterdienst``. Use them like::
+
+    pip install wetterdienst[sql]
+
+- ipython: Install iPython stack.
+- excel: Install openpyxl for Excel export.
+- docs: Install the Sphinx documentation generator.
+- sql: Install DuckDB for querying data using SQL.
+- duckdb: Install support for DuckDB.
+- influxdb: Install support for InfluxDB.
+- cratedb: Install support for CrateDB.
+- mysql: Install support for MySQL.
+- postgresql: Install support for PostgreSQL.
 
 In order to check the installation, invoke::
 

--- a/example/sql.py
+++ b/example/sql.py
@@ -1,0 +1,54 @@
+"""
+=====
+About
+=====
+Acquire measurement information from DWD and filter using SQL.
+
+
+=====
+Setup
+=====
+::
+
+    pip install wetterdienst[sql]
+
+"""
+import logging
+
+from wetterdienst import DWDStationRequest, DataPackage
+from wetterdienst import Parameter, PeriodType, TimeResolution
+
+log = logging.getLogger()
+
+
+def sql_example():
+
+    request = DWDStationRequest(
+        station_ids=[1048],
+        parameter=[Parameter.TEMPERATURE_AIR],
+        time_resolution=TimeResolution.HOURLY,
+        start_date="2019-01-01",
+        end_date="2020-01-01",
+        tidy_data=True,
+        humanize_column_names=True,
+        prefer_local=True,
+        write_file=True,
+    )
+
+    sql = "SELECT * FROM data WHERE element='temperature_air_200' AND value < -7.0;"
+    log.info(f"Invoking SQL query '{sql}'")
+
+    data = DataPackage(request=request)
+    data.lowercase_fieldnames()
+    df = data.filter_by_sql(sql)
+
+    print(df)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    sql_example()
+
+
+if __name__ == "__main__":
+    main()

--- a/noxfile.py
+++ b/noxfile.py
@@ -11,15 +11,21 @@ from nox.sessions import Session
 @nox.session(python=["3.6", "3.7", "3.8"])
 def tests(session):
     """Run tests."""
-    session.run("poetry", "install", "--no-dev", "--extras=excel", external=True)
-    install_with_constraints(session, "pytest", "pytest-notebook", "matplotlib", "mock")
+    session.run(
+        "poetry", "install", "--no-dev", "--extras=sql", "--extras=excel", external=True
+    )
+    install_with_constraints(
+        session, "pytest", "pytest-notebook", "matplotlib", "mock", "surrogate"
+    )
     session.run("pytest")
 
 
 @nox.session(python=["3.7"])
 def coverage(session: Session) -> None:
     """Run tests and upload coverage data."""
-    session.run("poetry", "install", "--no-dev", "--extras=excel", external=True)
+    session.run(
+        "poetry", "install", "--no-dev", "--extras=sql", "--extras=excel", external=True
+    )
     install_with_constraints(
         session,
         "coverage[toml]",
@@ -28,6 +34,7 @@ def coverage(session: Session) -> None:
         "matplotlib",
         "pytest-cov",
         "mock",
+        "surrogate",
     )
     session.run("pytest", "--cov=wetterdienst", "tests/")
     session.run("coverage", "xml")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,13 +1,5 @@
 [[package]]
 category = "main"
-description = "File support for asyncio."
-name = "aiofiles"
-optional = false
-python-versions = "*"
-version = "0.4.0"
-
-[[package]]
-category = "main"
 description = "A configurable sidebar-enabled Sphinx theme"
 name = "alabaster"
 optional = true
@@ -255,6 +247,29 @@ toml = ["toml"]
 
 [[package]]
 category = "main"
+description = "CrateDB Python Client"
+name = "crate"
+optional = true
+python-versions = ">=3.4"
+version = "0.25.0"
+
+[package.dependencies]
+urllib3 = ">=1.9"
+
+[package.dependencies.geojson]
+optional = true
+version = ">=2.5.0"
+
+[package.dependencies.sqlalchemy]
+optional = true
+version = ">=1.0,<1.4"
+
+[package.extras]
+sqlalchemy = ["geojson (>=2.5.0)", "sqlalchemy (>=1.0,<1.4)"]
+test = ["zc.customdoctests (>=1.0.1)", "zope.testing"]
+
+[[package]]
+category = "main"
 description = "CSS HTML JS Minifier"
 name = "css-html-js-minify"
 optional = true
@@ -346,6 +361,17 @@ version = "1.0.2"
 [package.dependencies]
 decorator = ">=4.0.0"
 stevedore = ">=3.0.0"
+
+[[package]]
+category = "main"
+description = "DuckDB embedded database"
+name = "duckdb"
+optional = true
+python-versions = "*"
+version = "0.2.1"
+
+[package.dependencies]
+numpy = ">=1.14"
 
 [[package]]
 category = "dev"
@@ -450,6 +476,14 @@ version = "1.0.2"
 flake8 = "*"
 
 [[package]]
+category = "main"
+description = "Python bindings and utilities for GeoJSON"
+name = "geojson"
+optional = true
+python-versions = "*"
+version = "2.5.0"
+
+[[package]]
 category = "dev"
 description = "Git Object Database"
 name = "gitdb"
@@ -530,6 +564,24 @@ version = ">=0.4"
 
 [package.extras]
 docs = ["sphinx", "rst.linker", "jaraco.packaging"]
+
+[[package]]
+category = "main"
+description = "InfluxDB client"
+name = "influxdb"
+optional = true
+python-versions = "*"
+version = "5.3.0"
+
+[package.dependencies]
+msgpack = "0.6.1"
+python-dateutil = ">=2.6.0"
+pytz = "*"
+requests = ">=2.17.0"
+six = ">=1.10.0"
+
+[package.extras]
+test = ["nose", "nose-cov", "mock", "requests-mock"]
 
 [[package]]
 category = "dev"
@@ -772,6 +824,14 @@ version = "8.5.0"
 
 [[package]]
 category = "main"
+description = "MessagePack (de)serializer."
+name = "msgpack"
+optional = true
+python-versions = "*"
+version = "0.6.1"
+
+[[package]]
+category = "main"
 description = "A dot-accessible dictionary (a la JavaScript objects)"
 name = "munch"
 optional = false
@@ -792,6 +852,14 @@ name = "mypy-extensions"
 optional = false
 python-versions = "*"
 version = "0.4.3"
+
+[[package]]
+category = "main"
+description = "Python interface to MySQL"
+name = "mysqlclient"
+optional = true
+python-versions = ">=3.5"
+version = "2.0.1"
 
 [[package]]
 category = "dev"
@@ -1069,6 +1137,14 @@ version = "3.0.7"
 
 [package.dependencies]
 wcwidth = "*"
+
+[[package]]
+category = "main"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+name = "psycopg2"
+optional = true
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+version = "2.8.6"
 
 [[package]]
 category = "main"
@@ -1503,6 +1579,26 @@ CairoSVG = ["cairosvg (>=1.0)"]
 
 [[package]]
 category = "main"
+description = "Database Abstraction Library"
+name = "sqlalchemy"
+optional = true
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.3.19"
+
+[package.extras]
+mssql = ["pyodbc"]
+mssql_pymssql = ["pymssql"]
+mssql_pyodbc = ["pyodbc"]
+mysql = ["mysqlclient"]
+oracle = ["cx-oracle"]
+postgresql = ["psycopg2"]
+postgresql_pg8000 = ["pg8000"]
+postgresql_psycopg2binary = ["psycopg2-binary"]
+postgresql_psycopg2cffi = ["psycopg2cffi"]
+pymysql = ["pymysql"]
+
+[[package]]
+category = "main"
 description = "Manage dynamic plugins for Python applications"
 name = "stevedore"
 optional = false
@@ -1515,6 +1611,14 @@ pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 [package.dependencies.importlib-metadata]
 python = "<3.8"
 version = ">=1.7.0"
+
+[[package]]
+category = "dev"
+description = "A Python micro-lib to create stubs for non-existing modules."
+name = "surrogate"
+optional = false
+python-versions = "*"
+version = "0.1"
 
 [[package]]
 category = "main"
@@ -1712,20 +1816,22 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
+cratedb = ["crate"]
 docs = ["sphinx", "sphinx-material", "tomlkit", "sphinx-autodoc-typehints", "sphinxcontrib-svg2pdfconverter", "matplotlib", "ipython"]
+duckdb = ["duckdb"]
 excel = ["openpyxl"]
+influxdb = ["influxdb"]
 ipython = ["ipython", "ipython-genutils", "matplotlib"]
+mysql = ["mysqlclient"]
+postgresql = ["psycopg2"]
+sql = ["duckdb"]
 
 [metadata]
-content-hash = "e8ec432291daf4776b027fe84e4cf5e49f0fa582730f512c5d31904ff19cd837"
+content-hash = "c0dbb035013e8b560cffbee81896c2b3a0b0a2d0868598279b2a6e7004c42561"
 lock-version = "1.0"
 python-versions = "^3.6.1"
 
 [metadata.files]
-aiofiles = [
-    {file = "aiofiles-0.4.0-py3-none-any.whl", hash = "sha256:1e644c2573f953664368de28d2aa4c89dfd64550429d0c27c4680ccd3aa4985d"},
-    {file = "aiofiles-0.4.0.tar.gz", hash = "sha256:021ea0ba314a86027c166ecc4b4c07f2d40fc0f4b3a950d1868a0f2571c2bbee"},
-]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
@@ -1888,6 +1994,10 @@ coverage = [
     {file = "coverage-5.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:b8f58c7db64d8f27078cbf2a4391af6aa4e4767cc08b37555c4ae064b8558d9b"},
     {file = "coverage-5.2.1.tar.gz", hash = "sha256:a34cb28e0747ea15e82d13e14de606747e9e484fb28d63c999483f5d5188e89b"},
 ]
+crate = [
+    {file = "crate-0.25.0-py2.py3-none-any.whl", hash = "sha256:2de19674271e3a2feae8380fd9418bae536f5d246e93cd68dbb7a932f52c9c19"},
+    {file = "crate-0.25.0.tar.gz", hash = "sha256:23e525cfe83aa2e00c8c00bd2c4f7b3b7038bd65e27bd347d24491e42c42554a"},
+]
 css-html-js-minify = [
     {file = "css-html-js-minify-2.5.5.zip", hash = "sha256:4a9f11f7e0496f5284d12111f3ba4ff5ff2023d12f15d195c9c48bd97013746c"},
     {file = "css_html_js_minify-2.5.5-py2.py3-none-any.whl", hash = "sha256:3da9d35ac0db8ca648c1b543e0e801d7ca0bab9e6bfd8418fee59d5ae001727a"},
@@ -1927,6 +2037,23 @@ docutils = [
 "dogpile.cache" = [
     {file = "dogpile.cache-1.0.2.tar.gz", hash = "sha256:64fda39d25b46486a4876417ca03a4af06f35bfadba9f59613f9b3d748aa21ef"},
 ]
+duckdb = [
+    {file = "duckdb-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4efb197e3150044fe6a17b2e48b429579ad47948259d7ec27f1f447ab5247ced"},
+    {file = "duckdb-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:f20a8824b5ac576f95e01c6302aff9f1909d326e8b70664d95a7d3966a032b39"},
+    {file = "duckdb-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:d47690f07e9ca890c6065252138c108e930c5f5df7c42f7b9ca27634365d7d35"},
+    {file = "duckdb-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8a7162d1ba0842d75330b229288ca4759f71c1e8f9ddf8d8d2b6956a1171debe"},
+    {file = "duckdb-0.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e83861c24009fd610f40b8e290c68bfd1edd86daf927be58c9f82902e632ac6f"},
+    {file = "duckdb-0.2.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:1b2045774aa0d9a6f70e176c5aa74178aaa3544ccade7a5dc91629c5cd35f035"},
+    {file = "duckdb-0.2.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e123de6fd4f4107b5f7f253bf1dc0fcdc7d8bef6bdf524988fbf9b0874e3a29a"},
+    {file = "duckdb-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:30cab2ef5850cbd1d8dfe94a97430212aa2025b6dd40e2d8e841e3973ce8c242"},
+    {file = "duckdb-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:bbe9487969000558e1faa2e574e0902967ed6d85a619bc8edde77cf37ce722f2"},
+    {file = "duckdb-0.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bd34326fe0430115581a6fc6888c35da3b1c1d34e1aa208163aa051ee1a66fd0"},
+    {file = "duckdb-0.2.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:2b272c3a6c8ff32a0888f81a11ad192e9922fad8652c4892ca99373265ebed44"},
+    {file = "duckdb-0.2.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b4206ff282fe1c2edb6b186bc45356d0d4d62a0ef4a5c8ed50e30f9349f8887c"},
+    {file = "duckdb-0.2.1-cp38-cp38-win32.whl", hash = "sha256:59f96ffc5389a5bd68020f2440ef2b6444584fc15d799f039caf0db8bb84f67e"},
+    {file = "duckdb-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:35575d8ba5e3caf8c6a57dc6e404c7141ef7da7d73e365760d8a2a7ca1607665"},
+    {file = "duckdb-0.2.1.tar.gz", hash = "sha256:5cdada565776ba178d4e7d22e0ffffab07d3c310a91bcf8d13b4b4d3d1876e9f"},
+]
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
@@ -1958,6 +2085,10 @@ flake8-bugbear = [
 flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
     {file = "flake8_polyfill-1.0.2-py2.py3-none-any.whl", hash = "sha256:12be6a34ee3ab795b19ca73505e7b55826d5f6ad7230d31b18e106400169b9e9"},
+]
+geojson = [
+    {file = "geojson-2.5.0-py2.py3-none-any.whl", hash = "sha256:ccbd13368dd728f4e4f13ffe6aaf725b6e802c692ba0dde628be475040c534ba"},
+    {file = "geojson-2.5.0.tar.gz", hash = "sha256:6e4bb7ace4226a45d9c8c8b1348b3fc43540658359f93c3f7e03efa9f15f658a"},
 ]
 gitdb = [
     {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
@@ -2013,6 +2144,10 @@ importlib-metadata = [
 importlib-resources = [
     {file = "importlib_resources-3.0.0-py2.py3-none-any.whl", hash = "sha256:d028f66b66c0d5732dae86ba4276999855e162a749c92620a38c1d779ed138a7"},
     {file = "importlib_resources-3.0.0.tar.gz", hash = "sha256:19f745a6eca188b490b1428c8d1d4a0d2368759f32370ea8fb89cad2ab1106c3"},
+]
+influxdb = [
+    {file = "influxdb-5.3.0-py2.py3-none-any.whl", hash = "sha256:b4c034ee9c9ee888d43de547cf40c616bba35f0aa8f11e5a6f056bf5855970ac"},
+    {file = "influxdb-5.3.0.tar.gz", hash = "sha256:9bcaafd57ac152b9824ab12ed19f204206ef5df8af68404770554c5b55b475f6"},
 ]
 iniconfig = [
     {file = "iniconfig-1.0.1-py3-none-any.whl", hash = "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437"},
@@ -2179,6 +2314,25 @@ more-itertools = [
     {file = "more-itertools-8.5.0.tar.gz", hash = "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20"},
     {file = "more_itertools-8.5.0-py3-none-any.whl", hash = "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"},
 ]
+msgpack = [
+    {file = "msgpack-0.6.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:3129c355342853007de4a2a86e75eab966119733eb15748819b6554363d4e85c"},
+    {file = "msgpack-0.6.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:31f6d645ee5a97d59d3263fab9e6be76f69fa131cddc0d94091a3c8aca30d67a"},
+    {file = "msgpack-0.6.1-cp27-cp27m-win32.whl", hash = "sha256:fd509d4aa95404ce8d86b4e32ce66d5d706fd6646c205e1c2a715d87078683a2"},
+    {file = "msgpack-0.6.1-cp27-cp27m-win_amd64.whl", hash = "sha256:70cebfe08fb32f83051971264466eadf183101e335d8107b80002e632f425511"},
+    {file = "msgpack-0.6.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:8e68c76c6aff4849089962d25346d6784d38e02baa23ffa513cf46be72e3a540"},
+    {file = "msgpack-0.6.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:86b963a5de11336ec26bc4f839327673c9796b398b9f1fe6bb6150c2a5d00f0f"},
+    {file = "msgpack-0.6.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:72cb7cf85e9df5251abd7b61a1af1fb77add15f40fa7328e924a9c0b6bc7a533"},
+    {file = "msgpack-0.6.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:8c73c9bcdfb526247c5e4f4f6cf581b9bb86b388df82cfcaffde0a6e7bf3b43a"},
+    {file = "msgpack-0.6.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:26cb40116111c232bc235ce131cc3b4e76549088cb154e66a2eb8ff6fcc907ec"},
+    {file = "msgpack-0.6.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:62bd8e43d204580308d477a157b78d3fee2fb4c15d32578108dc5d89866036c8"},
+    {file = "msgpack-0.6.1-cp36-cp36m-win32.whl", hash = "sha256:a28e69fe5468c9f5251c7e4e7232286d71b7dfadc74f312006ebe984433e9746"},
+    {file = "msgpack-0.6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:97ac6b867a8f63debc64f44efdc695109d541ecc361ee2dce2c8884ab37360a1"},
+    {file = "msgpack-0.6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3ce7ef7ee2546c3903ca8c934d09250531b80c6127e6478781ae31ed835aac4c"},
+    {file = "msgpack-0.6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7c55649965c35eb32c499d17dadfb8f53358b961582846e1bc06f66b9bccc556"},
+    {file = "msgpack-0.6.1-cp37-cp37m-win32.whl", hash = "sha256:9d4f546af72aa001241d74a79caec278bcc007b4bcde4099994732e98012c858"},
+    {file = "msgpack-0.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:300fd3f2c664a3bf473d6a952f843b4a71454f4c592ed7e74a36b205c1782d28"},
+    {file = "msgpack-0.6.1.tar.gz", hash = "sha256:4008c72f5ef2b7936447dcb83db41d97e9791c83221be13d5e19db0796df1972"},
+]
 munch = [
     {file = "munch-2.5.0-py2.py3-none-any.whl", hash = "sha256:6f44af89a2ce4ed04ff8de41f70b226b984db10a91dcc7b9ac2efc1c77022fdd"},
     {file = "munch-2.5.0.tar.gz", hash = "sha256:2d735f6f24d4dba3417fa448cae40c6e896ec1fdab6cdb5e6510999758a4dbd2"},
@@ -2186,6 +2340,12 @@ munch = [
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+mysqlclient = [
+    {file = "mysqlclient-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:edd42ccaa444b00702d5374b2f5f7585c9d0ce201917f15339f1c3cf91c1b1ed"},
+    {file = "mysqlclient-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:3f39855a4ad22805361e782cc4d1010ac74796225fa2d1c03cc16673ccdc983a"},
+    {file = "mysqlclient-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:a6b5648f648b16335e3b1aaec93dc3fcc81a9a661180e306936437cc522c810b"},
+    {file = "mysqlclient-2.0.1.tar.gz", hash = "sha256:fb2f75aea14722390d2d8ddf384ad99da708c707a96656210a7be8af20a2c5e5"},
 ]
 nbconvert = [
     {file = "nbconvert-5.6.1-py2.py3-none-any.whl", hash = "sha256:f0d6ec03875f96df45aa13e21fd9b8450c42d7e1830418cccc008c0df725fcee"},
@@ -2349,6 +2509,21 @@ prometheus-client = [
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.7-py3-none-any.whl", hash = "sha256:83074ee28ad4ba6af190593d4d4c607ff525272a504eb159199b6dd9f950c950"},
     {file = "prompt_toolkit-3.0.7.tar.gz", hash = "sha256:822f4605f28f7d2ba6b0b09a31e25e140871e96364d1d377667b547bb3bf4489"},
+]
+psycopg2 = [
+    {file = "psycopg2-2.8.6-cp27-cp27m-win32.whl", hash = "sha256:068115e13c70dc5982dfc00c5d70437fe37c014c808acce119b5448361c03725"},
+    {file = "psycopg2-2.8.6-cp27-cp27m-win_amd64.whl", hash = "sha256:d160744652e81c80627a909a0e808f3c6653a40af435744de037e3172cf277f5"},
+    {file = "psycopg2-2.8.6-cp34-cp34m-win32.whl", hash = "sha256:b8cae8b2f022efa1f011cc753adb9cbadfa5a184431d09b273fb49b4167561ad"},
+    {file = "psycopg2-2.8.6-cp34-cp34m-win_amd64.whl", hash = "sha256:f22ea9b67aea4f4a1718300908a2fb62b3e4276cf00bd829a97ab5894af42ea3"},
+    {file = "psycopg2-2.8.6-cp35-cp35m-win32.whl", hash = "sha256:26e7fd115a6db75267b325de0fba089b911a4a12ebd3d0b5e7acb7028bc46821"},
+    {file = "psycopg2-2.8.6-cp35-cp35m-win_amd64.whl", hash = "sha256:00195b5f6832dbf2876b8bf77f12bdce648224c89c880719c745b90515233301"},
+    {file = "psycopg2-2.8.6-cp36-cp36m-win32.whl", hash = "sha256:a49833abfdede8985ba3f3ec641f771cca215479f41523e99dace96d5b8cce2a"},
+    {file = "psycopg2-2.8.6-cp36-cp36m-win_amd64.whl", hash = "sha256:f974c96fca34ae9e4f49839ba6b78addf0346777b46c4da27a7bf54f48d3057d"},
+    {file = "psycopg2-2.8.6-cp37-cp37m-win32.whl", hash = "sha256:6a3d9efb6f36f1fe6aa8dbb5af55e067db802502c55a9defa47c5a1dad41df84"},
+    {file = "psycopg2-2.8.6-cp37-cp37m-win_amd64.whl", hash = "sha256:56fee7f818d032f802b8eed81ef0c1232b8b42390df189cab9cfa87573fe52c5"},
+    {file = "psycopg2-2.8.6-cp38-cp38-win32.whl", hash = "sha256:ad2fe8a37be669082e61fb001c185ffb58867fdbb3e7a6b0b0d2ffe232353a3e"},
+    {file = "psycopg2-2.8.6-cp38-cp38-win_amd64.whl", hash = "sha256:56007a226b8e95aa980ada7abdea6b40b75ce62a433bd27cec7a8178d57f4051"},
+    {file = "psycopg2-2.8.6.tar.gz", hash = "sha256:fb23f6c71107c37fd667cb4ea363ddeb936b348bbd6449278eb92c189699f543"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.6.0-py2.py3-none-any.whl", hash = "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"},
@@ -2583,9 +2758,46 @@ sphinxcontrib-svg2pdfconverter = [
     {file = "sphinxcontrib-svg2pdfconverter-1.1.0.tar.gz", hash = "sha256:90ca55ae91d1fa360550d7cba9bd757309be9732e77ee2010443a575d3050fc6"},
     {file = "sphinxcontrib_svg2pdfconverter-1.1.0-py3-none-any.whl", hash = "sha256:bb0b7c402e0e5744ecc0dd28fd3f32b177a7a4ffa4bccfa5a1e0773996b75473"},
 ]
+sqlalchemy = [
+    {file = "SQLAlchemy-1.3.19-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:f2e8a9c0c8813a468aa659a01af6592f71cd30237ec27c4cc0683f089f90dcfc"},
+    {file = "SQLAlchemy-1.3.19-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:33d29ae8f1dc7c75b191bb6833f55a19c932514b9b5ce8c3ab9bc3047da5db36"},
+    {file = "SQLAlchemy-1.3.19-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:3292a28344922415f939ee7f4fc0c186f3d5a0bf02192ceabd4f1129d71b08de"},
+    {file = "SQLAlchemy-1.3.19-cp27-cp27m-win32.whl", hash = "sha256:883c9fb62cebd1e7126dd683222b3b919657590c3e2db33bdc50ebbad53e0338"},
+    {file = "SQLAlchemy-1.3.19-cp27-cp27m-win_amd64.whl", hash = "sha256:860d0fe234922fd5552b7f807fbb039e3e7ca58c18c8d38aa0d0a95ddf4f6c23"},
+    {file = "SQLAlchemy-1.3.19-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:73a40d4fcd35fdedce07b5885905753d5d4edf413fbe53544dd871f27d48bd4f"},
+    {file = "SQLAlchemy-1.3.19-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:5a49e8473b1ab1228302ed27365ea0fadd4bf44bc0f9e73fe38e10fdd3d6b4fc"},
+    {file = "SQLAlchemy-1.3.19-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:6547b27698b5b3bbfc5210233bd9523de849b2bb8a0329cd754c9308fc8a05ce"},
+    {file = "SQLAlchemy-1.3.19-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:107d4af989831d7b091e382d192955679ec07a9209996bf8090f1f539ffc5804"},
+    {file = "SQLAlchemy-1.3.19-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:eb1d71643e4154398b02e88a42fc8b29db8c44ce4134cf0f4474bfc5cb5d4dac"},
+    {file = "SQLAlchemy-1.3.19-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:b6ff91356354b7ff3bd208adcf875056d3d886ed7cef90c571aef2ab8a554b12"},
+    {file = "SQLAlchemy-1.3.19-cp35-cp35m-win32.whl", hash = "sha256:96f51489ac187f4bab588cf51f9ff2d40b6d170ac9a4270ffaed535c8404256b"},
+    {file = "SQLAlchemy-1.3.19-cp35-cp35m-win_amd64.whl", hash = "sha256:618db68745682f64cedc96ca93707805d1f3a031747b5a0d8e150cfd5055ae4d"},
+    {file = "SQLAlchemy-1.3.19-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:6557af9e0d23f46b8cd56f8af08eaac72d2e3c632ac8d5cf4e20215a8dca7cea"},
+    {file = "SQLAlchemy-1.3.19-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8280f9dae4adb5889ce0bb3ec6a541bf05434db5f9ab7673078c00713d148365"},
+    {file = "SQLAlchemy-1.3.19-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:b595e71c51657f9ee3235db8b53d0b57c09eee74dfb5b77edff0e46d2218dc02"},
+    {file = "SQLAlchemy-1.3.19-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:51064ee7938526bab92acd049d41a1dc797422256086b39c08bafeffb9d304c6"},
+    {file = "SQLAlchemy-1.3.19-cp36-cp36m-win32.whl", hash = "sha256:8afcb6f4064d234a43fea108859942d9795c4060ed0fbd9082b0f280181a15c1"},
+    {file = "SQLAlchemy-1.3.19-cp36-cp36m-win_amd64.whl", hash = "sha256:e49947d583fe4d29af528677e4f0aa21f5e535ca2ae69c48270ebebd0d8843c0"},
+    {file = "SQLAlchemy-1.3.19-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:9e865835e36dfbb1873b65e722ea627c096c11b05f796831e3a9b542926e979e"},
+    {file = "SQLAlchemy-1.3.19-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:276936d41111a501cf4a1a0543e25449108d87e9f8c94714f7660eaea89ae5fe"},
+    {file = "SQLAlchemy-1.3.19-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:c7adb1f69a80573698c2def5ead584138ca00fff4ad9785a4b0b2bf927ba308d"},
+    {file = "SQLAlchemy-1.3.19-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:465c999ef30b1c7525f81330184121521418a67189053bcf585824d833c05b66"},
+    {file = "SQLAlchemy-1.3.19-cp37-cp37m-win32.whl", hash = "sha256:aa0554495fe06172b550098909be8db79b5accdf6ffb59611900bea345df5eba"},
+    {file = "SQLAlchemy-1.3.19-cp37-cp37m-win_amd64.whl", hash = "sha256:15c0bcd3c14f4086701c33a9e87e2c7ceb3bcb4a246cd88ec54a49cf2a5bd1a6"},
+    {file = "SQLAlchemy-1.3.19-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fe7fe11019fc3e6600819775a7d55abc5446dda07e9795f5954fdbf8a49e1c37"},
+    {file = "SQLAlchemy-1.3.19-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c898b3ebcc9eae7b36bd0b4bbbafce2d8076680f6868bcbacee2d39a7a9726a7"},
+    {file = "SQLAlchemy-1.3.19-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:072766c3bd09294d716b2d114d46ffc5ccf8ea0b714a4e1c48253014b771c6bb"},
+    {file = "SQLAlchemy-1.3.19-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:26c5ca9d09f0e21b8671a32f7d83caad5be1f6ff45eef5ec2f6fd0db85fc5dc0"},
+    {file = "SQLAlchemy-1.3.19-cp38-cp38-win32.whl", hash = "sha256:b70bad2f1a5bd3460746c3fb3ab69e4e0eb5f59d977a23f9b66e5bdc74d97b86"},
+    {file = "SQLAlchemy-1.3.19-cp38-cp38-win_amd64.whl", hash = "sha256:83469ad15262402b0e0974e612546bc0b05f379b5aa9072ebf66d0f8fef16bea"},
+    {file = "SQLAlchemy-1.3.19.tar.gz", hash = "sha256:3bba2e9fbedb0511769780fe1d63007081008c5c2d7d715e91858c94dbaa260e"},
+]
 stevedore = [
     {file = "stevedore-3.2.2-py3-none-any.whl", hash = "sha256:5e1ab03eaae06ef6ce23859402de785f08d97780ed774948ef16c4652c41bc62"},
     {file = "stevedore-3.2.2.tar.gz", hash = "sha256:f845868b3a3a77a2489d226568abe7328b5c2d4f6a011cc759dfa99144a521f0"},
+]
+surrogate = [
+    {file = "surrogate-0.1.tar.gz", hash = "sha256:edebec660d728325be1d52cab40d778d4c75ba04f927f4aba12d35f730b2df03"},
 ]
 tables = [
     {file = "tables-3.6.1-2-cp36-cp36m-win32.whl", hash = "sha256:db163df08ded7804d596dee14d88397f6c55cdf4671b3992cb885c0b3890a54d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "wetterdienst"
 version = "0.7.0"
-description = "Python library to ease access to open weather data"
+description = "Open weather data for humans"
 authors = [
     "Benjamin Gutzmann <gutzemann@gmail.com>",
     "Daniel Lassahn <daniel.lassahn@meteointelligence.de>",
@@ -70,7 +70,6 @@ numpy = "1.18.3"
 scipy = "1.4.1"
 h5py = "2.10.0"
 cachetools = "^3.1.1"
-aiofiles = "^0.4.0"
 fire = "^0.3.1"
 docopt = "^0.6.2"
 munch = "^2.5.0"
@@ -95,6 +94,12 @@ sphinx-autodoc-typehints        = { version = "1.11.0", optional = true }
 sphinxcontrib-svg2pdfconverter  = { version = "1.1.0", optional = true }
 tomlkit                         = { version = "0.7.0", optional = true }
 
+duckdb                          = { version = "^0.2.1", optional = true }
+influxdb                        = { version = "^5.3.0", optional = true }
+crate                           = { version = "^0.25.0", optional = true, extras = ["sqlalchemy"] }
+mysqlclient                     = { version = "^2.0.1", optional = true }
+psycopg2                        = { version = "^2.8.6", optional = true }
+
 
 [tool.poetry.extras]
 ipython = ["ipython", "ipython-genutils", "matplotlib"]
@@ -108,6 +113,12 @@ docs = [
     "matplotlib",
     "ipython"
 ]
+sql = ["duckdb"]
+duckdb = ["duckdb"]
+influxdb = ["influxdb"]
+cratedb = ["crate"]
+mysql = ["mysqlclient"]
+postgresql = ["psycopg2"]
 
 [tool.poetry.dev-dependencies]
 nox = "^2020.8.22"
@@ -122,7 +133,7 @@ pytest-cov = "^2.10.1"
 pytest-notebook = "^0.6.0"
 nbconvert = ">=5.0, <6.0"
 mock = "^4.0"
-pygments = "^2.7.0"
+surrogate = "^0.1"
 matplotlib = "^3.0.3"
 
 [tool.poetry.scripts]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,18 @@ def test_cli_about_periods(capsys):
     assert "now" in response
 
 
+def test_cli_about_coverage(capsys):
+
+    sys.argv = ["wetterdienst", "about", "coverage"]
+    cli.run()
+    stdout, stderr = capsys.readouterr()
+
+    response = stdout
+    assert "TimeResolution.ANNUAL" in response
+    assert "Parameter.CLIMATE_SUMMARY" in response
+    assert "PeriodType.HISTORICAL" in response
+
+
 def invoke_wetterdienst_stations(format="json"):
     argv = shlex.split(
         f"wetterdienst stations --resolution=daily --parameter=kl --period=recent --lat=49.9195 --lon=8.9671 --num=5 --format={format}"  # noqa:E501,B950

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,285 @@
+import json
+import mock
+import pandas as pd
+import pytest
+from surrogate import surrogate
+
+from wetterdienst import DWDStationRequest, Parameter, TimeResolution, PeriodType
+from wetterdienst.additionals.time_handling import parse_datetime
+from wetterdienst.io import DataPackage
+
+
+original = pd.DataFrame.from_dict(
+    [
+        {
+            "STATION_ID": 1048,
+            "PARAMETER": "climate_summary",
+            "ELEMENT": "temperature_air_max_200",
+            "DATE": parse_datetime("2019-12-28T00:00:00.000"),
+            "VALUE": 1.3,
+            "QUALITY": None,
+        }
+    ]
+)
+
+
+def test_lowercase_fieldnames():
+
+    dp = DataPackage(df=original)
+    dp.lowercase_fieldnames()
+
+    assert list(dp.df.columns) == [
+        "station_id",
+        "parameter",
+        "element",
+        "date",
+        "value",
+        "quality",
+    ]
+
+
+def test_filter_by_date():
+
+    dp = DataPackage(df=original)
+    df = dp.filter_by_date("2019-12-28", TimeResolution.HOURLY)
+    assert not df.empty
+
+    dp = DataPackage(df=original)
+    df = dp.filter_by_date("2019-12-27", TimeResolution.HOURLY)
+    assert df.empty
+
+
+def test_filter_by_date_interval():
+
+    dp = DataPackage(df=original)
+    df = dp.filter_by_date("2019-12-27/2019-12-29", TimeResolution.HOURLY)
+    assert not df.empty
+
+    dp = DataPackage(df=original)
+    df = dp.filter_by_date("2020/2022", TimeResolution.HOURLY)
+    assert df.empty
+
+
+def test_filter_by_date_monthly():
+
+    result = pd.DataFrame.from_dict(
+        [
+            {
+                "STATION_ID": 1048,
+                "PARAMETER": "climate_summary",
+                "ELEMENT": "temperature_air_max_200",
+                "FROM_DATE": parse_datetime("2019-12-28T00:00:00.000"),
+                "TO_DATE": parse_datetime("2020-01-28T00:00:00.000"),
+                "VALUE": 1.3,
+                "QUALITY": None,
+            }
+        ]
+    )
+
+    dp = DataPackage(df=result)
+    df = dp.filter_by_date("2019-12/2020-01", TimeResolution.MONTHLY)
+    assert not df.empty
+
+    dp = DataPackage(df=result)
+    df = dp.filter_by_date("2020/2022", TimeResolution.MONTHLY)
+    assert df.empty
+
+    dp = DataPackage(df=result)
+    df = dp.filter_by_date("2020", TimeResolution.MONTHLY)
+    assert df.empty
+
+
+def test_filter_by_date_annual():
+
+    result = pd.DataFrame.from_dict(
+        [
+            {
+                "STATION_ID": 1048,
+                "PARAMETER": "climate_summary",
+                "ELEMENT": "temperature_air_max_200",
+                "FROM_DATE": parse_datetime("2019-01-01T00:00:00.000"),
+                "TO_DATE": parse_datetime("2019-12-31T00:00:00.000"),
+                "VALUE": 1.3,
+                "QUALITY": None,
+            }
+        ]
+    )
+
+    dp = DataPackage(df=result)
+    df = dp.filter_by_date("2019-05/2019-09", TimeResolution.ANNUAL)
+    assert not df.empty
+
+    dp = DataPackage(df=result)
+    df = dp.filter_by_date("2020/2022", TimeResolution.ANNUAL)
+    assert df.empty
+
+    dp = DataPackage(df=result)
+    df = dp.filter_by_date("2020", TimeResolution.ANNUAL)
+    assert df.empty
+
+
+def test_filter_by_sql():
+
+    dp = DataPackage(df=original)
+    dp.lowercase_fieldnames()
+    df = dp.filter_by_sql(
+        "SELECT * FROM data WHERE element='temperature_air_max_200' AND value < 1.5"
+    )
+    assert not df.empty
+
+    dp = DataPackage(df=original)
+    dp.lowercase_fieldnames()
+    df = dp.filter_by_sql(
+        "SELECT * FROM data WHERE element='temperature_air_max_200' AND value > 1.5"
+    )
+    assert df.empty
+
+
+def test_format_json():
+
+    dp = DataPackage(df=original)
+    dp.lowercase_fieldnames()
+    output = dp.format("json")
+
+    response = json.loads(output)
+    station_ids = list(set([reading["station_id"] for reading in response]))
+
+    assert 1048 in station_ids
+
+
+def test_format_csv():
+
+    dp = DataPackage(df=original)
+    dp.lowercase_fieldnames()
+    output = dp.format("csv").strip()
+
+    assert "station_id,parameter,element,date,value,quality" in output
+    assert (
+        "1048,climate_summary,temperature_air_max_200,2019-12-28T00-00-00,1.3,"
+        in output
+    )
+
+
+def test_format_unknown():
+
+    dp = DataPackage(df=original)
+
+    with pytest.raises(KeyError):
+        dp.format("foobar")
+
+
+def test_request():
+
+    request = DWDStationRequest(
+        station_ids=[1048],
+        parameter=Parameter.CLIMATE_SUMMARY,
+        time_resolution=TimeResolution.DAILY,
+        period_type=PeriodType.RECENT,
+    )
+
+    dp = DataPackage(request=request)
+    assert not dp.df.empty
+
+
+def test_export_sqlite():
+
+    request = DWDStationRequest(
+        station_ids=[1048],
+        parameter=Parameter.CLIMATE_SUMMARY,
+        time_resolution=TimeResolution.DAILY,
+        period_type=PeriodType.RECENT,
+    )
+
+    with mock.patch(
+        "pandas.DataFrame.to_sql",
+    ) as mock_to_sql:
+
+        dp = DataPackage(request=request)
+        dp.export("sqlite:///test.sqlite?table=testdrive")
+
+        mock_to_sql.assert_called_once_with(
+            name="testdrive",
+            con="sqlite:///test.sqlite?table=testdrive",
+            if_exists="replace",
+            index=False,
+            method="multi",
+            chunksize=5000,
+        )
+
+
+def test_export_crate():
+
+    request = DWDStationRequest(
+        station_ids=[1048],
+        parameter=Parameter.CLIMATE_SUMMARY,
+        time_resolution=TimeResolution.DAILY,
+        period_type=PeriodType.RECENT,
+    )
+
+    with mock.patch(
+        "pandas.DataFrame.to_sql",
+    ) as mock_to_sql:
+
+        dp = DataPackage(request=request)
+        dp.export("crate://localhost/?database=test&table=testdrive")
+
+        mock_to_sql.assert_called_once_with(
+            name="testdrive",
+            con="crate://localhost/?database=test&table=testdrive",
+            if_exists="replace",
+            index=False,
+            method="multi",
+            chunksize=5000,
+        )
+
+
+@surrogate("duckdb.connect")
+def test_export_duckdb():
+
+    request = DWDStationRequest(
+        station_ids=[1048],
+        parameter=Parameter.CLIMATE_SUMMARY,
+        time_resolution=TimeResolution.DAILY,
+        period_type=PeriodType.RECENT,
+    )
+
+    mock_connection = mock.MagicMock()
+    with mock.patch(
+        "duckdb.connect", side_effect=[mock_connection], create=True
+    ) as mock_connect:
+
+        dp = DataPackage(request=request)
+        dp.export("duckdb:///test.duckdb?table=testdrive")
+
+        mock_connect.assert_called_once_with(database="test.duckdb", read_only=False)
+        mock_connection.register.assert_called_once()
+        mock_connection.execute.assert_called()
+        mock_connection.table.assert_called_once_with("testdrive")
+        # a.table.to_df.assert_called()
+        mock_connection.close.assert_called_once()
+
+
+@surrogate("influxdb.dataframe_client.DataFrameClient")
+def test_export_influxdb():
+
+    request = DWDStationRequest(
+        station_ids=[1048],
+        parameter=Parameter.CLIMATE_SUMMARY,
+        time_resolution=TimeResolution.DAILY,
+        period_type=PeriodType.RECENT,
+    )
+
+    mock_client = mock.MagicMock()
+    with mock.patch(
+        "influxdb.dataframe_client.DataFrameClient",
+        side_effect=[mock_client],
+        create=True,
+    ) as mock_connect:
+
+        dp = DataPackage(request=request)
+        dp.lowercase_fieldnames()
+        dp.export("influxdb://localhost/?database=dwd&table=weather")
+
+        mock_connect.assert_called_once_with(database="dwd")
+        mock_client.create_database.assert_called_once_with("dwd")
+        mock_client.write_points.assert_called_once()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,18 @@
+import sys
+import shlex
+import mock
+import runpy
+
+
+@mock.patch(
+    "wetterdienst.data_collection.collect_climate_observations_data", side_effect=[None]
+)
+def test_run(mock_ccod):
+    args = (
+        "run.py collect_climate_observations_data "
+        '"[1048]" "kl" "daily" "recent" /app/dwd_data/ '
+        "False False True False True False"
+    )
+    sys.argv = shlex.split(args)
+    runpy.run_module("wetterdienst.run", run_name="__main__")
+    mock_ccod.assert_called_once()

--- a/wetterdienst/__init__.py
+++ b/wetterdienst/__init__.py
@@ -18,6 +18,7 @@ from wetterdienst.data_collection import (
     collect_radolan_data,
 )
 from wetterdienst.api import DWDStationRequest, DWDRadolanRequest
+from wetterdienst.io import DataPackage
 
 # Single-sourcing the package version
 # https://cjolowicz.github.io/posts/hypermodern-python-06-ci-cd/

--- a/wetterdienst/io.py
+++ b/wetterdienst/io.py
@@ -1,0 +1,375 @@
+import json
+import logging
+from typing import Union
+from urllib.parse import urlparse, parse_qs
+
+import pandas as pd
+
+from wetterdienst import DWDStationRequest, TimeResolution
+from wetterdienst.additionals.geo_location import stations_to_geojson
+from wetterdienst.additionals.time_handling import parse_datetime, mktimerange
+from wetterdienst.enumerations.column_names_enumeration import DWDMetaColumns
+
+log = logging.getLogger(__name__)
+
+
+class DataPackage:
+    """
+    Postprocessing DWD data.
+
+    This aids in collecting, filtering, formatting and emitting data
+    acquired through the core machinery.
+    """
+
+    def __init__(
+        self, df: pd.DataFrame = None, request: Union[DWDStationRequest] = None
+    ):
+        self.df = df
+        self.request = request
+
+        if self.request is not None:
+            self.collect(self.request)
+
+    def collect(self, request: Union[DWDStationRequest]):
+        """
+        Collect all data from ``DWDStationRequest`` and assign to ``self.df``.
+
+        :param request: The DWDStationRequest instance.
+        :return: self
+        """
+
+        data = list(request.collect_data())
+
+        if not data:
+            raise ValueError("No data available for given constraints")
+
+        self.df = pd.concat(data)
+
+        return self
+
+    def filter_by_date(
+        self, date: str, time_resolution: TimeResolution
+    ) -> pd.DataFrame:
+        """
+        Filter Pandas DataFrame by date or date interval.
+
+        Accepts different kinds of date formats, like:
+
+        - 2020-05-01
+        - 2020-06-15T12
+        - 2020-05
+        - 2019
+        - 2020-05-01/2020-05-05
+        - 2017-01/2019-12
+        - 2010/2020
+
+        :param date:
+        :param time_resolution:
+        :return: Filtered DataFrame
+        """
+
+        # Filter by date interval.
+        if "/" in date:
+            date_from, date_to = date.split("/")
+            date_from = parse_datetime(date_from)
+            date_to = parse_datetime(date_to)
+            if time_resolution in (
+                TimeResolution.ANNUAL,
+                TimeResolution.MONTHLY,
+            ):
+                date_from, date_to = mktimerange(time_resolution, date_from, date_to)
+                expression = (date_from <= self.df[DWDMetaColumns.FROM_DATE.value]) & (
+                    self.df[DWDMetaColumns.TO_DATE.value] <= date_to
+                )
+            else:
+                expression = (date_from <= self.df[DWDMetaColumns.DATE.value]) & (
+                    self.df[DWDMetaColumns.DATE.value] <= date_to
+                )
+            df = self.df[expression]
+
+        # Filter by specific date.
+        else:
+            date = parse_datetime(date)
+            if time_resolution in (
+                TimeResolution.ANNUAL,
+                TimeResolution.MONTHLY,
+            ):
+                date_from, date_to = mktimerange(time_resolution, date)
+                expression = (date_from <= self.df[DWDMetaColumns.FROM_DATE.value]) & (
+                    self.df[DWDMetaColumns.TO_DATE.value] <= date_to
+                )
+            else:
+                expression = date == self.df[DWDMetaColumns.DATE.value]
+            df = self.df[expression]
+
+        return df
+
+    def lowercase_fieldnames(self):
+        """
+        Make Pandas DataFrame column names lowercase.
+
+        :return: Mungled DataFrame
+        """
+        self.df = self.df.rename(columns=str.lower)
+        for attribute in DWDMetaColumns.PARAMETER, DWDMetaColumns.ELEMENT:
+            attribute_name = attribute.value.lower()
+            if attribute_name in self.df:
+                self.df[attribute_name] = self.df[attribute_name].str.lower()
+        return self
+
+    def filter_by_sql(self, sql: str) -> pd.DataFrame:
+        """
+        Filter Pandas DataFrame using an SQL query.
+        The virtual table name is "data", so queries
+        should look like ``SELECT * FROM data;``.
+
+        This implementation is based on DuckDB, so please
+        have a look at its SQL documentation.
+
+        - https://duckdb.org/docs/sql/introduction
+
+        :param sql: A SQL expression.
+        :return: Filtered DataFrame
+        """
+        import duckdb
+
+        return duckdb.query(self.df, "data", sql).df()
+
+    def format(self, format: str) -> str:
+        """
+        Format/render Pandas DataFrame to given output format.
+
+        :param format: One of json, geojson, csv, excel.
+        :return: Rendered payload.
+        """
+
+        # Output as JSON.
+        if format == "json":
+            output = self.df.to_json(orient="records", date_format="iso", indent=4)
+
+        # Output as GeoJSON.
+        elif format == "geojson":
+            output = json.dumps(stations_to_geojson(self.df), indent=4)
+
+        # Output as CSV.
+        elif format == "csv":
+            output = self.df.to_csv(index=False, date_format="%Y-%m-%dT%H-%M-%S")
+
+        # Output as XLSX.
+        # FIXME: Make --format=excel write to a designated file.
+        elif format == "excel":
+            # TODO: Obtain output file name from command line.
+            output_filename = "output.xlsx"
+            log.info(f"Writing {output_filename}")
+            self.df.to_excel(output_filename, index=False)
+            output = None
+
+        else:
+            raise KeyError("Unknown output format")
+
+        return output
+
+    def export(self, target: str):
+        """
+        Emit Pandas DataFrame to target. A target
+        is identified by a connection string.
+
+        Examples:
+
+        - duckdb://dwd.duckdb?table=weather
+        - influxdb://localhost/?database=dwd&table=weather
+        - crate://localhost/?database=dwd&table=weather
+
+        Dispatch data to different data sinks. Currently, SQLite, DuckDB,
+        InfluxDB and CrateDB are implemented. However, through the SQLAlchemy
+        layer, it should actually work with any supported SQL database.
+
+        - https://docs.sqlalchemy.org/en/13/dialects/
+
+        :param target: Target connection string.
+        :return: self
+        """
+
+        database, tablename = ConnectionString(target).get()
+
+        if target.startswith("duckdb://"):
+            """
+            ====================
+            DuckDB database sink
+            ====================
+
+            Install Python driver::
+
+                pip install duckdb
+
+            Acquire data::
+
+                wetterdienst readings --station=1048,4411 --parameter=kl --resolution=daily --period=recent --target="duckdb:///dwd.duckdb?table=weather"
+
+            Example queries::
+
+                python -c 'import duckdb; c = duckdb.connect(database="dwd.duckdb"); print(c.table("weather"))'  # noqa
+                python -c 'import duckdb; c = duckdb.connect(database="dwd.duckdb"); print(c.execute("SELECT * FROM weather").df())'  # noqa
+
+            """
+            log.info(f"Writing to DuckDB {database, tablename}")
+            import duckdb
+
+            connection = duckdb.connect(database=database, read_only=False)
+            connection.register("origin", self.df)
+            connection.execute(f"DROP TABLE IF EXISTS {tablename};")
+            connection.execute(
+                f"CREATE TABLE {tablename} AS SELECT * FROM origin;"  # noqa:S608
+            )
+
+            weather_table = connection.table(tablename)
+            print(weather_table)
+            print("Cardinalities:")
+            print(weather_table.to_df().count())
+            connection.close()
+            log.info("Writing to DuckDB finished")
+
+        elif target.startswith("influxdb://"):
+            """
+            ======================
+            InfluxDB database sink
+            ======================
+
+            Install Python driver::
+
+                pip install influxdb
+
+            Run database::
+
+                docker run --publish "8086:8086" influxdb/influxdb:1.8.2
+
+            Acquire data::
+
+                wetterdienst readings --station=1048,4411 --parameter=kl --resolution=daily --period=recent --target="influxdb://localhost/?database=dwd&table=weather"
+
+            Example queries::
+
+                http 'localhost:8086/query?db=dwd&q=SELECT * FROM weather;'
+                http 'localhost:8086/query?db=dwd&q=SELECT COUNT(*) FROM weather;'
+            """
+            log.info(f"Writing to InfluxDB {database, tablename}")
+            from influxdb.dataframe_client import DataFrameClient
+
+            # Setup the connection.
+            c = DataFrameClient(database=database)
+            c.create_database(database)
+
+            # Mungle the data frame.
+            df = self.df.set_index(pd.DatetimeIndex(self.df["date"]))
+            df = df.drop(["date"], axis=1)
+            df = df.dropna()
+
+            # Write to InfluxDB.
+            c.write_points(
+                dataframe=df,
+                measurement=tablename,
+                tag_columns=["station_id", "parameter", "element"],
+            )
+            log.info("Writing to InfluxDB finished")
+
+        elif target.startswith("crate://"):
+            """
+            =====================
+            CrateDB database sink
+            =====================
+
+            Install Python driver::
+
+                pip install crate[sqlalchemy] crash
+
+            Run database::
+
+                docker run --publish "4200:4200" --env CRATE_HEAP_SIZE=512M crate/crate:4.2.4
+
+            Acquire data::
+
+                wetterdienst readings --station=1048,4411 --parameter=kl --resolution=daily --period=recent --target="crate://localhost/?database=dwd&table=weather"
+
+            Example queries::
+
+                crash -c 'select * from weather;'
+                crash -c 'select count(*) from weather;'
+                crash -c "select *, date_format('%Y-%m-%dT%H:%i:%s.%fZ', date) as datetime from weather order by datetime limit 10;"  # noqa
+
+            """
+            log.info("Writing to CrateDB")
+            self.df.to_sql(
+                name=tablename,
+                con=target,
+                if_exists="replace",
+                index=False,
+                method="multi",
+                chunksize=5000,
+            )
+            log.info("Writing to CrateDB finished")
+
+        else:
+            """
+            ========================
+            SQLAlchemy database sink
+            ========================
+
+            Install Python driver::
+
+                pip install sqlalchemy
+
+            Examples::
+
+                # Prepare
+                alias fetch='wetterdienst readings --station=1048,4411 --parameter=kl --resolution=daily --period=recent'
+
+                # Acquire data.
+                fetch --target="sqlite:///dwd.sqlite?table=weather"
+
+                # Query data.
+                sqlite3 dwd.sqlite "SELECT * FROM weather;"
+
+            """
+            log.info("Writing to SQL database")
+            self.df.to_sql(
+                name=tablename,
+                con=target,
+                if_exists="replace",
+                index=False,
+                method="multi",
+                chunksize=5000,
+            )
+            log.info("Writing to SQL database finished")
+
+        return self
+
+
+class ConnectionString:
+    def __init__(self, url):
+        self.url_raw = url
+        self.url = urlparse(url)
+
+    def get_query_param(self, name):
+        query = parse_qs(self.url.query)
+        try:
+            return query[name][0]
+        except (KeyError, IndexError):
+            return None
+
+    def get_table(self):
+        return self.get_query_param("table") or "weather"
+
+    def get_database(self):
+        database = None
+        if self.url.netloc:
+            database = self.get_query_param("database")
+        else:
+            if self.url.path.startswith("/"):
+                database = self.url.path[1:]
+
+        return database or "dwd"
+
+    def get(self):
+        database = self.get_database()
+        tablename = self.get_table()
+        return database, tablename


### PR DESCRIPTION
Hi there,

## Introduction
This introduces `wetterdienst.io` in order to establish a backplane for different postprocessing tasks. This is what I roughly had in mind when writing about "Ingest data from DWD and conveniently submit it to different data sinks" within https://github.com/earthobservations/wetterdienst/issues/142#issuecomment-690821061. It builds upon things coming from `wetterdienst.cli` and tries to generalize its functionality into a new `DataPackage` class.

## Features
For demonstrating these features, let's define an alias first:
```
alias fetch='wetterdienst readings --station=1048,4411 --parameter=kl --resolution=daily --period=recent'
```

### Export data
Currently, exporting to SQLite, DuckDB, InfluxDB, CrateDB and other SQL databases is implemented.
```
# SQLite
fetch --target="sqlite:///dwd.sqlite&table=weather"

# DuckDB
fetch --target="duckdb:///dwd.duckdb&table=weather"

# InfluxDB
fetch --target="influxdb://localhost/?database=dwd&table=weather"

# CrateDB
fetch --target="crate://localhost/?database=dwd&table=weather"
```

### Filter data using SQL
Thanks to [DuckDB](https://github.com/cwida/duckdb), the results now can also be queried interactively using SQL.
```
# Filter measurements: Display daily climate observation readings where the maximum temperature is below two degrees.
fetch --sql="SELECT * FROM data WHERE element='temperature_air_max_200' AND value < 2.0;"

# Find stations by name (LIKE query).
wetterdienst stations --parameter=kl --resolution=daily --period=recent --sql="SELECT * FROM data WHERE lower(station_name) LIKE lower('%dresden%')"
```

Cheers,
Andreas.

P.S.:
> The background on this is that we would like to add features for data export into InfluxDB, PostGIS and other databases to `wetterdienst.cli`, see also https://github.com/earthobservations/wetterdienst/issues/106#issue-651151143.
