### PR TITLE
Compensate compensation for DWD folder anomaly at "hourly/solar" on the parameter level

### DIFF
--- a/wetterdienst/constants/parameter_mapping.py
+++ b/wetterdienst/constants/parameter_mapping.py
@@ -47,7 +47,7 @@ TIME_RESOLUTION_PARAMETER_MAPPING: Dict[
         Parameter.PRECIPITATION: [PeriodType.HISTORICAL, PeriodType.RECENT],
         Parameter.PRESSURE: [PeriodType.HISTORICAL, PeriodType.RECENT],
         Parameter.TEMPERATURE_SOIL: [PeriodType.HISTORICAL, PeriodType.RECENT],
-        Parameter.SOLAR: [PeriodType.RECENT],
+        Parameter.SOLAR: [PeriodType.HISTORICAL, PeriodType.RECENT],
         Parameter.SUNSHINE_DURATION: [PeriodType.HISTORICAL, PeriodType.RECENT],
         Parameter.VISIBILITY: [PeriodType.HISTORICAL, PeriodType.RECENT],
         Parameter.WIND: [PeriodType.HISTORICAL, PeriodType.RECENT],


### PR DESCRIPTION
Dear Benjamin and @e-dism,

after catching up on #147, I believe we might want to improve the situation transparently without going the extra mile to make the user even aware of this anomaly.

The implementation under the hood already compensates for this anomaly and so we should give this feature thoroughly back to the user without sacrificing it by pushing the obstacle to another place.

Please let me know if you have any objections on this. The tests will still pass and things like that will conveniently work without further ado:
```
wetterdienst readings --station=1048,4411 --parameter=air_temperature,solar --resolution=hourly --period=historical --persist --date=2017-09-16T12
```

Cheers,
Andreas.

P.S.: For all others reading this: The background of this issue is that the DWD data folder [`climate/hourly/solar`](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/hourly/solar/) does not discriminate between `historical` and `recent` data, in contrast to all other folders there. We already have been working hard to compensate for all kinds of things revolving hourly/solar, see also #63, #67, #69 and #89.
