### PR TITLE
Add tutorial stub based on iPython Sphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,10 @@ extensions = [
     "sphinx_rtd_theme",
     "sphinxcontrib.rsvgconverter",
     "sphinx.ext.imgconverter",
+    #"matplotlib.sphinxext.only_directives",
+    "matplotlib.sphinxext.plot_directive",
+    "IPython.sphinxext.ipython_directive",
+    "IPython.sphinxext.ipython_console_highlighting",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Usage
    :maxdepth: 1
 
    API overview <pages/api>
+   pages/tutorial
    pages/cli
    pages/library/index
    pages/behind_the_scenes

--- a/docs/pages/tutorial.rst
+++ b/docs/pages/tutorial.rst
@@ -1,0 +1,59 @@
+########
+Tutorial
+########
+
+
+=============
+Prerequisites
+=============
+Import modules necessary for general functioning.
+
+.. ipython::
+
+    In [1]: import warnings
+       ...: warnings.filterwarnings("ignore")
+       ...: import wetterdienst
+       ...: from wetterdienst import PeriodType, TimeResolution, Parameter
+       ...: import matplotlib as mpl
+       ...: import matplotlib.pyplot as plt
+       ...: from matplotlib import cm
+
+
+========
+Metadata
+========
+
+Which parameters are available?
+
+
+All available combinations
+==========================
+.. ipython::
+
+    In [2]: print(wetterdienst.discover_climate_observations())
+
+
+Daily historical data
+=====================
+.. ipython::
+
+    In [3]: print("Selection of daily historical data")
+       ...: print(
+       ...:     wetterdienst.discover_climate_observations(
+       ...:         time_resolution=TimeResolution.DAILY,
+       ...:         period_type=PeriodType.HISTORICAL
+       ...:     )
+       ...: )
+
+
+================
+Get station list
+================
+
+.. ipython::
+
+    In [1]: metadata_hdp = wetterdienst.metadata_for_climate_observations(
+       ...:     Parameter.PRECIPITATION_MORE, TimeResolution.DAILY, PeriodType.HISTORICAL)
+       ...: print("Number of stations with available data: ", metadata_hdp["HAS_FILE"].sum())
+       ...: print("Some of the stations:")
+       ...: metadata_hdp.head()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ importlib_metadata==1.6.1
 tomlkit==0.7.0
 sphinx-autodoc-typehints==1.11.0
 sphinxcontrib-svg2pdfconverter==1.1.0
+matplotlib==3.3.2


### PR DESCRIPTION
Dear Benjamin,

regarding #136, I gave `IPython.sphinxext.ipython_directive` a shot. With the updates coming from this PR, the iPython Sphinx extension will work in general, but currently will fail when actually hitting code from Wetterdienst [1].

Currently, I am clueless about how to solve this and will be happy if you could take a look. To reproduce, just invoke
```
cd docs
make html
```
on this branch.

Cheers,
Andreas.

[1] I've used code from [`example/simple_example.ipynb`](https://github.com/earthobservations/wetterdienst/blob/v0.7.0/example/simple_example.ipynb) for that. Thanks!

cc @larsrinn
