### PR TITLE
Fix RADOLAN data acquisition when used with "write_file=True"

### DIFF
--- a/wetterdienst/data_storing.py
+++ b/wetterdienst/data_storing.py
@@ -130,6 +130,9 @@ def store_radolan_data(
     with filepath.open("wb") as f:
         f.write(file.read())
 
+    # When the file has been written, reset seek pointer.
+    file.seek(0)
+
 
 def restore_radolan_data(
     date_time: datetime, time_resolution: TimeResolution, folder: Union[str, Path]


### PR DESCRIPTION
Dear Benjamin,

thanks for adding RADOLAN support through #129 the other day. This brings in a minor fix when used with the `write_file=True` option.

With kind regards,
Andreas.
