### PR TITLE
Remove reset_{meta,file}_index_cache() from tests

### DIFF
--- a/tests/indexing/test_file_index_creation.py
+++ b/tests/indexing/test_file_index_creation.py
@@ -5,7 +5,6 @@ import requests
 from wetterdienst.enumerations.column_names_enumeration import DWDMetaColumns
 from wetterdienst.indexing.file_index_creation import (
     create_file_index_for_climate_observations,
-    reset_file_index_cache,
 )
 from wetterdienst.enumerations.parameter_enumeration import Parameter
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
@@ -14,7 +13,6 @@ from wetterdienst.enumerations.period_type_enumeration import PeriodType
 
 @pytest.mark.remote
 def test_file_index_creation():
-    reset_file_index_cache()
 
     # Existing combination of parameters
     file_index = create_file_index_for_climate_observations(
@@ -22,14 +20,6 @@ def test_file_index_creation():
     )
 
     assert not file_index.empty
-
-    reset_file_index_cache()
-
-    file_index2 = create_file_index_for_climate_observations(
-        Parameter.CLIMATE_SUMMARY, TimeResolution.DAILY, PeriodType.RECENT
-    )
-
-    assert file_index.equals(file_index2)
 
     assert (
         file_index.loc[

--- a/tests/indexing/test_meta_index_creation.py
+++ b/tests/indexing/test_meta_index_creation.py
@@ -6,7 +6,6 @@ from pandas import Timestamp
 from wetterdienst.enumerations.column_names_enumeration import DWDMetaColumns
 from wetterdienst.indexing.meta_index_creation import (
     create_meta_index_for_climate_observations,
-    reset_meta_index_cache,
 )
 from wetterdienst.enumerations.parameter_enumeration import Parameter
 from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
@@ -15,7 +14,6 @@ from wetterdienst.enumerations.period_type_enumeration import PeriodType
 
 @pytest.mark.remote
 def test_meta_index_creation():
-    reset_meta_index_cache()
 
     # Existing combination of parameters
     meta_index = create_meta_index_for_climate_observations(
@@ -23,14 +21,6 @@ def test_meta_index_creation():
     )
 
     assert not meta_index.empty
-
-    reset_meta_index_cache()
-
-    meta_index2 = create_meta_index_for_climate_observations(
-        Parameter.CLIMATE_SUMMARY, TimeResolution.DAILY, PeriodType.HISTORICAL
-    )
-
-    assert meta_index.equals(meta_index2)
 
     # todo: replace IndexError with UrlError/WrongSetOfParametersError
     with pytest.raises(requests.exceptions.HTTPError):
@@ -41,7 +31,7 @@ def test_meta_index_creation():
 
 @pytest.mark.remote
 def test_meta_index_1mph_creation():
-    reset_meta_index_cache()
+
     meta_index_1mph = create_meta_index_for_climate_observations(
         Parameter.PRECIPITATION, TimeResolution.MINUTE_1, PeriodType.HISTORICAL
     )

--- a/tests/test_parse_metadata.py
+++ b/tests/test_parse_metadata.py
@@ -2,7 +2,6 @@ import pytest
 import requests
 from pandas import Timestamp
 
-from wetterdienst import reset_meta_index_cache
 from wetterdienst.additionals.geo_location import stations_to_geojson
 from wetterdienst.enumerations.column_names_enumeration import DWDMetaColumns
 from wetterdienst.parse_metadata import metadata_for_climate_observations
@@ -13,7 +12,6 @@ from wetterdienst.enumerations.time_resolution_enumeration import TimeResolution
 
 @pytest.mark.remote
 def test_metadata_for_climate_observations():
-    reset_meta_index_cache()
 
     # Existing combination of parameters
     metadata = metadata_for_climate_observations(
@@ -21,14 +19,6 @@ def test_metadata_for_climate_observations():
     )
 
     assert not metadata.empty
-
-    reset_meta_index_cache()
-
-    metadata2 = metadata_for_climate_observations(
-        Parameter.CLIMATE_SUMMARY, TimeResolution.DAILY, PeriodType.HISTORICAL
-    )
-
-    assert metadata.equals(metadata2)
 
     assert metadata.loc[
         metadata[DWDMetaColumns.STATION_ID.value] == 1, :
@@ -55,7 +45,6 @@ def test_metadata_for_climate_observations():
 
 @pytest.mark.remote
 def test_metadata_geojson():
-    reset_meta_index_cache()
 
     # Existing combination of parameters
     df = metadata_for_climate_observations(


### PR DESCRIPTION
These calls might not be required. If we strictly need an empty cache before running the tests, we should provide a pytest fixture calling out to `reset_meta_index_cache()` and `reset_file_index_cache()`.