### PR TITLE
CLI: Obtain "--tidy" argument from command line

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Development
 ===========
 
-...
+- CLI: Obtain "--tidy" argument from command line
 
 0.9.0 (09.10.2020)
 ==================

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,6 +103,14 @@ def invoke_wetterdienst_readings_static(format="json"):
     cli.run()
 
 
+def invoke_wetterdienst_readings_static_tidy(format="json"):
+    argv = shlex.split(
+        f"wetterdienst dwd readings --resolution=daily --parameter=kl --period=recent --station=4411,7341 --date=2020-06-30 --format={format} --tidy"  # noqa:E501,B950
+    )
+    sys.argv = argv
+    cli.run()
+
+
 def invoke_wetterdienst_readings_geo(format="json"):
     argv = shlex.split(
         f"wetterdienst dwd readings --resolution=daily --parameter=kl --period=recent --lat=49.9195 --lon=8.9671 --num=5 --date=2020-06-30 --format={format}"  # noqa:E501,B950
@@ -182,6 +190,50 @@ def test_cli_readings_json(capsys):
 
     assert 4411 in station_ids
     assert 7341 in station_ids
+
+    first = response[0]
+    assert list(first.keys()) == [
+        "station_id",
+        "date",
+        "quality_wind",
+        "wind_gust_max",
+        "wind_velocity",
+        "quality_general",
+        "precipitation_height",
+        "precipitation_form",
+        "sunshine_duration",
+        "snow_depth",
+        "cloud_coverage_total",
+        "pressure_vapor",
+        "pressure_air",
+        "temperature_air_200",
+        "humidity",
+        "temperature_air_max_200",
+        "temperature_air_min_200",
+        "temperature_air_min_005",
+    ]
+
+
+def test_cli_readings_json_tidy(capsys):
+
+    invoke_wetterdienst_readings_static_tidy(format="json")
+
+    stdout, stderr = capsys.readouterr()
+    response = json.loads(stdout)
+
+    station_ids = list(set([reading["station_id"] for reading in response]))
+    assert 4411 in station_ids
+    assert 7341 in station_ids
+
+    first = response[0]
+    assert list(first.keys()) == [
+        "station_id",
+        "date",
+        "parameter",
+        "element",
+        "value",
+        "quality",
+    ]
 
 
 def test_cli_readings_geojson(capsys):

--- a/wetterdienst/cli.py
+++ b/wetterdienst/cli.py
@@ -25,8 +25,8 @@ def run():
     """
     Usage:
       wetterdienst dwd stations --parameter=<parameter> --resolution=<resolution> --period=<period> [--station=<station>] [--latitude=<latitude>] [--longitude=<longitude>] [--number=<number>] [--distance=<distance>] [--persist] [--sql=<sql>] [--format=<format>]
-      wetterdienst dwd readings --parameter=<parameter> --resolution=<resolution> --station=<station> [--period=<period>] [--persist] [--date=<date>] [--sql=<sql>] [--format=<format>] [--target=<target>]
-      wetterdienst dwd readings --parameter=<parameter> --resolution=<resolution> --latitude=<latitude> --longitude=<longitude> [--period=<period>] [--number=<number>] [--distance=<distance>] [--persist] [--date=<date>] [--sql=<sql>] [--format=<format>] [--target=<target>]
+      wetterdienst dwd readings --parameter=<parameter> --resolution=<resolution> --station=<station> [--period=<period>] [--persist] [--date=<date>] [--tidy] [--sql=<sql>] [--format=<format>] [--target=<target>]
+      wetterdienst dwd readings --parameter=<parameter> --resolution=<resolution> --latitude=<latitude> --longitude=<longitude> [--period=<period>] [--number=<number>] [--distance=<distance>] [--persist] [--tidy] [--date=<date>] [--sql=<sql>] [--format=<format>] [--target=<target>]
       wetterdienst dwd about [parameters] [resolutions] [periods]
       wetterdienst dwd about coverage [--parameter=<parameter>] [--resolution=<resolution>] [--period=<period>]
       wetterdienst service [--listen=<listen>]
@@ -243,7 +243,7 @@ def run():
             period_type=read_list(options.period),
             storage=storage,
             humanize_column_names=True,
-            tidy_data=True,
+            tidy_data=options.tidy,
         )
 
         # Collect data and merge together.
@@ -251,7 +251,7 @@ def run():
             df = observations.collect_safe()
 
         except ValueError as ex:
-            log.error(ex)
+            log.exception(ex)
             sys.exit(1)
 
     # Sanity checks.

--- a/wetterdienst/dwd/pandas.py
+++ b/wetterdienst/dwd/pandas.py
@@ -164,9 +164,8 @@ class PandasDwdExtension:
 
     def tidy_up_data(self) -> pd.DataFrame:
         """
-        Function to create a tidy DataFrame by reshaping it, putting quality in a
-        separate column, so that for each timestamp there is a tuple of parameter, value
-        and quality.
+        Create a tidy DataFrame by reshaping it, putting quality in a separate column,
+        so that for each timestamp there is a tuple of parameter, value and quality.
 
         :return:            The tidied DataFrame
         """


### PR DESCRIPTION
This improvement makes it optional to output results in "tidy"-format.