### PR TITLE
Improve DWD PDF parser to extract quality information and select language

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,9 @@ Development
 - Increase efficiency by downloading only historical files with overlapping dates if start_date and end_date are given
 - Use periods dynamically depending on start and end date
 - Fix inconsistency within 1 minute precipitation data where historical files have more columns
+- Improve DWD PDF parser to extract quality information and select language.
+  Also, add an example at ``example/dwd_describe_fields.py`` as well as
+  respective documentation.
 
 0.10.1 (14.11.2020)
 ===================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ About
    Introduction <pages/welcome>
    pages/installation
    pages/data_coverage
+   pages/dwd_quality
    pages/license_and_citation
 
 

--- a/docs/pages/dwd_quality.rst
+++ b/docs/pages/dwd_quality.rst
@@ -1,0 +1,124 @@
+################
+DWD data quality
+################
+
+
+************
+Introduction
+************
+The DWD designates its data points with specific quality levels expressed as "quality bytes".
+
+- The "recent" data have not completed quality control yet.
+- The "historical" data are quality controlled measurements and observations.
+
+The following information has been taken from PDF documents on the DWD open data
+server like `data set description for historical hourly station observations of precipitation for Germany <https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/hourly/precipitation/historical/DESCRIPTION_obsgermany_climate_hourly_precipitation_historical_en.pdf>`_.
+Wetterdienst provides convenient access to the relevant details
+by using routines to parse specific sections of the PDF documents.
+
+For example, use commands like these for accessing this information::
+
+    # Historical hourly station observations of precipitation for Germany.
+    # English language.
+    wetterdienst dwd about fields --parameter=precipitation --resolution=hourly --period=historical
+
+    # Historical 10-minute station observations of pressure, air temperature (at 5cm and 2m height), humidity and dew point for Germany.
+    # German language.
+    wetterdienst dwd about fields --parameter=air_temperature --resolution=10_minutes --period=historical --language=de
+
+or have a look at the example program `dwd_describe_fields.py <https://github.com/earthobservations/wetterdienst/blob/master/example/dwd_describe_fields.py>`_.
+
+
+*******
+Details
+*******
+
+Validation and uncertainty estimate
+===================================
+Considerations of quality assurance are explained in Kaspar et al., 2013.
+
+Several steps of quality control, including automatic tests for completeness,
+temporal and internal consistency, and against statistical thresholds based
+on the software QualiMet (see Spengler, 2002) and manual inspection had been
+applied.
+
+Data are provided "as observed", no homogenization has been carried out.
+
+The history of instrumental design, observation practice, and possibly changing
+representativity has to be considered for the individual stations when interpreting
+changes in the statistical properties of the time series. It is strongly suggested
+to investigate the records of the station history which are provided together with
+the data. Note that in the 1990s many stations had the transition from manual to
+automated stations, entailing possible changes in certain statistical properties.
+
+Additional information
+======================
+When data from both directories "historical" and "recent" are used together,
+the difference in the quality control procedure should be considered.
+There are still issues to be discovered in the historical data.
+The DWD welcomes any hints to improve the data basis (see contact).
+
+
+********
+Examples
+********
+As an example, these sections display different means of
+quality designations related to ``daily``/``hourly`` and
+``10_minutes`` resolutions/products.
+
+Daily and hourly quality
+========================
+
+The quality levels "Qualitätsniveau" (QN) given here
+apply for the respective following columns. The values
+are the minima of the QN of the respective daily
+values. QN denotes the method of quality control,
+with which erroneous values are identified and apply
+for the whole set of parameters at a certain time.
+
+For the individual parameters there exist quality bytes
+in the internal DWD data base, which are not published here.
+Values identified as wrong are not published.
+
+Various methods of quality control (at different levels) are
+employed to decide which value is identified as wrong. In the
+past, different procedures have been employed.
+The quality procedures are coded as following.
+
+Quality level (column header: ``QN_``):
+
+.. code-block:: text
+
+    1- Only formal control during decoding and import
+    2- Controlled with individually defined criteria
+    3- ROUTINE control with QUALIMET and QCSY
+    5- Historic, subjective procedures
+    7- ROUTINE control, not yet corrected
+    8- Quality control outside ROUTINE
+    9- ROUTINE control, not all parameters corrected
+    10- ROUTINE control finished, respective corrections finished
+
+10 minutes quality
+==================
+
+The quality level "Qualitätsniveau" (QN) given here
+applies for the following columns. QN describes
+the method of quality control applied to a complete
+set of parameters, reported at a common time.
+
+The individual parameters of the set are connected with
+individual quality bytes in the DWD data base, which are
+not given here. Values marked as wrong are not given here.
+
+Different quality control procedures (and at different
+levels) have been applied to detect which values are
+identified as erroneous or suspicious. Over time,
+these procedures have changed.
+
+Quality level (column header: ``QN``):
+
+.. code-block:: text
+
+    1- Only formal control during decoding and import
+    2- Controlled with individually defined criteria
+    3- ROUTINE automatic control and correction with QUALIMET

--- a/example/dwd_describe_fields.py
+++ b/example/dwd_describe_fields.py
@@ -1,0 +1,47 @@
+"""
+=====
+About
+=====
+Acquire information about the data fields from DWD.
+
+"""
+import logging
+from pprint import pprint
+
+
+from wetterdienst.dwd.observations import DWDObservationMetadata
+from wetterdienst.dwd.observations import (
+    DWDObservationParameterSet,
+    DWDObservationResolution,
+    DWDObservationPeriod,
+)
+
+log = logging.getLogger()
+
+
+def fields_example():
+
+    metadata = DWDObservationMetadata(
+        parameter_set=DWDObservationParameterSet.CLIMATE_SUMMARY,
+        resolution=DWDObservationResolution.DAILY,
+        period=DWDObservationPeriod.RECENT,
+    )
+
+    # Output in JSON format.
+    # import json; print(json.dumps(metadata.describe_fields(), indent=4))
+
+    # Output in YAML format.
+    # import yaml; print(yaml.dump(dict(metadata.describe_fields()), default_style="|"))
+
+    # Output in pretty-print format.
+    pprint(dict(metadata.describe_fields(language="en")))
+    pprint(dict(metadata.describe_fields(language="de")))
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    fields_example()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dwd/observations/test_api_metadata.py
+++ b/tests/dwd/observations/test_api_metadata.py
@@ -23,7 +23,7 @@ def test_dwd_observation_metadata_discover_parameters():
     }
 
 
-def test_dwd_observation_metadata_describe_fields_kl_daily():
+def test_dwd_observation_metadata_describe_fields_kl_daily_english():
 
     metadata = DWDObservationMetadata(
         parameter_set=DWDObservationParameterSet.CLIMATE_SUMMARY,
@@ -32,6 +32,46 @@ def test_dwd_observation_metadata_describe_fields_kl_daily():
     )
 
     assert list(metadata.describe_fields().keys()) == [
+        "parameters",
+        "quality_information",
+    ]
+
+    assert list(metadata.describe_fields()["parameters"].keys()) == [
+        "STATIONS_ID",
+        "MESS_DATUM",
+        "QN_3",
+        "FX",
+        "FM",
+        "QN_4",
+        "RSK",
+        "RSKF",
+        "SDK",
+        "SHK_TAG",
+        "NM",
+        "VPM",
+        "PM",
+        "TMK",
+        "UPM",
+        "TXK",
+        "TNK",
+        "TGK",
+    ]
+
+
+def test_dwd_observation_metadata_describe_fields_kl_daily_german():
+
+    metadata = DWDObservationMetadata(
+        parameter_set=DWDObservationParameterSet.CLIMATE_SUMMARY,
+        resolution=DWDObservationResolution.DAILY,
+        period=DWDObservationPeriod.RECENT,
+    )
+
+    assert list(metadata.describe_fields().keys()) == [
+        "parameters",
+        "quality_information",
+    ]
+
+    assert list(metadata.describe_fields(language="de")["parameters"].keys()) == [
         "STATIONS_ID",
         "MESS_DATUM",
         "QN_3",
@@ -62,6 +102,11 @@ def test_dwd_observation_metadata_describe_fields_solar_hourly():
     )
 
     assert list(metadata.describe_fields().keys()) == [
+        "parameters",
+        "quality_information",
+    ]
+
+    assert list(metadata.describe_fields()["parameters"].keys()) == [
         "STATIONS_ID",
         "MESS_DATUM",
         "QN_592",
@@ -82,6 +127,11 @@ def test_dwd_observation_metadata_describe_fields_temperature_10minutes():
     )
 
     assert list(metadata.describe_fields().keys()) == [
+        "parameters",
+        "quality_information",
+    ]
+
+    assert list(metadata.describe_fields()["parameters"].keys()) == [
         "STATIONS_ID",
         "MESS_DATUM",
         "QN",

--- a/wetterdienst/cli.py
+++ b/wetterdienst/cli.py
@@ -3,6 +3,7 @@ import json
 import sys
 import logging
 from datetime import datetime, timedelta
+from pprint import pformat
 
 from docopt import docopt
 from munch import Munch
@@ -36,6 +37,7 @@ def run():
       wetterdienst dwd forecasts readings --mosmix-type=<mosmix-type> --station=<station> [--parameter=<parameter>] [--persist] [--date=<date>] [--tidy] [--sql=<sql>] [--format=<format>] [--target=<target>]
       wetterdienst dwd about [parameters] [resolutions] [periods]
       wetterdienst dwd about coverage [--parameter=<parameter>] [--resolution=<resolution>] [--period=<period>]
+      wetterdienst dwd about fields --parameter=<parameter> --resolution=<resolution> --period=<period> [--language=<language>]
       wetterdienst service [--listen=<listen>]
       wetterdienst --version
       wetterdienst (-h | --help)
@@ -56,6 +58,7 @@ def run():
       --sql=<sql>                   SQL query to apply to DataFrame.
       --format=<format>             Output format. [Default: json]
       --target=<target>             Output target for storing data into different data sinks.
+      --language=<language>         Output language. [Default: en]
       --version                     Show version information
       --debug                       Enable debug messages
       --listen=<listen>             HTTP server listen address. [Default: localhost:7890]
@@ -392,14 +395,21 @@ def about(options: Munch):
         output(DWDObservationPeriod)
 
     elif options.coverage:
-        output = json.dumps(
-            DWDObservationMetadata(
-                resolution=options.resolution,
-                parameter_set=read_list(options.parameter),
-                period=read_list(options.period),
-            ).discover_parameter_sets(),
-            indent=4,
+        metadata = DWDObservationMetadata(
+            resolution=options.resolution,
+            parameter_set=read_list(options.parameter),
+            period=read_list(options.period),
         )
+        output = json.dumps(metadata.discover_parameter_sets(), indent=4)
+        print(output)
+
+    elif options.fields:
+        metadata = DWDObservationMetadata(
+            resolution=options.resolution,
+            parameter_set=read_list(options.parameter),
+            period=read_list(options.period),
+        )
+        output = pformat(dict(metadata.describe_fields(language=options.language)))
         print(output)
 
     else:

--- a/wetterdienst/dwd/observations/api.py
+++ b/wetterdienst/dwd/observations/api.py
@@ -630,7 +630,7 @@ class DWDObservationMetadata:
 
         return available_parameters
 
-    def describe_fields(self) -> dict:
+    def describe_fields(self, language: str = "en") -> dict:
         if len(self.parameter) > 1 or len(self.resolution) > 1 or len(self.period) > 1:
             raise NotImplementedError(
                 "'describe_fields is only available for a single"
@@ -644,16 +644,24 @@ class DWDObservationMetadata:
             cdc_base=DWDCDCBase.CLIMATE_OBSERVATIONS,
         )
 
+        if language == "en":
+            file_prefix = "DESCRIPTION_"
+        elif language == "de":
+            file_prefix = "BESCHREIBUNG_"
+        else:
+            raise ValueError("Only language 'en' or 'de' supported")
+
         file_index = file_index[
-            file_index[DWDMetaColumns.FILENAME.value].str.contains("DESCRIPTION_")
+            file_index[DWDMetaColumns.FILENAME.value].str.contains(file_prefix)
         ]
 
         description_file_url = str(
             file_index[DWDMetaColumns.FILENAME.value].tolist()[0]
         )
+        log.info(f"Acquiring field information from {description_file_url}")
 
         from wetterdienst.dwd.observations.fields import read_description
 
-        document = read_description(description_file_url)
+        document = read_description(description_file_url, language=language)
 
         return document


### PR DESCRIPTION
Dear @larsrinn,

in order to support #228 a bit, this improves the DWD PDF parser to also extract quality information and select the output language. As this is rather a hack, this feature has not been documented yet. However, it is the best thing Wetterdienst has to offer so far.

In order to get started with it quickly, I added an example program at `example/dwd_describe_fields.py`.

In the long run, we should bring this information into a respective knowledgebase module within the code base itself. Even for doing that, these helper routines might prove useful.

With kind regards,
Andreas.

---

As an example, these are the PDF files on `opendata.dwd.de` I am referring to:

- [DESCRIPTION_obsgermany_climate_daily_kl_recent_en.pdf](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/daily/kl/recent/DESCRIPTION_obsgermany_climate_daily_kl_recent_en.pdf)
- [BESCHREIBUNG_obsgermany_climate_daily_kl_recent_de.pdf](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/daily/kl/recent/BESCHREIBUNG_obsgermany_climate_daily_kl_recent_de.pdf)
