### PR TITLE
Fix flaky radar tests again

### DIFF
--- a/tests/dwd/radar/test_api_historic.py
+++ b/tests/dwd/radar/test_api_historic.py
@@ -205,7 +205,7 @@ def test_radar_request_composite_historic_radolan_rw_yesterday():
     month_year = request.start_date.strftime("%m%y")
     header = (
         f"RW{date_time}10000{month_year}BY.......VS 3SW   2.28.1PR E-01INT  60GP 900x 900MF 00000001MS "  # noqa:E501,B950
-        f"..<asb,boo,ros,hnr,umd,pro,ess,fld,drs,neu,(nhb,)?oft,eis,tur,(isn,)?fbg,mem>"
+        f"..<asb,boo,ros,hnr,umd,pro,ess,fld,drs,neu,(nhb,)?oft,eis,(tur,)?(isn,)?fbg,mem>"  # noqa:E501,B950
     )
 
     assert re.match(bytes(header, encoding="ascii"), payload[:160])
@@ -771,7 +771,7 @@ def test_radar_request_radvor_re_yesterday():
     month_year = request.start_date.strftime("%m%y")
     header = (
         f"RE{date_time}10000{month_year}BY.......VS 3SW P100004HPR E-03INT  60GP 900x 900VV 000MF 00000008QN "  # noqa:E501,B950
-        f"016MS...<deasb,deboo,dedrs,deeis,deess,defbg,defld,dehnr,(deisn,)?demem(,deneu,denhb,deoft,depro,deros(,detur)?(,deumd)?)?>"  # noqa:E501,B950
+        f"016MS...<deasb,deboo,dedrs,deeis,deess,(defbg,)?defld,dehnr,(deisn,)?demem(,deneu,denhb,deoft,depro,deros(,detur)?(,deumd)?)?>"  # noqa:E501,B950
     )
 
     assert re.match(bytes(header, encoding="ascii"), payload[:200])
@@ -833,7 +833,7 @@ def test_radar_request_radvor_rq_yesterday():
     month_year = request.start_date.strftime("%m%y")
     header = (
         f"RQ{date_time}10000{month_year}BY.......VS 3SW   2.28.1PR E-01INT  60GP 900x 900VV   0MF 00000008QN ...MS "  # noqa:E501,B950
-        f"..<asb,boo,drs,eis,ess,fbg,fld,hnr,(isn,)?mem(,neu,nhb,oft,pro,ros(,tur)?(,umd)?)?>"  # noqa:E501,B950
+        f"..<asb,boo,drs,eis,ess,(fbg,)?fld,hnr,(isn,)?mem(,neu,nhb,oft,pro,ros(,tur)?(,umd)?)?>"  # noqa:E501,B950
     )
 
     assert re.match(bytes(header, encoding="ascii"), payload[:180])

--- a/tests/dwd/radar/test_api_latest.py
+++ b/tests/dwd/radar/test_api_latest.py
@@ -26,7 +26,7 @@ def test_radar_request_composite_latest_rx_reflectivity():
     month_year = datetime.utcnow().strftime("%m%y")
     header = (
         f"RX......10000{month_year}BY 8101..VS 3SW   2.28.1PR E\\+00INT   5GP 900x 900MS "  # noqa:E501,B950
-        f"..<asb,boo,ros,hnr,umd,pro,ess,fld,drs,neu,(nhb,)?oft,eis,tur,(isn,)?fbg(,mem)?>"  # noqa:E501,B950
+        f"..<(asb,)?boo,ros,hnr,umd,pro,ess,fld,drs,neu,(nhb,)?oft,eis,tur,(isn,)?fbg(,mem)?>"  # noqa:E501,B950
     )
 
     assert re.match(bytes(header, encoding="ascii"), payload[:160])


### PR DESCRIPTION
Hi there,

radar tests are more often painful than not. Some radar sites are not always reporting data, so we have to compensate.

When this keeps going on, we might want to mark them with `@pytest.mark.radar` and exclude them from being invoked on GHA by using `pytest -m "not radar"`.

The rationale behind this is: While it is okay for me to keep on improving them iteratively by compensating for missing radar sites, it will be weird when contributions from others might be coming in and CI will croak at them.

With kind regards,
Andreas.

cc @kmuehlbauer