### PR TITLE
Adjust periods to be used also for cases with defined start and end date

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -100,7 +100,11 @@ Use the ``DWDObservationData`` class in order to get hold of measurement informa
 
 This gives us the most options to work with the data, getting multiple parameters at
 once, parsed nicely into column structure with improved parameter names and stored
-automatically on the drive if wanted.
+automatically on the drive if wanted. Instead of ``start_date`` and ``end_date`` you may
+as well want to use periods to update your database once in a while with a fixed set of
+records. You can also define start_date and end_date in order to reduce the amount of
+data loaded for a request. Just make sure that you are really meeting the date range with
+the specified periods.
 
 
 Geospatial support

--- a/tests/dwd/observations/test_api_data.py
+++ b/tests/dwd/observations/test_api_data.py
@@ -153,8 +153,6 @@ def test_dwd_observation_data_time_input():
         resolution=DWDObservationResolution.DAILY,
         periods=[
             DWDObservationPeriod.HISTORICAL,
-            DWDObservationPeriod.RECENT,
-            DWDObservationPeriod.NOW,
         ],
         start_date=pd.Timestamp("1971-01-01"),
         end_date=pd.Timestamp("1971-01-01"),
@@ -174,8 +172,6 @@ def test_dwd_observation_data_time_input():
         resolution=DWDObservationResolution.DAILY,
         periods=[
             DWDObservationPeriod.HISTORICAL,
-            DWDObservationPeriod.RECENT,
-            DWDObservationPeriod.NOW,
         ],
         start_date=pd.Timestamp("1971-01-01"),
         end_date=pd.Timestamp("1971-01-01"),

--- a/wetterdienst/dwd/observations/api.py
+++ b/wetterdienst/dwd/observations/api.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import List, Union, Generator, Dict, Optional
 
 import dateparser
@@ -133,8 +133,10 @@ class DWDObservationData(WDDataCore):
             )
 
             if start_date or end_date:
-                log.warning(f"start_date and end_date filtering limited to defined "
-                            f"periods {periods}")
+                log.warning(
+                    f"start_date and end_date filtering limited to defined "
+                    f"periods {periods}"
+                )
 
         if start_date or end_date:
             # If only one date given, make the other one equal

--- a/wetterdienst/dwd/observations/api.py
+++ b/wetterdienst/dwd/observations/api.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import List, Union, Generator, Dict, Optional
 
 import dateparser
@@ -62,9 +62,9 @@ class DWDObservationData(WDDataCore):
         ],
         resolution: Union[str, DWDObservationResolution],
         periods: Optional[List[Union[str, DWDObservationPeriod]]] = None,
-        start_date: Union[None, str, Timestamp, datetime] = None,
-        end_date: Union[None, str, Timestamp, datetime] = None,
-        storage: StorageAdapter = None,
+        start_date: Optional[Union[None, str, Timestamp, datetime]] = None,
+        end_date: Optional[Union[None, str, Timestamp, datetime]] = None,
+        storage: Optional[StorageAdapter] = None,
         tidy_data: bool = True,
         humanize_column_names: bool = False,
     ) -> None:
@@ -121,9 +121,8 @@ class DWDObservationData(WDDataCore):
 
         # If any date is given, use all period types and filter, else if not period type
         # is given use all period types
-        if start_date or end_date or not periods:
+        if not periods:
             self.periods = [*DWDObservationPeriod]
-        # Otherwise period types will be parsed
         else:
             # For the case that a period_type is given, parse the period type(s)
             self.periods = (
@@ -132,6 +131,10 @@ class DWDObservationData(WDDataCore):
                 .sort_values()
                 .tolist()
             )
+
+            if start_date or end_date:
+                log.warning(f"start_date and end_date filtering limited to defined "
+                            f"periods {periods}")
 
         if start_date or end_date:
             # If only one date given, make the other one equal


### PR DESCRIPTION
The dwd observations API was adjusted to accomodate the suggest changes at #225. Now even if start and end date are defined the given  periods are used. Automated selection of periods according to start and end date was rejected due to the unclear update process of the different files of the DWD - no clear statement exists upon the timing of the publishing of new versions of recent/now packages of data.