### PR TITLE
InfluxDB export: Use a batch size of 50000 to handle larger amounts of data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Development
 
 - InfluxDB export: Fix export in non-tidy format (#230). Thanks, @wetterfrosch!
 - InfluxDB export: Use "quality" column as tag (#234). Thanks, @wetterfrosch!
+- InfluxDB export: Use a batch size of 50000 to handle larger amounts of data (#235). Thanks, @wetterfrosch!
 
 0.10.1 (14.11.2020)
 ===================

--- a/wetterdienst/util/pandas.py
+++ b/wetterdienst/util/pandas.py
@@ -184,6 +184,7 @@ class IoAccessor:
                 dataframe=df,
                 measurement=tablename,
                 tag_columns=tag_columns,
+                batch_size=50000,
             )
             log.info("Writing to InfluxDB finished")
 


### PR DESCRIPTION
### Problem
Within #235, @wetterfrosch observed errors like
```
influxdb.exceptions.InfluxDBClientError: 413: {"error":"Request Entity Too Large"}
```
when writing larger amounts of data into InfluxDB.

### Mitigation
By using `batch_size=50000`, things start working again.
