### PR TITLE
Update radar examples to use "wradlib>=1.9.0"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Development
 - InfluxDB export: Fix export in non-tidy format (#230). Thanks, @wetterfrosch!
 - InfluxDB export: Use "quality" column as tag (#234). Thanks, @wetterfrosch!
 - InfluxDB export: Use a batch size of 50000 to handle larger amounts of data (#235). Thanks, @wetterfrosch!
+- Update radar examples to use ``wradlib>=1.9.0``. Thanks, @kmuehlbauer!
 
 0.10.1 (14.11.2020)
 ===================

--- a/example/radar/radar_scan_precip.py
+++ b/example/radar/radar_scan_precip.py
@@ -24,7 +24,6 @@ Setup
 import logging
 import os
 from itertools import chain
-from tempfile import NamedTemporaryFile
 
 import wradlib as wrl
 import matplotlib.pyplot as pl
@@ -102,12 +101,8 @@ def radar_scan_precip():
         request_velocity.collect_data(), request_reflectivity.collect_data()
     )
 
-    # Collect list of filenames.
-    files = []
-    for item in results:
-        tempfile = NamedTemporaryFile(delete=False)
-        tempfile.write(item.data.read())
-        files.append(tempfile.name)
+    # Collect list of buffers.
+    files = list(map(lambda item: item.data, results))
 
     # Decode data using wradlib.
     data = wrl.io.open_odim(files)

--- a/example/radar/radar_scan_volume.py
+++ b/example/radar/radar_scan_volume.py
@@ -24,7 +24,6 @@ Setup
 import logging
 import os
 from itertools import chain
-from tempfile import NamedTemporaryFile
 
 import wradlib as wrl
 import matplotlib.pyplot as pl
@@ -102,15 +101,10 @@ def radar_scan_volume():
         request_velocity.collect_data(), request_reflectivity.collect_data()
     )
 
-    # Collect list of filenames.
-    files = []
-    for item in results:
-        tempfile = NamedTemporaryFile(delete=False)
-        tempfile.write(item.data.read())
-        files.append(tempfile.name)
+    # Collect list of buffers.
+    files = list(map(lambda item: item.data, results))
 
     # Decode data using wradlib.
-    # log.info(f"Parsing radar data for {request.site} at '{item.timestamp}'")
     data = wrl.io.open_odim(files)
 
     # Output debug information.

--- a/example/radar/radar_site_dx.py
+++ b/example/radar/radar_site_dx.py
@@ -25,7 +25,6 @@ Setup
 
 """
 import logging
-from tempfile import NamedTemporaryFile
 
 import numpy as np
 import wradlib as wrl
@@ -76,13 +75,7 @@ def radar_dx_example():
 
         # Decode data using wradlib.
         log.info(f"Parsing radar data for {request.site} at '{item.timestamp}'")
-
-        tempfile = NamedTemporaryFile()
-        tempfile.write(item.data.read())
-        data, metadata = wrl.io.read_dx(tempfile.name)
-
-        # FIXME: Make this work.
-        # data, metadata = wrl.io.read_dx(buffer.read())
+        data, metadata = wrl.io.read_dx(item.data)
 
         # Output debug information.
         radar_info(data, metadata)

--- a/example/radar/radar_sweep_hdf5.py
+++ b/example/radar/radar_sweep_hdf5.py
@@ -21,7 +21,6 @@ Setup
 
 """
 import logging
-from tempfile import NamedTemporaryFile
 
 import numpy as np
 import wradlib as wrl
@@ -67,7 +66,7 @@ def radar_hdf5_example():
         parameter=DWDRadarParameter.SWEEP_PCP_VELOCITY_H,
         start_date=DWDRadarDate.MOST_RECENT,
         site=DWDRadarSite.BOO,
-        format=DWDRadarDataFormat.HDF5,
+        fmt=DWDRadarDataFormat.HDF5,
         subset=DWDRadarDataSubset.SIMPLE,
     )
 
@@ -75,13 +74,7 @@ def radar_hdf5_example():
 
         # Decode data using wradlib.
         log.info(f"Parsing radar data for {request.site} at '{item.timestamp}'")
-
-        tempfile = NamedTemporaryFile()
-        tempfile.write(item.data.read())
-        data = wrl.io.read_opera_hdf5(tempfile.name)
-
-        # FIXME: Make this work.
-        # data = wrl.io.read_opera_hdf5(buffer.read())
+        data = wrl.io.read_opera_hdf5(item.data)
 
         # Output debug information.
         radar_info(data)

--- a/poetry.lock
+++ b/poetry.lock
@@ -417,7 +417,7 @@ description = "DuckDB embedded database"
 name = "duckdb"
 optional = true
 python-versions = "*"
-version = "0.2.3.dev297"
+version = "0.2.2"
 
 [package.dependencies]
 numpy = ">=1.14"
@@ -2092,7 +2092,7 @@ radar = ["wradlib", "pybufrkit"]
 sql = ["duckdb"]
 
 [metadata]
-content-hash = "9655c1cf2ed4a444113d4930e905b78265190c6228858a0108525fdb26b94fba"
+content-hash = "67256582481d02bf1e4d5cb22931b9790fda4a74cc5bcceac5029ef88ea27d60"
 lock-version = "1.0"
 python-versions = "^3.6.1"
 
@@ -2338,25 +2338,21 @@ docutils = [
     {file = "dogpile.cache-1.1.1.tar.gz", hash = "sha256:40147b19696f387415a7efaaa4cf8ea0b5d31bdd1b53e5187e75d48ddfee9f0e"},
 ]
 duckdb = [
-    {file = "duckdb-0.2.3.dev297-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:98247285ee856d32bf5e9172a3bfb1ef82f56769c1d5998db604fb8f753d2fbf"},
-    {file = "duckdb-0.2.3.dev297-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:5e7620ae66931bffe2a0557c8591389a1aea4faaa88bd8ec8649d4232fb7f801"},
-    {file = "duckdb-0.2.3.dev297-cp36-cp36m-win32.whl", hash = "sha256:4376d91bbe49e7ff66228ced04ac8e73d595a148c2e6319633c6f7e101fc7580"},
-    {file = "duckdb-0.2.3.dev297-cp36-cp36m-win_amd64.whl", hash = "sha256:f81b97c46993a38bfd49998377b0dc9a2dcc2320d7101636f511136dccaecb1f"},
-    {file = "duckdb-0.2.3.dev297-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2f5eb32f625cad76cb2d2134ed98f86e8ed0a4552ec865d50858ff4116b1824b"},
-    {file = "duckdb-0.2.3.dev297-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:fda4d05580102cb410ab3bd9795b0428f27b5ca284ee77c612852790f1b688b7"},
-    {file = "duckdb-0.2.3.dev297-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:15af81ed189ada26ff912f3e7f300cfc5538598087179a005bcfc27751014396"},
-    {file = "duckdb-0.2.3.dev297-cp37-cp37m-win32.whl", hash = "sha256:f2102500ba94ec66396811f1defdf03259748eaa59e4cce403c40bfc2452d975"},
-    {file = "duckdb-0.2.3.dev297-cp37-cp37m-win_amd64.whl", hash = "sha256:3d0dd4a66aa0460856063a3959b2d00606ed8429af5a96c95d35cb50eb5a09c6"},
-    {file = "duckdb-0.2.3.dev297-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b54c71e9d9015eb2e469d42ed8bac5cd34a2e223ce1724cf6524af9614122d1b"},
-    {file = "duckdb-0.2.3.dev297-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:0ea24bff02166d10357cfd53fb118db778d738347c3a6504670628b7ed38f460"},
-    {file = "duckdb-0.2.3.dev297-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:f162abe0030dc5e32487d88953fe1405c720b1abc6ecd0112830b9807bd4c7cb"},
-    {file = "duckdb-0.2.3.dev297-cp38-cp38-win32.whl", hash = "sha256:4d905d86a8a3b8a5303e64b9ecfd43867e0293f7f6bdacb39739ca1a1674a048"},
-    {file = "duckdb-0.2.3.dev297-cp38-cp38-win_amd64.whl", hash = "sha256:c5baf3627df0ddeaf5ca72d03ee123e5545df7f37b282ef351e20effe988a5d6"},
-    {file = "duckdb-0.2.3.dev297-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2ca2e7010accf9f3f8d12158dd0f92c4264bc801b757aea64759d7cefcf5eca7"},
-    {file = "duckdb-0.2.3.dev297-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:b7d099c1dff58b14fcfd03723c7b399e11905bdc6dc042d2c1c24ae41d316852"},
-    {file = "duckdb-0.2.3.dev297-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:be4defd60980cd1c9dab5b6913dfea0866edfb9b3c66d0419d8dc22f5e70123f"},
-    {file = "duckdb-0.2.3.dev297-cp39-cp39-win32.whl", hash = "sha256:629a723c0b6298dcfbf18780da3807d5e4954715a3f6259b8c715e91f57de6d0"},
-    {file = "duckdb-0.2.3.dev297-cp39-cp39-win_amd64.whl", hash = "sha256:0cbdb0e567ed8d96142951805cfadb166354b078cc063bd9c0485b9ce223346c"},
+    {file = "duckdb-0.2.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e163175505dd1c2319fd59abde912e88c1c271a0abb8b6cfef9fd9aa6bef2414"},
+    {file = "duckdb-0.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:739d34b8a79596bffe243e9c72f06c6d1a554ef4201e47806c4559f3b9897066"},
+    {file = "duckdb-0.2.2-cp36-cp36m-win32.whl", hash = "sha256:2b06496210c8dfc57a057d2698caf30144c8477500b67661ea80dca70bb58829"},
+    {file = "duckdb-0.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:3c4e1b645c1c0df8096fb8fa06c6579be966ddb78c2fa8d3dd1023569cb29c22"},
+    {file = "duckdb-0.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:680b8dee8209465bb282ec2933b858a0f3b2ae869b9c4c5d8e134fd2a33a2d99"},
+    {file = "duckdb-0.2.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:4240a2944c9e2f5c09363a90749b87a595f5ecfd7b5e92ff54e9570963f967a4"},
+    {file = "duckdb-0.2.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:459423207af01719e90b060e0f1fc80701855ecfc2dd1bce8377e1558c4f282c"},
+    {file = "duckdb-0.2.2-cp37-cp37m-win32.whl", hash = "sha256:0606dfaec0377d79e2a0117753e34798b8aa974b18d69331dbc05ab7f1b68856"},
+    {file = "duckdb-0.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:268c038eaff98de1bd9f5c94dc781fcd9402ece5e84b9564ede29eb99f38e93e"},
+    {file = "duckdb-0.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d12887e3ed8866054ea4700cadd26a95b1525a3a5b2bcd4cfbad5ea38076f89d"},
+    {file = "duckdb-0.2.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:94ca81db6a774dd61835f14b6150d4071d939ae78735b36349301447b07e91af"},
+    {file = "duckdb-0.2.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:69f47fc9b24e485b64a0465ba41b62b59a402b244c18a26d903ff94e1bf263f7"},
+    {file = "duckdb-0.2.2-cp38-cp38-win32.whl", hash = "sha256:cd3b303e74fff39339e0e2ab79e2a7aa14cafa2e89963edd9731858bd58b7982"},
+    {file = "duckdb-0.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:8d3f1d5e40715774ad13c9acb481681cbfcfe7005d785ecabeafe5cadd8a6878"},
+    {file = "duckdb-0.2.2.tar.gz", hash = "sha256:aa1be246d8fd5c9a802ae541b9b2ebebe949cfdc3d70fb0e5e5185d6c416d9bd"},
 ]
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,12 +29,12 @@ description = "Bash tab completion for argparse"
 name = "argcomplete"
 optional = false
 python-versions = "*"
-version = "1.12.1"
+version = "1.12.2"
 
 [package.dependencies]
 [package.dependencies.importlib-metadata]
 python = ">=3.6,<3.7"
-version = ">=0.23,<3"
+version = ">=0.23,<4"
 
 [package.extras]
 test = ["coverage", "flake8", "pexpect", "wheel"]
@@ -134,7 +134,7 @@ lxml = ["lxml"]
 category = "main"
 description = "Simple construction, analysis and modification of binary data."
 name = "bitstring"
-optional = false
+optional = true
 python-versions = "*"
 version = "3.1.7"
 
@@ -199,7 +199,7 @@ description = "Foreign Function Interface for Python calling C code."
 name = "cffi"
 optional = false
 python-versions = "*"
-version = "1.14.3"
+version = "1.14.4"
 
 [package.dependencies]
 pycparser = "*"
@@ -210,7 +210,7 @@ description = "Time-handling functionality from netcdf4-python"
 name = "cftime"
 optional = true
 python-versions = "*"
-version = "1.2.1"
+version = "1.3.0"
 
 [package.dependencies]
 numpy = "*"
@@ -301,7 +301,7 @@ version = "2.5.5"
 category = "main"
 description = "Composable style cycles"
 name = "cycler"
-optional = false
+optional = true
 python-versions = "*"
 version = "0.10.0"
 
@@ -405,7 +405,7 @@ description = "A caching front-end based on the Dogpile lock."
 name = "dogpile.cache"
 optional = false
 python-versions = ">=3.6"
-version = "1.0.2"
+version = "1.1.1"
 
 [package.dependencies]
 decorator = ">=4.0.0"
@@ -417,7 +417,7 @@ description = "DuckDB embedded database"
 name = "duckdb"
 optional = true
 python-versions = "*"
-version = "0.2.3.dev29"
+version = "0.2.3.dev297"
 
 [package.dependencies]
 numpy = ">=1.14"
@@ -513,11 +513,14 @@ description = "A plugin for flake8 finding likely bugs and design problems in yo
 name = "flake8-bugbear"
 optional = false
 python-versions = ">=3.6"
-version = "20.1.4"
+version = "20.11.1"
 
 [package.dependencies]
 attrs = ">=19.2.0"
 flake8 = ">=3.0.0"
+
+[package.extras]
+dev = ["coverage", "black", "hypothesis", "hypothesmith"]
 
 [[package]]
 category = "dev"
@@ -828,8 +831,8 @@ category = "dev"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 name = "jupyter-core"
 optional = false
-python-versions = "!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,>=2.7"
-version = "4.6.3"
+python-versions = ">=3.6"
+version = "4.7.0"
 
 [package.dependencies]
 pywin32 = ">=1.0"
@@ -839,7 +842,7 @@ traitlets = "*"
 category = "main"
 description = "A fast implementation of the Cassowary constraint solver"
 name = "kiwisolver"
-optional = false
+optional = true
 python-versions = ">=3.6"
 version = "1.3.1"
 
@@ -869,7 +872,7 @@ version = "1.1.1"
 category = "main"
 description = "Python plotting package"
 name = "matplotlib"
-optional = false
+optional = true
 python-versions = ">=3.6"
 version = "3.3.3"
 
@@ -1197,7 +1200,7 @@ version = "0.7.5"
 category = "main"
 description = "Python Imaging Library (Fork)"
 name = "pillow"
-optional = false
+optional = true
 python-versions = ">=3.6"
 version = "8.0.1"
 
@@ -1223,7 +1226,7 @@ description = "Python client for the Prometheus monitoring system."
 name = "prometheus-client"
 optional = false
 python-versions = "*"
-version = "0.8.0"
+version = "0.9.0"
 
 [package.extras]
 twisted = ["twisted"]
@@ -1268,7 +1271,7 @@ version = "1.9.0"
 category = "main"
 description = "Python toolkit to work with BUFR files"
 name = "pybufrkit"
-optional = false
+optional = true
 python-versions = "*"
 version = "0.2.17"
 
@@ -1869,11 +1872,11 @@ category = "main"
 description = "Fast, Extensible Progress Meter"
 name = "tqdm"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "4.51.0"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "4.53.0"
 
 [package.extras]
-dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
+dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown", "wheel"]
 
 [[package]]
 category = "main"
@@ -1972,7 +1975,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.1.0"
+version = "20.2.1"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -1982,7 +1985,7 @@ six = ">=1.9.0,<2"
 
 [package.dependencies.importlib-metadata]
 python = "<3.8"
-version = ">=0.12,<3"
+version = ">=0.12"
 
 [package.dependencies.importlib-resources]
 python = "<3.7"
@@ -2022,7 +2025,7 @@ description = "wradlib - An Open Source Library for Weather Radar Data Processin
 name = "wradlib"
 optional = true
 python-versions = "*"
-version = "1.8.2"
+version = "1.9.0"
 
 [package.dependencies]
 deprecation = "*"
@@ -2089,7 +2092,7 @@ radar = ["wradlib", "pybufrkit"]
 sql = ["duckdb"]
 
 [metadata]
-content-hash = "5929088cde87382c97d58a5b5659888f7b448f7850e8e682ca42c3349126d9ec"
+content-hash = "9655c1cf2ed4a444113d4930e905b78265190c6228858a0108525fdb26b94fba"
 lock-version = "1.0"
 python-versions = "^3.6.1"
 
@@ -2107,8 +2110,8 @@ appnope = [
     {file = "appnope-0.1.0.tar.gz", hash = "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"},
 ]
 argcomplete = [
-    {file = "argcomplete-1.12.1-py2.py3-none-any.whl", hash = "sha256:5cd1ac4fc49c29d6016fc2cc4b19a3c08c3624544503495bf25989834c443898"},
-    {file = "argcomplete-1.12.1.tar.gz", hash = "sha256:849c2444c35bb2175aea74100ca5f644c29bf716429399c0f2203bb5d9a8e4e6"},
+    {file = "argcomplete-1.12.2-py2.py3-none-any.whl", hash = "sha256:17f01a9b9b9ece3e6b07058eae737ad6e10de8b4e149105f84614783913aba71"},
+    {file = "argcomplete-1.12.2.tar.gz", hash = "sha256:de0e1282330940d52ea92a80fea2e4b9e0da1932aaa570f84d268939d1897b04"},
 ]
 argon2-cffi = [
     {file = "argon2-cffi-20.1.0.tar.gz", hash = "sha256:d8029b2d3e4b4cea770e9e5a0104dd8fa185c1724a0f01528ae4826a6d25f97d"},
@@ -2173,57 +2176,63 @@ certifi = [
     {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 cffi = [
-    {file = "cffi-1.14.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:485d029815771b9fe4fa7e1c304352fe57df6939afe835dfd0182c7c13d5e92e"},
-    {file = "cffi-1.14.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:3cb3e1b9ec43256c4e0f8d2837267a70b0e1ca8c4f456685508ae6106b1f504c"},
-    {file = "cffi-1.14.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f0620511387790860b249b9241c2f13c3a80e21a73e0b861a2df24e9d6f56730"},
-    {file = "cffi-1.14.3-cp27-cp27m-win32.whl", hash = "sha256:005f2bfe11b6745d726dbb07ace4d53f057de66e336ff92d61b8c7e9c8f4777d"},
-    {file = "cffi-1.14.3-cp27-cp27m-win_amd64.whl", hash = "sha256:2f9674623ca39c9ebe38afa3da402e9326c245f0f5ceff0623dccdac15023e05"},
-    {file = "cffi-1.14.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:09e96138280241bd355cd585148dec04dbbedb4f46128f340d696eaafc82dd7b"},
-    {file = "cffi-1.14.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:3363e77a6176afb8823b6e06db78c46dbc4c7813b00a41300a4873b6ba63b171"},
-    {file = "cffi-1.14.3-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:52bf29af05344c95136df71716bb60508bbd217691697b4307dcae681612db9f"},
-    {file = "cffi-1.14.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0ef488305fdce2580c8b2708f22d7785ae222d9825d3094ab073e22e93dfe51f"},
-    {file = "cffi-1.14.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:0b1ad452cc824665ddc682400b62c9e4f5b64736a2ba99110712fdee5f2505c4"},
-    {file = "cffi-1.14.3-cp35-cp35m-win32.whl", hash = "sha256:85ba797e1de5b48aa5a8427b6ba62cf69607c18c5d4eb747604b7302f1ec382d"},
-    {file = "cffi-1.14.3-cp35-cp35m-win_amd64.whl", hash = "sha256:e66399cf0fc07de4dce4f588fc25bfe84a6d1285cc544e67987d22663393926d"},
-    {file = "cffi-1.14.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c687778dda01832555e0af205375d649fa47afeaeeb50a201711f9a9573323b8"},
-    {file = "cffi-1.14.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:15f351bed09897fbda218e4db5a3d5c06328862f6198d4fb385f3e14e19decb3"},
-    {file = "cffi-1.14.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4d7c26bfc1ea9f92084a1d75e11999e97b62d63128bcc90c3624d07813c52808"},
-    {file = "cffi-1.14.3-cp36-cp36m-win32.whl", hash = "sha256:a624fae282e81ad2e4871bdb767e2c914d0539708c0f078b5b355258293c98b0"},
-    {file = "cffi-1.14.3-cp36-cp36m-win_amd64.whl", hash = "sha256:de31b5164d44ef4943db155b3e8e17929707cac1e5bd2f363e67a56e3af4af6e"},
-    {file = "cffi-1.14.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:03d3d238cc6c636a01cf55b9b2e1b6531a7f2f4103fabb5a744231582e68ecc7"},
-    {file = "cffi-1.14.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f92cdecb618e5fa4658aeb97d5eb3d2f47aa94ac6477c6daf0f306c5a3b9e6b1"},
-    {file = "cffi-1.14.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:22399ff4870fb4c7ef19fff6eeb20a8bbf15571913c181c78cb361024d574579"},
-    {file = "cffi-1.14.3-cp37-cp37m-win32.whl", hash = "sha256:b0358e6fefc74a16f745afa366acc89f979040e0cbc4eec55ab26ad1f6a9bfbc"},
-    {file = "cffi-1.14.3-cp37-cp37m-win_amd64.whl", hash = "sha256:6642f15ad963b5092d65aed022d033c77763515fdc07095208f15d3563003869"},
-    {file = "cffi-1.14.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c2a33558fdbee3df370399fe1712d72464ce39c66436270f3664c03f94971aff"},
-    {file = "cffi-1.14.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2791f68edc5749024b4722500e86303a10d342527e1e3bcac47f35fbd25b764e"},
-    {file = "cffi-1.14.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:529c4ed2e10437c205f38f3691a68be66c39197d01062618c55f74294a4a4828"},
-    {file = "cffi-1.14.3-cp38-cp38-win32.whl", hash = "sha256:3b8eaf915ddc0709779889c472e553f0d3e8b7bdf62dab764c8921b09bf94522"},
-    {file = "cffi-1.14.3-cp38-cp38-win_amd64.whl", hash = "sha256:bbd2f4dfee1079f76943767fce837ade3087b578aeb9f69aec7857d5bf25db15"},
-    {file = "cffi-1.14.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5d9a7dc7cf8b1101af2602fe238911bcc1ac36d239e0a577831f5dac993856e9"},
-    {file = "cffi-1.14.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:cc75f58cdaf043fe6a7a6c04b3b5a0e694c6a9e24050967747251fb80d7bce0d"},
-    {file = "cffi-1.14.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:bf39a9e19ce7298f1bd6a9758fa99707e9e5b1ebe5e90f2c3913a47bc548747c"},
-    {file = "cffi-1.14.3-cp39-cp39-win32.whl", hash = "sha256:d80998ed59176e8cba74028762fbd9b9153b9afc71ea118e63bbf5d4d0f9552b"},
-    {file = "cffi-1.14.3-cp39-cp39-win_amd64.whl", hash = "sha256:c150eaa3dadbb2b5339675b88d4573c1be3cb6f2c33a6c83387e10cc0bf05bd3"},
-    {file = "cffi-1.14.3.tar.gz", hash = "sha256:f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591"},
+    {file = "cffi-1.14.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775"},
+    {file = "cffi-1.14.4-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2c24d61263f511551f740d1a065eb0212db1dbbbbd241db758f5244281590c06"},
+    {file = "cffi-1.14.4-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26"},
+    {file = "cffi-1.14.4-cp27-cp27m-win32.whl", hash = "sha256:5cf4be6c304ad0b6602f5c4e90e2f59b47653ac1ed9c662ed379fe48a8f26b0c"},
+    {file = "cffi-1.14.4-cp27-cp27m-win_amd64.whl", hash = "sha256:f60567825f791c6f8a592f3c6e3bd93dd2934e3f9dac189308426bd76b00ef3b"},
+    {file = "cffi-1.14.4-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d"},
+    {file = "cffi-1.14.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca"},
+    {file = "cffi-1.14.4-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:51a8b381b16ddd370178a65360ebe15fbc1c71cf6f584613a7ea08bfad946698"},
+    {file = "cffi-1.14.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1d2c4994f515e5b485fd6d3a73d05526aa0fcf248eb135996b088d25dfa1865b"},
+    {file = "cffi-1.14.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293"},
+    {file = "cffi-1.14.4-cp35-cp35m-win32.whl", hash = "sha256:594234691ac0e9b770aee9fcdb8fa02c22e43e5c619456efd0d6c2bf276f3eb2"},
+    {file = "cffi-1.14.4-cp35-cp35m-win_amd64.whl", hash = "sha256:64081b3f8f6f3c3de6191ec89d7dc6c86a8a43911f7ecb422c60e90c70be41c7"},
+    {file = "cffi-1.14.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f803eaa94c2fcda012c047e62bc7a51b0bdabda1cad7a92a522694ea2d76e49f"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:105abaf8a6075dc96c1fe5ae7aae073f4696f2905fde6aeada4c9d2926752362"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0638c3ae1a0edfb77c6765d487fee624d2b1ee1bdfeffc1f0b58c64d149e7eec"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b"},
+    {file = "cffi-1.14.4-cp36-cp36m-win32.whl", hash = "sha256:155136b51fd733fa94e1c2ea5211dcd4c8879869008fc811648f16541bf99668"},
+    {file = "cffi-1.14.4-cp36-cp36m-win_amd64.whl", hash = "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009"},
+    {file = "cffi-1.14.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb"},
+    {file = "cffi-1.14.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d"},
+    {file = "cffi-1.14.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03"},
+    {file = "cffi-1.14.4-cp37-cp37m-win32.whl", hash = "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e"},
+    {file = "cffi-1.14.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35"},
+    {file = "cffi-1.14.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d"},
+    {file = "cffi-1.14.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b"},
+    {file = "cffi-1.14.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53"},
+    {file = "cffi-1.14.4-cp38-cp38-win32.whl", hash = "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d"},
+    {file = "cffi-1.14.4-cp38-cp38-win_amd64.whl", hash = "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375"},
+    {file = "cffi-1.14.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909"},
+    {file = "cffi-1.14.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd"},
+    {file = "cffi-1.14.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a"},
+    {file = "cffi-1.14.4-cp39-cp39-win32.whl", hash = "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3"},
+    {file = "cffi-1.14.4-cp39-cp39-win_amd64.whl", hash = "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b"},
+    {file = "cffi-1.14.4.tar.gz", hash = "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c"},
 ]
 cftime = [
-    {file = "cftime-1.2.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1381b4ba9e53e932472a7da574d8553477d15aa8bc647425cb0110db4f4dfdac"},
-    {file = "cftime-1.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5ddbc9514719e6b964cd9fd5f306679af09f53f8f6792888d62448b1b6d764d9"},
-    {file = "cftime-1.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:7a2b0a3821071560d2ae01236215be6dd7bfa81328823ec602f37496aeea35d0"},
-    {file = "cftime-1.2.1-cp36-none-win32.whl", hash = "sha256:33b5180650a4aace7ce021af4af0f278477be94276da7b7c8ae51b49e5a022a9"},
-    {file = "cftime-1.2.1-cp36-none-win_amd64.whl", hash = "sha256:eba48c7e47468f16cb1c8caf6ce772e39d067100e3893b94cf7dd394ec23d943"},
-    {file = "cftime-1.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3c23e4b0109ff7b878fc60d7ed9131bdc8c2c8ea098c2f9200e19c596ffe0019"},
-    {file = "cftime-1.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:7cb8defe607da8cacbd4ebb3b983571732b0476be98decda37595ae49108797f"},
-    {file = "cftime-1.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fec04d3bed7078f1a62db7dab12790b96eb3b48e3522ad0c28c9d36175b99f89"},
-    {file = "cftime-1.2.1-cp37-none-win32.whl", hash = "sha256:d6bf1c1954660a500d11ca047151205182212dfaa20b2eb0c6dfe372140868fc"},
-    {file = "cftime-1.2.1-cp37-none-win_amd64.whl", hash = "sha256:08bc1af49f92a31b8b58a4d8b61bf457e17832eb3440eac7eec79afca7d0be59"},
-    {file = "cftime-1.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bf797e0c71631406a19fe2a69ff311cb9be10610c30e02f7f75920e779076840"},
-    {file = "cftime-1.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b694aead858872b7102f860d00439147df1d867ea8fbaafe0be787f7fa59c264"},
-    {file = "cftime-1.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8390ea907988b11a93fa263365ca6a4ea829378b1e24e48b1087803d6bb6089c"},
-    {file = "cftime-1.2.1-cp38-none-win32.whl", hash = "sha256:b4bb4ae6c6e44f4d8bc080042515e70423bec20f5279e49b564c0238dc4319ad"},
-    {file = "cftime-1.2.1-cp38-none-win_amd64.whl", hash = "sha256:650e3ca771f6b6e9d6984af007c1045eb77eae40f9342e2982a45162a097cac5"},
-    {file = "cftime-1.2.1.tar.gz", hash = "sha256:ab5d5076f7d3e699758a244ada7c66da96bae36e22b9e351ce0ececc36f0a57f"},
+    {file = "cftime-1.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c858e811cd882768dc07954a4ad9b52e145646a89ebafad18ed3eb2b03cc17a8"},
+    {file = "cftime-1.3.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:895919e2eac55966ad29f4797aaf39b123facf396f69f70d13f056739d544686"},
+    {file = "cftime-1.3.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:200cec673f0a53c54ba2a267fc4bf50ade145c097d0616ab214db72aab1453a1"},
+    {file = "cftime-1.3.0-cp36-none-win32.whl", hash = "sha256:318d81d216b834dc3fa3cb9ec7a42f0c57f3fc64e288376f5452b81ef9c907d6"},
+    {file = "cftime-1.3.0-cp36-none-win_amd64.whl", hash = "sha256:9fef4a646f34d9379dc8502479d370017ec3858f0f6e0372df9cb18f4729b73b"},
+    {file = "cftime-1.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ea1dd0ba9a73bed855818d94005e02e1e9e45f4beef10d3126a232e4d7ca9271"},
+    {file = "cftime-1.3.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:bb4999df1b221873cd698519b3a8a858e13fbae6e0b2541bbef251152266e554"},
+    {file = "cftime-1.3.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c357779291d99f204978bfc63d1a099184279606661739760b3edb2632c474b2"},
+    {file = "cftime-1.3.0-cp37-none-win32.whl", hash = "sha256:956748bf1700b4c9c41ae2cbb4d971ad082d713f5958c9539c9b04b8b484660d"},
+    {file = "cftime-1.3.0-cp37-none-win_amd64.whl", hash = "sha256:57ac1d8820b37d91a34dc79e15777da8950856cd68ed3b642de200de302213f1"},
+    {file = "cftime-1.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:771090fe99b01c1eba8a5b1e5ba2439edde8eb2bf1fbd9bcfbb3b1b27466fc74"},
+    {file = "cftime-1.3.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d3b85a7bd725709dd090a60323c57beb735a2db4dbd1d13d5d7c508906fba2a6"},
+    {file = "cftime-1.3.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4beedc3c39d628257bbba6fb220b6284f3e88e1c4a53fa3d6e6410eded079c16"},
+    {file = "cftime-1.3.0-cp38-none-win32.whl", hash = "sha256:338192cc1b45063dc4f54bb43824f0a1c23a85da6999d1abcda05cc918f5ec90"},
+    {file = "cftime-1.3.0-cp38-none-win_amd64.whl", hash = "sha256:68316b20289158869060124d33018df4e2cd12d24aa1c72e15625ae34a5d84a4"},
+    {file = "cftime-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50f36442165ad462e7cbac8dc7b8696f0bc5e6b8e56483770818cb3137be0da2"},
+    {file = "cftime-1.3.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:afed15aedc8bd9613328d36f0fc4342c168db5a70a2713c0c803d8b821d54995"},
+    {file = "cftime-1.3.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4cb924be13665fdb1fcdc52cc251cf6565ea25fb3376133b100352a5d0dd3c55"},
+    {file = "cftime-1.3.0-cp39-none-win32.whl", hash = "sha256:a9bd0d0bdd2ba927e4b852fa4bd8a89bcbf08e0504711fb63f2de2ed263c8982"},
+    {file = "cftime-1.3.0-cp39-none-win_amd64.whl", hash = "sha256:085e1af41db22a543c40d4a294b63db80bdf4ee8933273ea6083a0f9cd9d74d7"},
+    {file = "cftime-1.3.0.tar.gz", hash = "sha256:8d6a1144f43b9d7a180d7ceb3aa8015b7133c615fbac231bed184a91129f0207"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
@@ -2326,24 +2335,28 @@ docutils = [
     {file = "docutils-0.16.tar.gz", hash = "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"},
 ]
 "dogpile.cache" = [
-    {file = "dogpile.cache-1.0.2.tar.gz", hash = "sha256:64fda39d25b46486a4876417ca03a4af06f35bfadba9f59613f9b3d748aa21ef"},
+    {file = "dogpile.cache-1.1.1.tar.gz", hash = "sha256:40147b19696f387415a7efaaa4cf8ea0b5d31bdd1b53e5187e75d48ddfee9f0e"},
 ]
 duckdb = [
-    {file = "duckdb-0.2.3.dev29-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:09cfceac07e88e3a0949857d09772c048ed1e027517be56a95e22723a90c7b8a"},
-    {file = "duckdb-0.2.3.dev29-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1d52b101935e88f6a8268bffa4d42b0c455421bff95448dd233d2bc5ab859251"},
-    {file = "duckdb-0.2.3.dev29-cp36-cp36m-win32.whl", hash = "sha256:213b89536f0cd74b9974b864d829ed6de23434e7a551c628a10764d4a75f59eb"},
-    {file = "duckdb-0.2.3.dev29-cp36-cp36m-win_amd64.whl", hash = "sha256:94b83aa9d2885ccdbb064594e85ff0d039fb8ddb929848abd74a62663ebef418"},
-    {file = "duckdb-0.2.3.dev29-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:08f5b51e6aab5c2e7e0a7f0fbf26a5eeb12718614cf1be146485d33767dc501b"},
-    {file = "duckdb-0.2.3.dev29-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:7faefe141005f8d7fdd0681de8f44caa2aa7dea9e193874f82dd617489677e7a"},
-    {file = "duckdb-0.2.3.dev29-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ef2154cfd55a4bbfa8c7c0e9750cb13084cb48a92bc0b568d50e3a26833d1df6"},
-    {file = "duckdb-0.2.3.dev29-cp37-cp37m-win32.whl", hash = "sha256:910e776c4c87bde84ded83df3f27a68805460034a8f081bb1b647ba7dc3d30cb"},
-    {file = "duckdb-0.2.3.dev29-cp37-cp37m-win_amd64.whl", hash = "sha256:704df07d7396b8ef0719e4d6d621a6dfb6f1c6e35a4e4c0822fca83b25d18afb"},
-    {file = "duckdb-0.2.3.dev29-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:737fd00f9d890499b0a416061d19170afe3fc2098e03fc62d2d82abe00ed7c01"},
-    {file = "duckdb-0.2.3.dev29-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:87537c088ba2c508a47aa625838aa9a5fd5827052d57a7166af77a81203e8707"},
-    {file = "duckdb-0.2.3.dev29-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:9d666c2de0ced04fd3ef00ea947f46e7ddc65a97b52282630b725f29491318e9"},
-    {file = "duckdb-0.2.3.dev29-cp38-cp38-win32.whl", hash = "sha256:b5f47af3252a4981f71c34bde71d5a5f64a2c9981c6dbfb1339535d661493799"},
-    {file = "duckdb-0.2.3.dev29-cp38-cp38-win_amd64.whl", hash = "sha256:f8c8f7eac5e31f67cefd325ca6eacb2836e77e3702caef248a54d0fbc4782fb4"},
-    {file = "duckdb-0.2.3.dev29.tar.gz", hash = "sha256:1aee8192998deaaf37e9d2398235007ae8b715eb21ed23cd9e6a9482eef650f6"},
+    {file = "duckdb-0.2.3.dev297-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:98247285ee856d32bf5e9172a3bfb1ef82f56769c1d5998db604fb8f753d2fbf"},
+    {file = "duckdb-0.2.3.dev297-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:5e7620ae66931bffe2a0557c8591389a1aea4faaa88bd8ec8649d4232fb7f801"},
+    {file = "duckdb-0.2.3.dev297-cp36-cp36m-win32.whl", hash = "sha256:4376d91bbe49e7ff66228ced04ac8e73d595a148c2e6319633c6f7e101fc7580"},
+    {file = "duckdb-0.2.3.dev297-cp36-cp36m-win_amd64.whl", hash = "sha256:f81b97c46993a38bfd49998377b0dc9a2dcc2320d7101636f511136dccaecb1f"},
+    {file = "duckdb-0.2.3.dev297-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2f5eb32f625cad76cb2d2134ed98f86e8ed0a4552ec865d50858ff4116b1824b"},
+    {file = "duckdb-0.2.3.dev297-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:fda4d05580102cb410ab3bd9795b0428f27b5ca284ee77c612852790f1b688b7"},
+    {file = "duckdb-0.2.3.dev297-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:15af81ed189ada26ff912f3e7f300cfc5538598087179a005bcfc27751014396"},
+    {file = "duckdb-0.2.3.dev297-cp37-cp37m-win32.whl", hash = "sha256:f2102500ba94ec66396811f1defdf03259748eaa59e4cce403c40bfc2452d975"},
+    {file = "duckdb-0.2.3.dev297-cp37-cp37m-win_amd64.whl", hash = "sha256:3d0dd4a66aa0460856063a3959b2d00606ed8429af5a96c95d35cb50eb5a09c6"},
+    {file = "duckdb-0.2.3.dev297-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b54c71e9d9015eb2e469d42ed8bac5cd34a2e223ce1724cf6524af9614122d1b"},
+    {file = "duckdb-0.2.3.dev297-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:0ea24bff02166d10357cfd53fb118db778d738347c3a6504670628b7ed38f460"},
+    {file = "duckdb-0.2.3.dev297-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:f162abe0030dc5e32487d88953fe1405c720b1abc6ecd0112830b9807bd4c7cb"},
+    {file = "duckdb-0.2.3.dev297-cp38-cp38-win32.whl", hash = "sha256:4d905d86a8a3b8a5303e64b9ecfd43867e0293f7f6bdacb39739ca1a1674a048"},
+    {file = "duckdb-0.2.3.dev297-cp38-cp38-win_amd64.whl", hash = "sha256:c5baf3627df0ddeaf5ca72d03ee123e5545df7f37b282ef351e20effe988a5d6"},
+    {file = "duckdb-0.2.3.dev297-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2ca2e7010accf9f3f8d12158dd0f92c4264bc801b757aea64759d7cefcf5eca7"},
+    {file = "duckdb-0.2.3.dev297-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:b7d099c1dff58b14fcfd03723c7b399e11905bdc6dc042d2c1c24ae41d316852"},
+    {file = "duckdb-0.2.3.dev297-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:be4defd60980cd1c9dab5b6913dfea0866edfb9b3c66d0419d8dc22f5e70123f"},
+    {file = "duckdb-0.2.3.dev297-cp39-cp39-win32.whl", hash = "sha256:629a723c0b6298dcfbf18780da3807d5e4954715a3f6259b8c715e91f57de6d0"},
+    {file = "duckdb-0.2.3.dev297-cp39-cp39-win_amd64.whl", hash = "sha256:0cbdb0e567ed8d96142951805cfadb166354b078cc063bd9c0485b9ce223346c"},
 ]
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
@@ -2371,8 +2384,8 @@ flake8-black = [
     {file = "flake8-black-0.2.1.tar.gz", hash = "sha256:f26651bc10db786c03f4093414f7c9ea982ed8a244cec323c984feeffdf4c118"},
 ]
 flake8-bugbear = [
-    {file = "flake8-bugbear-20.1.4.tar.gz", hash = "sha256:bd02e4b009fb153fe6072c31c52aeab5b133d508095befb2ffcf3b41c4823162"},
-    {file = "flake8_bugbear-20.1.4-py36.py37.py38-none-any.whl", hash = "sha256:a3ddc03ec28ba2296fc6f89444d1c946a6b76460f859795b35b77d4920a51b63"},
+    {file = "flake8-bugbear-20.11.1.tar.gz", hash = "sha256:528020129fea2dea33a466b9d64ab650aa3e5f9ffc788b70ea4bc6cf18283538"},
+    {file = "flake8_bugbear-20.11.1-py36.py37.py38-none-any.whl", hash = "sha256:f35b8135ece7a014bc0aee5b5d485334ac30a6da48494998cc1fabf7ec70d703"},
 ]
 flake8-polyfill = [
     {file = "flake8-polyfill-1.0.2.tar.gz", hash = "sha256:e44b087597f6da52ec6393a709e7108b2905317d0c0b744cdca6208e670d8eda"},
@@ -2503,8 +2516,8 @@ jupyter-client = [
     {file = "jupyter_client-6.1.7.tar.gz", hash = "sha256:49e390b36fe4b4226724704ea28d9fb903f1a3601b6882ce3105221cd09377a1"},
 ]
 jupyter-core = [
-    {file = "jupyter_core-4.6.3-py2.py3-none-any.whl", hash = "sha256:a4ee613c060fe5697d913416fc9d553599c05e4492d58fac1192c9a6844abb21"},
-    {file = "jupyter_core-4.6.3.tar.gz", hash = "sha256:394fd5dd787e7c8861741880bdf8a00ce39f95de5d18e579c74b882522219e7e"},
+    {file = "jupyter_core-4.7.0-py3-none-any.whl", hash = "sha256:0a451c9b295e4db772bdd8d06f2f1eb31caeec0e81fbb77ba37d4a3024e3b315"},
+    {file = "jupyter_core-4.7.0.tar.gz", hash = "sha256:aa1f9496ab3abe72da4efe0daab0cb2233997914581f9a071e07498c6add8ed3"},
 ]
 kiwisolver = [
     {file = "kiwisolver-1.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fd34fbbfbc40628200730bc1febe30631347103fc8d3d4fa012c21ab9c11eca9"},
@@ -2884,8 +2897,8 @@ pluggy = [
     {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
 ]
 prometheus-client = [
-    {file = "prometheus_client-0.8.0-py2.py3-none-any.whl", hash = "sha256:983c7ac4b47478720db338f1491ef67a100b474e3bc7dafcbaefb7d0b8f9b01c"},
-    {file = "prometheus_client-0.8.0.tar.gz", hash = "sha256:c6e6b706833a6bd1fd51711299edee907857be10ece535126a158f911ee80915"},
+    {file = "prometheus_client-0.9.0-py2.py3-none-any.whl", hash = "sha256:b08c34c328e1bf5961f0b4352668e6c8f145b4a087e09b7296ef62cbe4693d35"},
+    {file = "prometheus_client-0.9.0.tar.gz", hash = "sha256:9da7b32f02439d8c04f7777021c304ed51d9ec180604700c1ba72a4d44dceb03"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.8-py3-none-any.whl", hash = "sha256:7debb9a521e0b1ee7d2fe96ee4bd60ef03c6492784de0547337ca4433e46aa63"},
@@ -3356,8 +3369,8 @@ tornado = [
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
 ]
 tqdm = [
-    {file = "tqdm-4.51.0-py2.py3-none-any.whl", hash = "sha256:9ad44aaf0fc3697c06f6e05c7cf025dd66bc7bcb7613c66d85f4464c47ac8fad"},
-    {file = "tqdm-4.51.0.tar.gz", hash = "sha256:ef54779f1c09f346b2b5a8e5c61f96fbcb639929e640e59f8cf810794f406432"},
+    {file = "tqdm-4.53.0-py2.py3-none-any.whl", hash = "sha256:5ff3f5232b19fa4c5531641e480b7fad4598819f708a32eb815e6ea41c5fa313"},
+    {file = "tqdm-4.53.0.tar.gz", hash = "sha256:3d3f1470d26642e88bd3f73353cb6ff4c51ef7d5d7efef763238f4bc1f7e4e81"},
 ]
 traitlets = [
     {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},
@@ -3419,8 +3432,8 @@ uvloop = [
     {file = "uvloop-0.14.0.tar.gz", hash = "sha256:123ac9c0c7dd71464f58f1b4ee0bbd81285d96cdda8bc3519281b8973e3a461e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.1.0-py2.py3-none-any.whl", hash = "sha256:b0011228208944ce71052987437d3843e05690b2f23d1c7da4263fde104c97a2"},
-    {file = "virtualenv-20.1.0.tar.gz", hash = "sha256:b8d6110f493af256a40d65e29846c69340a947669eec8ce784fcf3dd3af28380"},
+    {file = "virtualenv-20.2.1-py2.py3-none-any.whl", hash = "sha256:07cff122e9d343140366055f31be4dcd61fd598c69d11cd33a9d9c8df4546dd7"},
+    {file = "virtualenv-20.2.1.tar.gz", hash = "sha256:e0aac7525e880a429764cefd3aaaff54afb5d9f25c82627563603f5d7de5a6e5"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
@@ -3455,7 +3468,7 @@ websockets = [
     {file = "websockets-8.1.tar.gz", hash = "sha256:5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f"},
 ]
 wradlib = [
-    {file = "wradlib-1.8.2.tar.gz", hash = "sha256:565bae9662707d829ae44c8f88b6be60b8e58645034470ddf8288ba16adf10bb"},
+    {file = "wradlib-1.9.0.tar.gz", hash = "sha256:5fbdcf69e9c403f825bb3447347d98712e75b93c8faf021ac95b2ba01d465c7a"},
 ]
 xarray = [
     {file = "xarray-0.16.1-py3-none-any.whl", hash = "sha256:72aa610a8d9ece583c3e94ad6a879aae2a33b632fea445b6685a14f288cbd9c6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ sphinx-autodoc-typehints        = { version = "^1.11.0", optional = true }
 sphinxcontrib-svg2pdfconverter  = { version = "^1.1.0", optional = true }
 tomlkit                         = { version = "^0.7.0", optional = true }
 
-duckdb                          = { version = "^0.2.2.dev254", optional = true }
+duckdb                          = { version = "^0.2.2", optional = true }
 influxdb                        = { version = "^5.3.0", optional = true }
 crate                           = { version = "^0.25.0", optional = true, extras = ["sqlalchemy"] }
 mysqlclient                     = { version = "^2.0.1", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ psycopg2-binary                 = { version = "^2.8.6", optional = true }
 fastapi                         = { version = "^0.61.1", optional = true }
 uvicorn                         = { version = "^0.11.8", optional = true }
 
-wradlib                         = { version = "^1.8.0", optional = true }
+wradlib                         = { version = "^1.9.0", optional = true }
 pybufrkit                       = { version = "^0.2.17", optional = true }
 
 
@@ -150,9 +150,6 @@ pytest-dictsdiff = "^0.5.8"
 nbconvert = ">=5.0, <6.0"
 mock = "^4.0.2"
 surrogate = "^0.1"
-matplotlib = "^3.3.2"
-pybufrkit = "^0.2.17"
-# wradlib = "^1.8.0"
 
 [tool.poetry.scripts]
 wetterdienst = 'wetterdienst.cli:run'

--- a/tests/dwd/observations/test_api_data.py
+++ b/tests/dwd/observations/test_api_data.py
@@ -102,7 +102,7 @@ def test_dwd_observation_data_parameter():
 
     assert request.parameters == [
         (
-            DWDObservationParameterSetStructure.DAILY.CLIMATE_SUMMARY.PRECIPITATION_HEIGHT,  # Noqa: E501
+            DWDObservationParameterSetStructure.DAILY.CLIMATE_SUMMARY.PRECIPITATION_HEIGHT,  # noqa: B950, E501
             DWDObservationParameterSet.CLIMATE_SUMMARY,
         )
     ]

--- a/tests/dwd/test_pandas.py
+++ b/tests/dwd/test_pandas.py
@@ -303,6 +303,7 @@ def test_export_influxdb_tabular():
             dataframe=mock.ANY,
             measurement="weather",
             tag_columns=["station_id", "quality"],
+            batch_size=50000,
         )
 
 
@@ -335,4 +336,5 @@ def test_export_influxdb_tidy():
             dataframe=mock.ANY,
             measurement="weather",
             tag_columns=["station_id", "quality", "parameter", "element"],
+            batch_size=50000,
         )

--- a/wetterdienst/dwd/observations/parser.py
+++ b/wetterdienst/dwd/observations/parser.py
@@ -107,7 +107,7 @@ def _parse_climate_observations_data(
         data = data.rename(
             columns={
                 "MESS_DATUM_WOZ": (
-                    DWDObservationParameterSetStructure.HOURLY.SOLAR.TRUE_LOCAL_TIME.value  # Noqa: E501
+                    DWDObservationParameterSetStructure.HOURLY.SOLAR.TRUE_LOCAL_TIME.value  # noqa: B950, E501
                 ),
             }
         )


### PR DESCRIPTION
Some `wradlib` reader functions are now able to consume file-like objects. So, the use of `tempfile` can be removed at some places. Thanks, @kmuehlbauer!

Closes #251.
