### PR TITLE
Efficient historical data acquistion with dynamic periods

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Development
 - InfluxDB export: Use a batch size of 50000 to handle larger amounts of data (#235). Thanks, @wetterfrosch!
 - Update radar examples to use ``wradlib>=1.9.0``. Thanks, @kmuehlbauer!
 - Change wherever possible column type to category
+- Increase efficiency by downloading only historical files with overlapping dates if start_date and end_date are given
+- Fix inconsistency within 1 minute precipitation data where historical files have more columns
 
 0.10.1 (14.11.2020)
 ===================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Development
 - Update radar examples to use ``wradlib>=1.9.0``. Thanks, @kmuehlbauer!
 - Change wherever possible column type to category
 - Increase efficiency by downloading only historical files with overlapping dates if start_date and end_date are given
+- Use periods dynamically depending on start and end date
 - Fix inconsistency within 1 minute precipitation data where historical files have more columns
 
 0.10.1 (14.11.2020)

--- a/poetry.lock
+++ b/poetry.lock
@@ -395,7 +395,7 @@ stevedore = ">=3.0.0"
 
 [[package]]
 name = "duckdb"
-version = "0.2.3.dev519"
+version = "0.2.3"
 description = "DuckDB embedded database"
 category = "main"
 optional = true
@@ -2037,7 +2037,7 @@ sql = ["duckdb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "a3950529b361332a740d8c479dac8aa687c5ed374a24084e0f68c3b30200083b"
+content-hash = "e96075b2a20b900771a31ee5de0ab3691d48e3b324b4d62cdb1033238941a709"
 
 [metadata.files]
 alabaster = [
@@ -2280,26 +2280,26 @@ docutils = [
     {file = "dogpile.cache-1.1.1.tar.gz", hash = "sha256:40147b19696f387415a7efaaa4cf8ea0b5d31bdd1b53e5187e75d48ddfee9f0e"},
 ]
 duckdb = [
-    {file = "duckdb-0.2.3.dev519-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:7702dd3a3b8a3cb3ae42a7f1074de4088c9e2dd29c83334adbe36ca08ed312d5"},
-    {file = "duckdb-0.2.3.dev519-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:e846c69d23bb894e70e8925858caf116ad490e276f432f9f02f09f435b7c73fc"},
-    {file = "duckdb-0.2.3.dev519-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:d45d08fcedd28e5d02fcefc77de9643343df0600263b8aaea3fcd44c4f20c154"},
-    {file = "duckdb-0.2.3.dev519-cp36-cp36m-win32.whl", hash = "sha256:da2f599060c9f7ee59f99c95d6b768fb786d2d0554f678a51a489ce23995199c"},
-    {file = "duckdb-0.2.3.dev519-cp36-cp36m-win_amd64.whl", hash = "sha256:41270dda900ac34ebff3caad30a80ee460401e532f88c06dc2313d34c0866988"},
-    {file = "duckdb-0.2.3.dev519-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bd29df1e01eabcd1880d30ed501c2072ff91e32f66ca33e8ab6e65a214358a54"},
-    {file = "duckdb-0.2.3.dev519-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ed15444c53177886af97adfa6979832711d2838d9a50cf016f7878d81516f766"},
-    {file = "duckdb-0.2.3.dev519-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2cb24cd67ae2243e1a5e0ed113747ea957cc0805a524e8af4ce9b13d2e422502"},
-    {file = "duckdb-0.2.3.dev519-cp37-cp37m-win32.whl", hash = "sha256:d76f5e134569792eb09cfeac0256bc7e1a844b37753b544d40c17e5a946a3569"},
-    {file = "duckdb-0.2.3.dev519-cp37-cp37m-win_amd64.whl", hash = "sha256:3e781603abd74232b7bce66778e522e8dc7d0f2b718928845b1c287acd7973cd"},
-    {file = "duckdb-0.2.3.dev519-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7c443c1589cd77f7dcbd35243fb3bbf5583542ae377e26e54ac41577549c70b5"},
-    {file = "duckdb-0.2.3.dev519-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:655f3759a2b14ad4fdeaabdeb7763da0f8312e8a0042c0f9d11068958fbadd3e"},
-    {file = "duckdb-0.2.3.dev519-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:2be35fd6cb9a2bfa4406a110030348607c42e922eaefdc854e1da64e5c1d0a59"},
-    {file = "duckdb-0.2.3.dev519-cp38-cp38-win32.whl", hash = "sha256:db579bd54347e9e378d4159a302f0271628d899bf076cc6a8ef96b8c80714afc"},
-    {file = "duckdb-0.2.3.dev519-cp38-cp38-win_amd64.whl", hash = "sha256:9754c294acd261f8cba415d4b82b3bb367e74e71003c56c0b534fecdc9cf8a07"},
-    {file = "duckdb-0.2.3.dev519-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0369c8403968147940bd324f1e47cc5ba0747f4d6596c3613a115480d4d2a9da"},
-    {file = "duckdb-0.2.3.dev519-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:42d5db66f87f7803a759addf1e911d3cddf50ca992f6ff345d450dedbd303280"},
-    {file = "duckdb-0.2.3.dev519-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:fe6033ad78c961b3e011722f66daf7b52705788cb2894259b0f2cb203afb4436"},
-    {file = "duckdb-0.2.3.dev519-cp39-cp39-win32.whl", hash = "sha256:0ea4eee3ccc6a2d02ca6e76b176aed35fec438feb9f93600ed2e9ca0a596425c"},
-    {file = "duckdb-0.2.3.dev519-cp39-cp39-win_amd64.whl", hash = "sha256:c829b8f57d05385cbddd0913a743ce45e77c6ef945a0f216ee8d8ecdf673ff96"},
+    {file = "duckdb-0.2.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:7841b275466b1611d68660425b89739795155a58fbd9f0a39b058e978af3598c"},
+    {file = "duckdb-0.2.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:2aee22d86ca689561e7bf4eda11d561084a361964cba3d0a3b4ca17795ccc288"},
+    {file = "duckdb-0.2.3-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:2637df59d69cc3aa2d5e4eb7a50de59fcdc0ff20163a48281c28ffdc37505284"},
+    {file = "duckdb-0.2.3-cp36-cp36m-win32.whl", hash = "sha256:53f767ba154f68a46a054725aea6f19c466e1113327dd99b3d550110edc659a7"},
+    {file = "duckdb-0.2.3-cp36-cp36m-win_amd64.whl", hash = "sha256:4bf8cf6657109247c9d4e92be33f3f30064b3f38986f396b2bc6d8202e39a833"},
+    {file = "duckdb-0.2.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fba3714a668876a450f7ba81b7cff2da2ec20241220f193a6cb7f93bc98cfee0"},
+    {file = "duckdb-0.2.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:9f35990b06f1877b4806f6942c3a697c11cc837f6d53566f1ec5c3465dabba51"},
+    {file = "duckdb-0.2.3-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5bc19a79ef69e132146468e40ef4a3c6904f1b97e9810b0859ce537407f56768"},
+    {file = "duckdb-0.2.3-cp37-cp37m-win32.whl", hash = "sha256:446bad271cf493c50835296ce170b180a4076626ffc2242454ce6ba57ff009e7"},
+    {file = "duckdb-0.2.3-cp37-cp37m-win_amd64.whl", hash = "sha256:598bd1fddfb310b02e9cc3df35a96cfffb9546e25e47fcdcb372eecc1510121b"},
+    {file = "duckdb-0.2.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:064e3c1b3df4a93255557e241fdc9286394c5d15b05b3fd0bc06e2bb19f042a1"},
+    {file = "duckdb-0.2.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:f0b8860c1f7c2a60dbf59b823bebda0a66ae7c1f4928a59516aeff7f638fa2b8"},
+    {file = "duckdb-0.2.3-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:589b984a781b42dcd400efa4346728e1ac9d3ff533d63bb3fd0c884a3a582e7a"},
+    {file = "duckdb-0.2.3-cp38-cp38-win32.whl", hash = "sha256:0d2b3a367f1fcfa3f08963f422f8d65810b0b9d7ee66c895bd1f34bb96955b67"},
+    {file = "duckdb-0.2.3-cp38-cp38-win_amd64.whl", hash = "sha256:34c8b3040941e0983531e72eb6fb113f9e80384f417a9f77520ccb257d9c3450"},
+    {file = "duckdb-0.2.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d43d5e0e98391dcaddbfbe2ca09d051dceb90a98a6f111036ae1fe4fcea788d2"},
+    {file = "duckdb-0.2.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:96169f48855deac278cfd5e7e68e8570539708cf9f45ce98520d3a602bea61ec"},
+    {file = "duckdb-0.2.3-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:e7a3aee76a98f574deda2057b0da79605579cc16f6ba49317f5c61f7e748abdb"},
+    {file = "duckdb-0.2.3-cp39-cp39-win32.whl", hash = "sha256:08538f3ffa5b03fc5bfec50413664192743feda94a6a7f5719c35c7b5ff4385e"},
+    {file = "duckdb-0.2.3-cp39-cp39-win_amd64.whl", hash = "sha256:366979b4eb3dcfb8dfb32ead5066c870003c5fd219cf46a0cfd6d64cf3f3f00a"},
 ]
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ sphinx-autodoc-typehints        = { version = "^1.11.0", optional = true }
 sphinxcontrib-svg2pdfconverter  = { version = "^1.1.0", optional = true }
 tomlkit                         = { version = "^0.7.0", optional = true }
 
-duckdb                          = { version = "0.2.3.dev519", optional = true }
+duckdb                          = { version = "^0.2.3", optional = true }
 influxdb                        = { version = "^5.3.0", optional = true }
 crate                           = { version = "^0.25.0", optional = true, extras = ["sqlalchemy"] }
 mysqlclient                     = { version = "^2.0.1", optional = true }

--- a/tests/dwd/observations/test_api_data.py
+++ b/tests/dwd/observations/test_api_data.py
@@ -1,5 +1,6 @@
 from io import StringIO
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 import pandas as pd
@@ -156,25 +157,6 @@ def test_dwd_observation_data_time_input():
         end_date=pd.Timestamp("1971-01-01"),
     )
 
-    request = DWDObservationData(
-        station_ids=[1],
-        parameters=[DWDObservationParameterSet.CLIMATE_SUMMARY],
-        resolution=DWDObservationResolution.DAILY,
-        periods=[DWDObservationPeriod.HISTORICAL],
-        start_date="1971-01-01",
-    )
-
-    assert request == DWDObservationData(
-        station_ids=[1],
-        parameters=[DWDObservationParameterSet.CLIMATE_SUMMARY],
-        resolution=DWDObservationResolution.DAILY,
-        periods=[
-            DWDObservationPeriod.HISTORICAL,
-        ],
-        start_date=pd.Timestamp("1971-01-01"),
-        end_date=pd.Timestamp("1971-01-01"),
-    )
-
     with pytest.raises(StartDateEndDateError):
         DWDObservationData(
             station_ids=[1],
@@ -183,6 +165,72 @@ def test_dwd_observation_data_time_input():
             start_date="1971-01-01",
             end_date="1951-01-01",
         )
+
+
+def test_dwd_observation_data_dynamic_period():
+    # Historical period expected
+    request = DWDObservationData(
+        station_ids=[1],
+        parameters=[DWDObservationParameterSet.CLIMATE_SUMMARY],
+        resolution=DWDObservationResolution.DAILY,
+        start_date="1971-01-01",
+    )
+
+    assert request.periods == [
+        DWDObservationPeriod.HISTORICAL,
+    ]
+
+    # Historical and recent period expected
+    request = DWDObservationData(
+        station_ids=[1],
+        parameters=[DWDObservationParameterSet.CLIMATE_SUMMARY],
+        resolution=DWDObservationResolution.DAILY,
+        start_date="1971-01-01",
+        end_date=pd.Timestamp(datetime.now()) - pd.Timedelta(days=400),
+    )
+
+    assert request.periods == [
+        DWDObservationPeriod.HISTORICAL,
+        DWDObservationPeriod.RECENT,
+    ]
+
+    # Historical, recent and now period expected
+    request = DWDObservationData(
+        station_ids=[1],
+        parameters=[DWDObservationParameterSet.CLIMATE_SUMMARY],
+        resolution=DWDObservationResolution.DAILY,
+        start_date="1971-01-01",
+        end_date=pd.Timestamp(datetime.now()),
+    )
+
+    assert request.periods == [
+        DWDObservationPeriod.HISTORICAL,
+        DWDObservationPeriod.RECENT,
+        DWDObservationPeriod.NOW,
+    ]
+
+    # !!!Recent and now period cant be tested dynamically
+    # TODO: add test with mocked datetime here
+
+    # Now period
+    request = DWDObservationData(
+        station_ids=[1],
+        parameters=[DWDObservationParameterSet.CLIMATE_SUMMARY],
+        resolution=DWDObservationResolution.DAILY,
+        start_date=pd.Timestamp(datetime.now()),
+    )
+
+    assert request.periods == [DWDObservationPeriod.NOW]
+
+    # No period (for example in future)
+    request = DWDObservationData(
+        station_ids=[1],
+        parameters=[DWDObservationParameterSet.CLIMATE_SUMMARY],
+        resolution=DWDObservationResolution.DAILY,
+        start_date=pd.Timestamp(datetime.now()) + pd.Timedelta(days=720),
+    )
+
+    assert request.periods == []
 
 
 def test_observation_data_storing():

--- a/tests/dwd/observations/test_api_data.py
+++ b/tests/dwd/observations/test_api_data.py
@@ -132,8 +132,6 @@ def test_dwd_observation_data_time_input():
         resolution=DWDObservationResolution.DAILY,
         periods=[
             DWDObservationPeriod.HISTORICAL,
-            DWDObservationPeriod.RECENT,
-            DWDObservationPeriod.NOW,
         ],
         start_date=pd.Timestamp("1971-01-01"),
         end_date=pd.Timestamp("1971-01-01"),

--- a/tests/dwd/observations/test_fileindex.py
+++ b/tests/dwd/observations/test_fileindex.py
@@ -53,3 +53,18 @@ def test_create_file_list_for_dwd_server():
         "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/"
         "daily/kl/recent/tageswerte_KL_01048_akt.zip"
     ]
+
+    # with date range
+    remote_file_path = create_file_list_for_climate_observations(
+        station_id=3,
+        parameter_set=DWDObservationParameterSet.TEMPERATURE_AIR,
+        resolution=DWDObservationResolution.MINUTE_10,
+        period=DWDObservationPeriod.HISTORICAL,
+        date_range="19930428_19991231",
+    )
+
+    assert remote_file_path == [
+        "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/"
+        "10_minutes/air_temperature/historical/"
+        "10minutenwerte_TU_00003_19930428_19991231_hist.zip"
+    ]

--- a/tests/dwd/observations/test_parser.py
+++ b/tests/dwd/observations/test_parser.py
@@ -8,6 +8,7 @@ import pandas as pd
 from wetterdienst.dwd.observations import (
     DWDObservationParameterSet,
     DWDObservationResolution,
+    DWDObservationPeriod,
 )
 from wetterdienst.dwd.observations.parser import (
     parse_climate_observations_data,
@@ -28,6 +29,7 @@ def test_parse_dwd_data():
         filenames_and_files=[(filename, BytesIO(file_in_bytes.read().encode()))],
         parameter=DWDObservationParameterSet.CLIMATE_SUMMARY,
         resolution=DWDObservationResolution.DAILY,
+        period=DWDObservationPeriod.HISTORICAL,
     )
 
     station_data.equals(station_data_original)

--- a/wetterdienst/dwd/metadata/column_names.py
+++ b/wetterdienst/dwd/metadata/column_names.py
@@ -36,6 +36,8 @@ class DWDMetaColumns(Enum):
     FILENAME = "FILENAME"
     HAS_FILE = "HAS_FILE"
     FILEID = "FILEID"
+    DATE_RANGE = "DATE_RANGE"
+    INTERVAL = "INTERVAL"
     # Columns used for tidy data
     # Column for quality
     PARAMETER = "PARAMETER"

--- a/wetterdienst/dwd/metadata/constants.py
+++ b/wetterdienst/dwd/metadata/constants.py
@@ -17,6 +17,7 @@ DWD_FOLDER_MAIN = "./dwd_data"
 DWD_FOLDER_STATION_DATA = "station_data"
 DWD_FILE_STATION_DATA = "dwd_station_data"
 STATION_ID_REGEX = r"(?<!\d)\d{5}(?!\d)"
+DATE_RANGE_REGEX = r"(?<!\d)\d{8}_\d{8}(?!\d)"
 NA_STRING = "-999"
 STATION_DATA_SEP = ";"
 

--- a/wetterdienst/dwd/observations/fileindex.py
+++ b/wetterdienst/dwd/observations/fileindex.py
@@ -109,6 +109,21 @@ def create_file_index_for_climate_observations(
             file_index[DWDMetaColumns.TO_DATE.value], format=DatetimeFormat.YMD.value
         )
 
+        # Temporary fix for filenames with wrong ordered/faulty dates
+        # Fill those cases with minimum/maximum date to ensure that they are loaded as
+        # we don't know what exact date range the included data has
+        wrong_date_order_index = (
+            file_index[DWDMetaColumns.FROM_DATE.value]
+            > file_index[DWDMetaColumns.TO_DATE.value]
+        )
+
+        file_index.loc[
+            wrong_date_order_index, DWDMetaColumns.FROM_DATE.value
+        ] = file_index[DWDMetaColumns.FROM_DATE.value].min()
+        file_index.loc[
+            wrong_date_order_index, DWDMetaColumns.TO_DATE.value
+        ] = file_index[DWDMetaColumns.TO_DATE.value].max()
+
         file_index[DWDMetaColumns.INTERVAL.value] = file_index.apply(
             lambda x: pd.Interval(
                 left=x[DWDMetaColumns.FROM_DATE.value],

--- a/wetterdienst/dwd/observations/metadata/resolution.py
+++ b/wetterdienst/dwd/observations/metadata/resolution.py
@@ -19,6 +19,12 @@ class DWDObservationResolution(Enum):
     ANNUAL = "annual"
 
 
+HIGH_RESOLUTIONS = (
+    DWDObservationResolution.MINUTE_1,
+    DWDObservationResolution.MINUTE_10,
+)
+
+
 RESOLUTION_TO_DATETIME_FORMAT_MAPPING: Dict[DWDObservationResolution, str] = {
     DWDObservationResolution.MINUTE_1: DatetimeFormat.YMDHM.value,
     DWDObservationResolution.MINUTE_10: DatetimeFormat.YMDHM.value,

--- a/wetterdienst/dwd/observations/parser.py
+++ b/wetterdienst/dwd/observations/parser.py
@@ -11,9 +11,11 @@ from wetterdienst.dwd.metadata.column_names import (
     DWDOrigMetaColumns,
     DWDMetaColumns,
 )
+from wetterdienst.dwd.metadata.datetime import DatetimeFormat
 from wetterdienst.dwd.observations.metadata import (
     DWDObservationParameterSet,
     DWDObservationResolution,
+    DWDObservationPeriod,
 )
 from wetterdienst.dwd.observations.metadata.parameter import (
     DWDObservationParameterSetStructure,
@@ -21,11 +23,23 @@ from wetterdienst.dwd.observations.metadata.parameter import (
 
 log = logging.getLogger(__name__)
 
+# Parameter names used to create full 1 minute precipitation dataset wherever those
+# columns are missing (which is the case for non historical data)
+PRECIPITATION_PARAMETERS = (
+    DWDObservationParameterSetStructure.MINUTE_1.PRECIPITATION.PRECIPITATION_HEIGHT_DROPLET.value,  # Noqa: E501, B950
+    DWDObservationParameterSetStructure.MINUTE_1.PRECIPITATION.PRECIPITATION_HEIGHT_ROCKER.value,  # Noqa: E501, B950
+)
+
+PRECIPITATION_MINUTE_1_QUALITY = (
+    DWDObservationParameterSetStructure.MINUTE_1.PRECIPITATION.QUALITY
+)
+
 
 def parse_climate_observations_data(
     filenames_and_files: List[Tuple[str, BytesIO]],
     parameter: DWDObservationParameterSet,
     resolution: DWDObservationResolution,
+    period: DWDObservationPeriod,
 ) -> pd.DataFrame:
     """
     This function is used to read the station data from given bytes object.
@@ -36,25 +50,29 @@ def parse_climate_observations_data(
         parameter: enumeration of parameter used to correctly parse the date field
         resolution: enumeration of time resolution used to correctly parse the
         date field
+        period: enumeration of period of data
     Returns:
         pandas.DataFrame with requested data, for different station ids the data is
         still put into one DataFrame
     """
 
     data = [
-        _parse_climate_observations_data(filename_and_file, parameter, resolution)
+        _parse_climate_observations_data(
+            filename_and_file, parameter, resolution, period
+        )
         for filename_and_file in filenames_and_files
     ]
 
-    data = pd.concat(data).reset_index(drop=True)
+    df = pd.concat(data).reset_index(drop=True)
 
-    return data
+    return df
 
 
 def _parse_climate_observations_data(
     filename_and_file: Tuple[str, BytesIO],
-    parameter: DWDObservationParameterSet,
+    parameter_set: DWDObservationParameterSet,
     resolution: DWDObservationResolution,
+    period: DWDObservationPeriod,
 ) -> pd.DataFrame:
     """
     A wrapping function that only handles data for one station id. The files passed to
@@ -71,7 +89,7 @@ def _parse_climate_observations_data(
     filename, file = filename_and_file
 
     try:
-        data = pd.read_csv(
+        df = pd.read_csv(
             filepath_or_buffer=BytesIO(
                 file.read().replace(b" ", b"")
             ),  # prevent leading/trailing whitespace
@@ -89,22 +107,22 @@ def _parse_climate_observations_data(
         return pd.DataFrame()
 
     # Column names contain spaces, so strip them away.
-    data = data.rename(columns=str.strip)
+    df = df.rename(columns=str.strip)
 
     # Make column names uppercase.
-    data = data.rename(columns=str.upper)
+    df = df.rename(columns=str.upper)
 
     # End of record (EOR) has no value, so drop it right away.
-    data = data.drop(columns=DWDMetaColumns.EOR.value, errors="ignore")
+    df = df.drop(columns=DWDMetaColumns.EOR.value, errors="ignore")
 
     # Special handling for hourly solar data, as it has more date columns
     if (
         resolution == DWDObservationResolution.HOURLY
-        and parameter == DWDObservationParameterSet.SOLAR
+        and parameter_set == DWDObservationParameterSet.SOLAR
     ):
         # Rename date column correctly to end of interval, as it has additional minute
         # information. Also rename column with true local time to english one
-        data = data.rename(
+        df = df.rename(
             columns={
                 "MESS_DATUM_WOZ": (
                     DWDObservationParameterSetStructure.HOURLY.SOLAR.TRUE_LOCAL_TIME.value  # Noqa: E501, B950
@@ -113,16 +131,61 @@ def _parse_climate_observations_data(
         )
 
         # Duplicate the date column to end of interval column
-        data[
-            DWDObservationParameterSetStructure.HOURLY.SOLAR.END_OF_INTERVAL.value
-        ] = data[DWDOrigMetaColumns.DATE.value]
-
-        # Fix real date column by cutting of minutes
-        data[DWDOrigMetaColumns.DATE.value] = data[DWDOrigMetaColumns.DATE.value].str[
-            :-3
+        df[DWDObservationParameterSetStructure.HOURLY.SOLAR.END_OF_INTERVAL.value] = df[
+            DWDOrigMetaColumns.DATE.value
         ]
 
-    # Assign meaningful column names (baseline).
-    data = data.rename(columns=GERMAN_TO_ENGLISH_COLUMNS_MAPPING)
+        # Fix real date column by cutting of minutes
+        df[DWDOrigMetaColumns.DATE.value] = df[DWDOrigMetaColumns.DATE.value].str[:-3]
 
-    return data
+    if (
+        resolution == DWDObservationResolution.MINUTE_1
+        and parameter_set == DWDObservationParameterSet.PRECIPITATION
+    ):
+        if period == DWDObservationPeriod.HISTORICAL:
+            df[DWDOrigMetaColumns.FROM_DATE_ALTERNATIVE.value] = pd.to_datetime(
+                df[DWDOrigMetaColumns.FROM_DATE_ALTERNATIVE.value],
+                format=DatetimeFormat.YMDHM.value,
+            )
+            df[DWDOrigMetaColumns.TO_DATE_ALTERNATIVE.value] = pd.to_datetime(
+                df[DWDOrigMetaColumns.TO_DATE_ALTERNATIVE.value],
+                format=DatetimeFormat.YMDHM.value,
+            )
+
+            df.insert(
+                1,
+                DWDOrigMetaColumns.DATE.value,
+                df.apply(
+                    lambda x: pd.date_range(
+                        x[DWDOrigMetaColumns.FROM_DATE_ALTERNATIVE.value],
+                        x[DWDOrigMetaColumns.TO_DATE_ALTERNATIVE.value],
+                        freq="1min",
+                    ),
+                    axis=1,
+                ),
+            )
+
+            df = df.drop(
+                columns=[
+                    DWDOrigMetaColumns.FROM_DATE_ALTERNATIVE.value,
+                    DWDOrigMetaColumns.TO_DATE_ALTERNATIVE.value,
+                ]
+            )
+
+            df = df.explode(DWDOrigMetaColumns.DATE.value)
+        else:
+            for parameter in PRECIPITATION_PARAMETERS:
+                if parameter not in df:
+                    df[parameter] = pd.NA
+
+    # Assign meaningful column names (baseline).
+    df = df.rename(columns=GERMAN_TO_ENGLISH_COLUMNS_MAPPING)
+
+    df = df.astype(
+        {
+            DWDMetaColumns.STATION_ID.value: "category",
+            PRECIPITATION_MINUTE_1_QUALITY.value: "category",
+        }
+    )
+
+    return df

--- a/wetterdienst/dwd/observations/store.py
+++ b/wetterdienst/dwd/observations/store.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Union
+from typing import Union, Optional
 
 import pandas as pd
 
@@ -30,12 +30,13 @@ class StorageAdapter:
         self.invalidate = invalidate
         self.folder = folder
 
-    def hdf5(self, parameter, resolution, period):
+    def hdf5(self, parameter, resolution, period, date_range=None):
         return LocalHDF5Store(
             parameter_set=parameter,
             resolution=resolution,
             period=period,
             folder=self.folder,
+            date_range=date_range,
         )
 
 
@@ -46,11 +47,13 @@ class LocalHDF5Store:
         resolution: DWDObservationResolution,
         period: DWDObservationPeriod,
         folder: Union[str, Path] = DWD_FOLDER_MAIN,
+        date_range: Optional[str] = None,
     ):
         self.parameter_set = parameter_set
         self.resolution = resolution
         self.period = period
         self.folder = folder
+        self.date_range = date_range
 
     @property
     def filename(self) -> str:
@@ -73,7 +76,11 @@ class LocalHDF5Store:
         """
 
         return build_parameter_set_identifier(
-            self.parameter_set, self.resolution, self.period, station_id
+            self.parameter_set,
+            self.resolution,
+            self.period,
+            station_id,
+            self.date_range,
         )
 
     def invalidate(self):

--- a/wetterdienst/dwd/pandas.py
+++ b/wetterdienst/dwd/pandas.py
@@ -129,7 +129,6 @@ class PandasDwdExtension:
         Convert DWD station information into GeoJSON format.
 
         Args:
-            df: Input DataFrame containing station information.
 
         Return:
              Dictionary in GeoJSON FeatureCollection format.
@@ -175,27 +174,6 @@ class PandasDwdExtension:
 
         :return:            The tidied DataFrame
         """
-        if self.df.empty:
-            df = pd.DataFrame(
-                columns=[
-                    DWDMetaColumns.STATION_ID.value,
-                    DWDMetaColumns.DATE.value,
-                    DWDMetaColumns.ELEMENT.value,
-                    DWDMetaColumns.VALUE.value,
-                    DWDMetaColumns.QUALITY.value,
-                ]
-            )
-
-            df = df.astype(
-                {
-                    DWDMetaColumns.STATION_ID.value: "category",
-                    DWDMetaColumns.ELEMENT.value: "category",
-                    DWDMetaColumns.QUALITY.value: "category",
-                }
-            )
-
-            return df
-
         id_vars = []
         date_vars = []
 
@@ -223,6 +201,9 @@ class PandasDwdExtension:
             var_name=DWDMetaColumns.ELEMENT.value,
             value_name=DWDMetaColumns.VALUE.value,
         )
+
+        if DWDMetaColumns.STATION_ID.value not in df_tidy:
+            df_tidy[DWDMetaColumns.STATION_ID.value] = pd.NA
 
         df_tidy[DWDMetaColumns.QUALITY.value] = quality.reset_index(drop=True).astype(
             pd.Int64Dtype()

--- a/wetterdienst/dwd/pandas.py
+++ b/wetterdienst/dwd/pandas.py
@@ -238,4 +238,8 @@ class PandasDwdExtension:
             }
         )
 
+        df_tidy.loc[
+            df_tidy[DWDMetaColumns.VALUE.value].isna(), DWDMetaColumns.QUALITY.value
+        ] = pd.NA
+
         return df_tidy

--- a/wetterdienst/dwd/util.py
+++ b/wetterdienst/dwd/util.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Union, Tuple
+from typing import Union, Tuple, Optional
 
 import dateparser
 import pandas as pd
@@ -29,12 +29,18 @@ def build_parameter_set_identifier(
     resolution: DWDObservationResolution,
     period: DWDObservationPeriod,
     station_id: int,
+    date_range_string: Optional[str] = None,
 ) -> str:
     """ Create parameter set identifier that is used for storage interactions """
-    return (
+    identifier = (
         f"{parameter_set.value}/{resolution.value}/"
         f"{period.value}/station_id_{str(station_id)}"
     )
+
+    if date_range_string:
+        identifier = f"{identifier}/{date_range_string}"
+
+    return identifier
 
 
 def coerce_field_types(


### PR DESCRIPTION
This should improve on efficiency in situations like outlined by @wetterfrosch at #256.

The summary of what I am trying here:
- At the `1_minute`/`10_minute` resolutions, before starting the actual collection, let's look for the corresponding date strings in the file name.
- These are used for the local memory then.
- If no record is found there, use `collect_observations` again.
- Now, there is an additional parameter `datestring` which is used for filtering. This has been extracted before to access the local memory.
