### PR TITLE
Add timezone information to fileindex intervals

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Development
 ===========
 
-
+- Fix 10minutes file index interval range by adding timezone information
 
 0.12.0 (23.12.2020)
 ===================

--- a/poetry.lock
+++ b/poetry.lock
@@ -641,7 +641,7 @@ testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
-version = "4.1.0"
+version = "4.1.1"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
@@ -1240,7 +1240,7 @@ python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [[package]]
 name = "ptyprocess"
-version = "0.6.0"
+version = "0.7.0"
 description = "Run a subprocess in a pseudo terminal"
 category = "main"
 optional = false
@@ -2431,8 +2431,8 @@ importlib-metadata = [
     {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-4.1.0-py3-none-any.whl", hash = "sha256:1de368454cabd37265215f584eaefa92f7ea5dffd1c22c8de48d565431ecd9f1"},
-    {file = "importlib_resources-4.1.0.tar.gz", hash = "sha256:01fe9f1f2000677b2cdc7838473143341401d010eee276d2fcb64c219f624a25"},
+    {file = "importlib_resources-4.1.1-py3-none-any.whl", hash = "sha256:0a948d0c8c3f9344de62997e3f73444dbba233b1eaf24352933c2d264b9e4182"},
+    {file = "importlib_resources-4.1.1.tar.gz", hash = "sha256:6b45007a479c4ec21165ae3ffbe37faf35404e2041fac6ae1da684f38530ca73"},
 ]
 influxdb = [
     {file = "influxdb-5.3.1-py2.py3-none-any.whl", hash = "sha256:65040a1f53d1a2a4f88a677e89e3a98189a7d30cf2ab61c318aaa89733280747"},
@@ -2893,8 +2893,8 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd"},
 ]
 ptyprocess = [
-    {file = "ptyprocess-0.6.0-py2.py3-none-any.whl", hash = "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"},
-    {file = "ptyprocess-0.6.0.tar.gz", hash = "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0"},
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},

--- a/wetterdienst/dwd/observations/api.py
+++ b/wetterdienst/dwd/observations/api.py
@@ -482,7 +482,7 @@ class DWDObservationStations(StationsCore):
         self,
         parameter_set: Union[str, DWDObservationParameterSet],
         resolution: Union[str, DWDObservationResolution],
-        period: Union[str, DWDObservationPeriod] = None,
+        period: Union[str, DWDObservationPeriod],
         start_date: Union[None, str, Timestamp] = None,
         end_date: Union[None, str, Timestamp] = None,
     ):

--- a/wetterdienst/dwd/observations/fileindex.py
+++ b/wetterdienst/dwd/observations/fileindex.py
@@ -102,11 +102,15 @@ def create_file_index_for_climate_observations(
         ] = file_index[DWDMetaColumns.DATE_RANGE.value].str.split("_", expand=True)
 
         file_index[DWDMetaColumns.FROM_DATE.value] = pd.to_datetime(
-            file_index[DWDMetaColumns.FROM_DATE.value], format=DatetimeFormat.YMD.value
+            file_index[DWDMetaColumns.FROM_DATE.value],
+            format=DatetimeFormat.YMD.value,
+            utc=True,
         )
 
         file_index[DWDMetaColumns.TO_DATE.value] = pd.to_datetime(
-            file_index[DWDMetaColumns.TO_DATE.value], format=DatetimeFormat.YMD.value
+            file_index[DWDMetaColumns.TO_DATE.value],
+            format=DatetimeFormat.YMD.value,
+            utc=True,
         )
 
         # Temporary fix for filenames with wrong ordered/faulty dates


### PR DESCRIPTION
This fixes an error that is caused by the fileindex intervals not having a timezone thus filtering by the given start and end dates had failed before. Now uses UTC to make filtering possible.