### PR TITLE
Add "setup.py" shim to make GitHub detect this as a Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+# This is a shim to hopefully allow GitHub to detect the package.
+# The build is done with Poetry.
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup(name="wetterdienst")


### PR DESCRIPTION
Hi there,

through [1], we learned that this might bring back the "Used by" widget on the right hand side of the GitHub front page. Thanks a stack, @willmcgugan.

With kind regards,
Andreas.

[1] https://github.com/willmcgugan/rich/blob/master/setup.py
