### PR TITLE
Make dates timezone aware, restrict date parsing to isoformat

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Development
 - Create general Resolution and Period enumerations that can be used anywhere
 - Create a full dataframe even if no values exist at requested time
 - Add further attributes to the class structure
+- Make dates timezone aware
+- Restrict dates to isoformat
 
 0.12.1 (29.12.2020)
 *******************

--- a/example/observations_stations.py
+++ b/example/observations_stations.py
@@ -19,8 +19,7 @@ log = logging.getLogger()
 
 
 def station_example():
-
-    sites = DWDObservationStations(
+    stations = DWDObservationStations(
         parameter_set=DWDObservationParameterSet.TEMPERATURE_AIR,
         resolution=DWDObservationResolution.HOURLY,
         period=DWDObservationPeriod.RECENT,
@@ -28,7 +27,7 @@ def station_example():
         end_date=datetime(2020, 1, 20),
     )
 
-    df = sites.nearby_radius(latitude=50.0, longitude=8.9, max_distance_in_km=30)
+    df = stations.nearby_radius(latitude=50.0, longitude=8.9, max_distance_in_km=30)
 
     print(df)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -179,7 +179,7 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "bleach"
-version = "3.2.1"
+version = "3.2.2"
 description = "An easy safelist-based HTML-sanitizing tool."
 category = "dev"
 optional = false
@@ -1491,7 +1491,7 @@ twisted = ["twisted"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.10"
+version = "3.0.11"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
 optional = false
@@ -1632,7 +1632,7 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 name = "pytest-cov"
-version = "2.11.0"
+version = "2.11.1"
 description = "Pytest plugin for measuring coverage."
 category = "dev"
 optional = false
@@ -1731,7 +1731,7 @@ python-versions = "*"
 
 [[package]]
 name = "pyyaml"
-version = "5.4"
+version = "5.4.1"
 description = "YAML parser and emitter for Python"
 category = "dev"
 optional = false
@@ -1843,8 +1843,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "snowballstemmer"
-version = "2.0.0"
-description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
+version = "2.1.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "main"
 optional = false
 python-versions = "*"
@@ -2494,8 +2494,8 @@ black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 bleach = [
-    {file = "bleach-3.2.1-py2.py3-none-any.whl", hash = "sha256:9f8ccbeb6183c6e6cddea37592dfb0167485c1e3b13b3363bc325aa8bda3adbd"},
-    {file = "bleach-3.2.1.tar.gz", hash = "sha256:52b5919b81842b1854196eaae5ca29679a2f2e378905c346d3ca8227c2c66080"},
+    {file = "bleach-3.2.2-py2.py3-none-any.whl", hash = "sha256:a690ccc41a10d806a7c0a9130767750925e4863e332f7e4ea93da1bc12a24300"},
+    {file = "bleach-3.2.2.tar.gz", hash = "sha256:ce6270dd0ae56cd810495b8d994551ae16b41f2b4043cf50064f298985afdb3c"},
 ]
 cached-property = [
     {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
@@ -3341,8 +3341,8 @@ prometheus-client = [
     {file = "prometheus_client-0.9.0.tar.gz", hash = "sha256:9da7b32f02439d8c04f7777021c304ed51d9ec180604700c1ba72a4d44dceb03"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.10-py3-none-any.whl", hash = "sha256:ac329c69bd8564cb491940511957312c7b8959bb5b3cf3582b406068a51d5bb7"},
-    {file = "prompt_toolkit-3.0.10.tar.gz", hash = "sha256:b8b3d0bde65da350290c46a8f54f336b3cbf5464a4ac11239668d986852e79d5"},
+    {file = "prompt_toolkit-3.0.11-py3-none-any.whl", hash = "sha256:0bdd2585e5afd00c5f91dd28eb2090ea67e94c385878921939bb4ccfa3904723"},
+    {file = "prompt_toolkit-3.0.11.tar.gz", hash = "sha256:dc83e6368b0edd9ceabe17a055f2e22f6ed95b9aa39dbd59d0b4f3585bdfe9ed"},
 ]
 psycopg2-binary = [
     {file = "psycopg2-binary-2.8.6.tar.gz", hash = "sha256:11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0"},
@@ -3444,8 +3444,8 @@ pytest = [
     {file = "pytest-6.2.1.tar.gz", hash = "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.11.0.tar.gz", hash = "sha256:e90e034cde61dacb1394639a33f449725c591025b182d69752c1dd0bfec639a7"},
-    {file = "pytest_cov-2.11.0-py2.py3-none-any.whl", hash = "sha256:626a8a6ab188656c4f84b67d22436d6c494699d917e567e0048dda6e7f59e028"},
+    {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
+    {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
 ]
 pytest-dictsdiff = [
     {file = "pytest-dictsdiff-0.5.8.tar.gz", hash = "sha256:3fca5c706232ab723ab2a06b41c195a6abf1f0df56fb3bf67d6bc83a305dd659"},
@@ -3491,27 +3491,27 @@ pywinpty = [
     {file = "pywinpty-0.5.7.tar.gz", hash = "sha256:2d7e9c881638a72ffdca3f5417dd1563b60f603e1b43e5895674c2a1b01f95a0"},
 ]
 pyyaml = [
-    {file = "PyYAML-5.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:f7a21e3d99aa3095ef0553e7ceba36fb693998fbb1226f1392ce33681047465f"},
-    {file = "PyYAML-5.4-cp27-cp27m-win32.whl", hash = "sha256:52bf0930903818e600ae6c2901f748bc4869c0c406056f679ab9614e5d21a166"},
-    {file = "PyYAML-5.4-cp27-cp27m-win_amd64.whl", hash = "sha256:a36a48a51e5471513a5aea920cdad84cbd56d70a5057cca3499a637496ea379c"},
-    {file = "PyYAML-5.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:5e7ac4e0e79a53451dc2814f6876c2fa6f71452de1498bbe29c0b54b69a986f4"},
-    {file = "PyYAML-5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc552b6434b90d9dbed6a4f13339625dc466fd82597119897e9489c953acbc22"},
-    {file = "PyYAML-5.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0dc9f2eb2e3c97640928dec63fd8dc1dd91e6b6ed236bd5ac00332b99b5c2ff9"},
-    {file = "PyYAML-5.4-cp36-cp36m-win32.whl", hash = "sha256:5a3f345acff76cad4aa9cb171ee76c590f37394186325d53d1aa25318b0d4a09"},
-    {file = "PyYAML-5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:f3790156c606299ff499ec44db422f66f05a7363b39eb9d5b064f17bd7d7c47b"},
-    {file = "PyYAML-5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:124fd7c7bc1e95b1eafc60825f2daf67c73ce7b33f1194731240d24b0d1bf628"},
-    {file = "PyYAML-5.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8b818b6c5a920cbe4203b5a6b14256f0e5244338244560da89b7b0f1313ea4b6"},
-    {file = "PyYAML-5.4-cp37-cp37m-win32.whl", hash = "sha256:737bd70e454a284d456aa1fa71a0b429dd527bcbf52c5c33f7c8eee81ac16b89"},
-    {file = "PyYAML-5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:7242790ab6c20316b8e7bb545be48d7ed36e26bbe279fd56f2c4a12510e60b4b"},
-    {file = "PyYAML-5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cc547d3ead3754712223abb7b403f0a184e4c3eae18c9bb7fd15adef1597cc4b"},
-    {file = "PyYAML-5.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8635d53223b1f561b081ff4adecb828fd484b8efffe542edcfdff471997f7c39"},
-    {file = "PyYAML-5.4-cp38-cp38-win32.whl", hash = "sha256:26fcb33776857f4072601502d93e1a619f166c9c00befb52826e7b774efaa9db"},
-    {file = "PyYAML-5.4-cp38-cp38-win_amd64.whl", hash = "sha256:b2243dd033fd02c01212ad5c601dafb44fbb293065f430b0d3dbf03f3254d615"},
-    {file = "PyYAML-5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:31ba07c54ef4a897758563e3a0fcc60077698df10180abe4b8165d9895c00ebf"},
-    {file = "PyYAML-5.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:02c78d77281d8f8d07a255e57abdbf43b02257f59f50cc6b636937d68efa5dd0"},
-    {file = "PyYAML-5.4-cp39-cp39-win32.whl", hash = "sha256:fdc6b2cb4b19e431994f25a9160695cc59a4e861710cc6fc97161c5e845fc579"},
-    {file = "PyYAML-5.4-cp39-cp39-win_amd64.whl", hash = "sha256:8bf38641b4713d77da19e91f8b5296b832e4db87338d6aeffe422d42f1ca896d"},
-    {file = "PyYAML-5.4.tar.gz", hash = "sha256:3c49e39ac034fd64fd576d63bb4db53cda89b362768a67f07749d55f128ac18a"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 pyzmq = [
     {file = "pyzmq-21.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b2a5d5fd2857e5006a5fd9067f5aa7aff0cd4f994180681b13a6bd724a5ce289"},
@@ -3671,8 +3671,8 @@ smmap = [
     {file = "smmap-3.0.4.tar.gz", hash = "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"},
 ]
 snowballstemmer = [
-    {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
-    {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
+    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
+    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 soupsieve = [
     {file = "soupsieve-2.1-py3-none-any.whl", hash = "sha256:4bb21a6ee4707bf43b61230e80740e71bfe56e55d1f1f50924b087bb2975c851"},

--- a/tests/dwd/observations/test_api_data.py
+++ b/tests/dwd/observations/test_api_data.py
@@ -96,13 +96,22 @@ def test_dwd_observation_data_parameter():
         )
     ]
 
-    with pytest.raises(NoParametersFound):
+    with pytest.raises(StartDateEndDateError):
         DWDObservationData(
             station_ids=[1],
             parameters=["abc"],
             resolution=DWDObservationResolution.DAILY,
             start_date="1971-01-01",
             end_date="1951-01-01",
+        )
+
+    with pytest.raises(NoParametersFound):
+        DWDObservationData(
+            station_ids=[1],
+            parameters=["abc"],
+            resolution=DWDObservationResolution.DAILY,
+            start_date="1951-01-01",
+            end_date="1961-01-01",
         )
 
 

--- a/tests/dwd/radar/test_api_most_recent.py
+++ b/tests/dwd/radar/test_api_most_recent.py
@@ -54,6 +54,7 @@ def test_radar_request_site_most_recent_sweep_pcp_v_hdf5():
     assert hdf["/dataset1/data1/data"].shape == (360, 600)
 
 
+@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_most_recent_sweep_vol_v_hdf5():
     """

--- a/tests/dwd/test_date.py
+++ b/tests/dwd/test_date.py
@@ -1,60 +1,45 @@
-from datetime import datetime
-
-import dateparser
+import dateutil.parser
 import pytest
-from pandas import Timestamp
-from pytz import timezone
+import pytz
 
-from wetterdienst.dwd.observations import DWDObservationResolution
-from wetterdienst.dwd.util import mktimerange, parse_datetime
-
-# TODO: differentiate between no given timezone and given timezone
-
-
-def test_parse_datetime():
-    assert parse_datetime("2020-05-01") == datetime(2020, 5, 1, 0, 0).replace(
-        tzinfo=timezone("UTC")
-    )
-    assert parse_datetime("2020-05-01T13:14:15") == datetime(
-        2020, 5, 1, 13, 14, 15
-    ).replace(tzinfo=timezone("UTC"))
-    assert parse_datetime("2020-05-01T13") == datetime(2020, 5, 1, 13, 0).replace(
-        tzinfo=timezone("UTC")
-    )
+from wetterdienst import Resolution
+from wetterdienst.util.datetime import mktimerange
 
 
 def test_mktimerange_annual():
-    assert mktimerange(DWDObservationResolution.ANNUAL, dateparser.parse("2019")) == (
-        Timestamp("2019-01-01 00:00:00").tz_localize("UTC"),
-        Timestamp("2019-12-31 00:00:00").tz_localize("UTC"),
+    assert mktimerange(
+        Resolution.ANNUAL, dateutil.parser.isoparse("2019").replace(tzinfo=pytz.UTC)
+    ) == (
+        dateutil.parser.isoparse("2019-01-01 00:00:00Z"),
+        dateutil.parser.isoparse("2019-12-31 00:00:00Z"),
     )
     assert mktimerange(
-        DWDObservationResolution.ANNUAL,
-        dateparser.parse("2010"),
-        dateparser.parse("2020"),
+        Resolution.ANNUAL,
+        dateutil.parser.isoparse("2010").replace(tzinfo=pytz.UTC),
+        dateutil.parser.isoparse("2020").replace(tzinfo=pytz.UTC),
     ) == (
-        Timestamp("2010-01-01 00:00:00").tz_localize("UTC"),
-        Timestamp("2020-12-31 00:00:00").tz_localize("UTC"),
+        dateutil.parser.isoparse("2010-01-01 00:00:00Z"),
+        dateutil.parser.isoparse("2020-12-31 00:00:00Z"),
     )
 
 
 def test_mktimerange_monthly():
     assert mktimerange(
-        DWDObservationResolution.MONTHLY, dateparser.parse("2020-05")
+        Resolution.MONTHLY, dateutil.parser.isoparse("2020-05").replace(tzinfo=pytz.UTC)
     ) == (
-        Timestamp("2020-05-01 00:00:00").tz_localize("UTC"),
-        Timestamp("2020-05-31 00:00:00").tz_localize("UTC"),
+        dateutil.parser.isoparse("2020-05-01 00:00:00Z"),
+        dateutil.parser.isoparse("2020-05-31 00:00:00Z"),
     )
     assert mktimerange(
-        DWDObservationResolution.MONTHLY,
-        dateparser.parse("2017-01"),
-        dateparser.parse("2019-12"),
+        Resolution.MONTHLY,
+        dateutil.parser.isoparse("2017-01").replace(tzinfo=pytz.UTC),
+        dateutil.parser.isoparse("2019-12").replace(tzinfo=pytz.UTC),
     ) == (
-        Timestamp("2017-01-01 00:00:00").tz_localize("UTC"),
-        Timestamp("2019-12-31 00:00:00").tz_localize("UTC"),
+        dateutil.parser.isoparse("2017-01-01 00:00:00Z"),
+        dateutil.parser.isoparse("2019-12-31 00:00:00Z"),
     )
 
 
 def test_mktimerange_invalid():
     with pytest.raises(NotImplementedError):
-        mktimerange(DWDObservationResolution.DAILY, dateparser.parse("2020-05-01"))
+        mktimerange(Resolution.DAILY, dateutil.parser.isoparse("2020-05-01"))

--- a/tests/dwd/test_pandas.py
+++ b/tests/dwd/test_pandas.py
@@ -1,5 +1,6 @@
 import json
 
+import dateutil.parser
 import mock
 import pandas as pd
 import pytest
@@ -11,13 +12,13 @@ from wetterdienst.dwd.observations import (
     DWDObservationPeriod,
     DWDObservationResolution,
 )
-from wetterdienst.dwd.util import parse_datetime
+from wetterdienst.metadata.resolution import Resolution
 
 df_station = pd.DataFrame.from_dict(
     {
         "STATION_ID": ["19087"],
-        "FROM_DATE": [parse_datetime("1957-05-01T00:00:00.000Z")],
-        "TO_DATE": [parse_datetime("1995-11-30T00:00:00.000Z")],
+        "FROM_DATE": [dateutil.parser.isoparse("1957-05-01T00:00:00.000Z")],
+        "TO_DATE": [dateutil.parser.isoparse("1995-11-30T00:00:00.000Z")],
         "STATION_HEIGHT": [645.0],
         "LAT": [48.8049],
         "LON": [13.5528],
@@ -32,7 +33,7 @@ df_data = pd.DataFrame.from_dict(
         "STATION_ID": ["01048"],
         "PARAMETER_SET": ["CLIMATE_SUMMARY"],
         "PARAMETER": ["TEMPERATURE_AIR_MAX_200"],
-        "DATE": [parse_datetime("2019-12-28T00:00:00.000Z")],
+        "DATE": [dateutil.parser.isoparse("2019-12-28T00:00:00.000Z")],
         "VALUE": [1.3],
         "QUALITY": [None],
     }
@@ -58,47 +59,43 @@ def test_lowercase():
 
 def test_filter_by_date():
 
-    df = df_data.dwd.filter_by_date("2019-12-28Z", DWDObservationResolution.HOURLY)
+    df = df_data.dwd.filter_by_date("2019-12-28", Resolution.HOURLY)
     assert not df.empty
 
-    df = df_data.dwd.filter_by_date("2019-12-27Z", DWDObservationResolution.HOURLY)
+    df = df_data.dwd.filter_by_date("2019-12-27", Resolution.HOURLY)
     assert df.empty
 
 
 def test_filter_by_date_interval():
 
-    df = df_data.dwd.filter_by_date(
-        "2019-12-27Z/2019-12-29Z", DWDObservationResolution.HOURLY
-    )
+    df = df_data.dwd.filter_by_date("2019-12-27/2019-12-29", Resolution.HOURLY)
     assert not df.empty
 
-    df = df_data.dwd.filter_by_date("2020Z/2022Z", DWDObservationResolution.HOURLY)
+    df = df_data.dwd.filter_by_date("2020/2022", Resolution.HOURLY)
     assert df.empty
 
 
 def test_filter_by_date_monthly():
 
     result = pd.DataFrame.from_dict(
-        [
-            {
-                "STATION_ID": "01048",
-                "PARAMETER": "climate_summary",
-                "ELEMENT": "temperature_air_max_200",
-                "FROM_DATE": parse_datetime("2019-12-28T00:00:00.000"),
-                "TO_DATE": parse_datetime("2020-01-28T00:00:00.000"),
-                "VALUE": 1.3,
-                "QUALITY": None,
-            }
-        ]
+        {
+            "STATION_ID": ["01048"],
+            "PARAMETER": ["climate_summary"],
+            "ELEMENT": ["temperature_air_max_200"],
+            "FROM_DATE": [dateutil.parser.isoparse("2019-12-28T00:00:00.000Z")],
+            "TO_DATE": [dateutil.parser.isoparse("2020-01-28T00:00:00.000Z")],
+            "VALUE": [1.3],
+            "QUALITY": [None],
+        }
     )
 
-    df = result.dwd.filter_by_date("2019-12/2020-01", DWDObservationResolution.MONTHLY)
+    df = result.dwd.filter_by_date("2019-12/2020-01", Resolution.MONTHLY)
     assert not df.empty
 
-    df = result.dwd.filter_by_date("2020/2022", DWDObservationResolution.MONTHLY)
+    df = result.dwd.filter_by_date("2020/2022", Resolution.MONTHLY)
     assert df.empty
 
-    df = result.dwd.filter_by_date("2020", DWDObservationResolution.MONTHLY)
+    df = result.dwd.filter_by_date("2020", Resolution.MONTHLY)
     assert df.empty
 
 
@@ -109,20 +106,20 @@ def test_filter_by_date_annual():
             "STATION_ID": ["01048"],
             "PARAMETER_SET": ["climate_summary"],
             "PARAMETER": ["temperature_air_max_200"],
-            "FROM_DATE": [parse_datetime("2019-01-01T00:00:00.000")],
-            "TO_DATE": [parse_datetime("2019-12-31T00:00:00.000")],
+            "FROM_DATE": [dateutil.parser.isoparse("2019-01-01T00:00:00.000Z")],
+            "TO_DATE": [dateutil.parser.isoparse("2019-12-31T00:00:00.000Z")],
             "VALUE": [1.3],
             "QUALITY": [None],
         }
     )
 
-    df = result.dwd.filter_by_date("2019-05/2019-09", DWDObservationResolution.ANNUAL)
+    df = result.dwd.filter_by_date("2019-05/2019-09", Resolution.ANNUAL)
     assert not df.empty
 
-    df = result.dwd.filter_by_date("2020/2022", DWDObservationResolution.ANNUAL)
+    df = result.dwd.filter_by_date("2020/2022", Resolution.ANNUAL)
     assert df.empty
 
-    df = result.dwd.filter_by_date("2020", DWDObservationResolution.ANNUAL)
+    df = result.dwd.filter_by_date("2020", Resolution.ANNUAL)
     assert df.empty
 
 

--- a/wetterdienst/dwd/forecasts/api.py
+++ b/wetterdienst/dwd/forecasts/api.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 import pandas as pd
 from requests import HTTPError
 
-from wetterdienst.core.point_data import PointDataStationsCore, PointDataValuesCore
+from wetterdienst.core.scalar import ScalarStationsCore, ScalarValuesCore
 from wetterdienst.dwd.forecasts.access import KMLReader
 from wetterdienst.dwd.forecasts.metadata import (
     DWDForecastDate,
@@ -35,7 +35,7 @@ from wetterdienst.util.network import list_remote_files
 log = logging.getLogger(__name__)
 
 
-class DWDMosmixData(PointDataValuesCore):
+class DWDMosmixData(ScalarValuesCore):
     """
     Fetch weather forecast data (KML/MOSMIX_S dataset).
 
@@ -361,7 +361,7 @@ class DWDMosmixData(PointDataValuesCore):
         return df_urls["URL"].item()
 
 
-class DWDMosmixStations(PointDataStationsCore):
+class DWDMosmixStations(ScalarStationsCore):
     """ Implementation of sites for MOSMIX forecast sites """
 
     @property

--- a/wetterdienst/dwd/observations/api.py
+++ b/wetterdienst/dwd/observations/api.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import pandas as pd
 from pandas import Timestamp
 
-from wetterdienst.core.point_data import PointDataStationsCore, PointDataValuesCore
+from wetterdienst.core.scalar import ScalarStationsCore, ScalarValuesCore
 from wetterdienst.dwd.index import _create_file_index_for_dwd_server
 from wetterdienst.dwd.metadata.column_names import DWDMetaColumns
 from wetterdienst.dwd.metadata.constants import DWDCDCBase
@@ -59,7 +59,7 @@ log = logging.getLogger(__name__)
 # TODO: change to DWDObservationValues
 
 
-class DWDObservationData(PointDataValuesCore):
+class DWDObservationData(ScalarValuesCore):
     """
     The DWDObservationData class represents a request for
     observation data as provided by the DWD service.
@@ -262,10 +262,12 @@ class DWDObservationData(PointDataValuesCore):
         """Interval of historical data release schedule. Historical data is typically
         release once in a year somewhere in the first few months with updated quality
         """
+        start_date = Timestamp(self.start_date)
+
         historical_end = pd.Timestamp(self._now_local.replace(month=1, day=1))
 
-        if self.start_date < historical_end:
-            historical_begin = self.start_date.tz_convert(historical_end.tz)
+        if start_date < historical_end:
+            historical_begin = start_date.tz_convert(historical_end.tz)
         else:
             historical_begin = historical_end + pd.tseries.offsets.DateOffset(years=-1)
 
@@ -489,7 +491,7 @@ class DWDObservationData(PointDataValuesCore):
 
         return super(DWDObservationData, self)._parse_station_ids(series)
 
-    def _parse_datetimes(self, series: pd.Series) -> pd.Series:
+    def _parse_dates(self, series: pd.Series) -> pd.Series:
         """Use predefined datetime format for given resolution to reduce processing
         time."""
         return pd.to_datetime(series, format=self._datetime_format).dt.tz_localize(
@@ -529,7 +531,7 @@ class DWDObservationData(PointDataValuesCore):
         return file_index_filtered[DWDMetaColumns.DATE_RANGE.value].tolist()
 
 
-class DWDObservationStations(PointDataStationsCore):
+class DWDObservationStations(ScalarStationsCore):
     """
     The DWDObservationStations class represents a request for
     a station list as provided by the DWD service.

--- a/wetterdienst/dwd/util.py
+++ b/wetterdienst/dwd/util.py
@@ -1,16 +1,6 @@
-from datetime import datetime
-from typing import Optional, Tuple, Union
+from typing import Optional
 
-import dateparser
-import pandas as pd
-import pytz
-from dateutil.relativedelta import relativedelta
-
-from wetterdienst.dwd.metadata.datetime import DatetimeFormat
-from wetterdienst.dwd.observations.metadata import (
-    DWDObservationParameterSet,
-    DWDObservationResolution,
-)
+from wetterdienst.dwd.observations.metadata import DWDObservationParameterSet
 from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.resolution import Resolution
 
@@ -31,61 +21,3 @@ def build_parameter_set_identifier(
         identifier = f"{identifier}/{date_range_string}"
 
     return identifier
-
-
-def parse_datetime(date_string: str) -> datetime:
-    """
-    Function used mostly for client to parse given date
-
-    Args:
-        date_string: the given date as string
-
-    Returns:
-        any kind of datetime
-    """
-    # Tries out any given format of DatetimeFormat enumeration
-    return dateparser.parse(
-        date_string, date_formats=[dt_format.value for dt_format in DatetimeFormat]
-    ).replace(tzinfo=pytz.UTC)
-
-
-def mktimerange(
-    resolution: DWDObservationResolution,
-    date_from: Union[datetime, str],
-    date_to: Union[datetime, str] = None,
-) -> Tuple[datetime, datetime]:
-    """
-    Compute appropriate time ranges for monthly and annual time resolutions.
-    This takes into account to properly floor/ceil the date_from/date_to
-    values to respective "begin of month/year" and "end of month/year" values.
-
-    Args:
-        resolution: time resolution as enumeration
-        date_from: datetime string or object
-        date_to: datetime string or object
-
-    Returns:
-        Tuple of two Timestamps: "date_from" and "date_to"
-    """
-
-    if date_to is None:
-        date_to = date_from
-
-    if resolution == DWDObservationResolution.ANNUAL:
-        date_from = pd.to_datetime(date_from) + relativedelta(month=1, day=1)
-        date_to = pd.to_datetime(date_to) + relativedelta(month=12, day=31)
-
-    elif resolution == DWDObservationResolution.MONTHLY:
-        date_from = pd.to_datetime(date_from) + relativedelta(day=1)
-        date_to = pd.to_datetime(date_to) + relativedelta(day=31)
-
-    else:
-        raise NotImplementedError(
-            "mktimerange only implemented for annual and monthly time ranges"
-        )
-
-    # TODO: make tz aware
-    date_from = date_from.replace(tzinfo=pytz.UTC)
-    date_to = date_to.replace(tzinfo=pytz.UTC)
-
-    return date_from, date_to

--- a/wetterdienst/exceptions.py
+++ b/wetterdienst/exceptions.py
@@ -36,3 +36,7 @@ class StartDateEndDateError(Exception):
 
 class DatetimeOutOfRangeError(Exception):
     pass
+
+
+class InvalidTimeInterval(ValueError):
+    pass

--- a/wetterdienst/util/datetime.py
+++ b/wetterdienst/util/datetime.py
@@ -1,4 +1,11 @@
 from datetime import datetime, timedelta
+from typing import Tuple, Union
+
+import pandas as pd
+import pytz
+from dateutil.relativedelta import relativedelta
+
+from wetterdienst.metadata.resolution import Resolution
 
 
 def round_minutes(timestamp: datetime, step: int):
@@ -36,3 +43,41 @@ def raster_minutes(timestamp: datetime, value: int):
     timestamp = timestamp.replace(minute=value)
 
     return timestamp
+
+
+def mktimerange(
+    resolution: Resolution,
+    date_from: datetime,
+    date_to: datetime = None,
+) -> Tuple[datetime, datetime]:
+    """
+    Compute appropriate time ranges for monthly and annual time resolutions.
+    This takes into account to properly floor/ceil the date_from/date_to
+    values to respective "begin of month/year" and "end of month/year" values.
+
+    Args:
+        resolution: time resolution as enumeration
+        date_from: datetime string or object
+        date_to: datetime string or object
+
+    Returns:
+        Tuple of two Timestamps: "date_from" and "date_to"
+    """
+
+    if date_to is None:
+        date_to = date_from
+
+    if resolution == Resolution.ANNUAL:
+        date_from = date_from + relativedelta(month=1, day=1)
+        date_to = date_to + relativedelta(month=12, day=31)
+
+    elif resolution == Resolution.MONTHLY:
+        date_from = date_from + relativedelta(day=1)
+        date_to = date_to + relativedelta(day=31)
+
+    else:
+        raise NotImplementedError(
+            "mktimerange only implemented for annual and monthly time ranges"
+        )
+
+    return date_from, date_to


### PR DESCRIPTION
Date parsing is changed to isoformat only using the module

dateutil.parser.isoparse

Fixes #258 , #247 