### PR TITLE
Fix renaming of "master" branch to "main" branch on some spots

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Overview
 
 .. image:: https://github.com/earthobservations/wetterdienst/workflows/Tests/badge.svg
    :target: https://github.com/earthobservations/wetterdienst/actions?workflow=Tests
-.. image:: https://codecov.io/gh/earthobservations/wetterdienst/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/earthobservations/wetterdienst/branch/main/graph/badge.svg
    :target: https://codecov.io/gh/earthobservations/wetterdienst
 .. image:: https://readthedocs.org/projects/wetterdienst/badge/?version=latest
    :target: https://wetterdienst.readthedocs.io/en/latest/?badge=latest
@@ -34,7 +34,7 @@ Overview
 .. image:: https://pepy.tech/badge/wetterdienst/month
    :target: https://pepy.tech/project/wetterdienst/month
 .. image:: https://img.shields.io/github/license/earthobservations/wetterdienst
-   :target: https://github.com/earthobservations/wetterdienst/blob/master/LICENSE.rst
+   :target: https://github.com/earthobservations/wetterdienst/blob/main/LICENSE.rst
 .. image:: https://zenodo.org/badge/160953150.svg
    :target: https://zenodo.org/badge/latestdoi/160953150
 .. image:: https://img.shields.io/discord/704622099750191174.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2

--- a/docs/data/coverage/dwd.rst
+++ b/docs/data/coverage/dwd.rst
@@ -151,7 +151,7 @@ For example, use commands like these for accessing this information::
     # German language.
     wetterdienst dwd about fields --parameter=air_temperature --resolution=10_minutes --period=historical --language=de
 
-or have a look at the example program `dwd_describe_fields.py <https://github.com/earthobservations/wetterdienst/blob/master/example/dwd_describe_fields.py>`_.
+or have a look at the example program `dwd_describe_fields.py <https://github.com/earthobservations/wetterdienst/blob/main/example/dwd_describe_fields.py>`_.
 
 Details
 ^^^^^^^

--- a/docs/usage/api.rst
+++ b/docs/usage/api.rst
@@ -17,7 +17,7 @@ Please also check out complete examples about how to use the API in the example_
 In order to explore all features interactively,
 you might want to try the :ref:`cli`.
 
-.. _example: https://github.com/earthobservations/wetterdienst/tree/master/example
+.. _example: https://github.com/earthobservations/wetterdienst/tree/main/example
 
 Request arguments
 =================
@@ -372,7 +372,7 @@ For more examples, please have a look at `example/radar/`_.
 
 
 .. _wradlib: https://wradlib.org/
-.. _example/radar/: https://github.com/earthobservations/wetterdienst/tree/master/example/radar
+.. _example/radar/: https://github.com/earthobservations/wetterdienst/tree/main/example/radar
 
 .. _SQLite: https://www.sqlite.org/
 .. _DuckDB: https://duckdb.org/docs/sql/introduction


### PR DESCRIPTION
Hi there,

some spots have been missed after renaming the "master" branch to the "main" branch. This patch accounts for that.

With kind regards,
Andreas.