### PR TITLE
DWD: Add missing radar site "Emden" (EMD, wmo=10204)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Changelog
 
 Development
 ***********
+- DWD: Add missing radar site "Emden" (EMD, wmo=10204)
 
 0.13.0 (21.01.2021)
 *******************

--- a/tests/dwd/radar/test_sites.py
+++ b/tests/dwd/radar/test_sites.py
@@ -1,10 +1,20 @@
 from wetterdienst.dwd.radar import DWDRadarData
+from wetterdienst.dwd.radar.sites import DWDRadarSite
 
 
-def test_radar_sites():
+def test_radar_sites_data():
 
     sites = DWDRadarData.get_sites()
 
-    assert len(sites) == 17
+    assert len(sites) == 18
     assert sites["ASB"]["name"] == "ASR Borkum"
+    assert sites["EMD"]["name"] == "Emden"
     assert sites["UMD"]["name"] == "Ummendorf"
+
+
+def test_radar_sites_enum():
+
+    assert len(DWDRadarSite) == 18
+    assert DWDRadarSite.ASB.value == "asb"
+    assert DWDRadarSite.EMD.value == "emd"
+    assert DWDRadarSite.UMD.value == "umd"

--- a/wetterdienst/dwd/radar/sites.py
+++ b/wetterdienst/dwd/radar/sites.py
@@ -44,6 +44,16 @@ RADAR_LOCATIONS = {
         "longitude": 12.402788,
         "altitude": 799,
     },
+    # Emden is missing in `koordinaten-radarverbund.pdf`.
+    # https://github.com/wradlib/wradlib-notebooks/issues/49#issuecomment-768262146
+    "EMD": {
+        "name": "Emden",
+        "dwd_id": "EMD",
+        "wmo_id": 10204,
+        "latitude": 53.33872,
+        "longitude": 7.02377,
+        "altitude": 58,
+    },
     "ESS": {
         "name": "Essen",
         "dwd_id": "ESS",
@@ -160,6 +170,7 @@ class DWDRadarSite(Enum):
     BOO = "boo"
     DRS = "drs"
     EIS = "eis"
+    EMD = "emd"
     ESS = "ess"
     FBG = "fbg"
     FLD = "fld"


### PR DESCRIPTION
Hi there,

according to https://github.com/wradlib/wradlib-notebooks/issues/49#issuecomment-768262146, Emden is missing in the official publication [koordinaten-radarverbund.pdf](https://www.dwd.de/DE/derdwd/messnetz/atmosphaerenbeobachtung/_functions/HaeufigGesucht/koordinaten-radarverbund.pdf?__blob=publicationFile). Thanks for spotting this, @kmuehlbauer.

a) This patch adds it back. Can you verify the coordinates, Kai?
b) We should also notify `opendata@dwd.de` about it.

With kind regards,
Andreas.
