### PR TITLE
Tests: Fix some xfailing radar tests

### DIFF
--- a/tests/provider/dwd/radar/test_api_current.py
+++ b/tests/provider/dwd/radar/test_api_current.py
@@ -32,32 +32,32 @@ def test_radar_request_site_current_sweep_pcp_v_hdf5():
 
     results = list(request.query())
 
-    if results:
+    if len(results) == 0:
+        raise pytest.skip("Data currently not available")
 
-        buffer = results[0].data
-        payload = buffer.getvalue()
+    buffer = results[0].data
+    payload = buffer.getvalue()
 
-        # Verify data.
-        assert payload.startswith(b"\x89HDF\r\n")
+    # Verify data.
+    assert payload.startswith(b"\x89HDF\r\n")
 
-        # Verify more details.
-        # wddump ras07-stqual-pcpng01_sweeph5onem_vradh_00-2020093000403400-boo-10132-hd5  # noqa:E501,B950
+    # Verify more details.
+    # wddump ras07-stqual-pcpng01_sweeph5onem_vradh_00-2020093000403400-boo-10132-hd5  # noqa:E501,B950
 
-        hdf = h5py.File(buffer, "r")
+    hdf = h5py.File(buffer, "r")
 
-        assert hdf["/how/radar_system"] is not None
-        assert hdf["/how"].attrs.get("task") == b"Sc_Pcp-NG-01_BOO"
-        assert hdf["/what"].attrs.get("source") == b"WMO:10132,NOD:deboo"
+    assert hdf["/how/radar_system"] is not None
+    assert hdf["/how"].attrs.get("task") == b"Sc_Pcp-NG-01_BOO"
+    assert hdf["/what"].attrs.get("source") == b"WMO:10132,NOD:deboo"
 
-        assert hdf["/how"].attrs.get("scan_count") == 1
-        assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
+    assert hdf["/how"].attrs.get("scan_count") == 1
+    assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-        shape = hdf["/dataset1/data1/data"].shape
+    shape = hdf["/dataset1/data1/data"].shape
 
-        assert shape == (360, 600) or shape == (361, 600)
+    assert shape == (360, 600) or shape == (361, 600)
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_current_sweep_vol_v_hdf5_full():
     """
@@ -75,29 +75,30 @@ def test_radar_request_site_current_sweep_vol_v_hdf5_full():
 
     results = list(request.query())
 
-    if results:
+    if len(results) == 0:
+        raise pytest.skip("Data currently not available")
 
-        buffer = results[0].data
-        payload = buffer.getvalue()
+    buffer = results[0].data
+    payload = buffer.getvalue()
 
-        # Verify data.
-        assert payload.startswith(b"\x89HDF\r\n")
+    # Verify data.
+    assert payload.startswith(b"\x89HDF\r\n")
 
-        # Verify more details.
-        # wddump ras07-stqual-vol5minng01_sweeph5onem_vradh_00-2020092917055800-boo-10132-hd5  # noqa:E501,B950
+    # Verify more details.
+    # wddump ras07-stqual-vol5minng01_sweeph5onem_vradh_00-2020092917055800-boo-10132-hd5  # noqa:E501,B950
 
-        hdf = h5py.File(buffer, "r")
+    hdf = h5py.File(buffer, "r")
 
-        assert hdf["/how/radar_system"] is not None
-        assert hdf["/how"].attrs.get("task") == b"Sc_Vol-5Min-NG-01_BOO"
-        assert hdf["/what"].attrs.get("source") == b"WMO:10132,NOD:deboo"
+    assert hdf["/how/radar_system"] is not None
+    assert hdf["/how"].attrs.get("task") == b"Sc_Vol-5Min-NG-01_BOO"
+    assert hdf["/what"].attrs.get("source") == b"WMO:10132,NOD:deboo"
 
-        assert hdf["/how"].attrs.get("scan_count") == 10
-        assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
+    assert hdf["/how"].attrs.get("scan_count") == 10
+    assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-        shape = hdf["/dataset1/data1/data"].shape
+    shape = hdf["/dataset1/data1/data"].shape
 
-        assert shape == (360, 180) or shape == (361, 180)
+    assert shape == (360, 180) or shape == (360, 720)
 
 
 @pytest.mark.remote
@@ -118,16 +119,18 @@ def test_radar_request_site_current_sweep_vol_v_hdf5_single():
 
     results = list(request.query())
 
+    if len(results) == 0:
+        raise pytest.skip("Data currently not available")
+
     assert len(results) <= 1
 
-    if results:
-        assert "vradh_01" in results[0].url
+    assert "vradh_01" in results[0].url
 
-        buffer = results[0].data
-        hdf = h5py.File(buffer, "r")
+    buffer = results[0].data
+    hdf = h5py.File(buffer, "r")
 
-        assert hdf["/how"].attrs.get("scan_count") == 10
-        assert hdf["/dataset1/how"].attrs.get("scan_index") == 2
+    assert hdf["/how"].attrs.get("scan_count") == 10
+    assert hdf["/dataset1/how"].attrs.get("scan_index") == 2
 
 
 @pytest.mark.remote
@@ -152,7 +155,10 @@ def test_radar_request_radolan_cdc_current(time_resolution):
         resolution=time_resolution,
     )
 
-    list(request.query())
+    results = list(request.query())
+
+    if len(results) == 0:
+        raise pytest.skip("Data currently not available")
 
 
 @pytest.mark.remote

--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -247,7 +247,6 @@ def test_radar_request_composite_historic_radolan_rw_timerange():
     # TODO: Verify data.
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_historic_dx_yesterday():
     """
@@ -268,7 +267,7 @@ def test_radar_request_site_historic_dx_yesterday():
     if len(results) == 0:
         raise pytest.skip("Data currently not available")
 
-    buffer = results[1]
+    buffer = results[0].data
     payload = buffer.getvalue()
 
     # Verify data.
@@ -309,7 +308,6 @@ def test_radar_request_site_historic_dx_timerange():
     # TODO: Verify data.
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_historic_pe_binary_yesterday():
     """
@@ -334,7 +332,7 @@ def test_radar_request_site_historic_pe_binary_yesterday():
     if len(results) == 0:
         raise pytest.skip("Data currently not available")
 
-    buffer = results[1]
+    buffer = results[0].data
     payload = buffer.getvalue()
 
     # Verify data.
@@ -350,7 +348,6 @@ def test_radar_request_site_historic_pe_binary_yesterday():
     assert re.match(bytes(header, encoding="ascii"), payload[:160])
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_historic_pe_bufr():
     """
@@ -375,7 +372,7 @@ def test_radar_request_site_historic_pe_bufr():
     if len(results) == 0:
         raise pytest.skip("Data currently not available")
 
-    buffer = results[1]
+    buffer = results[0].data
     payload = buffer.getvalue()
 
     # Verify data.
@@ -431,7 +428,6 @@ def test_radar_request_site_historic_pe_timerange(format):
     # TODO: Verify data.
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_historic_px250_bufr_yesterday():
     """
@@ -451,7 +447,7 @@ def test_radar_request_site_historic_px250_bufr_yesterday():
     if len(results) == 0:
         raise pytest.skip("Data currently not available")
 
-    buffer = results[1]
+    buffer = results[0].data
     payload = buffer.getvalue()
 
     # Verify data.
@@ -721,7 +717,6 @@ def test_radar_request_site_historic_sweep_pcp_v_hdf5_timerange():
     # TODO: Verify data.
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_historic_sweep_vol_v_hdf5_yesterday():
     """
@@ -765,7 +760,7 @@ def test_radar_request_site_historic_sweep_vol_v_hdf5_yesterday():
     assert hdf["/how"].attrs.get("scan_count") == 10
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape in ((360, 180), (361, 180))
+    assert hdf["/dataset1/data1/data"].shape in ((360, 180), (360, 720))
 
     timestamp = round_minutes(request.start_date, 5)
     assert hdf["/what"].attrs.get("date") == bytes(
@@ -888,7 +883,6 @@ def test_radar_request_radvor_re_timerange():
     # TODO: Verify data.
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_radvor_rq_yesterday():
     """

--- a/tests/provider/dwd/radar/test_api_latest.py
+++ b/tests/provider/dwd/radar/test_api_latest.py
@@ -30,7 +30,7 @@ def test_radar_request_composite_latest_rx_reflectivity():
 
     month_year = datetime.utcnow().strftime("%m%y")
     header = (
-        f"RX......10000{month_year}BY 8101..VS 3SW   2.28.1PR E\\+00INT   5GP 900x 900MS "  # noqa:E501,B950
+        f"RX......10000{month_year}BY 8101..VS 3SW   2.28..PR E\\+00INT   5GP 900x 900MS "  # noqa:E501,B950
         f"..<{station_reference_pattern_unsorted}>"  # noqa:E501,B950
     )
 
@@ -60,7 +60,7 @@ def test_radar_request_composite_latest_rw_reflectivity():
     month_year = datetime.utcnow().strftime("%m%y")
     header = (
         f"RW......10000{month_year}"
-        f"BY16201..VS 3SW   2.28.1PR E-01INT  60GP 900x 900MF 00000001MS "
+        f"BY16201..VS 3SW   2.28..PR E-01INT  60GP 900x 900MF 00000001MS "
         f"..<{station_reference_pattern_unsorted}>"
     )
 

--- a/tests/provider/dwd/radar/test_api_most_recent.py
+++ b/tests/provider/dwd/radar/test_api_most_recent.py
@@ -61,7 +61,6 @@ def test_radar_request_site_most_recent_sweep_pcp_v_hdf5():
     assert hdf["/dataset1/data1/data"].shape == (360, 600)
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_most_recent_sweep_vol_v_hdf5():
     """
@@ -103,7 +102,7 @@ def test_radar_request_site_most_recent_sweep_vol_v_hdf5():
     assert hdf["/how"].attrs.get("scan_count") == 10
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape == (360, 180)
+    assert hdf["/dataset1/data1/data"].shape == (360, 720)
 
     # Verify that the second file is the second scan / elevation level.
     buffer = results[1].data

--- a/tests/provider/dwd/radar/test_api_recent.py
+++ b/tests/provider/dwd/radar/test_api_recent.py
@@ -58,7 +58,6 @@ def test_radar_request_site_recent_sweep_pcp_v_hdf5():
     assert hdf["/dataset1/data1/data"].shape == (360, 600)
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_recent_sweep_vol_v_hdf5():
     """
@@ -100,7 +99,7 @@ def test_radar_request_site_recent_sweep_vol_v_hdf5():
     assert hdf["/how"].attrs.get("scan_count") == 10
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape == (360, 180)
+    assert hdf["/dataset1/data1/data"].shape == (360, 720)
 
     # Verify that the second file is the second scan / elevation level.
     buffer = results[1].data


### PR DESCRIPTION
With this patch, I tried to improve the test situation with radar a bit. Some tests have been marked as `xfail`, where I tried to use more conditional runtime `skip`s instead, like:

```python
    if len(results) == 0:
        raise pytest.skip("Data currently not available")
```
