### PR TITLE
Radar: Verify HDF5 responses instead of returning invalid data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_build/
 dist/
 tmp/
 geckodriver.log
+troubleshooting

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Development
 - Add capability to export data to Zarr format
 - Add Wetterdienst UI. Thanks, @meteoDaniel!
 - Add MAC ARM64 supoort with dependency restrictions
+- Radar: Verify HDF5 responses instead of returning invalid data
 
 0.16.1 (31.03.2021)
 *******************

--- a/example/radar/radar_composite_rw.py
+++ b/example/radar/radar_composite_rw.py
@@ -26,7 +26,7 @@ Setup
 import logging
 import os
 
-import matplotlib.pyplot as pl
+import matplotlib.pyplot as plt
 import numpy as np
 import wradlib as wrl
 
@@ -61,21 +61,21 @@ def plot_radolan(data: np.ndarray, attrs: dict, grid: np.dstack, clabel: str = N
 
     Thanks!
     """
-    fig = pl.figure(figsize=(10, 8))
+    fig = plt.figure(figsize=(10, 8))
     ax = fig.add_subplot(111, aspect="equal")
     x = grid[:, :, 0]
     y = grid[:, :, 1]
     pm = ax.pcolormesh(x, y, data, cmap="viridis", shading="auto")
     cb = fig.colorbar(pm, shrink=0.75)
     cb.set_label(clabel)
-    pl.xlabel("x [km]")
-    pl.ylabel("y [km]")
-    pl.title(
+    plt.xlabel("x [km]")
+    plt.ylabel("y [km]")
+    plt.title(
         "{0} Product\n{1}".format(attrs["producttype"], attrs["datetime"].isoformat())
     )
-    pl.xlim((x[0, 0], x[-1, -1]))
-    pl.ylim((y[0, 0], y[-1, -1]))
-    pl.grid(color="r")
+    plt.xlim((x[0, 0], x[-1, -1]))
+    plt.ylim((y[0, 0], y[-1, -1]))
+    plt.grid(color="r")
 
 
 def radar_info(data: np.ndarray, attributes: dict):
@@ -108,7 +108,7 @@ def radar_rw_example():
         # Plot and display data.
         plot(data, attributes)
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            pl.show()
+            plt.show()
 
 
 def main():

--- a/example/radar/radar_composite_rw.py
+++ b/example/radar/radar_composite_rw.py
@@ -5,7 +5,7 @@
 =====
 About
 =====
-Example for DWD RADOLAN Composite RX using wetterdienst and wradlib.
+Example for DWD RADOLAN Composite RW using wetterdienst and wradlib.
 
 See also:
 - https://docs.wradlib.org/en/stable/notebooks/radolan/radolan_showcase.html.
@@ -24,6 +24,7 @@ Setup
 
 """
 import logging
+import os
 
 import matplotlib.pyplot as pl
 import numpy as np
@@ -88,29 +89,30 @@ def radar_info(data: np.ndarray, attributes: dict):
         print(f"- {key}: {value}")
 
 
-def radar_rx_example():
+def radar_rw_example():
 
-    log.info("Acquiring radar RX composite data")
+    log.info("Acquiring radar RW composite data")
     radolan = DwdRadarValues(
-        parameter=DwdRadarParameter.RX_REFLECTIVITY,
+        parameter=DwdRadarParameter.RW_REFLECTIVITY,
         start_date=DwdRadarDate.LATEST,
     )
 
-    for item in radolan.collect_data():
+    for item in radolan.query():
 
         # Decode data using wradlib.
-        log.info("Parsing radar RX composite data for %s", item.timestamp)
+        log.info("Parsing radar RW composite data for %s", item.timestamp)
         data, attributes = wrl.io.read_radolan_composite(item.data)
 
         radar_info(data, attributes)
 
         # Plot and display data.
         plot(data, attributes)
-        pl.show()
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            pl.show()
 
 
 def main():
-    radar_rx_example()
+    radar_rw_example()
 
 
 if __name__ == "__main__":

--- a/example/radar/radar_radolan_cdc.py
+++ b/example/radar/radar_radolan_cdc.py
@@ -45,6 +45,7 @@ real-time for Germany.
 - Daily: https://docs.wradlib.org/en/stable/notebooks/radolan/radolan_showcase.html#RADOLAN-SF-Product # noqa
 """
 import logging
+import os
 
 import matplotlib.pyplot as pl
 import numpy as np
@@ -140,7 +141,7 @@ def radolan_grid_example():
         end_date="2020-09-04T12:00:00",
     )
 
-    for item in radolan.collect_data():
+    for item in radolan.query():
 
         # Decode data using wradlib.
         log.info("Parsing RADOLAN_CDC composite data for %s", item.timestamp)
@@ -151,7 +152,8 @@ def radolan_grid_example():
 
         # Plot and display data.
         plot(data, attributes, label)
-        pl.show()
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            pl.show()
 
 
 def main():

--- a/example/radar/radar_radolan_cdc.py
+++ b/example/radar/radar_radolan_cdc.py
@@ -47,7 +47,7 @@ real-time for Germany.
 import logging
 import os
 
-import matplotlib.pyplot as pl
+import matplotlib.pyplot as plt
 import numpy as np
 import wradlib as wrl
 
@@ -86,21 +86,21 @@ def plot_radolan(data: np.ndarray, attrs: dict, grid: np.dstack, clabel: str = N
 
     Thanks!
     """
-    fig = pl.figure(figsize=(10, 8))
+    fig = plt.figure(figsize=(10, 8))
     ax = fig.add_subplot(111, aspect="equal")
     x = grid[:, :, 0]
     y = grid[:, :, 1]
     pm = ax.pcolormesh(x, y, data, cmap="viridis", shading="auto")
     cb = fig.colorbar(pm, shrink=0.75)
     cb.set_label(clabel)
-    pl.xlabel("x [km]")
-    pl.ylabel("y [km]")
-    pl.title(
+    plt.xlabel("x [km]")
+    plt.ylabel("y [km]")
+    plt.title(
         "{0} Product\n{1}".format(attrs["producttype"], attrs["datetime"].isoformat())
     )
-    pl.xlim((x[0, 0], x[-1, -1]))
-    pl.ylim((y[0, 0], y[-1, -1]))
-    pl.grid(color="r")
+    plt.xlim((x[0, 0], x[-1, -1]))
+    plt.ylim((y[0, 0], y[-1, -1]))
+    plt.grid(color="r")
 
 
 def radolan_info(data: np.ndarray, attributes: dict):
@@ -153,7 +153,7 @@ def radolan_grid_example():
         # Plot and display data.
         plot(data, attributes, label)
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            pl.show()
+            plt.show()
 
 
 def main():

--- a/example/radar/radar_radolan_rw.py
+++ b/example/radar/radar_radolan_rw.py
@@ -47,7 +47,7 @@ real-time for Germany.
 import logging
 import os
 
-import matplotlib.pyplot as pl
+import matplotlib.pyplot as plt
 import numpy as np
 import wradlib as wrl
 
@@ -85,21 +85,21 @@ def plot_radolan(data: np.ndarray, attrs: dict, grid: np.dstack, clabel: str = N
 
     Thanks!
     """
-    fig = pl.figure(figsize=(10, 8))
+    fig = plt.figure(figsize=(10, 8))
     ax = fig.add_subplot(111, aspect="equal")
     x = grid[:, :, 0]
     y = grid[:, :, 1]
     pm = ax.pcolormesh(x, y, data, cmap="viridis", shading="auto")
     cb = fig.colorbar(pm, shrink=0.75)
     cb.set_label(clabel)
-    pl.xlabel("x [km]")
-    pl.ylabel("y [km]")
-    pl.title(
+    plt.xlabel("x [km]")
+    plt.ylabel("y [km]")
+    plt.title(
         "{0} Product\n{1}".format(attrs["producttype"], attrs["datetime"].isoformat())
     )
-    pl.xlim((x[0, 0], x[-1, -1]))
-    pl.ylim((y[0, 0], y[-1, -1]))
-    pl.grid(color="r")
+    plt.xlim((x[0, 0], x[-1, -1]))
+    plt.ylim((y[0, 0], y[-1, -1]))
+    plt.grid(color="r")
 
 
 def radolan_info(data: np.ndarray, attributes: dict):
@@ -148,7 +148,7 @@ def radolan_rw_example():
         # Plot and display data.
         plot(data, attributes, label)
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            pl.show()
+            plt.show()
 
 
 def main():

--- a/example/radar/radar_radolan_rw.py
+++ b/example/radar/radar_radolan_rw.py
@@ -45,6 +45,7 @@ real-time for Germany.
 - Daily: https://docs.wradlib.org/en/stable/notebooks/radolan/radolan_showcase.html#RADOLAN-SF-Product # noqa
 """
 import logging
+import os
 
 import matplotlib.pyplot as pl
 import numpy as np
@@ -135,7 +136,7 @@ def radolan_rw_example():
         start_date=DwdRadarDate.LATEST,
     )
 
-    for item in radolan.collect_data():
+    for item in radolan.query():
 
         # Decode data using wradlib.
         log.info("Parsing RADOLAN RW composite data for %s", item.timestamp)
@@ -146,7 +147,8 @@ def radolan_rw_example():
 
         # Plot and display data.
         plot(data, attributes, label)
-        pl.show()
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            pl.show()
 
 
 def main():

--- a/example/radar/radar_scan_precip.py
+++ b/example/radar/radar_scan_precip.py
@@ -12,7 +12,7 @@ See also:
 - https://docs.wradlib.org/en/stable/notebooks/fileio/wradlib_radar_formats.html#OPERA-HDF5-(ODIM_H5) # noqa
 
 This program will request the most recent complete SWEEP_PCP data
-for Boostedt and plot the outcome with matplotlib.
+for Essen and plot the outcome with matplotlib.
 
 
 =====
@@ -82,27 +82,25 @@ def radar_scan_precip():
     request_velocity = DwdRadarValues(
         parameter=DwdRadarParameter.SWEEP_PCP_VELOCITY_H,
         start_date=DwdRadarDate.MOST_RECENT,
-        site=DwdRadarSite.BOO,
+        site=DwdRadarSite.ESS,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.POLARIMETRIC,
     )
     request_reflectivity = DwdRadarValues(
         parameter=DwdRadarParameter.SWEEP_PCP_REFLECTIVITY_H,
         start_date=DwdRadarDate.MOST_RECENT,
-        site=DwdRadarSite.BOO,
+        site=DwdRadarSite.ESS,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.POLARIMETRIC,
     )
 
     log.info(
-        f"Acquiring radar SWEEP_PCP data for {DwdRadarSite.BOO} at "
+        f"Acquiring radar SWEEP_PCP data for {DwdRadarSite.ESS} at "
         f"{request_velocity.start_date}"
     )
 
     # Submit requests.
-    results = chain(
-        request_velocity.collect_data(), request_reflectivity.collect_data()
-    )
+    results = chain(request_velocity.query(), request_reflectivity.query())
 
     # Collect list of buffers.
     files = list(map(lambda item: item.data, results))
@@ -115,11 +113,8 @@ def radar_scan_precip():
 
     # Plot and display data.
     plot(data)
-    pl.show()
-
-    # Remove temporary files.
-    for tmpfile in files:
-        os.unlink(tmpfile)
+    if "PYTEST_CURRENT_TEST" not in os.environ:
+        pl.show()
 
 
 def main():

--- a/example/radar/radar_scan_precip.py
+++ b/example/radar/radar_scan_precip.py
@@ -28,7 +28,7 @@ import logging
 import os
 from itertools import chain
 
-import matplotlib.pyplot as pl
+import matplotlib.pyplot as plt
 import wradlib as wrl
 
 from wetterdienst.provider.dwd.radar import (
@@ -56,7 +56,7 @@ def plot(data: wrl.io.XRadVolume):
     swp0 = swp0.pipe(wrl.georef.georeference_dataset)
 
     # Plot and display data using cartopy.
-    fig = pl.figure(figsize=(20, 8))
+    fig = plt.figure(figsize=(20, 8))
     ax1 = fig.add_subplot(121, aspect="equal")
     swp0.DBZH[0].plot(x="x", y="y", ax=ax1)
     ax2 = fig.add_subplot(122, aspect="equal")
@@ -114,7 +114,7 @@ def radar_scan_precip():
     # Plot and display data.
     plot(data)
     if "PYTEST_CURRENT_TEST" not in os.environ:
-        pl.show()
+        plt.show()
 
 
 def main():

--- a/example/radar/radar_scan_volume.py
+++ b/example/radar/radar_scan_volume.py
@@ -28,7 +28,7 @@ import logging
 import os
 from itertools import chain
 
-import matplotlib.pyplot as pl
+import matplotlib.pyplot as plt
 import wradlib as wrl
 
 from wetterdienst.provider.dwd.radar import (
@@ -56,7 +56,7 @@ def plot(data: wrl.io.XRadVolume):
     swp0 = swp0.pipe(wrl.georef.georeference_dataset)
 
     # Plot and display data using cartopy.
-    fig = pl.figure(figsize=(20, 8))
+    fig = plt.figure(figsize=(20, 8))
     ax1 = fig.add_subplot(121, aspect="equal")
     swp0.DBZH[0].plot(x="x", y="y", ax=ax1)
     ax2 = fig.add_subplot(122, aspect="equal")
@@ -118,7 +118,7 @@ def radar_scan_volume():
     # Plot and display data.
     plot(data)
     if "PYTEST_CURRENT_TEST" not in os.environ:
-        pl.show()
+        plt.show()
 
 
 def main():

--- a/example/radar/radar_site_dx.py
+++ b/example/radar/radar_site_dx.py
@@ -30,7 +30,7 @@ Setup
 import logging
 import os
 
-import matplotlib.pyplot as pl
+import matplotlib.pyplot as plt
 import numpy as np
 import wradlib as wrl
 
@@ -50,7 +50,7 @@ def plot(data: np.ndarray):
     Convenience function for plotting radar data.
     """
 
-    fig = pl.figure(figsize=(10, 8))
+    fig = plt.figure(figsize=(10, 8))
     wrl.vis.plot_ppi(data, fig=fig, proj="cg")
 
 
@@ -87,7 +87,7 @@ def radar_dx_example():
         # Plot and display data.
         plot(data)
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            pl.show()
+            plt.show()
 
 
 def main():

--- a/example/radar/radar_site_dx.py
+++ b/example/radar/radar_site_dx.py
@@ -28,6 +28,7 @@ Setup
 
 """
 import logging
+import os
 
 import matplotlib.pyplot as pl
 import numpy as np
@@ -74,7 +75,7 @@ def radar_dx_example():
         site=DwdRadarSite.BOO,
     )
 
-    for item in request.collect_data():
+    for item in request.query():
 
         # Decode data using wradlib.
         log.info(f"Parsing radar data for {request.site} at '{item.timestamp}'")
@@ -85,7 +86,8 @@ def radar_dx_example():
 
         # Plot and display data.
         plot(data)
-        pl.show()
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            pl.show()
 
 
 def main():

--- a/example/radar/radar_sweep_hdf5.py
+++ b/example/radar/radar_sweep_hdf5.py
@@ -26,7 +26,7 @@ Setup
 import logging
 import os
 
-import matplotlib.pyplot as pl
+import matplotlib.pyplot as plt
 import numpy as np
 import wradlib as wrl
 
@@ -48,7 +48,7 @@ def plot(data: np.ndarray):
     Convenience function for plotting radar data.
     """
 
-    fig = pl.figure(figsize=(10, 8))
+    fig = plt.figure(figsize=(10, 8))
     wrl.vis.plot_ppi(data["dataset1/data1/data"], fig=fig, proj="cg")
 
 
@@ -86,7 +86,7 @@ def radar_hdf5_example():
         # Plot and display data.
         plot(data)
         if "PYTEST_CURRENT_TEST" not in os.environ:
-            pl.show()
+            plt.show()
 
 
 def main():

--- a/example/radar/radar_sweep_hdf5.py
+++ b/example/radar/radar_sweep_hdf5.py
@@ -24,6 +24,7 @@ Setup
 
 """
 import logging
+import os
 
 import matplotlib.pyplot as pl
 import numpy as np
@@ -73,7 +74,7 @@ def radar_hdf5_example():
         subset=DwdRadarDataSubset.SIMPLE,
     )
 
-    for item in request.collect_data():
+    for item in request.query():
 
         # Decode data using wradlib.
         log.info(f"Parsing radar data for {request.site} at '{item.timestamp}'")
@@ -84,7 +85,8 @@ def radar_hdf5_example():
 
         # Plot and display data.
         plot(data)
-        pl.show()
+        if "PYTEST_CURRENT_TEST" not in os.environ:
+            pl.show()
 
 
 def main():

--- a/poetry.lock
+++ b/poetry.lock
@@ -672,7 +672,7 @@ stevedore = ">=3.0.0"
 
 [[package]]
 name = "duckdb"
-version = "0.2.6.dev307"
+version = "0.2.6.dev318"
 description = "DuckDB embedded database"
 category = "main"
 optional = true
@@ -932,7 +932,7 @@ name = "h5netcdf"
 version = "0.10.0"
 description = "netCDF4 via h5py"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -1923,7 +1923,7 @@ py = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "regex"
-version = "2021.3.17"
+version = "2021.4.4"
 description = "Alternative regular expression module, to replace re."
 category = "main"
 optional = false
@@ -2599,7 +2599,7 @@ ui = ["plotly", "dash", "dash-bootstrap-components"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "8253dca33d8f63fb1b611b5d2749c46186a3c32cbd73488df84ad6a525d4c417"
+content-hash = "0e946dc00c136767ad33d42a182d5b31a785d6d05e34d10c6cbd91d61b20ec15"
 
 [metadata.files]
 aiohttp = [
@@ -2670,8 +2670,6 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:6678bb047373f52bcff02db8afab0d2a77d83bde61cfecea7c5c62e2335cb203"},
     {file = "argon2_cffi-20.1.0-cp38-cp38-win32.whl", hash = "sha256:77e909cc756ef81d6abb60524d259d959bab384832f0c651ed7dcb6e5ccdbb78"},
     {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
-    {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
-    {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
 ]
 asciitree = [
     {file = "asciitree-0.3.3.tar.gz", hash = "sha256:4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e"},
@@ -2709,6 +2707,7 @@ bitstring = [
     {file = "bitstring-3.1.7.tar.gz", hash = "sha256:fdf3eb72b229d2864fb507f8f42b1b2c57af7ce5fec035972f9566de440a864a"},
 ]
 black = [
+    {file = "black-20.8b1-py3-none-any.whl", hash = "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"},
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 bleach = [
@@ -3027,27 +3026,27 @@ docutils = [
     {file = "dogpile.cache-1.1.2.tar.gz", hash = "sha256:2134464672a3deb7ef1366a8691726686d8c62540e4208f1a40c9aaa1a0b6a45"},
 ]
 duckdb = [
-    {file = "duckdb-0.2.6.dev307-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:42235e6dc5295ed3795aa47d270bf0af56cb155acf509fc1ea2bd29b9bf2cc02"},
-    {file = "duckdb-0.2.6.dev307-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f955a90e57b0ad853b967b99961f9e085ccd8211dcafdda4f6650ed2834b2025"},
-    {file = "duckdb-0.2.6.dev307-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f6579a1e6f3f8b521e810c4f37dec3df7a5c018e09961ccdc2ce906e6cddb2e5"},
-    {file = "duckdb-0.2.6.dev307-cp36-cp36m-win32.whl", hash = "sha256:c56f15aeba1c8eb8fc8b471b3f2a973457524be40bfd37f09ea37afec918f4c4"},
-    {file = "duckdb-0.2.6.dev307-cp36-cp36m-win_amd64.whl", hash = "sha256:be7101796aa943cd9fa7c8637fc4653f2c1e47bda3acd401652cb7b5eb8ee5a0"},
-    {file = "duckdb-0.2.6.dev307-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:9db12019cb879e97b59339b7708f6d4565a9e8c0d523b33f37fd43a5c64059b7"},
-    {file = "duckdb-0.2.6.dev307-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:8793761b60636d388725229be7cfea2e95cf27ad1ec9473a6211c5080cf5bbf2"},
-    {file = "duckdb-0.2.6.dev307-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2ae13d4b681b0899e70902c57353fd051619aa0c01eaf26f3dd709b6839ea279"},
-    {file = "duckdb-0.2.6.dev307-cp37-cp37m-win32.whl", hash = "sha256:62fb3f9c4d03a7b40d98dba105e3ed81bec4a73b5a6c9a229b18a2a478f81f34"},
-    {file = "duckdb-0.2.6.dev307-cp37-cp37m-win_amd64.whl", hash = "sha256:0f6b44ec2b9a89ae14e06e4f81af4dcd1d2e106efa840d3a0465fcbc34cf1b9b"},
-    {file = "duckdb-0.2.6.dev307-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7b36ccc3b124863b6746e5652223a51de31208ca1d28850a729563055c055e7c"},
-    {file = "duckdb-0.2.6.dev307-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:8d9674e4d7bae16c66f83f4ea73eaadd21a454cb0cc54fdf7c2e2c29df053704"},
-    {file = "duckdb-0.2.6.dev307-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b79caf4d6c821feb6033268f15fb70fe552ace309f848532fbe955a9f9ad3e03"},
-    {file = "duckdb-0.2.6.dev307-cp38-cp38-win32.whl", hash = "sha256:c59778b3389e435d0b79f9f6587e1cfbfba761f92df69fa236cb5d2d3615e0e4"},
-    {file = "duckdb-0.2.6.dev307-cp38-cp38-win_amd64.whl", hash = "sha256:f7cf992169829594138e3e6dda2ef8f18c25089e82d855789715edb94d1d43d3"},
-    {file = "duckdb-0.2.6.dev307-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4afcaccc922999dd7e18665717684e7efee6ae234af56761d25bb0a9042336e9"},
-    {file = "duckdb-0.2.6.dev307-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:09a0071e7378e46e2bc8a5453306a2d661a280df2a7bed768a92e4e395a673f9"},
-    {file = "duckdb-0.2.6.dev307-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:1ea34e59078c893c3c3b8e85f13f6cd89279c8ec2ef81be14e259b2b77ea0381"},
-    {file = "duckdb-0.2.6.dev307-cp39-cp39-win32.whl", hash = "sha256:0feb37486a10fef1c903f8f1586e0de8a6a1b3907298bfae64aaf1070942ba37"},
-    {file = "duckdb-0.2.6.dev307-cp39-cp39-win_amd64.whl", hash = "sha256:8772e7153107a487b26a35f62befdd4c404ca3c6f99cd34cce9a0a446d71192a"},
-    {file = "duckdb-0.2.6.dev307.tar.gz", hash = "sha256:8adad97f50548b004a2f92cf93e801b57ac36f702acdbba36762c9bb14c7f9c8"},
+    {file = "duckdb-0.2.6.dev318-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ef6f49af40f0291519b4922b1916fcfda86fe340498829b6702db05292fd024e"},
+    {file = "duckdb-0.2.6.dev318-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:58fa7140dbd87133cd11f0d39f33a496ddf25297199c4c503479b19e504d3fcf"},
+    {file = "duckdb-0.2.6.dev318-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:0024fdf8934eef93418f1f3ae165482f27036c844f1a68c2b44fc23e927814f7"},
+    {file = "duckdb-0.2.6.dev318-cp36-cp36m-win32.whl", hash = "sha256:a3ab4522b7b28d73640ba170a3959e58cb82d2dabdaa6603bb9b945981da0206"},
+    {file = "duckdb-0.2.6.dev318-cp36-cp36m-win_amd64.whl", hash = "sha256:c29c89ae82252f382b5972ad39db9d34f38a0e06b26416adf78d48ae192ee243"},
+    {file = "duckdb-0.2.6.dev318-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f8c0ff97c3d9170b85c8ec9688141cc3fc7cc7d0f2c9c5729c0b170b39256594"},
+    {file = "duckdb-0.2.6.dev318-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:5dbd067e9354030155909eeb9545d8051880d51ea5724177c513faffa1864f01"},
+    {file = "duckdb-0.2.6.dev318-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6fc6916d1851cebe8319129fbfe7fb6b910a0e9f06bbfb03b077c18a765f9004"},
+    {file = "duckdb-0.2.6.dev318-cp37-cp37m-win32.whl", hash = "sha256:db415d0deeadd18e8811f93eb49d9f4e56985185e4c4e93b92e57d2efcfcc59e"},
+    {file = "duckdb-0.2.6.dev318-cp37-cp37m-win_amd64.whl", hash = "sha256:f8fa44f877952db18ba6173617cca328ba757ddf179c0153f2316fafb0f41343"},
+    {file = "duckdb-0.2.6.dev318-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4bff665e57cd362f9e9e77ee3e8b2a1c28f7b26c1fafa647fc216eff0ec1b51f"},
+    {file = "duckdb-0.2.6.dev318-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:44a3dd9e169623e7da756014b2e4bbd4631a7affec8612539ddd24e6ace43874"},
+    {file = "duckdb-0.2.6.dev318-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:8d8a4c95afa0975bd45eaea28cc937430bf938d55db3efab0fd1dbcbe826f4f4"},
+    {file = "duckdb-0.2.6.dev318-cp38-cp38-win32.whl", hash = "sha256:bf3de00f7227639f5a95d256b160244aae8ad5b171a5a144a673a2ee1cecf5f2"},
+    {file = "duckdb-0.2.6.dev318-cp38-cp38-win_amd64.whl", hash = "sha256:3750a6e73f0916e1d08b0a441dbaab698b1aea2e5cbbbc3fa9fb9b14c178c9ef"},
+    {file = "duckdb-0.2.6.dev318-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ac80800bbdcc4f6d0f221f10b40ce93f418a5a1e160cdd3c49759c7c40ff0a98"},
+    {file = "duckdb-0.2.6.dev318-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:be93a069663dc13014714179b1bc9f62846ecb080ad9a38992483bf8291c3067"},
+    {file = "duckdb-0.2.6.dev318-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:7bca66265c1590dea1aaaa578275f7239fa3c5d93a71b73e4fd70d77b29f856c"},
+    {file = "duckdb-0.2.6.dev318-cp39-cp39-win32.whl", hash = "sha256:0b0dbc470e7103db76a28dfce99f03aec55a7a126387802019ee971f7e593f89"},
+    {file = "duckdb-0.2.6.dev318-cp39-cp39-win_amd64.whl", hash = "sha256:1f382a4bde61dbef83002bfd9c75fa95519a5c90eaa0fbab0ee8c3c6aa3893ad"},
+    {file = "duckdb-0.2.6.dev318.tar.gz", hash = "sha256:f0ed5d69a65c781d731c1bb10d3f03bf28de43675acdc2cf71610c9e6ff4365b"},
 ]
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
@@ -3301,39 +3300,20 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
     {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
-    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
     {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
-    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
     {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
-    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 matplotlib = [
@@ -3713,11 +3693,8 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.6-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2dac98e85565d5688e8ab7bdea5446674a83a3945a8f416ad0110018d1501b94"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win32.whl", hash = "sha256:bd1be66dde2b82f80afb9459fc618216753f67109b859a361cf7def5c7968729"},
     {file = "psycopg2_binary-2.8.6-cp38-cp38-win_amd64.whl", hash = "sha256:8cd0fb36c7412996859cb4606a35969dd01f4ea34d9812a141cd920c3b18be77"},
-    {file = "psycopg2_binary-2.8.6-cp39-cp39-macosx_10_9_x86_64.macosx_10_9_intel.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:89705f45ce07b2dfa806ee84439ec67c5d9a0ef20154e0e475e2b2ed392a5b83"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_i686.whl", hash = "sha256:42ec1035841b389e8cc3692277a0bd81cdfe0b65d575a2c8862cec7a80e62e52"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd"},
-    {file = "psycopg2_binary-2.8.6-cp39-cp39-win32.whl", hash = "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056"},
-    {file = "psycopg2_binary-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6"},
 ]
 ptable = [
     {file = "PTable-0.9.2.tar.gz", hash = "sha256:aa7fc151cb40f2dabcd2275ba6f7fd0ff8577a86be3365cd3fb297cbe09cc292"},
@@ -3864,26 +3841,18 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
     {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
     {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347"},
-    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
     {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
     {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
     {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa"},
-    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
     {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
     {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
     {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247"},
-    {file = "PyYAML-5.4.1-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
     {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
     {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
     {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122"},
-    {file = "PyYAML-5.4.1-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6"},
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
@@ -3923,47 +3892,47 @@ pyzmq = [
     {file = "pyzmq-22.0.3.tar.gz", hash = "sha256:f7f63ce127980d40f3e6a5fdb87abf17ce1a7c2bd8bf2c7560e1bbce8ab1f92d"},
 ]
 regex = [
-    {file = "regex-2021.3.17-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6"},
-    {file = "regex-2021.3.17-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:cb4ee827857a5ad9b8ae34d3c8cc51151cb4a3fe082c12ec20ec73e63cc7c6f0"},
-    {file = "regex-2021.3.17-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:633497504e2a485a70a3268d4fc403fe3063a50a50eed1039083e9471ad0101c"},
-    {file = "regex-2021.3.17-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:a59a2ee329b3de764b21495d78c92ab00b4ea79acef0f7ae8c1067f773570afa"},
-    {file = "regex-2021.3.17-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f85d6f41e34f6a2d1607e312820971872944f1661a73d33e1e82d35ea3305e14"},
-    {file = "regex-2021.3.17-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:4651f839dbde0816798e698626af6a2469eee6d9964824bb5386091255a1694f"},
-    {file = "regex-2021.3.17-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:39c44532d0e4f1639a89e52355b949573e1e2c5116106a395642cbbae0ff9bcd"},
-    {file = "regex-2021.3.17-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:3d9a7e215e02bd7646a91fb8bcba30bc55fd42a719d6b35cf80e5bae31d9134e"},
-    {file = "regex-2021.3.17-cp36-cp36m-win32.whl", hash = "sha256:159fac1a4731409c830d32913f13f68346d6b8e39650ed5d704a9ce2f9ef9cb3"},
-    {file = "regex-2021.3.17-cp36-cp36m-win_amd64.whl", hash = "sha256:13f50969028e81765ed2a1c5fcfdc246c245cf8d47986d5172e82ab1a0c42ee5"},
-    {file = "regex-2021.3.17-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b9d8d286c53fe0cbc6d20bf3d583cabcd1499d89034524e3b94c93a5ab85ca90"},
-    {file = "regex-2021.3.17-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:201e2619a77b21a7780580ab7b5ce43835e242d3e20fef50f66a8df0542e437f"},
-    {file = "regex-2021.3.17-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d47d359545b0ccad29d572ecd52c9da945de7cd6cf9c0cfcb0269f76d3555689"},
-    {file = "regex-2021.3.17-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ea2f41445852c660ba7c3ebf7d70b3779b20d9ca8ba54485a17740db49f46932"},
-    {file = "regex-2021.3.17-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:486a5f8e11e1f5bbfcad87f7c7745eb14796642323e7e1829a331f87a713daaa"},
-    {file = "regex-2021.3.17-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:18e25e0afe1cf0f62781a150c1454b2113785401ba285c745acf10c8ca8917df"},
-    {file = "regex-2021.3.17-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:a2ee026f4156789df8644d23ef423e6194fad0bc53575534101bb1de5d67e8ce"},
-    {file = "regex-2021.3.17-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:4c0788010a93ace8a174d73e7c6c9d3e6e3b7ad99a453c8ee8c975ddd9965643"},
-    {file = "regex-2021.3.17-cp37-cp37m-win32.whl", hash = "sha256:575a832e09d237ae5fedb825a7a5bc6a116090dd57d6417d4f3b75121c73e3be"},
-    {file = "regex-2021.3.17-cp37-cp37m-win_amd64.whl", hash = "sha256:8e65e3e4c6feadf6770e2ad89ad3deb524bcb03d8dc679f381d0568c024e0deb"},
-    {file = "regex-2021.3.17-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a0df9a0ad2aad49ea3c7f65edd2ffb3d5c59589b85992a6006354f6fb109bb18"},
-    {file = "regex-2021.3.17-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b98bc9db003f1079caf07b610377ed1ac2e2c11acc2bea4892e28cc5b509d8d5"},
-    {file = "regex-2021.3.17-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:808404898e9a765e4058bf3d7607d0629000e0a14a6782ccbb089296b76fa8fe"},
-    {file = "regex-2021.3.17-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:5770a51180d85ea468234bc7987f5597803a4c3d7463e7323322fe4a1b181578"},
-    {file = "regex-2021.3.17-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:976a54d44fd043d958a69b18705a910a8376196c6b6ee5f2596ffc11bff4420d"},
-    {file = "regex-2021.3.17-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:63f3ca8451e5ff7133ffbec9eda641aeab2001be1a01878990f6c87e3c44b9d5"},
-    {file = "regex-2021.3.17-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:bcd945175c29a672f13fce13a11893556cd440e37c1b643d6eeab1988c8b209c"},
-    {file = "regex-2021.3.17-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:3d9356add82cff75413bec360c1eca3e58db4a9f5dafa1f19650958a81e3249d"},
-    {file = "regex-2021.3.17-cp38-cp38-win32.whl", hash = "sha256:f5d0c921c99297354cecc5a416ee4280bd3f20fd81b9fb671ca6be71499c3fdf"},
-    {file = "regex-2021.3.17-cp38-cp38-win_amd64.whl", hash = "sha256:14de88eda0976020528efc92d0a1f8830e2fb0de2ae6005a6fc4e062553031fa"},
-    {file = "regex-2021.3.17-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4c2e364491406b7888c2ad4428245fc56c327e34a5dfe58fd40df272b3c3dab3"},
-    {file = "regex-2021.3.17-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8bd4f91f3fb1c9b1380d6894bd5b4a519409135bec14c0c80151e58394a4e88a"},
-    {file = "regex-2021.3.17-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:882f53afe31ef0425b405a3f601c0009b44206ea7f55ee1c606aad3cc213a52c"},
-    {file = "regex-2021.3.17-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:07ef35301b4484bce843831e7039a84e19d8d33b3f8b2f9aab86c376813d0139"},
-    {file = "regex-2021.3.17-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:360a01b5fa2ad35b3113ae0c07fb544ad180603fa3b1f074f52d98c1096fa15e"},
-    {file = "regex-2021.3.17-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:709f65bb2fa9825f09892617d01246002097f8f9b6dde8d1bb4083cf554701ba"},
-    {file = "regex-2021.3.17-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:c66221e947d7207457f8b6f42b12f613b09efa9669f65a587a2a71f6a0e4d106"},
-    {file = "regex-2021.3.17-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c782da0e45aff131f0bed6e66fbcfa589ff2862fc719b83a88640daa01a5aff7"},
-    {file = "regex-2021.3.17-cp39-cp39-win32.whl", hash = "sha256:dc9963aacb7da5177e40874585d7407c0f93fb9d7518ec58b86e562f633f36cd"},
-    {file = "regex-2021.3.17-cp39-cp39-win_amd64.whl", hash = "sha256:a0d04128e005142260de3733591ddf476e4902c0c23c1af237d9acf3c96e1b38"},
-    {file = "regex-2021.3.17.tar.gz", hash = "sha256:4b8a1fb724904139149a43e172850f35aa6ea97fb0545244dc0b805e0154ed68"},
+    {file = "regex-2021.4.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a"},
+    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7"},
+    {file = "regex-2021.4.4-cp36-cp36m-win32.whl", hash = "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29"},
+    {file = "regex-2021.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79"},
+    {file = "regex-2021.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e"},
+    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439"},
+    {file = "regex-2021.4.4-cp37-cp37m-win32.whl", hash = "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d"},
+    {file = "regex-2021.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3"},
+    {file = "regex-2021.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f"},
+    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87"},
+    {file = "regex-2021.4.4-cp38-cp38-win32.whl", hash = "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac"},
+    {file = "regex-2021.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2"},
+    {file = "regex-2021.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c"},
+    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"},
+    {file = "regex-2021.4.4-cp39-cp39-win32.whl", hash = "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6"},
+    {file = "regex-2021.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07"},
+    {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
 ]
 requests = [
     {file = "requests-2.25.1-py2.py3-none-any.whl", hash = "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ ipython-genutils = { version = "^0.2.0", optional = true }
 requests-ftp = "^0.3.1"
 zarr = {version = "^2.7.0", optional = true, markers = "sys_platform != 'darwin' or (sys_platform == 'darwin' and platform_machine != 'arm64')"}  # not supported through numcodecs
 xarray = {version = "^0.17.0", optional = true}
+h5netcdf = "^0.10.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/tests/example/test_regular_examples.py
+++ b/tests/example/test_regular_examples.py
@@ -28,15 +28,24 @@ def test_regular_examples(example):
     assert example.main() is None
 
 
-""" Testing radar currently not possible as GDAL is required """
-# def test_radar_examples():
-#     from example.radar import radar_composite_rx, radar_radolan_cdc, radar_radolan_rw,
-#     radar_scan_precip, radar_scan_volume, radar_site_dx, radar_sweep_hdf5
-#
-#     assert radar_composite_rx.main() is None
-#     assert radar_radolan_cdc.main() is None
-#     assert radar_radolan_rw.main() is None
-#     assert radar_scan_precip.main() is None
-#     assert radar_scan_volume.main() is None
-#     assert radar_site_dx.main() is None
-#     assert radar_sweep_hdf5.main() is None
+def test_radar_examples():
+
+    pytest.importorskip("osgeo.gdal")
+
+    from example.radar import (
+        radar_composite_rw,
+        radar_radolan_cdc,
+        radar_radolan_rw,
+        radar_scan_precip,
+        radar_scan_volume,
+        radar_site_dx,
+        radar_sweep_hdf5,
+    )
+
+    assert radar_composite_rw.main() is None
+    assert radar_radolan_cdc.main() is None
+    assert radar_radolan_rw.main() is None
+    assert radar_scan_precip.main() is None
+    assert radar_scan_volume.main() is None
+    assert radar_site_dx.main() is None
+    assert radar_sweep_hdf5.main() is None

--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -198,7 +198,6 @@ def test_radar_request_composite_historic_fx_timerange():
     )
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_composite_historic_radolan_rw_yesterday():
     """
@@ -213,8 +212,12 @@ def test_radar_request_composite_historic_radolan_rw_yesterday():
         start_date=timestamp,
     )
 
-    buffer = next(request.query())[1]
-    payload = buffer.getvalue()
+    results = list(request.query())
+
+    if len(results) == 0:
+        raise pytest.skip("Data currently not available")
+
+    payload = results[0].data.getvalue()
 
     # Verify data.
     # TODO: Use wradlib to parse binary format.
@@ -222,7 +225,7 @@ def test_radar_request_composite_historic_radolan_rw_yesterday():
     date_time = request.start_date.strftime("%d%H%M")
     month_year = request.start_date.strftime("%m%y")
     header = (
-        f"RW{date_time}10000{month_year}BY.......VS 3SW   2.28.1PR E-01INT  60GP 900x 900MF 00000001MS "  # noqa:E501,B950
+        f"RW{date_time}10000{month_year}BY.......VS 3SW   2.28..PR E-01INT  60GP 900x 900MF 00000001MS "  # noqa:E501,B950
         f"..<{station_reference_pattern_unsorted}>"  # noqa:E501,B950
     )
 
@@ -889,7 +892,6 @@ def test_radar_request_radvor_re_timerange():
     # TODO: Verify data.
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_radvor_rq_yesterday():
     """
@@ -923,7 +925,7 @@ def test_radar_request_radvor_rq_yesterday():
     date_time = request.start_date.strftime("%d%H%M")
     month_year = request.start_date.strftime("%m%y")
     header = (
-        f"RQ{date_time}10000{month_year}BY.......VS 3SW   2.28.1PR E-01INT  60GP 900x 900VV   0MF 00000008QN ...MS "  # noqa:E501,B950
+        f"RQ{date_time}10000{month_year}BY.......VS 3SW   2.28..PR E-01INT  60GP 900x 900VV   0MF 00000008QN ...MS "  # noqa:E501,B950
         f"..<{station_reference_pattern_sorted}"  # noqa:E501,B950
     )
 

--- a/tests/provider/dwd/radar/test_util.py
+++ b/tests/provider/dwd/radar/test_util.py
@@ -1,0 +1,47 @@
+import datetime
+import re
+from io import BytesIO
+
+import pytest
+import requests
+
+from wetterdienst.provider.dwd.radar.util import get_date_from_filename, verify_hdf5
+
+
+def test_radar_get_date_from_filename():
+    date = get_date_from_filename("sweep_pcp_v_0-20200926143033_10132--buf.bz2")
+    assert date == datetime.datetime(2020, 9, 26, 14, 30)
+
+    date = get_date_from_filename(
+        "ras07-stqual-vol5minng01_sweeph5onem_vradh_00-2020092614305700-boo-10132-hd5"
+    )
+    assert date == datetime.datetime(2020, 9, 26, 14, 30)
+
+    date = get_date_from_filename(
+        "ras07-vol5minng01_sweeph5onem_vradh_00-2020092614305700-boo-10132-hd5"
+    )
+    assert date == datetime.datetime(2020, 9, 26, 14, 30)
+
+    date = get_date_from_filename("rab02-tt_10132-20200926161533-boo---buf")
+    assert date == datetime.datetime(2020, 9, 26, 16, 15)
+
+
+hdf5_example = (
+    "https://github.com/earthobservations/testdata/raw/main/opendata.dwd.de"
+    "/weather/radar/sites/sweep_vol_v/ess/hdf5/filter_polarimetric"
+    "/ras07-vol5minng01_sweeph5onem_vradh_00-2021040423555700-ess-10410-hd5"
+)
+
+
+def test_radar_verify_hdf5_valid():
+    buffer = BytesIO(requests.get(hdf5_example).content)
+
+    verify_hdf5(buffer)
+
+
+def test_radar_verify_hdf5_invalid():
+    with pytest.raises(Exception) as ex:
+        buffer = BytesIO()
+        verify_hdf5(buffer)
+
+    assert ex.match(re.escape("Unable to open file (file signature not found)"))

--- a/wetterdienst/provider/dwd/radar/api.py
+++ b/wetterdienst/provider/dwd/radar/api.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Optional, Union
 
 import pandas as pd
+from tqdm import tqdm
 
 from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.resolution import Resolution
@@ -238,7 +239,17 @@ class DwdRadarValues:
 
         :return: Generator of ``RadarResult`` instances.
         """
-        return collect_radar_data(
+        log.info(
+            f"Collecting radar data for "
+            f"site={self.site}, "
+            f"parameter={self.parameter}, "
+            f"subset={self.subset}, "
+            f"elevation={self.elevation}, "
+            f"resolution={self.resolution}, "
+            f"period={self.period}"
+        )
+        progressbar = tqdm(total=240)
+        for item in collect_radar_data(
             parameter=self.parameter,
             site=self.site,
             fmt=self.format,
@@ -248,7 +259,9 @@ class DwdRadarValues:
             end_date=self.end_date,
             resolution=self.resolution,
             period=self.period,
-        )
+        ):
+            progressbar.update()
+            yield item
 
 
 class DwdRadarSites(OperaRadarSites):

--- a/wetterdienst/provider/dwd/radar/util.py
+++ b/wetterdienst/provider/dwd/radar/util.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
 import re
+from io import BytesIO
 
 import dateparser
 
@@ -46,3 +47,16 @@ def get_date_from_filename(filename):
         )
     except IndexError:
         pass
+
+
+def verify_hdf5(buffer: BytesIO):
+    import h5netcdf
+
+    buffer.seek(0)
+    try:
+        nc = h5netcdf.File(buffer, mode="r")
+        nc.close()
+        buffer.seek(0)
+    except Exception:
+        buffer.seek(0)
+        raise


### PR DESCRIPTION
Hi,

while trying to bring [1] up to speed (see https://github.com/wradlib/wradlib-notebooks/pull/51), I observed occasional data acquisition errors. Apparently, two files of the whole acquired sweep data set have not been valid HDF5, so `wrl.io.open_odim(files)` croaked on it and hasn't been able to skip the invalid ones.

With this patch, HDF5 responses will be verified by Wetterdienst for being valid HDF5 files before returning them in the result. All invalid items are logged with level WARNING, including their URL.

Along the lines, this patch also improves some other radar tests again.

With kind regards,
Andreas.

[1] https://github.com/wradlib/wradlib-notebooks/blob/v1.9.0/notebooks/fileio/wradlib_load_DWD_opendata_volumes.ipynb

cc @kmuehlbauer 