### PR TITLE
REST API: Rename query parameters "lat" and "lon" to their long variants

### DIFF
--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -20,7 +20,7 @@ def test_robots():
     assert response.status_code == 200
 
 
-def test_dwd_stations():
+def test_dwd_stations_basic():
 
     response = client.get(
         "/api/dwd/observation/stations",
@@ -33,6 +33,28 @@ def test_dwd_stations():
     assert response.status_code == 200
     assert response.json()["data"][0]["station_id"] == "00011"
     assert response.json()["data"][0]["station_name"] == "Donaueschingen (Landeplatz)"
+    assert response.json()["data"][0]["latitude"] == 47.9737
+    assert response.json()["data"][0]["longitude"] == 8.5205
+
+
+def test_dwd_stations_geo():
+
+    response = client.get(
+        "/api/dwd/observation/stations",
+        params={
+            "parameter": "kl",
+            "resolution": "daily",
+            "period": "recent",
+            "latitude": 45.54,
+            "longitude": 10.10,
+            "number_nearby": 5,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["data"][0]["station_id"] == "03730"
+    assert response.json()["data"][0]["station_name"] == "Oberstdorf"
+    assert response.json()["data"][0]["latitude"] == 47.3984
+    assert response.json()["data"][0]["longitude"] == 10.2759
 
 
 def test_dwd_stations_sql():

--- a/wetterdienst/ui/restapi.py
+++ b/wetterdienst/ui/restapi.py
@@ -68,8 +68,8 @@ def dwd_stations(
     resolution: str = Query(default=None),
     period: str = Query(default=None),
     mosmix_type: str = Query(default=None),
-    lon: float = Query(default=None),
-    lat: float = Query(default=None),
+    longitude: float = Query(default=None),
+    latitude: float = Query(default=None),
     number_nearby: int = Query(default=None),
     max_distance_in_km: int = Query(default=None),
     sql: str = Query(default=None),
@@ -94,14 +94,16 @@ def dwd_stations(
     else:
         stations = DwdMosmixRequest(parameter=parameter, mosmix_type=mosmix_type)
 
-    if lon and lat and (number_nearby or max_distance_in_km):
+    if longitude and latitude and (number_nearby or max_distance_in_km):
         if number_nearby:
             results = stations.nearby_number(
-                latitude=lat, longitude=lon, number=number_nearby
+                latitude=latitude, longitude=longitude, number=number_nearby
             )
         else:
             results = stations.nearby_radius(
-                latitude=lat, longitude=lon, max_distance_in_km=max_distance_in_km
+                latitude=latitude,
+                longitude=longitude,
+                max_distance_in_km=max_distance_in_km,
             )
     else:
         results = stations.all()


### PR DESCRIPTION
Hi Benjamin,

this patch just adjusts another occurrance where I would prefer long names over short names.

With kind regards,
Andreas.