### PR TITLE
Fix radar tests

### DIFF
--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -225,7 +225,7 @@ def test_radar_request_composite_historic_radolan_rw_yesterday():
     date_time = request.start_date.strftime("%d%H%M")
     month_year = request.start_date.strftime("%m%y")
     header = (
-        f"RW{date_time}10000{month_year}BY.......VS 3SW   2.28..PR E-01INT  60GP 900x 900MF 00000001MS "  # noqa:E501,B950
+        f"RW{date_time}10000{month_year}BY.......VS 3SW   ......PR E-01INT  60GP 900x 900MF 00000001MS "  # noqa:E501,B950
         f"..<{station_reference_pattern_unsorted}>"  # noqa:E501,B950
     )
 
@@ -925,7 +925,7 @@ def test_radar_request_radvor_rq_yesterday():
     date_time = request.start_date.strftime("%d%H%M")
     month_year = request.start_date.strftime("%m%y")
     header = (
-        f"RQ{date_time}10000{month_year}BY.......VS 3SW   2.28..PR E-01INT  60GP 900x 900VV   0MF 00000008QN ...MS "  # noqa:E501,B950
+        f"RQ{date_time}10000{month_year}BY.......VS 3SW   ......PR E-01INT  60GP 900x 900VV   0MF 00000008QN ...MS "  # noqa:E501,B950
         f"..<{station_reference_pattern_sorted}"  # noqa:E501,B950
     )
 

--- a/tests/provider/dwd/radar/test_api_latest.py
+++ b/tests/provider/dwd/radar/test_api_latest.py
@@ -30,7 +30,7 @@ def test_radar_request_composite_latest_rx_reflectivity():
 
     month_year = datetime.utcnow().strftime("%m%y")
     header = (
-        f"RX......10000{month_year}BY 8101..VS 3SW   2.28..PR E\\+00INT   5GP 900x 900MS "  # noqa:E501,B950
+        f"RX......10000{month_year}BY 8101..VS 3SW   ......PR E\\+00INT   5GP 900x 900MS "  # noqa:E501,B950
         f"..<{station_reference_pattern_unsorted}>"  # noqa:E501,B950
     )
 
@@ -60,7 +60,7 @@ def test_radar_request_composite_latest_rw_reflectivity():
     month_year = datetime.utcnow().strftime("%m%y")
     header = (
         f"RW......10000{month_year}"
-        f"BY16201..VS 3SW   2.28..PR E-01INT  60GP 900x 900MF 00000001MS "
+        f"BY16201..VS 3SW   ......PR E-01INT  60GP 900x 900MF 00000001MS "
         f"..<{station_reference_pattern_unsorted}>"
     )
 

--- a/tests/provider/dwd/radar/test_api_most_recent.py
+++ b/tests/provider/dwd/radar/test_api_most_recent.py
@@ -142,7 +142,7 @@ def test_radar_request_radolan_cdc_most_recent():
     date_time = request.start_date.strftime("%d%H%M")
     month_year = request.start_date.strftime("%m%y")
     header = (
-        f"SF{date_time}10000{month_year}BY.......VS 3SW   2.28.1PR E-01INT1440GP 900x 900MS "  # noqa:E501,B950
+        f"SF{date_time}10000{month_year}BY.......VS 3SW   ......PR E-01INT1440GP 900x 900MS "  # noqa:E501,B950
         f"..<{station_reference_pattern_unsorted}>"  # noqa:E501,B950
     )
 

--- a/tests/ui/explorer/test_ui.py
+++ b/tests/ui/explorer/test_ui.py
@@ -82,10 +82,10 @@ def test_app_data_stations_failed(wetterdienst_ui, dash_tre):
     time.sleep(0.5)
 
     # Wait for status element.
-    dash_tre.wait_for_contains_text("#status-response-stations", "No data", timeout=1)
-    dash_tre.wait_for_contains_text("#status-response-values", "No data", timeout=1)
-    dash_tre.wait_for_contains_text("#map", "No data to display", timeout=1)
-    dash_tre.wait_for_contains_text("#graph", "No variable selected", timeout=1)
+    dash_tre.wait_for_contains_text("#status-response-stations", "No data", timeout=2)
+    dash_tre.wait_for_contains_text("#status-response-values", "No data", timeout=2)
+    dash_tre.wait_for_contains_text("#map", "No data to display", timeout=2)
+    dash_tre.wait_for_contains_text("#graph", "No variable selected", timeout=2)
 
 
 @pytest.mark.slow
@@ -120,8 +120,8 @@ def test_app_data_values(wetterdienst_ui, dash_tre):
     dash_tre.wait_for_element_by_id("dataframe-values")
 
     # Wait for status element.
-    dash_tre.wait_for_contains_text("#status-response", "Records", timeout=1)
-    dash_tre.wait_for_contains_text("#status-response", "Begin date", timeout=1)
+    dash_tre.wait_for_contains_text("#status-response", "Records", timeout=2)
+    dash_tre.wait_for_contains_text("#status-response", "Begin date", timeout=2)
 
     # Read payload from data element.
     dom: BeautifulSoup = dash_tre.dash_innerhtml_dom


### PR DESCRIPTION
Some version embedded into the radar files has been bumped from 2.28.1 to 2.29.1. This patch accounts for that.