### PR TITLE
Fix "Wetterdienst Explorer" documentation about Docker port

### DIFF
--- a/docs/usage/explorer.rst
+++ b/docs/usage/explorer.rst
@@ -63,7 +63,7 @@ Invoke using Docker
 
 Run the Wetterdienst user interface using Docker::
 
-    docker run -it --rm --publish=7891:7891 ghcr.io/earthobservations/wetterdienst-full wetterdienst explorer --listen 0.0.0.0:7890
+    docker run -it --rm --publish=7891:7891 ghcr.io/earthobservations/wetterdienst-full wetterdienst explorer --listen 0.0.0.0:7891
 
 
 *******

--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -769,7 +769,7 @@ def test_radar_request_site_historic_sweep_vol_v_hdf5_yesterday():
     assert hdf["/how"].attrs.get("scan_count") == 10
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape in ((360, 180), (360, 720))
+    assert hdf["/dataset1/data1/data"].shape in ((360, 180), (360, 720), (361, 720))
 
     timestamp = round_minutes(request.start_date, 5)
     assert hdf["/what"].attrs.get("date") == bytes(


### PR DESCRIPTION
There was a typo with the port number within the documentation.