### PR TITLE
Fix sandbox setup documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -296,10 +296,11 @@ Development
     cd wetterdienst
 
     # Install package in editable mode.
-    pip install --editable=.[http,sql,export,ui]
+    pip install --editable=.[sql,export,restapi,explorer]
 
     # Alternatively, when using Poetry.
-    poetry install --extras=http --extras=sql --extras=export --extras=ui
+    poetry install --extras=sql --extras=export --extras=restapi --extras=explorer
+    poetry shell
 
 2. For running the whole test suite, you will need to have Firefox and
    geckodriver installed on your machine. Install them like::

--- a/tests/provider/dwd/radar/__init__.py
+++ b/tests/provider/dwd/radar/__init__.py
@@ -4,11 +4,11 @@
 
 station_reference_pattern_unsorted = (
     "(asb,)?(boo,)?ros,hnr,umd,pro,ess,fld,drs,"
-    "neu,(nhb,)?oft,eis,(tur,)?(isn,)?fbg,mem"
+    "(neu,)?(nhb,)?oft,eis,(tur,)?(isn,)?fbg,mem"
 )
 station_reference_pattern_sorted = (
     "(asb,)?(boo,)?drs,eis,ess,fbg,fld,hnr,(isn,)?"
-    "mem,neu,(nhb,)?oft,pro,ros,(tur,)?umd"
+    "mem,(neu,)?(nhb,)?oft,pro,ros,(tur,)?umd"
 )
 station_reference_pattern_de = (
     "(deasb,)?(deboo,)?dedrs,deeis,deess,(defbg,)?defld,dehnr,"


### PR DESCRIPTION
Hi,

we renamed some of the Python package "extras" labels. This patch accounts for that and fixes the sandbox setup documentation.

With kind regards,
Andreas.