### PR TITLE
Fix DWD Mosmix generator to return all contained dataframes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Development
 ***********
 
 - Make tidy method a abstract core method of Values class
+- Fix DWD Mosmix generator to return all contained dataframes
 
 0.18.0 (04.05.2021)
 *******************

--- a/tests/provider/dwd/radar/__init__.py
+++ b/tests/provider/dwd/radar/__init__.py
@@ -3,12 +3,12 @@
 # Distributed under the MIT License. See LICENSE for more info.
 
 station_reference_pattern_unsorted = (
-    "(asb,)?(boo,)?ros,hnr,umd,pro,ess,fld,(drs,)?"
-    "(neu,)?(nhb,)?oft,eis,(tur,)?(isn,)?fbg(,mem)?"
+    "(asb,)?(boo,)?(ros,)?hnr,umd,pro,ess,fld,(drs,)?"
+    "(neu,)?(nhb,)?(oft,)?eis,(tur,)?(isn,)?fbg(,mem)?"
 )
 station_reference_pattern_sorted = (
     "(asb,)?(boo,)?(drs,)?eis,ess,fbg,fld,hnr,(isn,)?"
-    "(mem,)?(neu,)?(nhb,)?oft,pro,ros,(tur,)?umd"
+    "(mem,)?(neu,)?(nhb,)?oft,pro,(ros,)?(tur,)?umd"
 )
 station_reference_pattern_de = (
     "(deasb,)?(deboo,)?(dedrs,)?deeis,deess,(defbg,)?defld,dehnr,"

--- a/wetterdienst/provider/dwd/forecast/api.py
+++ b/wetterdienst/provider/dwd/forecast/api.py
@@ -154,9 +154,8 @@ class DwdMosmixValues(ScalarValuesCore):
         :return:
         """
         if self.stations.start_issue == DwdForecastDate.LATEST:
-            df = next(self.read_mosmix(self.stations.stations.start_issue))
-
-            yield df
+            for df in self.read_mosmix(self.stations.stations.start_issue):
+                yield df
         else:
             for date in pd.date_range(
                 self.stations.stations.start_issue,
@@ -164,9 +163,8 @@ class DwdMosmixValues(ScalarValuesCore):
                 freq=self.stations.frequency.value,
             ):
                 try:
-                    df = next(self.read_mosmix(date))
-
-                    yield df
+                    for df in self.read_mosmix(date):
+                        yield df
                 except IndexError as e:
                     log.warning(e)
                     continue


### PR DESCRIPTION
Bizarrely we were using next() to return Mosmix data, which led to the generator only returning data for the first station. Thanks to @tsjfd we could fix this.

fixes #446 