### PR TITLE
Add show method for wetterdienst instance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Development
 - Export: Use InfluxDBClient instead of DataFrameClient and improve connection handling with InfluxDB 1.x
 - Export: Add support for InfluxDB 2.x
 - Fix InfluxDB export by skipping empty fields
+- Add show() method with basic information on the wetterdienst instance
 
 0.19.0 (14.05.2021)
 *******************

--- a/tests/ui/test_cli.py
+++ b/tests/ui/test_cli.py
@@ -54,8 +54,8 @@ def test_cli_help():
 
     assert "Options:\n --help  Show this message and exit."
     assert (
-        "Commands:\n  about\n  explorer\n  radar\n  restapi\n  stations\n  values\n"
-        in result.output
+        "Commands:\n  about\n  explorer\n  radar\n  "
+        "restapi\n  show\n  stations\n  values\n" in result.output
     )
 
 

--- a/wetterdienst/__init__.py
+++ b/wetterdienst/__init__.py
@@ -1,10 +1,14 @@
+# """Wetterdienst - Open weather data for humans"""
 # -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
-"""Wetterdienst - Open weather data for humans"""
 __appname__ = "wetterdienst"
 
-from wetterdienst.api import Wetterdienst  # rather use this as entry point
+from pathlib import Path
+
+import tomlkit
+
+from wetterdienst.api import Wetterdienst
 from wetterdienst.metadata.kind import Kind
 from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.provider import Provider
@@ -12,6 +16,8 @@ from wetterdienst.metadata.resolution import Resolution
 
 # Single-sourcing the package version
 # https://cjolowicz.github.io/posts/hypermodern-python-06-ci-cd/
+from wetterdienst.util.cache import cache_dir
+
 try:
     from importlib.metadata import PackageNotFoundError, version  # noqa
 except ImportError:  # pragma: no cover
@@ -21,3 +27,34 @@ try:
     __version__ = version(__name__)
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
+
+
+def show() -> None:
+    here = Path(__name__).parent
+
+    with Path(here.parent / "pyproject.toml").open() as f:
+        pyproject_dict = tomlkit.parse(f.read())["tool"]["poetry"]
+
+    wd_info = {
+        "version": pyproject_dict["version"],
+        "authors": ", ".join(pyproject_dict["authors"]),
+        "documentation": pyproject_dict["homepage"],
+        "repository": pyproject_dict["homepage"],
+        "cache_dir": cache_dir,
+    }
+
+    text = (
+        "Wetterdienst - Open weather data for humans\n"
+        "-------------------------------------------"
+    )
+
+    for key, value in wd_info.items():
+        text += f"\n{key}:\t {value}"
+
+    print(text)
+
+    return
+
+
+if __name__ == "__main__":
+    show()

--- a/wetterdienst/ui/cli.py
+++ b/wetterdienst/ui/cli.py
@@ -372,6 +372,15 @@ def explorer(listen: str, reload: bool, debug: bool):
     return
 
 
+@cli.command("show")
+def show():
+    from wetterdienst import show
+
+    show()
+
+    return
+
+
 @cli.group()
 def about():
     pass


### PR DESCRIPTION
This adds a method show() that prints basic information about the used wetterdienst instance. Currently we have
- version
- authors
- documentation
- repository
- cache dir

We should further add environment settings like tidy, si_units,... as defaults as soon as those settings are separated from the classes.

Fixes #246 