### PR TITLE
Improve tidying function

### DIFF
--- a/wetterdienst/provider/dwd/forecast/api.py
+++ b/wetterdienst/provider/dwd/forecast/api.py
@@ -75,10 +75,6 @@ class DwdMosmixValues(ScalarValuesCore):
     _data_tz = Timezone.UTC
     _has_quality = False
 
-    # @property
-    # def _tidy(self) -> bool:
-    #     return self.stations.tidy
-
     _irregular_parameters = tuple()
     _integer_parameters = INTEGER_PARAMETERS
     _string_parameters = tuple()
@@ -136,14 +132,16 @@ class DwdMosmixValues(ScalarValuesCore):
             df = self._coerce_parameter_types(df)
 
             if self.stations.stations.tidy:
-                df = self._tidy_up_df(df)
+                df = self.tidy_up_df(df, self.stations.stations.mosmix_type)
 
-                df[
-                    Columns.DATASET.value
-                ] = self.stations.stations.mosmix_type.value.lower()
-                df[Columns.VALUE.value] = pd.to_numeric(
-                    df[Columns.VALUE.value], errors="coerce"
-                ).astype(float)
+                # df = self._tidy_up_df(df)
+
+                # df[
+                #     Columns.DATASET.value
+                # ] = self.stations.stations.mosmix_type.value.lower()
+                # df[Columns.VALUE.value] = pd.to_numeric(
+                #     df[Columns.VALUE.value], errors="coerce"
+                # ).astype(float)
 
             df = self._coerce_meta_fields(df)
 
@@ -179,7 +177,7 @@ class DwdMosmixValues(ScalarValuesCore):
                     log.warning(e)
                     continue
 
-    def _tidy_up_df(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _tidy_up_df(self, df: pd.DataFrame, dataset) -> pd.DataFrame:
         """
 
         :param df:

--- a/wetterdienst/provider/dwd/observation/api.py
+++ b/wetterdienst/provider/dwd/observation/api.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from itertools import repeat
 from typing import Dict, List, Optional, Tuple, Union
 
-import numpy as np
 import pandas as pd
 
 from wetterdienst.core.scalar.request import ScalarRequestCore
@@ -302,8 +301,6 @@ class DwdObservationValues(ScalarValuesCore):
         )
 
         df_tidy[Columns.QUALITY.value] = quality.reset_index(drop=True)
-
-        df_tidy.loc[df_tidy[Columns.VALUE.value].isna(), Columns.QUALITY.value] = np.NaN
 
         return df_tidy
 


### PR DESCRIPTION
This PR resolves some further problems with tidying taking parts from subfunctions (implemented at provider specific apis) to main level and this reducing redundancy. Also parameter types are actually already coerced correctly after tyding however this closes this issue fully.

Fixes #377 