### PR TITLE
Use pdbufr to read DWD radar data in bufr format

### DIFF
--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -24,7 +24,8 @@ if [ "${flavor}" = "testing" ]; then
     --extras=radar \
     --extras=radarplus \
     --extras=restapi \
-    --extras=sql
+    --extras=sql \
+    --extras=bufr
 
 elif [ "${flavor}" = "docs" ]; then
   poetry install --verbose --no-interaction --with=docs --extras=interpolation

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,12 @@ jobs:
           brew install eccodes
           export WD_ECCODES_DIR=$(brew --prefix eccodes)
 
+      - name: Install eccodes (Mac only)
+        run: |
+          if [ "$RUNNER_OS" == "macOS" ]; then
+               brew install eccodes && export WD_ECCODES_DIR=$(brew --prefix eccodes)
+          fi       
+
       - name: Install project
         run: .github/workflows/install.sh testing
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -32,6 +32,7 @@ def test_default_settings(caplog):
     default_settings = Settings.default()
     assert not default_settings.cache_disable
     assert re.match(WD_CACHE_DIR_PATTERN, default_settings.cache_dir)
+    assert default_settings.eccodes_dir is None
     assert default_settings.fsspec_client_kwargs == {}
     assert default_settings.ts_humanize
     assert default_settings.ts_shape == "long"
@@ -44,6 +45,7 @@ def test_default_settings(caplog):
         "precipitation_height": 20.0,
     }
     assert default_settings.ts_interpolation_use_nearby_station_distance == 1
+    assert not default_settings.read_bufr
     log_message = caplog.messages[0]
     assert re.match(WD_CACHE_ENABLED_PATTERN, log_message)
 

--- a/wetterdienst/eccodes.py
+++ b/wetterdienst/eccodes.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018-2022, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+def ensure_eccodes() -> bool:
+    """Function to ensure that eccodes is loaded"""
+    try:
+        import eccodes
+
+        eccodes.eccodes.codes_get_api_version()
+    except (ModuleNotFoundError, RuntimeError):
+        return False
+
+    return True


### PR DESCRIPTION
As suggested by @meteoDaniel this adds pdbufr to the requirements and allows to parse the provided bufr radar data by DWD to a pandas DataFrame. (testing not possible atm as data is not available)

Fixes #364 

UPDATE
This won't currently work as of the loose connection between eccodes (the core library) and its python bindings. Differences between versions can lead to an ImportError which is caused by the core library not being found. We should wait for this to be solved to be able to run ordinary checks on bufr files.

UPDATE2
Provision errors of eccodes library can now individually be solved by setting such environmental variable