### PR TITLE
Fix deprecated code snippets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Added
 Changed
 =======
 
+- Rename wetterdienst show to wetterdienst info, make version accessible via cli with
+  wetterdienst version
+
 Deprecated
 ==========
 
@@ -28,9 +31,8 @@ Fixed
 
 - Bug when querying an entire DWD dataset for 10_minutes/1_minute resolution without providing start_date/end_date,
   which results in the interval of the request being None
-
--Test of restapi with recent period
--Get rid of pandas performance warning from DWD Mosmix data
+- Test of restapi with recent period
+- Get rid of pandas performance warning from DWD Mosmix data
 
 0.20.3 (15.07.2021)
 *******************

--- a/README.rst
+++ b/README.rst
@@ -214,8 +214,9 @@ The ``wetterdienst`` command is also available:
     # Make an alias to use it conveniently from your shell.
     alias wetterdienst='docker run -ti ghcr.io/earthobservations/wetterdienst-standard wetterdienst'
 
-    wetterdienst --version
     wetterdienst --help
+    wetterdienst version
+    wetterdienst info
 
 Example
 *******
@@ -299,7 +300,7 @@ as we make progress with this library:
 
 https://wetterdienst.readthedocs.io/
 
-For the whole functionality, check out the `Wetterdienst API`_ section of our
+For the whole functionality, check out the `Usage documentation and examples`_ section of our
 documentation, which will be constantly updated. To stay up to date with the
 development, take a look at the changelog_. Also, don't miss out our examples_.
 

--- a/docs/usage/cli.rst
+++ b/docs/usage/cli.rst
@@ -9,8 +9,9 @@ Command Line Interface
 
     Usage:
 
-        wetterdienst --version
         wetterdienst (-h | --help)
+        wetterdienst version
+        wetterdienst info
 
         wetterdienst radar [--dwd=<dwd>] [--all=<all>] [--odim-code=<odim-code>] [--wmo-code=<wmo-code>] [--country-name=<country-name>]
 
@@ -51,7 +52,6 @@ Command Line Interface
         --target=<target>                     Output target for storing data into different data sinks.
         --format=<format>                     Output format. [Default: json]
         --language=<language>                 Output language. [Default: en]
-        --version                             Show version information
         --tidy                                Tidy DataFrame
         --humanize                            Humanize parameters
         --si-units                            Convert to SI units

--- a/tests/ui/test_cli.py
+++ b/tests/ui/test_cli.py
@@ -54,8 +54,8 @@ def test_cli_help():
 
     assert "Options:\n --help  Show this message and exit."
     assert (
-        "Commands:\n  about\n  explorer\n  radar\n  "
-        "restapi\n  show\n  stations\n  values\n" in result.output
+        "Commands:\n  about\n  explorer\n  info\n  radar\n  "
+        "restapi\n  stations\n  values\n  version\n" in result.output
     )
 
 

--- a/wetterdienst/__init__.py
+++ b/wetterdienst/__init__.py
@@ -24,7 +24,7 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 
 
-def show() -> None:
+def info() -> None:
     """ Function that prints some basic information about the wetterdienst instance """
     wd_info = {
         "version": __version__,

--- a/wetterdienst/ui/cli.py
+++ b/wetterdienst/ui/cli.py
@@ -118,8 +118,9 @@ def cli():
     """
     Usage:
 
-        wetterdienst --version
         wetterdienst (-h | --help)
+        wetterdienst version
+        wetterdienst info
 
         wetterdienst radar [--dwd=<dwd>] [--all=<all>] [--odim-code=<odim-code>] [--wmo-code=<wmo-code>] [--country-name=<country-name>]
 
@@ -160,7 +161,6 @@ def cli():
         --target=<target>                     Output target for storing data into different data sinks.
         --format=<format>                     Output format. [Default: json]
         --language=<language>                 Output language. [Default: en]
-        --version                             Show version information
         --tidy                                Tidy DataFrame
         --humanize                            Humanize parameters
         --si-units                            Convert to SI units
@@ -342,6 +342,22 @@ def cli():
     pass
 
 
+@cli.command("info")
+def info():
+    from wetterdienst import info
+
+    info()
+
+    return
+
+
+@cli.command("version")
+def version():
+    print(__version__)
+
+    return
+
+
 @cli.command("restapi")
 @cloup.option("--listen", type=click.STRING, default=None)
 @cloup.option("--reload", is_flag=True)
@@ -372,15 +388,6 @@ def explorer(listen: str, reload: bool, debug: bool):
     from wetterdienst.ui.explorer.app import start_service
 
     start_service(listen, reload=reload)
-    return
-
-
-@cli.command("show")
-def show():
-    from wetterdienst import show
-
-    show()
-
     return
 
 


### PR DESCRIPTION
We had some code snippets in the README that invoked `wetterdienst --version` and `wetterdienst info`. This updates them to `wetterdienst version` and `wetterdienst info`