### PR TITLE
Merge unit enums

### DIFF
--- a/wetterdienst/metadata/unit.py
+++ b/wetterdienst/metadata/unit.py
@@ -68,7 +68,7 @@ class OriginUnit(Enum):
     KILOJOULE_PER_SQUARE_METER = REGISTRY.kilojoule / (REGISTRY.meter ** 2)
 
 
-class MetricUnit(Enum):
+class SIUnit(Enum):
     DIMENSIONLESS = REGISTRY.dimensionless
 
     # Length

--- a/wetterdienst/provider/dwd/forecast/api.py
+++ b/wetterdienst/provider/dwd/forecast/api.py
@@ -31,10 +31,7 @@ from wetterdienst.provider.dwd.forecast.metadata import (
     DwdMosmixType,
 )
 from wetterdienst.provider.dwd.forecast.metadata.field_types import INTEGER_PARAMETERS
-from wetterdienst.provider.dwd.forecast.metadata.unit import (
-    DwdMosmixUnitOrigin,
-    DwdMosmixUnitSI,
-)
+from wetterdienst.provider.dwd.forecast.metadata.unit import DwdMosmixUnit
 from wetterdienst.provider.dwd.metadata.column_names import DwdColumns
 from wetterdienst.provider.dwd.metadata.constants import (
     DWD_MOSMIX_L_SINGLE_PATH,
@@ -365,8 +362,7 @@ class DwdMosmixRequest(ScalarRequestCore):
     _unique_dataset = True
     _dataset_base = DwdMosmixDataset
 
-    _origin_unit_tree = DwdMosmixUnitOrigin
-    _si_unit_tree = DwdMosmixUnitSI
+    _unit_tree = DwdMosmixUnit
 
     @property
     def _dataset_accessor(self) -> str:

--- a/wetterdienst/provider/dwd/forecast/metadata/unit.py
+++ b/wetterdienst/provider/dwd/forecast/metadata/unit.py
@@ -1,367 +1,564 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
-from wetterdienst.metadata.unit import MetricUnit, OriginUnit, UnitEnum
+from wetterdienst.metadata.unit import OriginUnit, SIUnit, UnitEnum
 from wetterdienst.util.parameter import DatasetTreeCore
 
 
-class DwdMosmixUnitOrigin(DatasetTreeCore):
+class DwdMosmixUnit(DatasetTreeCore):
     class SMALL(UnitEnum):
-        TEMPERATURE_AIR_200 = OriginUnit.DEGREE_KELVIN.value
-        TEMPERATURE_DEW_POINT_200 = OriginUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_KELVIN.value
-        WIND_DIRECTION = OriginUnit.WIND_DIRECTION.value
-        WIND_SPEED = OriginUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_1H = OriginUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_3H = OriginUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_12H = OriginUnit.METER_PER_SECOND.value
-        PRECIPITATION_CONSIST_LAST_1H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_3H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_SNOW_EQUIV_LAST_1H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_SNOW_EQUIV_LAST_3H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        WEATHER_SIGNIFICANT = OriginUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_LAST_6H = OriginUnit.DIMENSIONLESS.value
-        CLOUD_COVER_TOTAL = OriginUnit.PERCENT.value
-        CLOUD_COVER_EFFECTIVE = OriginUnit.PERCENT.value
-        CLOUD_COVER_BELOW_500_FT = OriginUnit.PERCENT.value
-        CLOUD_COVER_BELOW_1000_FT = OriginUnit.PERCENT.value
-        CLOUD_COVER_BETWEEN_2_TO_7_KM = OriginUnit.PERCENT.value
-        CLOUD_COVER_ABOVE_7_KM = OriginUnit.PERCENT.value
-        PRESSURE_AIR_SURFACE_REDUCED = OriginUnit.PASCAL.value
-        TEMPERATURE_AIR_005 = OriginUnit.DEGREE_KELVIN.value
-        RADIATION_GLOBAL = OriginUnit.GLOBAL_IRRADIANCE.value
-        VISIBILITY = OriginUnit.METER.value
-        SUNSHINE_DURATION = OriginUnit.SECOND.value
-        PROBABILITY_WIND_GUST_GE_25_KN_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_40_KN_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_55_KN_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_24H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_24H = OriginUnit.PERCENT.value
+        TEMPERATURE_AIR_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        TEMPERATURE_DEW_POINT_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        TEMPERATURE_AIR_MAX_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        TEMPERATURE_AIR_MIN_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        WIND_DIRECTION = (
+            OriginUnit.WIND_DIRECTION.value,
+            SIUnit.WIND_DIRECTION.value,
+        )
+        WIND_SPEED = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        WIND_GUST_MAX_LAST_1H = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        WIND_GUST_MAX_LAST_3H = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        WIND_GUST_MAX_LAST_12H = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        PRECIPITATION_CONSIST_LAST_1H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_CONSIST_LAST_3H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_SNOW_EQUIV_LAST_1H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_SNOW_EQUIV_LAST_3H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        WEATHER_SIGNIFICANT = (
+            OriginUnit.SIGNIFICANT_WEATHER.value,
+            SIUnit.SIGNIFICANT_WEATHER.value,
+        )
+        WEATHER_LAST_6H = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+        CLOUD_COVER_TOTAL = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        CLOUD_COVER_EFFECTIVE = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        CLOUD_COVER_BELOW_500_FT = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        CLOUD_COVER_BELOW_1000_FT = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        CLOUD_COVER_BETWEEN_2_TO_7_KM = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        CLOUD_COVER_ABOVE_7_KM = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PRESSURE_AIR_SURFACE_REDUCED = OriginUnit.PASCAL.value, SIUnit.PASCAL.value
+        TEMPERATURE_AIR_005 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        RADIATION_GLOBAL = (
+            OriginUnit.GLOBAL_IRRADIANCE.value,
+            SIUnit.GLOBAL_IRRADIANCE.value,
+        )
+        VISIBILITY = OriginUnit.METER.value, SIUnit.METER.value
+        SUNSHINE_DURATION = OriginUnit.SECOND.value, SIUnit.SECOND.value
+        PROBABILITY_WIND_GUST_GE_25_KN_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_WIND_GUST_GE_40_KN_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_WIND_GUST_GE_55_KN_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_FOG_LAST_1H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_FOG_LAST_6H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_FOG_LAST_12H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_24H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_24H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
 
     class LARGE(UnitEnum):
         # https://opendata.dwd.de/weather/lib/MetElementDefinition.xml
-        TEMPERATURE_AIR_200 = OriginUnit.DEGREE_KELVIN.value
-        TEMPERATURE_DEW_POINT_200 = OriginUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_KELVIN.value
-        WIND_DIRECTION = OriginUnit.WIND_DIRECTION.value
-        WIND_SPEED = OriginUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_1H = OriginUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_3H = OriginUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_12H = OriginUnit.METER_PER_SECOND.value
-        PRECIPITATION_CONSIST_LAST_1H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_LAST_1H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_3H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_LAST_3H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_SNOW_EQUIV_LAST_1H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_SNOW_EQUIV_LAST_3H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        WEATHER_SIGNIFICANT = OriginUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_LAST_6H = OriginUnit.DIMENSIONLESS.value
-        CLOUD_COVER_TOTAL = OriginUnit.PERCENT.value
-        CLOUD_COVER_EFFECTIVE = OriginUnit.PERCENT.value
-        CLOUD_COVER_BELOW_500_FT = OriginUnit.PERCENT.value
-        CLOUD_COVER_BELOW_1000_FT = OriginUnit.PERCENT.value
-        CLOUD_COVER_BETWEEN_2_TO_7_KM = OriginUnit.PERCENT.value
-        CLOUD_COVER_ABOVE_7_KM = OriginUnit.PERCENT.value
-        PRESSURE_AIR_SURFACE_REDUCED = OriginUnit.PASCAL.value
-        TEMPERATURE_AIR_005 = OriginUnit.DEGREE_KELVIN.value
+        TEMPERATURE_AIR_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        TEMPERATURE_DEW_POINT_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        TEMPERATURE_AIR_MAX_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        TEMPERATURE_AIR_MIN_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        WIND_DIRECTION = (
+            OriginUnit.WIND_DIRECTION.value,
+            SIUnit.WIND_DIRECTION.value,
+        )
+        WIND_SPEED = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        WIND_GUST_MAX_LAST_1H = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        WIND_GUST_MAX_LAST_3H = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        WIND_GUST_MAX_LAST_12H = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        PRECIPITATION_CONSIST_LAST_1H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_LAST_1H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_CONSIST_LAST_3H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_LAST_3H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_SNOW_EQUIV_LAST_1H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_SNOW_EQUIV_LAST_3H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        WEATHER_SIGNIFICANT = (
+            OriginUnit.SIGNIFICANT_WEATHER.value,
+            SIUnit.SIGNIFICANT_WEATHER.value,
+        )
+        WEATHER_LAST_6H = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+        CLOUD_COVER_TOTAL = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        CLOUD_COVER_EFFECTIVE = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        CLOUD_COVER_BELOW_500_FT = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        CLOUD_COVER_BELOW_1000_FT = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        CLOUD_COVER_BETWEEN_2_TO_7_KM = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        CLOUD_COVER_ABOVE_7_KM = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PRESSURE_AIR_SURFACE_REDUCED = OriginUnit.PASCAL.value, SIUnit.PASCAL.value
+        TEMPERATURE_AIR_005 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
         RADIATION_SHORT_WAVE_BALANCE_LAST_3H = (
-            OriginUnit.KILOJOULE_PER_SQUARE_METER.value
+            OriginUnit.KILOJOULE_PER_SQUARE_METER.value,
+            SIUnit.JOULE_PER_SQUARE_METER.value,
         )
-        RADIATION_GLOBAL = OriginUnit.GLOBAL_IRRADIANCE.value
+        RADIATION_GLOBAL = (
+            OriginUnit.GLOBAL_IRRADIANCE.value,
+            SIUnit.GLOBAL_IRRADIANCE.value,
+        )
         RADIATION_LONG_WAVE_BALANCE_LAST_3H = (
-            OriginUnit.KILOJOULE_PER_SQUARE_METER.value
+            OriginUnit.KILOJOULE_PER_SQUARE_METER.value,
+            SIUnit.JOULE_PER_SQUARE_METER.value,
         )
-        VISIBILITY = OriginUnit.METER.value
-        SUNSHINE_DURATION = OriginUnit.SECOND.value
-        PROBABILITY_WIND_GUST_GE_25_KN_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_40_KN_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_55_KN_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_24H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_24H = OriginUnit.PERCENT.value
-        TEMPERATURE_AIR_MIN_005_LAST_12H = OriginUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_200_LAST_24H = OriginUnit.DEGREE_KELVIN.value
-        PRECIPITATION_DURATION = OriginUnit.SECOND.value
-        PROBABILITY_DRIZZLE_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_STRAT_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_CONV_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_THUNDERSTORM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LIQUID_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_SOLID_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_FREEZING_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_VISIBILITY_BELOW_1000_M = OriginUnit.PERCENT.value
-        ERROR_ABSOLUTE_TEMPERATURE_AIR_200 = OriginUnit.DEGREE_KELVIN.value
-        ERROR_ABSOLUTE_WIND_SPEED = OriginUnit.METER_PER_SECOND.value
-        ERROR_ABSOLUTE_WIND_DIRECTION = OriginUnit.WIND_DIRECTION.value
-        ERROR_ABSOLUTE_TEMPERATURE_DEW_POINT_200 = OriginUnit.DEGREE_KELVIN.value
-        PRECIPITATION_LAST_6H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_6H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_1_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_3_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_5_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_7_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_2_0_MM_LAST_1H = OriginUnit.PERCENT.value
-        SUNSHINE_DURATION_YESTERDAY = OriginUnit.SECOND.value
-        SUNSHINE_DURATION_RELATIVE_LAST_24H = OriginUnit.DIMENSIONLESS.value
+        VISIBILITY = OriginUnit.METER.value, SIUnit.METER.value
+        SUNSHINE_DURATION = OriginUnit.SECOND.value, SIUnit.SECOND.value
+        PROBABILITY_WIND_GUST_GE_25_KN_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_WIND_GUST_GE_40_KN_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_WIND_GUST_GE_55_KN_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_FOG_LAST_1H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_FOG_LAST_6H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_FOG_LAST_12H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_24H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_24H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        TEMPERATURE_AIR_MIN_005_LAST_12H = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        TEMPERATURE_AIR_200_LAST_24H = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        PRECIPITATION_DURATION = OriginUnit.SECOND.value, SIUnit.SECOND.value
+        PROBABILITY_DRIZZLE_LAST_1H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_PRECIPITATION_STRAT_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_CONV_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_THUNDERSTORM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_LIQUID_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_SOLID_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_FREEZING_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_VISIBILITY_BELOW_1000_M = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        ERROR_ABSOLUTE_TEMPERATURE_AIR_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        ERROR_ABSOLUTE_WIND_SPEED = (
+            OriginUnit.METER_PER_SECOND.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        ERROR_ABSOLUTE_WIND_DIRECTION = (
+            OriginUnit.WIND_DIRECTION.value,
+            SIUnit.WIND_DIRECTION.value,
+        )
+        ERROR_ABSOLUTE_TEMPERATURE_DEW_POINT_200 = (
+            OriginUnit.DEGREE_KELVIN.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        PRECIPITATION_LAST_6H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_CONSIST_LAST_6H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_1_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_3_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_5_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_0_7_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_2_0_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        SUNSHINE_DURATION_YESTERDAY = OriginUnit.SECOND.value, SIUnit.SECOND.value
+        SUNSHINE_DURATION_RELATIVE_LAST_24H = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
         PROBABILITY_SUNSHINE_DURATION_RELATIVE_GT_0_PCT_LAST_24H = (
-            OriginUnit.PERCENT.value
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
         )
         PROBABILITY_SUNSHINE_DURATION_RELATIVE_GT_30_PCT_LAST_24H = (
-            OriginUnit.PERCENT.value
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
         )
         PROBABILITY_SUNSHINE_DURATION_RELATIVE_GT_60_PCT_LAST_24H = (
-            OriginUnit.PERCENT.value
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
         )
-        PROBABILITY_RADIATION_GLOBAL_LAST_1H = OriginUnit.PERCENT.value
+        PROBABILITY_RADIATION_GLOBAL_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
         EVAPOTRANSPIRATION_POTENTIAL_LAST_24H = (
-            OriginUnit.KILOGRAM_PER_SQUARE_METER.value
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
         )
-        PROBABILITY_PRECIPITATION_GT_3_0_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_10_0_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_15_0_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_25_0_MM_LAST_1H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_STRAT_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_CONV_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_THUNDERSTORM_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LIQUID_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_FREEZING_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_SOLID_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_DRIZZLE_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_24H = OriginUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_25_KN_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_40_KN_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_55_KN_LAST_6H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_STRAT_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_CONV_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_THUNDERSTORM_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LIQUID_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_FREEZING_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_SOLID_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_DRIZZLE_LAST_12H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_6H = OriginUnit.PERCENT.value
-        PRECIPITATION_LAST_12H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_12H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        WEATHER_SIGNIFICANT_LAST_3H = OriginUnit.SIGNIFICANT_WEATHER.value
+        PROBABILITY_PRECIPITATION_GT_3_0_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_10_0_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_15_0_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_25_0_MM_LAST_1H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_STRAT_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_CONV_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_THUNDERSTORM_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_LIQUID_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_FREEZING_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_SOLID_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_DRIZZLE_LAST_6H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_FOG_LAST_24H = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_WIND_GUST_GE_25_KN_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_WIND_GUST_GE_40_KN_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_WIND_GUST_GE_55_KN_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_STRAT_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_CONV_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_THUNDERSTORM_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_LIQUID_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_FREEZING_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_SOLID_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_DRIZZLE_LAST_12H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_6H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        PRECIPITATION_LAST_12H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        PRECIPITATION_CONSIST_LAST_12H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        WEATHER_SIGNIFICANT_LAST_3H = (
+            OriginUnit.SIGNIFICANT_WEATHER.value,
+            SIUnit.SIGNIFICANT_WEATHER.value,
+        )
         PRECIPITATION_LIQUID_CONSIST_LAST_1H = (
-            OriginUnit.KILOGRAM_PER_SQUARE_METER.value
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
         )
-        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_24H = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_24H = OriginUnit.PERCENT.value
-        PRECIPITATION_LAST_24H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_24H = OriginUnit.KILOGRAM_PER_SQUARE_METER.value
-        CLOUD_COVER_BELOW_7000_M = OriginUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LAST_24H = OriginUnit.PERCENT.value
-        CLOUD_BASE_CONVECTIVE = OriginUnit.METER.value
-        PROBABILITY_THUNDERSTORM_LAST_24H = OriginUnit.PERCENT.value
-        ERROR_ABSOLUTE_PRESSURE_AIR_SURFACE = OriginUnit.PASCAL.value
-        SUNSHINE_DURATION_LAST_3H = OriginUnit.SECOND.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_1H = OriginUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_3H = OriginUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_6H = OriginUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_12H = OriginUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_24H = OriginUnit.SIGNIFICANT_WEATHER.value
-
-
-class DwdMosmixUnitSI(DatasetTreeCore):
-    class SMALL(UnitEnum):
-        TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-        TEMPERATURE_DEW_POINT_200 = MetricUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-        WIND_DIRECTION = MetricUnit.WIND_DIRECTION.value
-        WIND_SPEED = MetricUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_1H = MetricUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_3H = MetricUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_12H = MetricUnit.METER_PER_SECOND.value
-        PRECIPITATION_CONSIST_LAST_1H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_3H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_SNOW_EQUIV_LAST_1H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_SNOW_EQUIV_LAST_3H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        WEATHER_SIGNIFICANT = MetricUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_LAST_6H = MetricUnit.DIMENSIONLESS.value
-        CLOUD_COVER_TOTAL = MetricUnit.PERCENT.value
-        CLOUD_COVER_EFFECTIVE = MetricUnit.PERCENT.value
-        CLOUD_COVER_BELOW_500_FT = MetricUnit.PERCENT.value
-        CLOUD_COVER_BELOW_1000_FT = MetricUnit.PERCENT.value
-        CLOUD_COVER_BETWEEN_2_TO_7_KM = MetricUnit.PERCENT.value
-        CLOUD_COVER_ABOVE_7_KM = MetricUnit.PERCENT.value
-        PRESSURE_AIR_SURFACE_REDUCED = MetricUnit.PASCAL.value
-        TEMPERATURE_AIR_005 = MetricUnit.DEGREE_KELVIN.value
-        RADIATION_GLOBAL = MetricUnit.GLOBAL_IRRADIANCE.value
-        VISIBILITY = MetricUnit.METER.value
-        SUNSHINE_DURATION = MetricUnit.SECOND.value
-        PROBABILITY_WIND_GUST_GE_25_KN_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_40_KN_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_55_KN_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_24H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_24H = MetricUnit.PERCENT.value
-
-    class LARGE(UnitEnum):
-        # https://opendata.dwd.de/weather/lib/MetElementDefinition.xml
-        TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-        TEMPERATURE_DEW_POINT_200 = MetricUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-        WIND_DIRECTION = MetricUnit.WIND_DIRECTION.value
-        WIND_SPEED = MetricUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_1H = MetricUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_3H = MetricUnit.METER_PER_SECOND.value
-        WIND_GUST_MAX_LAST_12H = MetricUnit.METER_PER_SECOND.value
-        PRECIPITATION_CONSIST_LAST_1H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_LAST_1H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_3H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_LAST_3H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_SNOW_EQUIV_LAST_1H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_SNOW_EQUIV_LAST_3H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        WEATHER_SIGNIFICANT = MetricUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_LAST_6H = MetricUnit.DIMENSIONLESS.value
-        CLOUD_COVER_TOTAL = MetricUnit.PERCENT.value
-        CLOUD_COVER_EFFECTIVE = MetricUnit.PERCENT.value
-        CLOUD_COVER_BELOW_500_FT = MetricUnit.PERCENT.value
-        CLOUD_COVER_BELOW_1000_FT = MetricUnit.PERCENT.value
-        CLOUD_COVER_BETWEEN_2_TO_7_KM = MetricUnit.PERCENT.value
-        CLOUD_COVER_ABOVE_7_KM = MetricUnit.PERCENT.value
-        PRESSURE_AIR_SURFACE_REDUCED = MetricUnit.PASCAL.value
-        TEMPERATURE_AIR_005 = MetricUnit.DEGREE_KELVIN.value
-        RADIATION_SHORT_WAVE_BALANCE_LAST_3H = MetricUnit.JOULE_PER_SQUARE_METER.value
-        RADIATION_GLOBAL = MetricUnit.GLOBAL_IRRADIANCE.value
-        RADIATION_LONG_WAVE_BALANCE_LAST_3H = MetricUnit.JOULE_PER_SQUARE_METER.value
-        VISIBILITY = MetricUnit.METER.value
-        SUNSHINE_DURATION = MetricUnit.SECOND.value
-        PROBABILITY_WIND_GUST_GE_25_KN_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_40_KN_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_55_KN_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_24H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_24H = MetricUnit.PERCENT.value
-        TEMPERATURE_AIR_MIN_005_LAST_12H = MetricUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_200_LAST_24H = MetricUnit.DEGREE_KELVIN.value
-        PRECIPITATION_DURATION = MetricUnit.SECOND.value
-        PROBABILITY_DRIZZLE_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_STRAT_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_CONV_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_THUNDERSTORM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LIQUID_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_SOLID_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_FREEZING_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_VISIBILITY_BELOW_1000_M = MetricUnit.PERCENT.value
-        ERROR_ABSOLUTE_TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-        ERROR_ABSOLUTE_WIND_SPEED = MetricUnit.METER_PER_SECOND.value
-        ERROR_ABSOLUTE_WIND_DIRECTION = MetricUnit.WIND_DIRECTION.value
-        ERROR_ABSOLUTE_TEMPERATURE_DEW_POINT_200 = MetricUnit.DEGREE_KELVIN.value
-        PRECIPITATION_LAST_6H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_6H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_1_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_2_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_3_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_5_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_0_7_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_2_0_MM_LAST_1H = MetricUnit.PERCENT.value
-        SUNSHINE_DURATION_YESTERDAY = MetricUnit.SECOND.value
-        SUNSHINE_DURATION_RELATIVE_LAST_24H = MetricUnit.DIMENSIONLESS.value
-        PROBABILITY_SUNSHINE_DURATION_RELATIVE_GT_0_PCT_LAST_24H = (
-            MetricUnit.PERCENT.value
+        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_24H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
         )
-        PROBABILITY_SUNSHINE_DURATION_RELATIVE_GT_30_PCT_LAST_24H = (
-            MetricUnit.PERCENT.value
+        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_24H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
         )
-        PROBABILITY_SUNSHINE_DURATION_RELATIVE_GT_60_PCT_LAST_24H = (
-            MetricUnit.PERCENT.value
+        PRECIPITATION_LAST_24H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
         )
-        PROBABILITY_RADIATION_GLOBAL_LAST_1H = MetricUnit.PERCENT.value
-        EVAPOTRANSPIRATION_POTENTIAL_LAST_24H = (
-            MetricUnit.KILOGRAM_PER_SQUARE_METER.value
+        PRECIPITATION_CONSIST_LAST_24H = (
+            OriginUnit.KILOGRAM_PER_SQUARE_METER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
         )
-        PROBABILITY_PRECIPITATION_GT_3_0_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_5_0_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_10_0_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_15_0_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_25_0_MM_LAST_1H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_STRAT_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_CONV_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_THUNDERSTORM_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LIQUID_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_FREEZING_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_SOLID_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_DRIZZLE_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_FOG_LAST_24H = MetricUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_25_KN_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_40_KN_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_WIND_GUST_GE_55_KN_LAST_6H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_STRAT_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_CONV_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_THUNDERSTORM_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LIQUID_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_FREEZING_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_SOLID_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_DRIZZLE_LAST_12H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_6H = MetricUnit.PERCENT.value
-        PRECIPITATION_LAST_12H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_12H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        WEATHER_SIGNIFICANT_LAST_3H = MetricUnit.SIGNIFICANT_WEATHER.value
-        PRECIPITATION_LIQUID_CONSIST_LAST_1H = (
-            MetricUnit.KILOGRAM_PER_SQUARE_METER.value
+        CLOUD_COVER_BELOW_7000_M = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        PROBABILITY_PRECIPITATION_LAST_24H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
         )
-        PROBABILITY_PRECIPITATION_GT_0_0_MM_LAST_24H = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_GT_1_0_MM_LAST_24H = MetricUnit.PERCENT.value
-        PRECIPITATION_LAST_24H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        PRECIPITATION_CONSIST_LAST_24H = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        CLOUD_COVER_BELOW_7000_M = MetricUnit.PERCENT.value
-        PROBABILITY_PRECIPITATION_LAST_24H = MetricUnit.PERCENT.value
-        CLOUD_BASE_CONVECTIVE = MetricUnit.METER.value
-        PROBABILITY_THUNDERSTORM_LAST_24H = MetricUnit.PERCENT.value
-        ERROR_ABSOLUTE_PRESSURE_AIR_SURFACE = MetricUnit.PASCAL.value
-        SUNSHINE_DURATION_LAST_3H = MetricUnit.SECOND.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_1H = MetricUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_3H = MetricUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_6H = MetricUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_12H = MetricUnit.SIGNIFICANT_WEATHER.value
-        WEATHER_SIGNIFICANT_OPTIONAL_LAST_24H = MetricUnit.SIGNIFICANT_WEATHER.value
+        CLOUD_BASE_CONVECTIVE = OriginUnit.METER.value, SIUnit.METER.value
+        PROBABILITY_THUNDERSTORM_LAST_24H = (
+            OriginUnit.PERCENT.value,
+            SIUnit.PERCENT.value,
+        )
+        ERROR_ABSOLUTE_PRESSURE_AIR_SURFACE = (
+            OriginUnit.PASCAL.value,
+            SIUnit.PASCAL.value,
+        )
+        SUNSHINE_DURATION_LAST_3H = OriginUnit.SECOND.value, SIUnit.SECOND.value
+        WEATHER_SIGNIFICANT_OPTIONAL_LAST_1H = (
+            OriginUnit.SIGNIFICANT_WEATHER.value,
+            SIUnit.SIGNIFICANT_WEATHER.value,
+        )
+        WEATHER_SIGNIFICANT_OPTIONAL_LAST_3H = (
+            OriginUnit.SIGNIFICANT_WEATHER.value,
+            SIUnit.SIGNIFICANT_WEATHER.value,
+        )
+        WEATHER_SIGNIFICANT_OPTIONAL_LAST_6H = (
+            OriginUnit.SIGNIFICANT_WEATHER.value,
+            SIUnit.SIGNIFICANT_WEATHER.value,
+        )
+        WEATHER_SIGNIFICANT_OPTIONAL_LAST_12H = (
+            OriginUnit.SIGNIFICANT_WEATHER.value,
+            SIUnit.SIGNIFICANT_WEATHER.value,
+        )
+        WEATHER_SIGNIFICANT_OPTIONAL_LAST_24H = (
+            OriginUnit.SIGNIFICANT_WEATHER.value,
+            SIUnit.SIGNIFICANT_WEATHER.value,
+        )

--- a/wetterdienst/provider/dwd/observation/api.py
+++ b/wetterdienst/provider/dwd/observation/api.py
@@ -47,10 +47,7 @@ from wetterdienst.provider.dwd.observation.metadata.resolution import (
     HIGH_RESOLUTIONS,
     RESOLUTION_TO_DATETIME_FORMAT_MAPPING,
 )
-from wetterdienst.provider.dwd.observation.metadata.unit import (
-    DwdObservationUnitOrigin,
-    DwdObservationUnitSI,
-)
+from wetterdienst.provider.dwd.observation.metadata.unit import DwdObservationUnit
 from wetterdienst.provider.dwd.observation.metaindex import (
     create_meta_index_for_climate_observations,
 )
@@ -395,8 +392,7 @@ class DwdObservationRequest(ScalarRequestCore):
     _dataset_tree = DwdObservationDatasetTree
     _parameter_to_dataset_mapping = PARAMETER_TO_DATASET_MAPPING
 
-    _origin_unit_tree = DwdObservationUnitOrigin
-    _si_unit_tree = DwdObservationUnitSI
+    _unit_tree = DwdObservationUnit
 
     @property
     def _interval(self) -> Optional[pd.Interval]:

--- a/wetterdienst/provider/dwd/observation/metadata/unit.py
+++ b/wetterdienst/provider/dwd/observation/metadata/unit.py
@@ -1,724 +1,711 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
-from wetterdienst.metadata.unit import MetricUnit, OriginUnit, UnitEnum
+from wetterdienst.metadata.unit import OriginUnit, SIUnit, UnitEnum
 from wetterdienst.util.parameter import DatasetTreeCore
 
 
-class DwdObservationUnitOrigin(DatasetTreeCore):
+class DwdObservationUnit(DatasetTreeCore):
     # 1_minute
     class MINUTE_1(DatasetTreeCore):  # noqa
         # precipitation
         class PRECIPITATION(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            PRECIPITATION_HEIGHT_DROPLET = OriginUnit.MILLIMETER.value
-            PRECIPITATION_HEIGHT_ROCKER = OriginUnit.MILLIMETER.value
-            PRECIPITATION_FORM = OriginUnit.DIMENSIONLESS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_HEIGHT_DROPLET = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_HEIGHT_ROCKER = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_FORM = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
 
     # 10_minutes
     class MINUTE_10(DatasetTreeCore):  # noqa
         # air_temperature
         class TEMPERATURE_AIR(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            PRESSURE_AIR_STATION_HEIGHT = OriginUnit.HECTOPASCAL.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_005 = OriginUnit.DEGREE_CELSIUS.value
-            HUMIDITY = OriginUnit.PERCENT.value
-            TEMPERATURE_DEW_POINT_200 = OriginUnit.DEGREE_CELSIUS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            PRESSURE_AIR_STATION_HEIGHT = (
+                OriginUnit.HECTOPASCAL.value,
+                SIUnit.PASCAL.value,
+            )
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_005 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            HUMIDITY = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+            TEMPERATURE_DEW_POINT_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
 
         # extreme_temperature
         class TEMPERATURE_EXTREME(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MAX_005 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MIN_005 = OriginUnit.DEGREE_CELSIUS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            TEMPERATURE_AIR_MAX_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MAX_005 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MIN_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MIN_005 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
 
         # extreme_wind
         class WIND_EXTREME(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            WIND_GUST_MAX = OriginUnit.METER_PER_SECOND.value
-            WIND_SPEED_MIN = OriginUnit.METER_PER_SECOND.value
-            WIND_SPEED_ROLLING_MEAN_MAX = OriginUnit.METER_PER_SECOND.value
-            WIND_DIRECTION_MAX_VELOCITY = OriginUnit.WIND_DIRECTION.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            WIND_GUST_MAX = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            WIND_SPEED_MIN = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            WIND_SPEED_ROLLING_MEAN_MAX = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            WIND_DIRECTION_MAX_VELOCITY = (
+                OriginUnit.WIND_DIRECTION.value,
+                SIUnit.WIND_DIRECTION.value,
+            )
 
         # precipitation
         class PRECIPITATION(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            PRECIPITATION_DURATION = OriginUnit.MINUTE.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            PRECIPITATION_INDICATOR_WR = OriginUnit.DIMENSIONLESS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            PRECIPITATION_DURATION = OriginUnit.MINUTE.value, SIUnit.SECOND.value
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_INDICATOR_WR = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
 
         # solar
         class SOLAR(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            RADIATION_SKY_DIFFUSE = OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
-            RADIATION_GLOBAL = OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
-            SUNSHINE_DURATION = OriginUnit.HOUR.value
-            RADIATION_SKY_LONG_WAVE = OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            RADIATION_SKY_DIFFUSE = (
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
+            )
+            RADIATION_GLOBAL = (
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
+            )
+            SUNSHINE_DURATION = OriginUnit.HOUR.value, SIUnit.SECOND.value
+            RADIATION_SKY_LONG_WAVE = (
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
+            )
 
         # wind
         class WIND(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            WIND_SPEED = OriginUnit.METER_PER_SECOND.value
-            WIND_DIRECTION = OriginUnit.DEGREE.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            WIND_SPEED = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            WIND_DIRECTION = OriginUnit.DEGREE.value, SIUnit.WIND_DIRECTION.value
 
     # hourly
     class HOURLY(DatasetTreeCore):
         # air_temperature
         class TEMPERATURE_AIR(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            HUMIDITY = OriginUnit.PERCENT.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            HUMIDITY = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
 
         # cloud_type
         class CLOUD_TYPE(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value
-            CLOUD_COVER_TOTAL_INDICATOR = OriginUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER1 = OriginUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER1_ABBREVIATION = OriginUnit.DIMENSIONLESS.value
-            CLOUD_HEIGHT_LAYER1 = OriginUnit.METER.value
-            CLOUD_COVER_LAYER1 = OriginUnit.ONE_EIGHTH.value
-            CLOUD_TYPE_LAYER2 = OriginUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER2_ABBREVIATION = OriginUnit.DIMENSIONLESS.value
-            CLOUD_HEIGHT_LAYER2 = OriginUnit.METER.value
-            CLOUD_COVER_LAYER2 = OriginUnit.ONE_EIGHTH.value
-            CLOUD_TYPE_LAYER3 = OriginUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER3_ABBREVIATION = OriginUnit.DIMENSIONLESS.value
-            CLOUD_HEIGHT_LAYER3 = OriginUnit.METER.value
-            CLOUD_COVER_LAYER3 = OriginUnit.ONE_EIGHTH.value
-            CLOUD_TYPE_LAYER4 = OriginUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER4_ABBREVIATION = OriginUnit.DIMENSIONLESS.value
-            CLOUD_HEIGHT_LAYER4 = OriginUnit.METER.value
-            CLOUD_COVER_LAYER4 = OriginUnit.ONE_EIGHTH.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
+            CLOUD_COVER_TOTAL_INDICATOR = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_TYPE_LAYER1 = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_TYPE_LAYER1_ABBREVIATION = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_HEIGHT_LAYER1 = OriginUnit.METER.value, SIUnit.METER.value
+            CLOUD_COVER_LAYER1 = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
+            CLOUD_TYPE_LAYER2 = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_TYPE_LAYER2_ABBREVIATION = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_HEIGHT_LAYER2 = OriginUnit.METER.value, SIUnit.METER.value
+            CLOUD_COVER_LAYER2 = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
+            CLOUD_TYPE_LAYER3 = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_TYPE_LAYER3_ABBREVIATION = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_HEIGHT_LAYER3 = OriginUnit.METER.value, SIUnit.METER.value
+            CLOUD_COVER_LAYER3 = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
+            CLOUD_TYPE_LAYER4 = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_TYPE_LAYER4_ABBREVIATION = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_HEIGHT_LAYER4 = OriginUnit.METER.value, SIUnit.METER.value
+            CLOUD_COVER_LAYER4 = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
 
         # cloudiness
         class CLOUDINESS(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL_INDICATOR = OriginUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            CLOUD_COVER_TOTAL_INDICATOR = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
 
         # dew_point
         class DEW_POINT(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_DEW_POINT_200 = OriginUnit.DEGREE_CELSIUS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_DEW_POINT_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
 
         # precipitation
         class PRECIPITATION(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            PRECIPITATION_INDICATOR = OriginUnit.DIMENSIONLESS.value
-            PRECIPITATION_FORM = OriginUnit.DIMENSIONLESS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_INDICATOR = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            PRECIPITATION_FORM = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
 
         # pressure
         class PRESSURE(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            PRESSURE_AIR_SEA_LEVEL = OriginUnit.HECTOPASCAL.value
-            PRESSURE_AIR_STATION_HEIGHT = OriginUnit.HECTOPASCAL.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            PRESSURE_AIR_SEA_LEVEL = (
+                OriginUnit.HECTOPASCAL.value,
+                SIUnit.PASCAL.value,
+            )
+            PRESSURE_AIR_STATION_HEIGHT = (
+                OriginUnit.HECTOPASCAL.value,
+                SIUnit.PASCAL.value,
+            )
 
         # soil_temperature
         class TEMPERATURE_SOIL(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            TEMPERATURE_SOIL_002 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_005 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_010 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_020 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_050 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_100 = OriginUnit.DEGREE_CELSIUS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            TEMPERATURE_SOIL_002 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_005 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_010 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_020 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_050 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_100 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
 
         # solar
         class SOLAR(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            END_OF_INTERVAL = OriginUnit.DIMENSIONLESS.value
-            RADIATION_SKY_LONG_WAVE = OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
-            RADIATION_SKY_SHORT_WAVE_DIFFUSE = (
-                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            END_OF_INTERVAL = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
             )
-            RADIATION_GLOBAL = OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
-            SUNSHINE_DURATION = OriginUnit.MINUTE.value
-            SUN_ZENITH = OriginUnit.DEGREE.value
-            TRUE_LOCAL_TIME = OriginUnit.DIMENSIONLESS.value
+            RADIATION_SKY_LONG_WAVE = (
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
+            )
+            RADIATION_SKY_SHORT_WAVE_DIFFUSE = (
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
+            )
+            RADIATION_GLOBAL = (
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
+            )
+            SUNSHINE_DURATION = OriginUnit.MINUTE.value, SIUnit.SECOND.value
+            SUN_ZENITH = OriginUnit.DEGREE.value, SIUnit.DEGREE.value
+            TRUE_LOCAL_TIME = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
 
         # sun
         class SUNSHINE_DURATION(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            SUNSHINE_DURATION = OriginUnit.MINUTE.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            SUNSHINE_DURATION = OriginUnit.MINUTE.value, SIUnit.SECOND.value
 
         # visibility
         class VISIBILITY(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            VISIBILITY_INDICATOR = OriginUnit.DIMENSIONLESS.value
-            VISIBILITY = OriginUnit.METER.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            VISIBILITY_INDICATOR = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            VISIBILITY = OriginUnit.METER.value, SIUnit.METER.value
 
         # wind
         class WIND(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            WIND_SPEED = OriginUnit.METER_PER_SECOND.value
-            WIND_DIRECTION = OriginUnit.WIND_DIRECTION.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            WIND_SPEED = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            WIND_DIRECTION = (
+                OriginUnit.WIND_DIRECTION.value,
+                SIUnit.WIND_DIRECTION.value,
+            )
 
         # wind_synop
         class WIND_SYNOPTIC(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            WIND_SPEED = OriginUnit.METER_PER_SECOND.value
-            WIND_DIRECTION = OriginUnit.WIND_DIRECTION.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            WIND_SPEED = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            WIND_DIRECTION = (
+                OriginUnit.WIND_DIRECTION.value,
+                SIUnit.WIND_DIRECTION.value,
+            )
 
         class MOISTURE(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            HUMIDITY_ABSOLUTE = OriginUnit.DIMENSIONLESS.value
-            PRESSURE_VAPOR = OriginUnit.HECTOPASCAL.value
-            TEMPERATURE_WET = OriginUnit.DEGREE_CELSIUS.value
-            PRESSURE_AIR = OriginUnit.HECTOPASCAL.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            HUMIDITY = OriginUnit.PERCENT.value
-            TEMPERATURE_DEW_POINT_200 = OriginUnit.DEGREE_CELSIUS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            HUMIDITY_ABSOLUTE = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            PRESSURE_VAPOR = OriginUnit.HECTOPASCAL.value, SIUnit.PASCAL.value
+            TEMPERATURE_WET = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            PRESSURE_AIR = OriginUnit.HECTOPASCAL.value, SIUnit.PASCAL.value
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            HUMIDITY = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+            TEMPERATURE_DEW_POINT_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
 
     # subdaily
     class SUBDAILY(DatasetTreeCore):  # noqa
         # air_temperature
         class TEMPERATURE_AIR(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            HUMIDITY = OriginUnit.PERCENT.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            HUMIDITY = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
 
         # cloudiness
         class CLOUDINESS(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value
-            CLOUD_DENSITY = OriginUnit.DIMENSIONLESS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
+            CLOUD_DENSITY = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
 
         # moisture
         class MOISTURE(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            PRESSURE_VAPOR = OriginUnit.HECTOPASCAL.value
-            TEMPERATURE_AIR_005 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            HUMIDITY = OriginUnit.PERCENT.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            PRESSURE_VAPOR = OriginUnit.HECTOPASCAL.value, SIUnit.PASCAL.value
+            TEMPERATURE_AIR_005 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            HUMIDITY = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
 
         # pressure
         class PRESSURE(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            PRESSURE_AIR = OriginUnit.HECTOPASCAL.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            PRESSURE_AIR = OriginUnit.HECTOPASCAL.value, SIUnit.PASCAL.value
 
         # soil
         class SOIL(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            TEMPERATURE_SOIL_005 = OriginUnit.DEGREE_CELSIUS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            TEMPERATURE_SOIL_005 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
 
         # visibility
         class VISIBILITY(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            VISIBILITY = OriginUnit.METER.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            VISIBILITY = OriginUnit.METER.value, SIUnit.METER.value
 
         # wind
         class WIND(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            WIND_DIRECTION = OriginUnit.DEGREE.value
-            WIND_FORCE_BEAUFORT = OriginUnit.BEAUFORT.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            WIND_DIRECTION = OriginUnit.DEGREE.value, SIUnit.WIND_DIRECTION.value
+            WIND_FORCE_BEAUFORT = OriginUnit.BEAUFORT.value, SIUnit.BEAUFORT.value
 
     # Daily
     class DAILY(DatasetTreeCore):
         # kl
         class CLIMATE_SUMMARY(UnitEnum):  # noqa
-            QUALITY_WIND = OriginUnit.DIMENSIONLESS.value
-            WIND_GUST_MAX = OriginUnit.METER_PER_SECOND.value
-            WIND_SPEED = OriginUnit.METER_PER_SECOND.value
-            QUALITY_GENERAL = OriginUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            PRECIPITATION_FORM = OriginUnit.DIMENSIONLESS.value
-            SUNSHINE_DURATION = OriginUnit.HOUR.value
-            SNOW_DEPTH = OriginUnit.CENTIMETER.value
-            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value
-            PRESSURE_VAPOR = OriginUnit.HECTOPASCAL.value
-            PRESSURE_AIR = OriginUnit.HECTOPASCAL.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            HUMIDITY = OriginUnit.PERCENT.value
-            TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MIN_005 = OriginUnit.DEGREE_CELSIUS.value
+            QUALITY_WIND = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            WIND_GUST_MAX = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            WIND_SPEED = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            QUALITY_GENERAL = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_FORM = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            SUNSHINE_DURATION = OriginUnit.HOUR.value, SIUnit.SECOND.value
+            SNOW_DEPTH = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
+            PRESSURE_VAPOR = OriginUnit.HECTOPASCAL.value, SIUnit.PASCAL.value
+            PRESSURE_AIR = OriginUnit.HECTOPASCAL.value, SIUnit.PASCAL.value
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            HUMIDITY = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+            TEMPERATURE_AIR_MAX_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MIN_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MIN_005 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
 
         # more_precip
         class PRECIPITATION_MORE(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            PRECIPITATION_FORM = OriginUnit.DIMENSIONLESS.value
-            SNOW_DEPTH = OriginUnit.CENTIMETER.value
-            SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_FORM = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            SNOW_DEPTH = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+            SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value, SIUnit.METER.value
 
         # soil_temperature
         class TEMPERATURE_SOIL(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_002 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_005 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_010 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_020 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_SOIL_050 = OriginUnit.DEGREE_CELSIUS.value
+            QUALITY = OriginUnit.DEGREE_CELSIUS.value, SIUnit.DIMENSIONLESS.value
+            TEMPERATURE_SOIL_002 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_005 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_010 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_020 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_SOIL_050 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
 
         # solar
         class SOLAR(UnitEnum):
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            RADIATION_SKY_LONG_WAVE = OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            RADIATION_SKY_LONG_WAVE = (
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
+            )
             RADIATION_SKY_SHORT_WAVE_DIFFUSE = (
-                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
             )
             RADIATION_SKY_SHORT_WAVE_DIRECT = (
-                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value
+                OriginUnit.JOULE_PER_SQUARE_CENTIMETER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
             )
-            SUNSHINE_DURATION = OriginUnit.HOUR.value
+            SUNSHINE_DURATION = OriginUnit.HOUR.value, SIUnit.SECOND.value
 
         # water_equiv
         class WATER_EQUIVALENT(UnitEnum):  # noqa
-            QN_6 = OriginUnit.DIMENSIONLESS.value
-            SNOW_DEPTH_EXCELLED = OriginUnit.CENTIMETER.value
-            SNOW_DEPTH = OriginUnit.CENTIMETER.value
-            WATER_EQUIVALENT_TOTAL_SNOW_DEPTH = OriginUnit.MILLIMETER.value
-            WATER_EQUIVALENT_SNOW = OriginUnit.MILLIMETER.value
-
-        # weather_phenomena
-        class WEATHER_PHENOMENA(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            FOG = OriginUnit.DIMENSIONLESS.value
-            THUNDER = OriginUnit.DIMENSIONLESS.value
-            STORM_STRONG_WIND = OriginUnit.DIMENSIONLESS.value
-            STORM_STORMIER_WIND = OriginUnit.DIMENSIONLESS.value
-            DEW = OriginUnit.DIMENSIONLESS.value
-            GLAZE = OriginUnit.DIMENSIONLESS.value
-            RIPE = OriginUnit.DIMENSIONLESS.value
-            SLEET = OriginUnit.DIMENSIONLESS.value
-            HAIL = OriginUnit.DIMENSIONLESS.value
-
-    # monthly
-    class MONTHLY(DatasetTreeCore):
-        # kl
-        class CLIMATE_SUMMARY(UnitEnum):  # noqa
-            QUALITY_GENERAL = OriginUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MAX_MEAN_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MIN_MEAN_200 = OriginUnit.DEGREE_CELSIUS.value
-            WIND_FORCE_BEAUFORT = OriginUnit.BEAUFORT.value
-            TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_CELSIUS.value
-            WIND_GUST_MAX = OriginUnit.METER_PER_SECOND.value
-            TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_CELSIUS.value
-            SUNSHINE_DURATION = OriginUnit.HOUR.value
-            QUALITY_PRECIPITATION = OriginUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            PRECIPITATION_HEIGHT_MAX = OriginUnit.MILLIMETER.value
-
-        # more_precip
-        class PRECIPITATION_MORE(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            SNOW_DEPTH = OriginUnit.CENTIMETER.value
-            PRECIPITATION_HEIGHT_MAX = OriginUnit.MILLIMETER.value
-
-        # weather_phenomena
-        class WEATHER_PHENOMENA(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            STORM_STRONG_WIND = OriginUnit.DIMENSIONLESS.value
-            STORM_STORMIER_WIND = OriginUnit.DIMENSIONLESS.value
-            THUNDER = OriginUnit.DIMENSIONLESS.value
-            GLAZE = OriginUnit.DIMENSIONLESS.value
-            SLEET = OriginUnit.DIMENSIONLESS.value
-            HAIL = OriginUnit.DIMENSIONLESS.value
-            FOG = OriginUnit.DIMENSIONLESS.value
-            DEW = OriginUnit.DIMENSIONLESS.value
-
-    # annual
-    class ANNUAL(DatasetTreeCore):
-        # kl
-        class CLIMATE_SUMMARY(UnitEnum):  # noqa
-            QUALITY_GENERAL = OriginUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value
-            TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MAX_MEAN_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MIN_MEAN_200 = OriginUnit.DEGREE_CELSIUS.value
-            WIND_FORCE_BEAUFORT = OriginUnit.BEAUFORT.value
-            SUNSHINE_DURATION = OriginUnit.HOUR.value
-            WIND_GUST_MAX = OriginUnit.METER_PER_SECOND.value
-            TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_CELSIUS.value
-            TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_CELSIUS.value
-            QUALITY_PRECIPITATION = OriginUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            PRECIPITATION_HEIGHT_MAX = OriginUnit.MILLIMETER.value
-
-        # more_precip
-        class PRECIPITATION_MORE(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value
-            PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-            SNOW_DEPTH = OriginUnit.CENTIMETER.value
-            PRECIPITATION_HEIGHT_MAX = OriginUnit.MILLIMETER.value
-
-        # weather_phenomena
-        class WEATHER_PHENOMENA(UnitEnum):  # noqa
-            QUALITY = OriginUnit.DIMENSIONLESS.value
-            STORM_STRONG_WIND = OriginUnit.DIMENSIONLESS.value
-            STORM_STORMIER_WIND = OriginUnit.DIMENSIONLESS.value
-            THUNDER = OriginUnit.DIMENSIONLESS.value
-            GLAZE = OriginUnit.DIMENSIONLESS.value
-            SLEET = OriginUnit.DIMENSIONLESS.value
-            HAIL = OriginUnit.DIMENSIONLESS.value
-            FOG = OriginUnit.DIMENSIONLESS.value
-            DEW = OriginUnit.DIMENSIONLESS.value
-
-
-class DwdObservationUnitSI(DatasetTreeCore):
-    # 1_minute
-    class MINUTE_1(DatasetTreeCore):  # noqa
-        # precipitation
-        class PRECIPITATION(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_HEIGHT_DROPLET = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_HEIGHT_ROCKER = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_FORM = MetricUnit.DIMENSIONLESS.value
-
-    # 10_minutes
-    class MINUTE_10(DatasetTreeCore):  # noqa
-        # air_temperature
-        class TEMPERATURE_AIR(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            PRESSURE_AIR_STATION_HEIGHT = MetricUnit.PASCAL.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_005 = MetricUnit.DEGREE_KELVIN.value
-            HUMIDITY = MetricUnit.PERCENT.value
-            TEMPERATURE_DEW_POINT_200 = MetricUnit.DEGREE_KELVIN.value
-
-        # extreme_temperature
-        class TEMPERATURE_EXTREME(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MAX_005 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MIN_005 = MetricUnit.DEGREE_KELVIN.value
-
-        # extreme_wind
-        class WIND_EXTREME(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            WIND_GUST_MAX = MetricUnit.METER_PER_SECOND.value
-            WIND_SPEED_MIN = MetricUnit.METER_PER_SECOND.value
-            WIND_SPEED_ROLLING_MEAN_MAX = MetricUnit.METER_PER_SECOND.value
-            WIND_DIRECTION_MAX_VELOCITY = MetricUnit.WIND_DIRECTION.value
-
-        # precipitation
-        class PRECIPITATION(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            PRECIPITATION_DURATION = MetricUnit.SECOND.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_INDICATOR_WR = MetricUnit.DIMENSIONLESS.value
-
-        # solar
-        class SOLAR(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            RADIATION_SKY_DIFFUSE = MetricUnit.JOULE_PER_SQUARE_METER.value
-            RADIATION_GLOBAL = MetricUnit.JOULE_PER_SQUARE_METER.value
-            SUNSHINE_DURATION = MetricUnit.SECOND.value
-            RADIATION_SKY_LONG_WAVE = MetricUnit.JOULE_PER_SQUARE_METER.value
-
-        # wind
-        class WIND(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            WIND_SPEED = MetricUnit.METER_PER_SECOND.value
-            WIND_DIRECTION = MetricUnit.WIND_DIRECTION.value
-
-    # hourly
-    class HOURLY(DatasetTreeCore):
-        # air_temperature
-        class TEMPERATURE_AIR(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            HUMIDITY = MetricUnit.PERCENT.value
-
-        # cloud_type
-        class CLOUD_TYPE(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = MetricUnit.PERCENT.value
-            CLOUD_COVER_TOTAL_INDICATOR = MetricUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER1 = MetricUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER1_ABBREVIATION = MetricUnit.DIMENSIONLESS.value
-            CLOUD_HEIGHT_LAYER1 = MetricUnit.METER.value
-            CLOUD_COVER_LAYER1 = MetricUnit.PERCENT.value
-            CLOUD_TYPE_LAYER2 = MetricUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER2_ABBREVIATION = MetricUnit.DIMENSIONLESS.value
-            CLOUD_HEIGHT_LAYER2 = MetricUnit.METER.value
-            CLOUD_COVER_LAYER2 = MetricUnit.PERCENT.value
-            CLOUD_TYPE_LAYER3 = MetricUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER3_ABBREVIATION = MetricUnit.DIMENSIONLESS.value
-            CLOUD_HEIGHT_LAYER3 = MetricUnit.METER.value
-            CLOUD_COVER_LAYER3 = MetricUnit.PERCENT.value
-            CLOUD_TYPE_LAYER4 = MetricUnit.DIMENSIONLESS.value
-            CLOUD_TYPE_LAYER4_ABBREVIATION = MetricUnit.DIMENSIONLESS.value
-            CLOUD_HEIGHT_LAYER4 = MetricUnit.METER.value
-            CLOUD_COVER_LAYER4 = MetricUnit.PERCENT.value
-
-        # cloudiness
-        class CLOUDINESS(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL_INDICATOR = MetricUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = MetricUnit.PERCENT.value
-
-        # dew_point
-        class DEW_POINT(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_DEW_POINT_200 = MetricUnit.DEGREE_KELVIN.value
-
-        # precipitation
-        class PRECIPITATION(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_INDICATOR = MetricUnit.DIMENSIONLESS.value
-            PRECIPITATION_FORM = MetricUnit.DIMENSIONLESS.value
-
-        # pressure
-        class PRESSURE(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            PRESSURE_AIR_SEA_LEVEL = MetricUnit.PASCAL.value
-            PRESSURE_AIR_STATION_HEIGHT = MetricUnit.PASCAL.value
-
-        # soil_temperature
-        class TEMPERATURE_SOIL(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            TEMPERATURE_SOIL_002 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_005 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_010 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_020 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_050 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_100 = MetricUnit.DEGREE_KELVIN.value
-
-        # solar
-        class SOLAR(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            END_OF_INTERVAL = MetricUnit.DIMENSIONLESS.value
-            RADIATION_SKY_LONG_WAVE = MetricUnit.JOULE_PER_SQUARE_METER.value
-            RADIATION_SKY_SHORT_WAVE_DIFFUSE = MetricUnit.JOULE_PER_SQUARE_METER.value
-            RADIATION_GLOBAL = MetricUnit.JOULE_PER_SQUARE_METER.value
-            SUNSHINE_DURATION = MetricUnit.SECOND.value
-            SUN_ZENITH = MetricUnit.DEGREE.value
-            TRUE_LOCAL_TIME = MetricUnit.DIMENSIONLESS.value
-
-        # sun
-        class SUNSHINE_DURATION(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            SUNSHINE_DURATION = MetricUnit.SECOND.value
-
-        # visibility
-        class VISIBILITY(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            VISIBILITY_INDICATOR = MetricUnit.DIMENSIONLESS.value
-            VISIBILITY = MetricUnit.METER.value
-
-        # wind
-        class WIND(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            WIND_SPEED = MetricUnit.METER_PER_SECOND.value
-            WIND_DIRECTION = MetricUnit.WIND_DIRECTION.value
-
-        # wind_synop
-        class WIND_SYNOPTIC(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            WIND_SPEED = MetricUnit.METER_PER_SECOND.value
-            WIND_DIRECTION = MetricUnit.WIND_DIRECTION.value
-
-        # moisture
-        class MOISTURE(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            HUMIDITY_ABSOLUTE = MetricUnit.DIMENSIONLESS.value
-            PRESSURE_VAPOR = MetricUnit.PASCAL.value
-            TEMPERATURE_WET = MetricUnit.DEGREE_KELVIN.value
-            PRESSURE_AIR = MetricUnit.PASCAL.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            HUMIDITY = MetricUnit.PERCENT.value
-            TEMPERATURE_DEW_POINT_200 = MetricUnit.DEGREE_KELVIN.value
-
-    # subdaily
-    class SUBDAILY(DatasetTreeCore):  # noqa
-        # air_temperature
-        class TEMPERATURE_AIR(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            HUMIDITY = MetricUnit.PERCENT.value
-
-        # cloudiness
-        class CLOUDINESS(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = MetricUnit.PERCENT.value
-            CLOUD_DENSITY = MetricUnit.DIMENSIONLESS.value
-
-        # moisture
-        class MOISTURE(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            PRESSURE_VAPOR = MetricUnit.PASCAL.value
-            TEMPERATURE_AIR_005 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            HUMIDITY = MetricUnit.PERCENT.value
-
-        # pressure
-        class PRESSURE(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            PRESSURE_AIR = MetricUnit.PASCAL.value
-
-        # soil
-        class SOIL(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            TEMPERATURE_SOIL_005 = MetricUnit.DEGREE_KELVIN.value
-
-        # visibility
-        class VISIBILITY(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            VISIBILITY = MetricUnit.METER.value
-
-        # wind
-        class WIND(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            WIND_DIRECTION = MetricUnit.WIND_DIRECTION.value
-            WIND_FORCE_BEAUFORT = MetricUnit.BEAUFORT.value
-
-    # Daily
-    class DAILY(DatasetTreeCore):
-        # kl
-        class CLIMATE_SUMMARY(UnitEnum):  # noqa
-            QUALITY_WIND = MetricUnit.DIMENSIONLESS.value
-            WIND_GUST_MAX = MetricUnit.METER_PER_SECOND.value
-            WIND_SPEED = MetricUnit.METER_PER_SECOND.value
-            QUALITY_GENERAL = MetricUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_FORM = MetricUnit.DIMENSIONLESS.value
-            SUNSHINE_DURATION = MetricUnit.SECOND.value
-            SNOW_DEPTH = MetricUnit.METER.value
-            CLOUD_COVER_TOTAL = MetricUnit.PERCENT.value
-            PRESSURE_VAPOR = MetricUnit.PASCAL.value
-            PRESSURE_AIR = MetricUnit.PASCAL.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            HUMIDITY = MetricUnit.PERCENT.value
-            TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MIN_005 = MetricUnit.DEGREE_KELVIN.value
-
-        # more_precip
-        class PRECIPITATION_MORE(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_FORM = MetricUnit.DIMENSIONLESS.value
-            SNOW_DEPTH = MetricUnit.METER.value
-            SNOW_DEPTH_NEW = MetricUnit.METER.value
-
-        # soil_temperature
-        class TEMPERATURE_SOIL(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            TEMPERATURE_SOIL_002 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_005 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_010 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_020 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_SOIL_050 = MetricUnit.DEGREE_KELVIN.value
-
-        # solar
-        class SOLAR(UnitEnum):
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            RADIATION_SKY_LONG_WAVE = MetricUnit.JOULE_PER_SQUARE_METER.value
-            RADIATION_SKY_SHORT_WAVE_DIFFUSE = MetricUnit.JOULE_PER_SQUARE_METER.value
-            RADIATION_SKY_SHORT_WAVE_DIRECT = MetricUnit.JOULE_PER_SQUARE_METER.value
-            SUNSHINE_DURATION = MetricUnit.SECOND.value
-
-        # water_equiv
-        class WATER_EQUIVALENT(UnitEnum):  # noqa
-            QN_6 = MetricUnit.DIMENSIONLESS.value
-            SNOW_DEPTH_EXCELLED = MetricUnit.METER.value
-            SNOW_DEPTH = MetricUnit.METER.value
+            QN_6 = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            SNOW_DEPTH_EXCELLED = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+            SNOW_DEPTH = OriginUnit.CENTIMETER.value, SIUnit.METER.value
             WATER_EQUIVALENT_TOTAL_SNOW_DEPTH = (
-                MetricUnit.KILOGRAM_PER_SQUARE_METER.value
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
             )
-            WATER_EQUIVALENT_SNOW = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
+            WATER_EQUIVALENT_SNOW = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
 
         # weather_phenomena
         class WEATHER_PHENOMENA(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            FOG = MetricUnit.DIMENSIONLESS.value
-            THUNDER = MetricUnit.DIMENSIONLESS.value
-            STORM_STRONG_WIND = MetricUnit.DIMENSIONLESS.value
-            STORM_STORMIER_WIND = MetricUnit.DIMENSIONLESS.value
-            DEW = MetricUnit.DIMENSIONLESS.value
-            GLAZE = MetricUnit.DIMENSIONLESS.value
-            RIPE = MetricUnit.DIMENSIONLESS.value
-            SLEET = MetricUnit.DIMENSIONLESS.value
-            HAIL = MetricUnit.DIMENSIONLESS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            FOG = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            THUNDER = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            STORM_STRONG_WIND = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            STORM_STORMIER_WIND = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            DEW = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            GLAZE = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            RIPE = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            SLEET = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            HAIL = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
 
     # monthly
     class MONTHLY(DatasetTreeCore):
         # kl
         class CLIMATE_SUMMARY(UnitEnum):  # noqa
-            QUALITY_GENERAL = MetricUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = MetricUnit.PERCENT.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MAX_MEAN_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MIN_MEAN_200 = MetricUnit.DEGREE_KELVIN.value
-            WIND_FORCE_BEAUFORT = MetricUnit.BEAUFORT.value
-            TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-            WIND_GUST_MAX = MetricUnit.METER_PER_SECOND.value
-            TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-            SUNSHINE_DURATION = MetricUnit.SECOND.value
-            QUALITY_PRECIPITATION = MetricUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_HEIGHT_MAX = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
+            QUALITY_GENERAL = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MAX_MEAN_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MIN_MEAN_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            WIND_FORCE_BEAUFORT = OriginUnit.BEAUFORT.value, SIUnit.BEAUFORT.value
+            TEMPERATURE_AIR_MAX_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            WIND_GUST_MAX = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            TEMPERATURE_AIR_MIN_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            SUNSHINE_DURATION = OriginUnit.HOUR.value, SIUnit.SECOND.value
+            QUALITY_PRECIPITATION = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_HEIGHT_MAX = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
 
         # more_precip
         class PRECIPITATION_MORE(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            SNOW_DEPTH_NEW = MetricUnit.METER.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            SNOW_DEPTH = MetricUnit.METER.value
-            PRECIPITATION_HEIGHT_MAX = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            SNOW_DEPTH = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+            PRECIPITATION_HEIGHT_MAX = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
 
         # weather_phenomena
         class WEATHER_PHENOMENA(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            STORM_STRONG_WIND = MetricUnit.DIMENSIONLESS.value
-            STORM_STORMIER_WIND = MetricUnit.DIMENSIONLESS.value
-            THUNDER = MetricUnit.DIMENSIONLESS.value
-            GLAZE = MetricUnit.DIMENSIONLESS.value
-            SLEET = MetricUnit.DIMENSIONLESS.value
-            HAIL = MetricUnit.DIMENSIONLESS.value
-            FOG = MetricUnit.DIMENSIONLESS.value
-            DEW = MetricUnit.DIMENSIONLESS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            STORM_STRONG_WIND = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            STORM_STORMIER_WIND = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            THUNDER = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            GLAZE = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            SLEET = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            HAIL = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            FOG = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            DEW = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
 
     # annual
     class ANNUAL(DatasetTreeCore):
         # kl
         class CLIMATE_SUMMARY(UnitEnum):  # noqa
-            QUALITY_GENERAL = MetricUnit.DIMENSIONLESS.value
-            CLOUD_COVER_TOTAL = MetricUnit.PERCENT.value
-            TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MAX_MEAN_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MIN_MEAN_200 = MetricUnit.DEGREE_KELVIN.value
-            WIND_FORCE_BEAUFORT = MetricUnit.BEAUFORT.value
-            SUNSHINE_DURATION = MetricUnit.SECOND.value
-            WIND_GUST_MAX = MetricUnit.METER_PER_SECOND.value
-            TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-            TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-            QUALITY_PRECIPITATION = MetricUnit.DIMENSIONLESS.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            PRECIPITATION_HEIGHT_MAX = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
+            QUALITY_GENERAL = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            CLOUD_COVER_TOTAL = OriginUnit.ONE_EIGHTH.value, SIUnit.PERCENT.value
+            TEMPERATURE_AIR_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MAX_MEAN_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MIN_MEAN_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            WIND_FORCE_BEAUFORT = OriginUnit.BEAUFORT.value, SIUnit.BEAUFORT.value
+            SUNSHINE_DURATION = OriginUnit.HOUR.value, SIUnit.SECOND.value
+            WIND_GUST_MAX = (
+                OriginUnit.METER_PER_SECOND.value,
+                SIUnit.METER_PER_SECOND.value,
+            )
+            TEMPERATURE_AIR_MAX_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            TEMPERATURE_AIR_MIN_200 = (
+                OriginUnit.DEGREE_CELSIUS.value,
+                SIUnit.DEGREE_KELVIN.value,
+            )
+            QUALITY_PRECIPITATION = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            PRECIPITATION_HEIGHT_MAX = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
 
         # more_precip
         class PRECIPITATION_MORE(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            SNOW_DEPTH_NEW = MetricUnit.METER.value
-            PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-            SNOW_DEPTH = MetricUnit.METER.value
-            PRECIPITATION_HEIGHT_MAX = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+            PRECIPITATION_HEIGHT = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
+            SNOW_DEPTH = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+            PRECIPITATION_HEIGHT_MAX = (
+                OriginUnit.MILLIMETER.value,
+                SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+            )
 
         # weather_phenomena
         class WEATHER_PHENOMENA(UnitEnum):  # noqa
-            QUALITY = MetricUnit.DIMENSIONLESS.value
-            STORM_STRONG_WIND = MetricUnit.DIMENSIONLESS.value
-            STORM_STORMIER_WIND = MetricUnit.DIMENSIONLESS.value
-            THUNDER = MetricUnit.DIMENSIONLESS.value
-            GLAZE = MetricUnit.DIMENSIONLESS.value
-            SLEET = MetricUnit.DIMENSIONLESS.value
-            HAIL = MetricUnit.DIMENSIONLESS.value
-            FOG = MetricUnit.DIMENSIONLESS.value
-            DEW = MetricUnit.DIMENSIONLESS.value
+            QUALITY = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            STORM_STRONG_WIND = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            STORM_STORMIER_WIND = (
+                OriginUnit.DIMENSIONLESS.value,
+                SIUnit.DIMENSIONLESS.value,
+            )
+            THUNDER = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            GLAZE = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            SLEET = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            HAIL = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            FOG = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+            DEW = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value

--- a/wetterdienst/provider/eccc/observation/api.py
+++ b/wetterdienst/provider/eccc/observation/api.py
@@ -34,10 +34,7 @@ from wetterdienst.provider.eccc.observation.metadata.parameter import (
 from wetterdienst.provider.eccc.observation.metadata.resolution import (
     EccObservationResolution,
 )
-from wetterdienst.provider.eccc.observation.metadata.unit import (
-    EcccObservationUnitOrigin,
-    EcccObservationUnitSI,
-)
+from wetterdienst.provider.eccc.observation.metadata.unit import EcccObservationUnit
 from wetterdienst.util.cache import payload_cache_twelve_hours
 
 log = logging.getLogger(__name__)
@@ -273,8 +270,7 @@ class EcccObservationRequest(ScalarRequestCore):
     _dataset_tree = EcccObservationDatasetTree
     _unique_dataset = True
 
-    _origin_unit_tree = EcccObservationUnitOrigin
-    _si_unit_tree = EcccObservationUnitSI
+    _unit_tree = EcccObservationUnit
 
     _values = EcccObservationValues
 

--- a/wetterdienst/provider/eccc/observation/metadata/unit.py
+++ b/wetterdienst/provider/eccc/observation/metadata/unit.py
@@ -1,209 +1,284 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
-from wetterdienst.metadata.unit import MetricUnit, OriginUnit, UnitEnum
+from wetterdienst.metadata.unit import OriginUnit, SIUnit, UnitEnum
 from wetterdienst.util.parameter import DatasetTreeCore
 
 
-class EcccObservationUnitOrigin(DatasetTreeCore):
+class EcccObservationUnit(DatasetTreeCore):
     class HOURLY(UnitEnum):
-        TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_200 = OriginUnit.DIMENSIONLESS
-        TEMPERATURE_DEW_POINT_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_DEW_POINT_200 = OriginUnit.DIMENSIONLESS.value
-        HUMIDITY = OriginUnit.PERCENT.value
-        QUALITY_HUMIDITY = OriginUnit.DIMENSIONLESS.value
-        WIND_DIRECTION = OriginUnit.WIND_DIRECTION.value
-        QUALITY_WIND_DIRECTION = OriginUnit.DIMENSIONLESS.value
-        WIND_SPEED = OriginUnit.KILOMETER_PER_HOUR.value
-        QUALITY_WIND_SPEED = OriginUnit.DIMENSIONLESS.value
-        VISIBILITY = OriginUnit.KILOMETER.value
-        QUALITY_VISIBILITY = OriginUnit.DIMENSIONLESS.value
-        PRESSURE_AIR_STATION_HEIGHT = OriginUnit.KILOPASCAL.value
-        QUALITY_PRESSURE_AIR_STATION_HEIGHT = OriginUnit.DIMENSIONLESS.value
-        HUMIDEX = OriginUnit.DIMENSIONLESS.value
-        QUALITY_HUMIDEX = OriginUnit.DIMENSIONLESS.value
-        WIND_GUST = OriginUnit.KILOMETER_PER_HOUR.value
-        QUALITY_WIND_GUST = OriginUnit.DIMENSIONLESS.value
-        WEATHER = OriginUnit.DIMENSIONLESS.value
+        TEMPERATURE_AIR_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_200 = OriginUnit.DIMENSIONLESS, SIUnit.DIMENSIONLESS
+        TEMPERATURE_DEW_POINT_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_DEW_POINT_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        HUMIDITY = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        QUALITY_HUMIDITY = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        WIND_DIRECTION = (
+            OriginUnit.WIND_DIRECTION.value,
+            SIUnit.WIND_DIRECTION.value,
+        )
+        QUALITY_WIND_DIRECTION = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        WIND_SPEED = (
+            OriginUnit.KILOMETER_PER_HOUR.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        QUALITY_WIND_SPEED = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        VISIBILITY = OriginUnit.KILOMETER.value, SIUnit.METER.value
+        QUALITY_VISIBILITY = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        PRESSURE_AIR_STATION_HEIGHT = (
+            OriginUnit.KILOPASCAL.value,
+            SIUnit.PASCAL.value,
+        )
+        QUALITY_PRESSURE_AIR_STATION_HEIGHT = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        HUMIDEX = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+        QUALITY_HUMIDEX = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
+        WIND_GUST = (
+            OriginUnit.KILOMETER_PER_HOUR.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        QUALITY_WIND_GUST = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        WEATHER = OriginUnit.DIMENSIONLESS.value, SIUnit.DIMENSIONLESS.value
 
     class DAILY(UnitEnum):
         # Data Quality  quality of all variables?
-        TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_MAX_200 = OriginUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_MIN_200 = OriginUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_200 = OriginUnit.DIMENSIONLESS.value
-        HEATING_DEGREE_DAYS = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_HEATING_DEGREE_DAYS = OriginUnit.DIMENSIONLESS.value
-        COOLING_DEGREE_DAYS = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_COOLING_DEGREE_DAYS = OriginUnit.DIMENSIONLESS.value
-        PRECIPITATION_HEIGHT_RAIN = OriginUnit.MILLIMETER.value
-        QUALITY_PRECIPITATION_HEIGHT_RAIN = OriginUnit.DIMENSIONLESS.value
-        SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value
-        QUALITY_SNOW_DEPTH_NEW = OriginUnit.DIMENSIONLESS.value
-        PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-        QUALITY_PRECIPITATION_HEIGHT = OriginUnit.DIMENSIONLESS.value
-        SNOW_DEPTH = OriginUnit.CENTIMETER.value
-        QUALITY_SNOW_DEPTH = OriginUnit.DIMENSIONLESS.value
-        WIND_DIRECTION_MAX_VELOCITY = OriginUnit.WIND_DIRECTION.value
-        QUALITY_WIND_DIRECTION_MAX_VELOCITY = OriginUnit.DIMENSIONLESS.value
-        WIND_GUST_MAX = OriginUnit.KILOMETER_PER_HOUR.value
-        QUALITY_WIND_GUST_MAX = OriginUnit.DIMENSIONLESS.value
+        TEMPERATURE_AIR_MAX_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_MAX_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        TEMPERATURE_AIR_MIN_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_MIN_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        TEMPERATURE_AIR_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        HEATING_DEGREE_DAYS = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_HEATING_DEGREE_DAYS = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        COOLING_DEGREE_DAYS = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_COOLING_DEGREE_DAYS = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        PRECIPITATION_HEIGHT_RAIN = (
+            OriginUnit.MILLIMETER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        QUALITY_PRECIPITATION_HEIGHT_RAIN = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+        QUALITY_SNOW_DEPTH_NEW = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        PRECIPITATION_HEIGHT = (
+            OriginUnit.MILLIMETER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        QUALITY_PRECIPITATION_HEIGHT = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        SNOW_DEPTH = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+        QUALITY_SNOW_DEPTH = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        WIND_DIRECTION_MAX_VELOCITY = (
+            OriginUnit.WIND_DIRECTION.value,
+            SIUnit.WIND_DIRECTION.value,
+        )
+        QUALITY_WIND_DIRECTION_MAX_VELOCITY = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        WIND_GUST_MAX = (
+            OriginUnit.KILOMETER_PER_HOUR.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        QUALITY_WIND_GUST_MAX = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
 
     class MONTHLY(UnitEnum):
-        TEMPERATURE_AIR_MAX_MEAN_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_MAX_MEAN_200 = OriginUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_MIN_MEAN_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_MIN_MEAN_200 = OriginUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_200 = OriginUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_MAX_200 = OriginUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_CELSIUS.value
-        QUALITY_TEMPERATURE_AIR_MIN_200 = OriginUnit.DIMENSIONLESS.value
-        PRECIPITATION_HEIGHT_RAIN = OriginUnit.MILLIMETER.value
-        QUALITY_PRECIPITATION_HEIGHT_RAIN = OriginUnit.DIMENSIONLESS.value
-        SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value
-        QUALITY_SNOW_DEPTH_NEW = OriginUnit.DIMENSIONLESS.value
-        PRECIPITATION_HEIGHT = OriginUnit.MILLIMETER.value
-        QUALITY_PRECIPITATION_HEIGHT = OriginUnit.DIMENSIONLESS.value
+        TEMPERATURE_AIR_MAX_MEAN_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_MAX_MEAN_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        TEMPERATURE_AIR_MIN_MEAN_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_MIN_MEAN_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        TEMPERATURE_AIR_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        TEMPERATURE_AIR_MAX_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_MAX_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        TEMPERATURE_AIR_MIN_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        QUALITY_TEMPERATURE_AIR_MIN_200 = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        PRECIPITATION_HEIGHT_RAIN = (
+            OriginUnit.MILLIMETER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        QUALITY_PRECIPITATION_HEIGHT_RAIN = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        SNOW_DEPTH_NEW = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+        QUALITY_SNOW_DEPTH_NEW = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        PRECIPITATION_HEIGHT = (
+            OriginUnit.MILLIMETER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
+        QUALITY_PRECIPITATION_HEIGHT = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
         # should name include previous day? how is it measured?
-        SNOW_DEPTH = OriginUnit.CENTIMETER.value
-        QUALITY_SNOW_DEPTH = OriginUnit.DIMENSIONLESS.value
-        WIND_DIRECTION_MAX_VELOCITY = OriginUnit.WIND_DIRECTION.value
-        QUALITY_WIND_DIRECTION_MAX_VELOCITY = OriginUnit.DIMENSIONLESS.value
-        WIND_GUST_MAX = OriginUnit.KILOMETER_PER_HOUR.value
-        QUALITY_WIND_GUST_MAX = OriginUnit.DIMENSIONLESS.value
+        SNOW_DEPTH = OriginUnit.CENTIMETER.value, SIUnit.METER.value
+        QUALITY_SNOW_DEPTH = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        WIND_DIRECTION_MAX_VELOCITY = (
+            OriginUnit.WIND_DIRECTION.value,
+            SIUnit.WIND_DIRECTION.value,
+        )
+        QUALITY_WIND_DIRECTION_MAX_VELOCITY = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
+        WIND_GUST_MAX = (
+            OriginUnit.KILOMETER_PER_HOUR.value,
+            SIUnit.METER_PER_SECOND.value,
+        )
+        QUALITY_WIND_GUST_MAX = (
+            OriginUnit.DIMENSIONLESS.value,
+            SIUnit.DIMENSIONLESS.value,
+        )
 
     class ANNUAL(UnitEnum):
-        TEMPERATURE_AIR_MAX_MEAN_200 = OriginUnit.DEGREE_CELSIUS.value
-        TEMPERATURE_AIR_MIN_MEAN_200 = OriginUnit.DEGREE_CELSIUS.value
-        PRECIPITATION_FREQUENCY = OriginUnit.PERCENT.value
-        TEMPERATURE_AIR_MAX_200 = OriginUnit.DEGREE_CELSIUS.value
+        TEMPERATURE_AIR_MAX_MEAN_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        TEMPERATURE_AIR_MIN_MEAN_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
+        PRECIPITATION_FREQUENCY = OriginUnit.PERCENT.value, SIUnit.PERCENT.value
+        TEMPERATURE_AIR_MAX_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
         # 'highest temp.year'
         # 'highest temp. period'
         # 'highest temp. data quality'
-        TEMPERATURE_AIR_MIN_200 = OriginUnit.DEGREE_CELSIUS.value
+        TEMPERATURE_AIR_MIN_200 = (
+            OriginUnit.DEGREE_CELSIUS.value,
+            SIUnit.DEGREE_KELVIN.value,
+        )
         # 'lowest temp. year'
         # 'lowest temp. period'
         # 'lowest temp. data quality'
-        PRECIPITATION_HEIGHT_MAX = OriginUnit.MILLIMETER.value
+        PRECIPITATION_HEIGHT_MAX = (
+            OriginUnit.MILLIMETER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
         # 'greatest precip. year'
         # 'greatest precip. period'
         # 'greatest precip. data quality'
-        PRECIPITATION_HEIGHT_RAIN_MAX = OriginUnit.MILLIMETER.value
+        PRECIPITATION_HEIGHT_RAIN_MAX = (
+            OriginUnit.MILLIMETER.value,
+            SIUnit.KILOGRAM_PER_SQUARE_METER.value,
+        )
         # 'greatest rainfall year'
         # 'greatest rainfall period'
         # 'greatest rainfall data quality'
-        SNOW_DEPTH_NEW_MAX = OriginUnit.CENTIMETER.value
+        SNOW_DEPTH_NEW_MAX = OriginUnit.CENTIMETER.value, SIUnit.METER.value
         # 'greatest snowfall year'
         # 'greatest snowfall period'
         # 'greatest snowfall data quality'
-        SNOW_DEPTH_MAX = OriginUnit.CENTIMETER.value
-        # 'most snow on the ground year'
-        # 'most snow on the ground period'
-        # 'most snow on the ground data quality'
-
-
-class EcccObservationUnitSI(DatasetTreeCore):
-    class HOURLY(UnitEnum):
-        TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_200 = MetricUnit.DIMENSIONLESS
-        TEMPERATURE_DEW_POINT_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_DEW_POINT_200 = MetricUnit.DIMENSIONLESS.value
-        HUMIDITY = MetricUnit.PERCENT.value
-        QUALITY_HUMIDITY = MetricUnit.DIMENSIONLESS.value
-        WIND_DIRECTION = MetricUnit.WIND_DIRECTION.value
-        QUALITY_WIND_DIRECTION = MetricUnit.DIMENSIONLESS.value
-        WIND_SPEED = MetricUnit.METER_PER_SECOND.value
-        QUALITY_WIND_SPEED = MetricUnit.DIMENSIONLESS.value
-        VISIBILITY = MetricUnit.METER.value
-        QUALITY_VISIBILITY = MetricUnit.DIMENSIONLESS.value
-        PRESSURE_AIR_STATION_HEIGHT = MetricUnit.PASCAL.value
-        QUALITY_PRESSURE_AIR_STATION_HEIGHT = MetricUnit.DIMENSIONLESS.value
-        HUMIDEX = MetricUnit.DIMENSIONLESS.value
-        QUALITY_HUMIDEX = MetricUnit.DIMENSIONLESS.value
-        WIND_GUST = MetricUnit.METER_PER_SECOND.value
-        QUALITY_WIND_GUST = MetricUnit.DIMENSIONLESS.value
-        WEATHER = MetricUnit.DIMENSIONLESS.value
-
-    class DAILY(UnitEnum):
-        # Data Quality  quality of all variables?
-        TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_MAX_200 = MetricUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_MIN_200 = MetricUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_200 = MetricUnit.DIMENSIONLESS.value
-        HEATING_DEGREE_DAYS = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_HEATING_DEGREE_DAYS = MetricUnit.DIMENSIONLESS.value
-        COOLING_DEGREE_DAYS = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_COOLING_DEGREE_DAYS = MetricUnit.DIMENSIONLESS.value
-        PRECIPITATION_HEIGHT_RAIN = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        QUALITY_PRECIPITATION_HEIGHT_RAIN = MetricUnit.DIMENSIONLESS.value
-        SNOW_DEPTH_NEW = MetricUnit.METER.value
-        QUALITY_SNOW_DEPTH_NEW = MetricUnit.DIMENSIONLESS.value
-        PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        QUALITY_PRECIPITATION_HEIGHT = MetricUnit.DIMENSIONLESS.value
-        SNOW_DEPTH = MetricUnit.METER.value
-        QUALITY_SNOW_DEPTH = MetricUnit.DIMENSIONLESS.value
-        WIND_DIRECTION_MAX_VELOCITY = MetricUnit.WIND_DIRECTION.value
-        QUALITY_WIND_DIRECTION_MAX_VELOCITY = MetricUnit.DIMENSIONLESS.value
-        WIND_GUST_MAX = MetricUnit.METER_PER_SECOND.value
-        QUALITY_WIND_GUST_MAX = MetricUnit.DIMENSIONLESS.value
-
-    class MONTHLY(UnitEnum):
-        TEMPERATURE_AIR_MAX_MEAN_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_MAX_MEAN_200 = MetricUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_MIN_MEAN_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_MIN_MEAN_200 = MetricUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_200 = MetricUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_MAX_200 = MetricUnit.DIMENSIONLESS.value
-        TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-        QUALITY_TEMPERATURE_AIR_MIN_200 = MetricUnit.DIMENSIONLESS.value
-        PRECIPITATION_HEIGHT_RAIN = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        QUALITY_PRECIPITATION_HEIGHT_RAIN = MetricUnit.DIMENSIONLESS.value
-        SNOW_DEPTH_NEW = MetricUnit.METER.value
-        QUALITY_SNOW_DEPTH_NEW = MetricUnit.DIMENSIONLESS.value
-        PRECIPITATION_HEIGHT = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        QUALITY_PRECIPITATION_HEIGHT = MetricUnit.DIMENSIONLESS.value
-        # should name include previous day? how is it measured?
-        SNOW_DEPTH = MetricUnit.METER.value
-        QUALITY_SNOW_DEPTH = MetricUnit.DIMENSIONLESS.value
-        WIND_DIRECTION_MAX_VELOCITY = MetricUnit.WIND_DIRECTION.value
-        QUALITY_WIND_DIRECTION_MAX_VELOCITY = MetricUnit.DIMENSIONLESS.value
-        WIND_GUST_MAX = MetricUnit.METER_PER_SECOND.value
-        QUALITY_WIND_GUST_MAX = MetricUnit.DIMENSIONLESS.value
-
-    class ANNUAL(UnitEnum):
-        TEMPERATURE_AIR_MAX_MEAN_200 = MetricUnit.DEGREE_KELVIN.value
-        TEMPERATURE_AIR_MIN_MEAN_200 = MetricUnit.DEGREE_KELVIN.value
-        PRECIPITATION_FREQUENCY = MetricUnit.PERCENT.value
-        TEMPERATURE_AIR_MAX_200 = MetricUnit.DEGREE_KELVIN.value
-        # 'highest temp.year'
-        # 'highest temp. period'
-        # 'highest temp. data quality'
-        TEMPERATURE_AIR_MIN_200 = MetricUnit.DEGREE_KELVIN.value
-        # 'lowest temp. year'
-        # 'lowest temp. period'
-        # 'lowest temp. data quality'
-        PRECIPITATION_HEIGHT_MAX = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        # 'greatest precip. year'
-        # 'greatest precip. period'
-        # 'greatest precip. data quality'
-        PRECIPITATION_HEIGHT_RAIN_MAX = MetricUnit.KILOGRAM_PER_SQUARE_METER.value
-        # 'greatest rainfall year'
-        # 'greatest rainfall period'
-        # 'greatest rainfall data quality'
-        SNOW_DEPTH_NEW_MAX = MetricUnit.METER.value
-        # 'greatest snowfall year'
-        # 'greatest snowfall period'
-        # 'greatest snowfall data quality'
-        SNOW_DEPTH_MAX = MetricUnit.METER.value
+        SNOW_DEPTH_MAX = OriginUnit.CENTIMETER.value, SIUnit.METER.value
         # 'most snow on the ground year'
         # 'most snow on the ground period'
         # 'most snow on the ground data quality'


### PR DESCRIPTION
Origin and SI Unit enums are merged to prevent misspelling of parameters and other related issues. Instead origin and SI unit are stored in the same place as tuple. This also reduces the number of external objects that have to be created to implement a new weather service and basically, units are stored in the same place.