### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Fix cli error with upgraded click ^8.0 where default False would be converted to "False"
+
 0.25.0 (30.01.2022)
 *******************
 

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -2568,9 +2568,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 click
-7.1.2
+8.0.3
 BSD License
-UNKNOWN
+Armin Ronacher
 https://palletsprojects.com/p/click/
 Copyright 2014 Pallets
 
@@ -5390,7 +5390,7 @@ THE SOFTWARE.
 
 
 flake8-black
-0.2.3
+0.2.4
 MIT License
 Peter J. A. Cock
 https://github.com/peterjc/flake8-black

--- a/poetry.lock
+++ b/poetry.lock
@@ -122,6 +122,20 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "asgiref"
+version = "3.5.0"
+description = "ASGI specs, helper code, and adapters"
+category = "main"
+optional = true
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+tests = ["pytest", "pytest-asyncio", "mypy (>=0.800)"]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.2"
 description = "Timeout context manager for asyncio programs"
@@ -341,11 +355,15 @@ unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
-version = "7.1.2"
+version = "8.0.3"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "click-params"
@@ -717,7 +735,7 @@ pycodestyle = "*"
 
 [[package]]
 name = "flake8-black"
-version = "0.2.3"
+version = "0.2.4"
 description = "flake8 plugin to call black as a code style validator"
 category = "dev"
 optional = false
@@ -2782,19 +2800,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "uvicorn"
-version = "0.13.4"
+version = "0.14.0"
 description = "The lightning-fast ASGI server."
 category = "main"
 optional = true
 python-versions = "*"
 
 [package.dependencies]
-click = ">=7.0.0,<8.0.0"
+asgiref = ">=3.3.4"
+click = ">=7"
 h11 = ">=0.8"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-standard = ["websockets (>=8.0.0,<9.0.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "httptools (>=0.1.0,<0.2.0)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
+standard = ["websockets (>=9.1)", "httptools (>=0.2.0,<0.3.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
 
 [[package]]
 name = "validators"
@@ -2965,7 +2984,7 @@ sql = ["duckdb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "4a59e238684ce363e689d312bbaec18532ea169aaebfd0f8118f711bcaac30f0"
+content-hash = "0da3fc0ef055394070875f22ca533d0094ab9ae846a7de49df2e4fb34aa5ddc7"
 
 [metadata.files]
 aenum = [
@@ -3096,6 +3115,10 @@ argon2-cffi-bindings = [
 ]
 asciitree = [
     {file = "asciitree-0.3.3.tar.gz", hash = "sha256:4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e"},
+]
+asgiref = [
+    {file = "asgiref-3.5.0-py3-none-any.whl", hash = "sha256:88d59c13d634dcffe0510be048210188edd79aeccb6a6c9028cdad6f31d730a9"},
+    {file = "asgiref-3.5.0.tar.gz", hash = "sha256:2f8abc20f7248433085eda803936d98992f1343ddb022065779f37c5da0181d0"},
 ]
 async-timeout = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
@@ -3311,8 +3334,8 @@ charset-normalizer = [
     {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
 ]
 click = [
-    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
-    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
+    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
 ]
 click-params = [
     {file = "click-params-0.1.2.tar.gz", hash = "sha256:249e7dfe958046aa2badffe9a5d3d63ac5f96a31716cb3d04af98c13c92b2eff"},
@@ -3510,8 +3533,8 @@ flake8-bandit = [
     {file = "flake8_bandit-2.1.2.tar.gz", hash = "sha256:687fc8da2e4a239b206af2e54a90093572a60d0954f3054e23690739b0b0de3b"},
 ]
 flake8-black = [
-    {file = "flake8-black-0.2.3.tar.gz", hash = "sha256:c199844bc1b559d91195ebe8620216f21ed67f2cc1ff6884294c91a0d2492684"},
-    {file = "flake8_black-0.2.3-py3-none-any.whl", hash = "sha256:cc080ba5b3773b69ba102b6617a00cc4ecbad8914109690cfda4d565ea435d96"},
+    {file = "flake8-black-0.2.4.tar.gz", hash = "sha256:a7871bfd1cbff431a1fc91ba60ae154510c80f575e6b9a2bbb13dfb4650afd22"},
+    {file = "flake8_black-0.2.4-py3-none-any.whl", hash = "sha256:0a70dfd97c8439827f365dc6dbc6c8c9cc087f0833625c6cc6848ff7876256be"},
 ]
 flake8-bugbear = [
     {file = "flake8-bugbear-20.11.1.tar.gz", hash = "sha256:528020129fea2dea33a466b9d64ab650aa3e5f9ffc788b70ea4bc6cf18283538"},
@@ -5081,8 +5104,8 @@ urllib3 = [
     {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
 uvicorn = [
-    {file = "uvicorn-0.13.4-py3-none-any.whl", hash = "sha256:7587f7b08bd1efd2b9bad809a3d333e972f1d11af8a5e52a9371ee3a5de71524"},
-    {file = "uvicorn-0.13.4.tar.gz", hash = "sha256:3292251b3c7978e8e4a7868f4baf7f7f7bb7e40c759ecc125c37e99cdea34202"},
+    {file = "uvicorn-0.14.0-py3-none-any.whl", hash = "sha256:2a76bb359171a504b3d1c853409af3adbfa5cef374a4a59e5881945a97a93eae"},
+    {file = "uvicorn-0.14.0.tar.gz", hash = "sha256:45ad7dfaaa7d55cab4cd1e85e03f27e9d60bc067ddc59db52a2b0aeca8870292"},
 ]
 validators = [
     {file = "validators-0.18.2-py3-none-any.whl", hash = "sha256:0143dcca8a386498edaf5780cbd5960da1a4c85e0719f3ee5c9b41249c4fefbd"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ measurement = "^3.2"
 rapidfuzz = "^1.4"
 Pint = "^0.17"
 aenum = "^3.0"
-click = "^7.1"
+click = "^8.0"
 click-params = "^0.1"
 cloup = "^0.8"
 fsspec = "2021.7"
@@ -126,7 +126,7 @@ psycopg2-binary                 = { version = "^2.8", optional = true }
 
 # HTTP REST API service
 fastapi                         = { version = "^0.61", optional = true }
-uvicorn                         = { version = "^0.13", optional = true }
+uvicorn                         = { version = "^0.14", optional = true }
 wradlib                         = { version = "^1.13", optional = true }
 
 # Explorer UI service

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,9 +23,9 @@ certifi==2021.10.8; python_version >= "3.5" and python_full_version < "3.0.0" or
 cffi==1.15.0; python_full_version >= "3.6.1" and python_version >= "3.7" and implementation_name == "pypy"
 charset-normalizer==2.0.10; python_full_version >= "3.6.0" and python_version >= "3.6"
 click-params==0.1.2; python_version >= "3.6" and python_version < "4.0"
-click==7.1.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+click==8.0.3; python_version >= "3.6"
 cloup==0.8.2; python_version >= "3.6"
-colorama==0.4.4; python_full_version >= "3.6.2" and platform_system == "Windows" and sys_platform == "win32" and python_version >= "3.5" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+colorama==0.4.4; python_full_version >= "3.6.2" and platform_system == "Windows" and python_version >= "3.6" and sys_platform == "win32" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and python_version < "4.0" and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
 coverage==5.5; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
 dateparser==1.1.0; python_version >= "3.5"
 decorator==5.1.1; python_version >= "3.6" and python_version < "4.0"
@@ -40,7 +40,7 @@ eradicate==2.0.0; python_version >= "3.6" and python_version < "4.0"
 execnet==1.9.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 flake8-2020==1.6.1; python_full_version >= "3.6.1"
 flake8-bandit==2.1.2
-flake8-black==0.2.3
+flake8-black==0.2.4
 flake8-bugbear==20.11.1; python_version >= "3.6"
 flake8-builtins==1.5.3
 flake8-comprehensions==3.8.0; python_version >= "3.7"

--- a/tests/ui/test_cli.py
+++ b/tests/ui/test_cli.py
@@ -171,7 +171,7 @@ def test_no_provider():
 
     result = runner.invoke(cli, "stations --provider=abc --kind=abc")
 
-    assert "Error: Invalid value for '--provider': invalid choice: abc." in result.output
+    assert "Error: Invalid value for '--provider': 'abc' is not one of 'DWD', 'ECCC', 'NOAA'" in result.output
 
 
 def test_no_kind():
@@ -179,7 +179,7 @@ def test_no_kind():
 
     result = runner.invoke(cli, "stations --provider=dwd --kind=abc")
 
-    assert "Invalid value for '--kind': invalid choice: abc." in result.output
+    assert "Invalid value for '--kind': 'abc' is not one of 'OBSERVATION', 'FORECAST'" in result.output
 
 
 def test_data_range():
@@ -337,7 +337,7 @@ def test_cli_values_geojson(provider, kind, setting, station_id, station_name, c
         provider=provider, kind=kind, setting=setting, station=station_id, fmt="geojson"
     )
 
-    assert "Error: Invalid value for '--format': invalid choice: " "geojson. (choose from json, csv)" in result.output
+    assert "Error: Invalid value for '--format': 'geojson' is not one of 'json', 'csv'" in result.output
 
 
 @pytest.mark.parametrize(
@@ -384,7 +384,7 @@ def test_cli_values_format_unknown(provider, kind, setting, station_id, station_
         provider=provider, kind=kind, setting=setting, station=station_id, fmt="foobar"
     )
 
-    assert "Error: Invalid value for '--format': " "invalid choice: foobar. (choose from json, csv)" in result.output
+    assert "Error: Invalid value for '--format': 'foobar' is not one of 'json', 'csv'" in result.output
 
 
 @pytest.mark.parametrize(

--- a/wetterdienst/provider/dwd/observation/util/parameter.py
+++ b/wetterdienst/provider/dwd/observation/util/parameter.py
@@ -47,7 +47,7 @@ def check_dwd_observations_dataset(
 ) -> bool:
     """
     Function to check for element (alternative name) and if existing return it
-    Differs from foldername e.g. air_temperature -> tu
+    Differs from folder name e.g. air_temperature -> tu
     """
     check = RESOLUTION_DATASET_MAPPING.get(resolution, {}).get(dataset, [])
 

--- a/wetterdienst/provider/dwd/radar/metadata/parameter.py
+++ b/wetterdienst/provider/dwd/radar/metadata/parameter.py
@@ -10,7 +10,7 @@ class DwdRadarParameter(Enum):
     """
 
     # /composites
-    # https://docs.wradlib.org/en/stable/notebooks/fileio/wradlib_radar_formats.html#German-Weather-Service:-RADOLAN-(quantitative)-composit  # noqa:E501,B950
+    # https://docs.wradlib.org/en/stable/notebooks/fileio/wradlib_radar_formats.html#German-Weather-Service:-RADOLAN-(quantitative)-composit  # noqa:B950
 
     # https://opendata.dwd.de/weather/radar/composit/
     HG_REFLECTIVITY = "hg"

--- a/wetterdienst/ui/cli.py
+++ b/wetterdienst/ui/cli.py
@@ -408,7 +408,7 @@ def about():
         ),
     ),
 )
-@cloup.option("--filter", "filter_", type=click.STRING, default=False)
+@cloup.option("--filter", "filter_", type=click.STRING, default=None)
 @debug_opt
 def coverage(provider, kind, filter_, debug):
     set_logging_level(debug)


### PR DESCRIPTION
Fixes #560 by upgrading to `click = "^8.0"`. Also, removes explicit pinning to patch releases for all other dependency constraints.
