### PR TITLE
Fix radar index by filtering out bz2 files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Development
 ***********
 
 - Add NOAA GHCN API
+- Fix radar index by filtering out bz2 files
 
 0.23.0 (21.11.2021)
 *******************

--- a/wetterdienst/provider/dwd/radar/index.py
+++ b/wetterdienst/provider/dwd/radar/index.py
@@ -102,6 +102,9 @@ def create_fileindex_radar(
         elif fmt == DwdRadarDataFormat.BUFR:
             files_server = files_server[files_server[DwdColumns.FILENAME.value].str.contains("--buf")]
 
+    # Drop duplicates of files packed as .bz2
+    files_server = files_server[~files_server[DwdColumns.FILENAME.value].str.endswith(".bz2")]
+
     # Decode datetime of file for filtering.
     if parse_datetime:
         files_server[DwdColumns.DATETIME.value] = files_server[DwdColumns.FILENAME.value].apply(get_date_from_filename)


### PR DESCRIPTION
Radar tests have recently failed because some files were duplicated on the server side and stored as additional .bz2 file. This is fixed by simply filtering out those files when creating the index.