### PR TITLE
Fix DWD intervals and add test for recent plus now interval

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Development
 
 - Fix access to ECCC stations listing using Google Drive storage
 - Remove/replace caching entirely by fsspec (+monkeypatch)
+- Fix bug with DWD intervals
 
 0.24.0 (24.01.2022)
 *******************

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -13,6 +13,7 @@ from pandas._testing import assert_frame_equal
 from wetterdienst.exceptions import StartDateEndDateError
 from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.resolution import Resolution
+from wetterdienst.metadata.timezone import Timezone
 from wetterdienst.provider.dwd.observation import (
     DwdObservationDataset,
     DwdObservationPeriod,
@@ -265,15 +266,25 @@ def test_request_period_historical_recent_now():
     ]
 
 
-def test_request_period_now():
+@freeze_time(datetime(2022, 1, 29, 1, 30, tzinfo=pytz.timezone(Timezone.GERMANY.value)))
+def test_request_period_recent_now():
+    request = DwdObservationRequest(
+        parameter=[DwdObservationDataset.CLIMATE_SUMMARY],
+        resolution=DwdObservationResolution.DAILY,
+        start_date=pd.Timestamp(datetime.utcnow()) - pd.Timedelta(hours=2),
+    )
+    assert request.period == [Period.RECENT, Period.NOW]
 
+
+@freeze_time(datetime(2022, 1, 29, 2, 30, tzinfo=pytz.timezone(Timezone.GERMANY.value)))
+def test_request_period_now():
     # Now period
     request = DwdObservationRequest(
         parameter=[DwdObservationDataset.CLIMATE_SUMMARY],
         resolution=DwdObservationResolution.DAILY,
         start_date=pd.Timestamp(datetime.utcnow()) - pd.Timedelta(hours=2),
     )
-    assert Period.NOW in request.period
+    assert request.period == [Period.NOW]
 
 
 @freeze_time("2021-03-28T18:38:00+02:00")

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -6,7 +6,8 @@ from pathlib import Path
 
 
 def test_readme():
-    readme_file = Path(__name__).parent / "README.rst"
+    readme_file = Path(__file__).parent.parent / "README.rst"
+
     failures, _ = doctest.testfile(
         filename=str(readme_file),
         module_relative=False,

--- a/wetterdienst/provider/dwd/observation/api.py
+++ b/wetterdienst/provider/dwd/observation/api.py
@@ -136,6 +136,7 @@ class DwdObservationValues(ScalarValuesCore):
         for period in self.stations.period:
             if self.stations.resolution in HIGH_RESOLUTIONS and period == Period.HISTORICAL:
                 date_ranges = self._get_historical_date_ranges(station_id, dataset)
+
                 for date_range in date_ranges:
                     periods_and_date_ranges.append((period, date_range))
             else:
@@ -395,8 +396,8 @@ class DwdObservationRequest(ScalarRequestCore):
         """
         if self.start_date:
             # cut of hours, seconds,...
-            start_date = Timestamp(self.start_date.date()).tz_localize(self.tz)
-            end_date = Timestamp(self.end_date.date()).tz_localize(self.tz)
+            start_date = Timestamp(self.start_date).tz_convert(self.tz)
+            end_date = Timestamp(self.end_date).tz_convert(self.tz)
             return pd.Interval(start_date, end_date, closed="both")
 
         return None


### PR DESCRIPTION
There was a bug where the DWD intervals where not using tz information but rather overwriting it. With the help of freezegun we can also test recent + now period.