### PR TITLE
Add wetterdienst settings with general settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Add Wetterdienst.Settings to manage general settings like tidy, humanize,...
+
 0.25.1 (30.01.2022)
 *******************
 

--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,7 @@ Load required request class:
     >>> import pandas as pd
     >>> pd.set_option('max_columns', 8)
     >>> from wetterdienst.provider.dwd.observation import DwdObservationRequest
+    >>> from wetterdienst import Settings
 
 Alternatively, though without argument/type hinting:
 
@@ -247,15 +248,14 @@ Alternatively, though without argument/type hinting:
 Get data:
 
 .. code-block:: python
-
+    >>> Settings.tidy = True  # default, tidy data
+    >>> Settings.humanize = True  # default, humanized parameters
+    >>> Settings.si_units = True  # default, convert values to SI units
     >>> request = DwdObservationRequest(
     ...    parameter=["climate_summary"],
     ...    resolution="daily",
     ...    start_date="1990-01-01",  # if not given timezone defaulted to UTC
     ...    end_date="2020-01-01",  # if not given timezone defaulted to UTC
-    ...    tidy=True,  # default, tidy data
-    ...    humanize=True,  # default, humanized parameters
-    ...    si_units=True  # default, convert values to SI units
     ... ).filter_by_station_id(station_id=(1048, 4411))
     >>> request.df.head()  # station list
          station_id                 from_date                   to_date  height  \

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -2541,7 +2541,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 
 charset-normalizer
-2.0.10
+2.0.11
 MIT License
 Ahmed TAHRI @Ousret
 https://github.com/ousret/charset_normalizer
@@ -4765,6 +4765,32 @@ https://github.com/takluyver/entrypoints
 The MIT License (MIT)
 
 Copyright (c) 2015 Thomas Kluyver and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+environs
+9.5.0
+MIT License
+Steven Loria
+https://github.com/sloria/environs
+Copyright 2022 Steven Loria
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -8239,6 +8265,32 @@ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+marshmallow
+3.14.1
+MIT License
+Steven Loria
+https://github.com/marshmallow-code/marshmallow
+Copyright 2021 Steven Loria and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 matplotlib
@@ -14248,6 +14300,100 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The above BSD License Applies to all code, even that also covered by Apache 2.0.
+
+python-dotenv
+0.19.2
+BSD License
+Saurabh Kumar
+https://github.com/theskumar/python-dotenv
+python-dotenv
+Copyright (c) 2014, Saurabh Kumar
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of python-dotenv nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+django-dotenv-rw
+Copyright (c) 2013, Ted Tieken
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of django-dotenv nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Original django-dotenv
+Copyright (c) 2013, Jacob Kaplan-Moss
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * Neither the name of django-dotenv nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 python-slugify
 5.0.2

--- a/docs/library/core.rst
+++ b/docs/library/core.rst
@@ -18,6 +18,12 @@ Core
 .. automodule:: wetterdienst.core.scalar
     :members:
 
+Settings
+========
+
+.. automodule:: wetterdienst.settings
+    :members:
+
 Data models
 ===========
 

--- a/example/mosmix_forecasts.py
+++ b/example/mosmix_forecasts.py
@@ -13,6 +13,7 @@ stations 01001 and 01008 and parameters DD and ww.
 Other MOSMIX variants are also listed and can be
 enabled on demand.
 """  # Noqa:D205,D400
+from wetterdienst import Settings
 from wetterdienst.provider.dwd.forecast import (
     DwdForecastDate,
     DwdMosmixRequest,
@@ -24,12 +25,13 @@ from wetterdienst.util.cli import setup_logging
 def mosmix_example():
     """Retrieve Mosmix forecast data by DWD."""
     # A. MOSMIX-L -- Specific stations - each station with own file
+    Settings.tidy = True
+    Settings.humanize = True
+
     request = DwdMosmixRequest(
         parameter=["DD", "ww"],
         start_issue=DwdForecastDate.LATEST,  # automatically set if left empty
         mosmix_type=DwdMosmixType.LARGE,
-        tidy=True,
-        humanize=True,
     )
 
     stations = request.filter_by_station_id(
@@ -48,8 +50,6 @@ def mosmix_example():
         parameter=["DD", "ww"],
         start_issue=DwdForecastDate.LATEST,  # automatically set if left empty
         mosmix_type=DwdMosmixType.SMALL,
-        tidy=True,
-        humanize=True,
     )
 
     stations = request.filter_by_station_id(

--- a/example/observations_sql.py
+++ b/example/observations_sql.py
@@ -18,6 +18,7 @@ Setup
 """  # Noqa:D205,D400
 import logging
 
+from wetterdienst import Settings
 from wetterdienst.provider.dwd.observation import (
     DwdObservationDataset,
     DwdObservationRequest,
@@ -29,14 +30,15 @@ log = logging.getLogger()
 
 def sql_example():
     """Retrieve temperature data by DWD and filter by sql statement."""
+    Settings.tidy = True
+    Settings.humanize = True
+    Settings.si_units = False
+
     request = DwdObservationRequest(
         parameter=[DwdObservationDataset.TEMPERATURE_AIR],
         resolution=DwdObservationResolution.HOURLY,
         start_date="2019-01-01",
         end_date="2020-01-01",
-        tidy=True,
-        humanize=True,
-        si_units=False,
     )
 
     stations = request.filter_by_station_id(station_id=(1048,))

--- a/example/observations_stations.py
+++ b/example/observations_stations.py
@@ -29,8 +29,6 @@ def station_example():
         period=DwdObservationPeriod.RECENT,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2020, 1, 20),
-        tidy=True,
-        humanize=True,
     )
 
     result = stations.filter_by_distance(latitude=50.0, longitude=8.9, distance=30)

--- a/poetry.lock
+++ b/poetry.lock
@@ -344,7 +344,7 @@ numpy = ">1.13.3"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.10"
+version = "2.0.11"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -639,6 +639,24 @@ description = "Discover and load entry points from installed packages."
 category = "dev"
 optional = false
 python-versions = ">=2.7"
+
+[[package]]
+name = "environs"
+version = "9.5.0"
+description = "simplified environment variable parsing"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+marshmallow = ">=3.0.0"
+python-dotenv = "*"
+
+[package.extras]
+dev = ["pytest", "dj-database-url", "dj-email-url", "django-cache-url", "flake8 (==4.0.1)", "flake8-bugbear (==21.9.2)", "mypy (==0.910)", "pre-commit (>=2.4,<3.0)", "tox"]
+django = ["dj-database-url", "dj-email-url", "django-cache-url"]
+lint = ["flake8 (==4.0.1)", "flake8-bugbear (==21.9.2)", "mypy (==0.910)", "pre-commit (>=2.4,<3.0)"]
+tests = ["pytest", "dj-database-url", "dj-email-url", "django-cache-url"]
 
 [[package]]
 name = "eradicate"
@@ -1409,6 +1427,20 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "marshmallow"
+version = "3.14.1"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pytest", "pytz", "simplejson", "mypy (==0.910)", "flake8 (==4.0.1)", "flake8-bugbear (==21.9.2)", "pre-commit (>=2.4,<3.0)", "tox"]
+docs = ["sphinx (==4.3.0)", "sphinx-issues (==1.2.0)", "alabaster (==0.7.12)", "sphinx-version-warning (==1.1.2)", "autodocsumm (==0.2.7)"]
+lint = ["mypy (==0.910)", "flake8 (==4.0.1)", "flake8-bugbear (==21.9.2)", "pre-commit (>=2.4,<3.0)"]
+tests = ["pytest", "pytz", "simplejson"]
+
+[[package]]
 name = "matplotlib"
 version = "3.5.1"
 description = "Python plotting package"
@@ -2132,6 +2164,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-dotenv"
+version = "0.19.2"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-slugify"
@@ -2984,7 +3027,7 @@ sql = ["duckdb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "0da3fc0ef055394070875f22ca533d0094ab9ae846a7de49df2e4fb34aa5ddc7"
+content-hash = "ddef54610d29865d4dd9ce39e6e28714f11e534b448a9921eb03c389728c8807"
 
 [metadata.files]
 aenum = [
@@ -3330,8 +3373,8 @@ cftime = [
     {file = "cftime-1.5.2.tar.gz", hash = "sha256:375d37d9ab8bf501c048e44efce2276296e3d67bb276e891e0e93b0a8bbb988a"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.10.tar.gz", hash = "sha256:876d180e9d7432c5d1dfd4c5d26b72f099d503e8fcc0feb7532c9289be60fcbd"},
-    {file = "charset_normalizer-2.0.10-py3-none-any.whl", hash = "sha256:cb957888737fc0bbcd78e3df769addb41fd1ff8cf950dc9e7ad7793f1bf44455"},
+    {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
+    {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
 ]
 click = [
     {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
@@ -3501,6 +3544,10 @@ duckdb = [
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
+]
+environs = [
+    {file = "environs-9.5.0-py2.py3-none-any.whl", hash = "sha256:1e549569a3de49c05f856f40bce86979e7d5ffbbc4398e7f338574c220189124"},
+    {file = "environs-9.5.0.tar.gz", hash = "sha256:a76307b36fbe856bdca7ee9161e6c466fd7fcffc297109a118c59b54e27e30c9"},
 ]
 eradicate = [
     {file = "eradicate-2.0.0.tar.gz", hash = "sha256:27434596f2c5314cc9b31410c93d8f7e8885747399773cd088d3adea647a60c8"},
@@ -3949,6 +3996,10 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
+]
+marshmallow = [
+    {file = "marshmallow-3.14.1-py3-none-any.whl", hash = "sha256:04438610bc6dadbdddb22a4a55bcc7f6f8099e69580b2e67f5a681933a1f4400"},
+    {file = "marshmallow-3.14.1.tar.gz", hash = "sha256:4c05c1684e0e97fe779c62b91878f173b937fe097b356cd82f793464f5bc6138"},
 ]
 matplotlib = [
     {file = "matplotlib-3.5.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:456cc8334f6d1124e8ff856b42d2cc1c84335375a16448189999496549f7182b"},
@@ -4563,6 +4614,10 @@ pytest-xdist = [
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.19.2.tar.gz", hash = "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"},
+    {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
 ]
 python-slugify = [
     {file = "python-slugify-5.0.2.tar.gz", hash = "sha256:f13383a0b9fcbe649a1892b9c8eb4f8eab1d6d84b84bb7a624317afa98159cab"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ zarr = { version = "^2.7", optional = true }
 xarray = { version = "^0.17", optional = true }
 timezonefinder = "^5.2"
 diskcache = "^5.4.0"
+environs = "^9.4.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ cached-property==1.5.2; python_version < "3.8" and python_version >= "3.7"
 cachetools==4.2.4; python_version >= "3.5" and python_version < "4.0"
 certifi==2021.10.8; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.5"
 cffi==1.15.0; python_full_version >= "3.6.1" and python_version >= "3.7" and implementation_name == "pypy"
-charset-normalizer==2.0.10; python_full_version >= "3.6.0" and python_version >= "3.6"
+charset-normalizer==2.0.11; python_full_version >= "3.6.0" and python_version >= "3.6"
 click-params==0.1.2; python_version >= "3.6" and python_version < "4.0"
 click==8.0.3; python_version >= "3.6"
 cloup==0.8.2; python_version >= "3.6"
@@ -36,6 +36,7 @@ diskcache==5.4.0; python_version >= "3"
 docformatter==1.4
 docutils==0.16; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 entrypoints==0.3; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+environs==9.5.0; python_version >= "3.6"
 eradicate==2.0.0; python_version >= "3.6" and python_version < "4.0"
 execnet==1.9.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 flake8-2020==1.6.1; python_full_version >= "3.6.1"
@@ -76,6 +77,7 @@ jupyter-server==1.13.4; python_version >= "3.7"
 livereload==2.6.3; python_version >= "3.6"
 lxml==4.7.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 markupsafe==2.0.1; python_version >= "3.6"
+marshmallow==3.14.1; python_version >= "3.6"
 mccabe==0.6.1; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and python_version >= "3.7" and python_version < "4.0"
 measurement==3.2.0
 mistune==0.8.4; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
@@ -120,6 +122,7 @@ pytest-notebook==0.6.1; python_version >= "3.6"
 pytest-xdist==2.5.0; python_version >= "3.6"
 pytest==6.2.5; python_version >= "3.6"
 python-dateutil==2.8.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.3.0")
+python-dotenv==0.19.2; python_version >= "3.6"
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.5" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.5")
 pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_full_version >= "3.6.1" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")

--- a/tests/provider/dwd/forecast/test_api_data.py
+++ b/tests/provider/dwd/forecast/test_api_data.py
@@ -4,6 +4,7 @@
 import pytest
 
 from wetterdienst.provider.dwd.forecast import DwdMosmixRequest, DwdMosmixType
+from wetterdienst.settings import Settings
 
 
 @pytest.mark.remote
@@ -11,8 +12,11 @@ def test_dwd_mosmix_l():
     """
     Test some details of a typical MOSMIX-L response.
     """
+    Settings.tidy = True
+    Settings.humanize = False
+    Settings.si_units = True
 
-    request = DwdMosmixRequest(parameter="large", mosmix_type=DwdMosmixType.LARGE, humanize=False).filter_by_station_id(
+    request = DwdMosmixRequest(parameter="large", mosmix_type=DwdMosmixType.LARGE).filter_by_station_id(
         station_id=["01001"],
     )
     response = next(request.values.query())
@@ -159,16 +163,12 @@ def test_dwd_mosmix_l():
 @pytest.mark.remote
 @pytest.mark.slow
 def test_dwd_mosmix_s():
-    """
-    Test some details of a typical MOSMIX-S response.
-    """
+    """Test some details of a typical MOSMIX-S response."""
+    Settings.tidy = True
+    Settings.humanize = False
+    Settings.si_units = True
 
-    request = DwdMosmixRequest(
-        parameter="small",
-        mosmix_type=DwdMosmixType.SMALL,
-        humanize=False,
-        tidy=True,
-    ).filter_by_station_id(
+    request = DwdMosmixRequest(parameter="small", mosmix_type=DwdMosmixType.SMALL,).filter_by_station_id(
         station_id=["01028"],
     )
     response = next(request.values.query())
@@ -243,12 +243,11 @@ def test_mosmix_l_parameters():
     """
     Test some details of a MOSMIX-L response when queried for specific parameters.
     """
+    Settings.tidy = True
+    Settings.humanize = False
+    Settings.si_units = True
 
-    request = DwdMosmixRequest(
-        mosmix_type=DwdMosmixType.LARGE,
-        parameter=["DD", "ww"],
-        humanize=False,
-    ).filter_by_station_id(
+    request = DwdMosmixRequest(mosmix_type=DwdMosmixType.LARGE, parameter=["DD", "ww"],).filter_by_station_id(
         station_id=("01001", "123"),
     )
     response = next(request.values.query())

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -24,6 +24,7 @@ from wetterdienst.provider.dwd.observation.metadata.parameter import (
     DwdObservationDatasetTree,
     DwdObservationParameter,
 )
+from wetterdienst.settings import Settings
 
 
 def test_dwd_observation_data_api():
@@ -314,12 +315,15 @@ def test_request_period_empty():
 def test_dwd_observation_data_result_missing_data():
     """Test for DataFrame having empty values for dates where the station should not
     have values"""
+    Settings.tidy = True
+    Settings.humanize = True
+    Settings.si_units = True
+
     request = DwdObservationRequest(
         parameter=[DwdObservationDataset.CLIMATE_SUMMARY],
         resolution=DwdObservationResolution.DAILY,
         start_date="1933-12-27",  # few days before official start
         end_date="1934-01-04",  # few days after official start,
-        tidy=True,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -362,14 +366,15 @@ def test_dwd_observation_data_result_missing_data():
 @pytest.mark.remote
 def test_dwd_observation_data_result_tabular():
     """Test for actual values (tabular)"""
+    Settings.tidy = False
+    Settings.humanize = False
+    Settings.si_units = False
+
     request = DwdObservationRequest(
         parameter=[DwdObservationDataset.CLIMATE_SUMMARY],
         resolution=DwdObservationResolution.DAILY,
         start_date="1933-12-31",  # few days before official start
         end_date="1934-01-01",  # few days after official start,
-        tidy=False,
-        humanize=False,
-        si_units=False,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -432,14 +437,15 @@ def test_dwd_observation_data_result_tabular():
 @pytest.mark.remote
 def test_dwd_observation_data_result_tabular_metric():
     """Test for actual values (tabular) in metric units"""
+    Settings.tidy = False
+    Settings.humanize = False
+    Settings.si_units = True
+
     request = DwdObservationRequest(
         parameter=[DwdObservationDataset.CLIMATE_SUMMARY],
         resolution=DwdObservationResolution.DAILY,
         start_date="1933-12-31",  # few days before official start
         end_date="1934-01-01",  # few days after official start,
-        tidy=False,
-        humanize=False,
-        si_units=True,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -502,14 +508,15 @@ def test_dwd_observation_data_result_tabular_metric():
 @pytest.mark.remote
 def test_dwd_observation_data_result_tidy_metric():
     """Test for actual values (tidy) in metric units"""
+    Settings.tidy = True
+    Settings.humanize = False
+    Settings.si_units = True
+
     request = DwdObservationRequest(
         parameter=[DwdObservationDataset.CLIMATE_SUMMARY],
         resolution=DwdObservationResolution.DAILY,
         start_date="1933-12-31",  # few days before official start
         end_date="1934-01-01",  # few days after official start,
-        tidy=True,
-        humanize=False,
-        si_units=True,
     ).filter_by_station_id(
         station_id=(1048,),
     )
@@ -697,14 +704,15 @@ def test_dwd_observation_data_result_tidy_metric():
 @pytest.mark.remote
 def test_dwd_observation_data_10_minutes_result_tidy():
     """Test for actual values (tidy) in metric units"""
+    Settings.tidy = True
+    Settings.humanize = False
+    Settings.si_units = False
+
     request = DwdObservationRequest(
         parameter=[DwdObservationDatasetTree.MINUTE_10.TEMPERATURE_AIR.PRESSURE_AIR_SITE],
         resolution=DwdObservationResolution.MINUTE_10,
         start_date="1999-12-31 22:00",
         end_date="1999-12-31 23:00",
-        tidy=True,
-        humanize=False,
-        si_units=False,
     ).filter_by_station_id(
         station_id=(1048,),
     )
@@ -782,13 +790,15 @@ def test_create_humanized_column_names_mapping():
 
 def test_tidy_up_data():
     """Test for function to tidy data"""
+    Settings.tidy = True
+    Settings.humanize = False
+    Settings.si_units = True
+
     request = DwdObservationRequest(
         "kl",
         "daily",
         "historical",
         start_date="2019-01-23 00:00:00",
-        tidy=True,
-        humanize=False,
     ).filter_by_station_id((1048,))
 
     df = pd.DataFrame(

--- a/tests/provider/dwd/test_util.py
+++ b/tests/provider/dwd/test_util.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 from pandas._testing import assert_frame_equal
 
+from wetterdienst import Settings
 from wetterdienst.exceptions import InvalidEnumeration
 from wetterdienst.provider.dwd.observation import (
     DwdObservationDataset,
@@ -38,12 +39,14 @@ def test_coerce_field_types():
     # We require a stations object with hourly resolution in order to accurately parse
     # the hourly timestamp (pandas would fail parsing it because it has a strange
     # format)
+    Settings.tidy = False
+    Settings.humanize = False
+    Settings.si_units = True
+
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.SOLAR,  # RS_IND_01,
         resolution=DwdObservationResolution.HOURLY,
         period=DwdObservationPeriod.RECENT,
-        humanize=False,
-        tidy=False,
     ).all()
 
     # Here we don't query the actual data because it takes too long
@@ -81,12 +84,14 @@ def test_coerce_field_types():
 
 def test_coerce_field_types_with_nans():
     """Test field coercion with NaNs"""
+    Settings.tidy = False
+    Settings.humanize = False
+    Settings.si_units = True
+
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.SOLAR,  # RS_IND_01,
         resolution=DwdObservationResolution.HOURLY,
         period=DwdObservationPeriod.RECENT,
-        humanize=False,
-        tidy=False,
     ).all()
 
     df = pd.DataFrame(

--- a/tests/provider/eccc/test_api.py
+++ b/tests/provider/eccc/test_api.py
@@ -7,17 +7,19 @@ import pytz
 from pandas._testing import assert_frame_equal
 
 from wetterdienst.provider.eccc.observation import EcccObservationRequest
+from wetterdienst.settings import Settings
 
 
 def test_eccc_api_stations():
+    Settings.tidy = True
+    Settings.humanize = True
+    Settings.si_units = False
+
     request = EcccObservationRequest(
         parameter="DAILY",
         resolution="DAILY",
         start_date="1990-01-01",
         end_date="1990-01-02",
-        humanize=True,
-        tidy=True,
-        si_units=False,
     ).filter_by_station_id(station_id=(14,))
 
     expected = pd.DataFrame(
@@ -37,14 +39,15 @@ def test_eccc_api_stations():
 
 
 def test_eccc_api_values():
+    Settings.tidy = True
+    Settings.humanize = True
+    Settings.si_units = False
+
     request = EcccObservationRequest(
         parameter="DAILY",
         resolution="DAILY",
         start_date="1980-01-01",
         end_date="1980-01-02",
-        humanize=True,
-        tidy=True,
-        si_units=False,
     ).filter_by_station_id(station_id=(1652,))
 
     values = request.values.all().df

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@
 # Distributed under the MIT License. See LICENSE for more info.
 import pytest
 
-from wetterdienst import Wetterdienst
+from wetterdienst import Settings, Wetterdienst
 
 
 @pytest.mark.remote
@@ -34,8 +34,10 @@ def test_api(provider, kind, kwargs, si_units):
     # Discover parameters
     assert api.discover()
 
+    Settings.si_units = si_units
+
     # All stations
-    request = api(**kwargs, si_units=si_units).all()
+    request = api(**kwargs).all()
 
     stations = request.df
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,47 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+
+from wetterdienst import Settings
+
+
+@pytest.mark.cflake
+def test_settings():
+    """Check Settings object"""
+    Settings.default()
+
+    assert not Settings.cache_disable
+    assert Settings.tidy
+    assert Settings.humanize
+    assert Settings.si_units
+
+    Settings.tidy = False
+    assert not Settings.tidy
+
+    with Settings:
+        Settings.humanize = False
+        assert not Settings.humanize
+
+    assert Settings.humanize
+
+    Settings.default()
+
+    assert Settings.tidy
+
+
+def test_settings_concurrent():
+    """Check leaking of Settings through threads"""
+
+    def settings_tidy_concurrent(tidy: bool):
+        with Settings:
+            Settings.tidy = tidy
+
+            return Settings.tidy
+
+    random_booleans = np.random.choice([True, False], 1000).tolist()
+
+    with ThreadPoolExecutor() as p:
+        tidy_array = list(p.map(settings_tidy_concurrent, random_booleans))
+
+    assert random_booleans == tidy_array

--- a/tests/ui/test_cli.py
+++ b/tests/ui/test_cli.py
@@ -39,7 +39,7 @@ SETTINGS_VALUES = (
     (
         "dwd",
         "forecast",
-        f"--parameter=DD --resolution=large "
+        f"--parameter=small --resolution=large "
         f"--date={datetime.strftime(datetime.today() + timedelta(days=2), '%Y-%m-%d')}",
         "10488",
         "DRESDEN",
@@ -299,6 +299,7 @@ def test_cli_values_json(setting, expected_columns, capsys, caplog):
     expected_columns = {"station_id", "date"}.union(expected_columns)
 
     first = response[0]
+
     assert set(first.keys()).issuperset(expected_columns)
 
 

--- a/wetterdienst/__init__.py
+++ b/wetterdienst/__init__.py
@@ -19,6 +19,7 @@ from wetterdienst.metadata.parameter import Parameter
 from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.provider import Provider
 from wetterdienst.metadata.resolution import Resolution
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import cache_dir
 
 # Single-sourcing the package version

--- a/wetterdienst/core/scalar/request.py
+++ b/wetterdienst/core/scalar/request.py
@@ -3,6 +3,7 @@
 # Distributed under the MIT License. See LICENSE for more info.
 import logging
 from abc import abstractmethod
+from copy import copy
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional, Tuple, Union
@@ -24,6 +25,7 @@ from wetterdienst.metadata.kind import Kind
 from wetterdienst.metadata.period import Period, PeriodType
 from wetterdienst.metadata.provider import Provider
 from wetterdienst.metadata.resolution import Frequency, Resolution, ResolutionType
+from wetterdienst.settings import Settings
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 from wetterdienst.util.geo import Coordinates, derive_nearest_neighbours
 
@@ -305,9 +307,6 @@ class ScalarRequestCore(Core):
         period: Period,
         start_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
         end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
-        humanize: bool = True,
-        tidy: bool = True,
-        si_units: bool = True,
     ) -> None:
         """
 
@@ -328,14 +327,15 @@ class ScalarRequestCore(Core):
 
         self.start_date, self.end_date = self.convert_timestamps(start_date, end_date)
         self.parameter = self._parse_parameter(parameter)
-        self.humanize = humanize
 
-        tidy = tidy
+        self.humanize = copy(Settings.humanize)
+
+        tidy = copy(Settings.tidy)
         if self._has_datasets:
             tidy = tidy or any([parameter not in self._dataset_base for parameter, dataset in self.parameter])
-
         self.tidy = tidy
-        self.si_units = si_units
+
+        self.si_units = copy(Settings.si_units)
 
         log.info(
             f"Processing request for "

--- a/wetterdienst/provider/dwd/forecast/api.py
+++ b/wetterdienst/provider/dwd/forecast/api.py
@@ -401,9 +401,6 @@ class DwdMosmixRequest(ScalarRequestCore):
         end_issue: Optional[Union[str, datetime]] = None,
         start_date: Optional[Union[str, datetime]] = None,
         end_date: Optional[Union[str, datetime]] = None,
-        humanize: bool = True,
-        tidy: bool = True,
-        si_units: bool = True,
     ) -> None:
         """
 
@@ -413,9 +410,6 @@ class DwdMosmixRequest(ScalarRequestCore):
         :param end_issue: end of issue
         :param start_date: start date for filtering returned dataframe
         :param end_date: end date
-        :param humanize: humanize parameter names
-        :param tidy: tidy data to be row-wise
-        :param si_units: convert to si units
         """
         self.mosmix_type = parse_enumeration_from_template(mosmix_type, DwdMosmixType)
 
@@ -425,7 +419,6 @@ class DwdMosmixRequest(ScalarRequestCore):
             end_date=end_date,
             resolution=Resolution.HOURLY,
             period=Period.FUTURE,
-            si_units=si_units,
         )
 
         if not start_issue:
@@ -464,8 +457,6 @@ class DwdMosmixRequest(ScalarRequestCore):
 
         self.start_issue = start_issue
         self.end_issue = end_issue
-        self.humanize = humanize
-        self.tidy = tidy
 
     @property
     def issue_start(self):

--- a/wetterdienst/provider/dwd/observation/api.py
+++ b/wetterdienst/provider/dwd/observation/api.py
@@ -484,9 +484,6 @@ class DwdObservationRequest(ScalarRequestCore):
         period: Optional[Union[str, Period, DwdObservationPeriod]] = None,
         start_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
         end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
-        humanize: bool = True,
-        tidy: bool = True,
-        si_units: bool = True,
     ):
         """
 
@@ -502,9 +499,6 @@ class DwdObservationRequest(ScalarRequestCore):
             period=period,
             start_date=start_date,
             end_date=end_date,
-            humanize=humanize,
-            tidy=tidy,
-            si_units=si_units,
         )
 
         if self.start_date and self.period:

--- a/wetterdienst/provider/eccc/observation/api.py
+++ b/wetterdienst/provider/eccc/observation/api.py
@@ -308,19 +308,20 @@ class EcccObservationRequest(ScalarRequestCore):
         resolution: Union[EccObservationResolution, Resolution],
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
-        humanize: bool = True,
-        tidy: bool = True,
-        si_units: bool = True,
     ):
+        """
+
+        :param parameter: parameter or list of parameters that are being queried
+        :param resolution: resolution of data
+        :param start_date: start date for values filtering
+        :param end_date: end date for values filtering
+        """
         super(EcccObservationRequest, self).__init__(
             parameter=parameter,
             resolution=resolution,
             period=Period.HISTORICAL,
             start_date=start_date,
             end_date=end_date,
-            humanize=humanize,
-            tidy=tidy,
-            si_units=si_units,
         )
 
     def _all(self) -> pd.DataFrame:

--- a/wetterdienst/provider/noaa/ghcn/api.py
+++ b/wetterdienst/provider/noaa/ghcn/api.py
@@ -238,18 +238,12 @@ class NoaaGhcnRequest(ScalarRequestCore):
         parameter: List[str],
         start_date: Optional[Union[str, dt.datetime, pd.Timestamp]] = None,
         end_date: Optional[Union[str, dt.datetime, pd.Timestamp]] = None,
-        humanize: bool = True,
-        tidy: bool = True,
-        si_units: bool = True,
     ) -> None:
         """
 
         :param parameter: list of parameter strings or parameter enums being queried
         :param start_date: start date for request or None if all data is requested
         :param end_date: end date for request or None if all data is requested
-        :param humanize: humanize parameters
-        :param tidy: return data in tidy format
-        :param si_units: convert values to SI units
         """
         super().__init__(
             parameter=parameter,
@@ -257,9 +251,6 @@ class NoaaGhcnRequest(ScalarRequestCore):
             period=Period.HISTORICAL,
             start_date=start_date,
             end_date=end_date,
-            humanize=humanize,
-            tidy=tidy,
-            si_units=si_units,
         )
 
     def _all(self) -> pd.DataFrame:

--- a/wetterdienst/settings.py
+++ b/wetterdienst/settings.py
@@ -1,0 +1,51 @@
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+from environs import Env
+
+
+@dataclass
+class Settings:
+    """Wetterdienst class for general settings"""
+
+    env = Env()
+    env.read_env()
+
+    with env.prefixed("WD_"):
+        # cache
+        cache_disable: bool = env.bool("CACHE_DISABLE", False)
+
+        with env.prefixed("SCALAR_"):
+            # scalar
+            humanize: bool = env.bool("HUMANIZE", True)
+            tidy: bool = env.bool("TIDY", True)
+            si_units: bool = env.bool("SI_UNITS", True)
+
+    @classmethod
+    def reset(cls):
+        """Reset Wetterdienst Settings to start"""
+        cls.env.read_env()
+        cls.__init__(cls)
+
+    @classmethod
+    def default(cls):
+        """Ignore environmental variables and use all default arguments as defined above"""
+        # Put empty env to force using the given defaults
+        cls.env = Env()
+        cls.__init__(cls)
+
+    _local_settings = ContextVar("local_settings")
+    _local_settings_token = None
+
+    # Context manager for managing settings in concurrent situations
+    def __enter__(self):
+        self._local_settings_token = self._local_settings.set(self)
+        return self._local_settings.get()
+
+    def __exit__(self, type_, value, traceback):
+        self._local_settings.reset(self._local_settings_token)
+        # this is not the same object as the original one
+        return Settings.__init__(self)
+
+
+Settings = Settings()

--- a/wetterdienst/ui/core.py
+++ b/wetterdienst/ui/core.py
@@ -13,6 +13,7 @@ from wetterdienst.metadata.datarange import DataRange
 from wetterdienst.metadata.period import PeriodType
 from wetterdienst.metadata.resolution import Resolution, ResolutionType
 from wetterdienst.provider.dwd.forecast import DwdMosmixType
+from wetterdienst.settings import Settings
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 
 log = logging.getLogger(__name__)
@@ -120,11 +121,7 @@ def get_stations(
         "parameter": unpack_parameters(parameter),
         "start_date": start_date,
         "end_date": end_date,
-        "si_units": si_units,
-        "tidy": tidy,
-        "humanize": humanize,
     }
-
     if api.provider == Provider.DWD and api.kind == Kind.FORECAST:
         kwargs["mosmix_type"] = resolution
         kwargs["start_issue"] = issue
@@ -134,7 +131,12 @@ def get_stations(
     if api._period_type == PeriodType.MULTI:
         kwargs["period"] = period
 
-    r = api(**kwargs)
+    with Settings:
+        Settings.tidy = tidy
+        Settings.humanize = humanize
+        Settings.si_units = si_units
+
+        r = api(**kwargs)
 
     if all_:
         return r.all()

--- a/wetterdienst/ui/explorer/app.py
+++ b/wetterdienst/ui/explorer/app.py
@@ -16,6 +16,7 @@ import plotly.graph_objects as go
 import requests
 from dash.dependencies import Input, Output, State
 
+from wetterdienst import Settings
 from wetterdienst.exceptions import InvalidParameterCombination
 from wetterdienst.metadata.columns import Columns
 from wetterdienst.provider.dwd.observation import (
@@ -120,12 +121,14 @@ def fetch_values(parameter: str, resolution: str, period: str, station_id: int):
         f"resolution={resolution}, "
         f"period={period}"
     )
+
+    Settings.tidy = False
+    Settings.humanize = True
+
     stations = DwdObservationRequest(
         parameter=DwdObservationDataset(parameter),
         resolution=DwdObservationResolution(resolution),
         period=DwdObservationPeriod(period),
-        tidy=False,
-        humanize=True,
     ).filter_by_station_id(station_id=(str(station_id),))
 
     try:


### PR DESCRIPTION
This PR introduces new wetterdienst settings, that manage all kinds of general settings about scalar requests, caching dirs, etc.

Backlog:

- [x] Describe Settings in docs, especially for threaded cases
- [x] Add basic tests for Settings
- [x] Add docstrings and method descriptions

Related issue: #572 