### PR TITLE
Update wetterdienst explorer to leverage all APIs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 Development
 ***********
 
+- Extend explorer to use all implemented APIs
 
 0.27.0 (16.02.2022)
 *******************

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -7968,7 +7968,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 lxml
-4.7.1
+4.8.0
 BSD License
 lxml dev team
 https://lxml.de/
@@ -17814,7 +17814,7 @@ disclaims all warranties with regard to this software.
 
 
 webdriver-manager
-3.5.2
+3.5.3
 Apache Software License
 Sergey Pirogov
 https://github.com/SergeyPirogov/webdriver_manager

--- a/poetry.lock
+++ b/poetry.lock
@@ -405,6 +405,18 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "configparser"
+version = "5.2.0"
+description = "Updated configparser from Python 3.8 for Python 2.6+."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "types-backports", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[[package]]
 name = "coverage"
 version = "5.5"
 description = "Code coverage measurement for Python"
@@ -436,6 +448,17 @@ sqlalchemy = ["geojson (>=2.5.0)", "sqlalchemy (>=1.0,<1.4)"]
 test = ["zc.customdoctests (>=1.0.1)", "zope.testing"]
 
 [[package]]
+name = "crayons"
+version = "0.4.0"
+description = "TextUI colors for Python."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+colorama = "*"
+
+[[package]]
 name = "css-html-js-minify"
 version = "2.5.5"
 description = "CSS HTML JS Minifier"
@@ -453,42 +476,44 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "dash"
-version = "1.21.0"
+version = "2.1.0"
 description = "A Python framework for building reactive web-apps. Developed by Plotly."
 category = "main"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-dash-core-components = "1.17.1"
-dash-html-components = "1.1.4"
-dash-table = "4.12.0"
+dash-core-components = "2.0.0"
+dash-html-components = "2.0.0"
+dash-table = "5.0.0"
 Flask = ">=1.0.4"
 flask-compress = "*"
-future = "*"
-plotly = "*"
+plotly = ">=5.0.0"
 
 [package.extras]
-dev = ["dash_flow_example (==0.0.5)", "dash-dangerously-set-inner-html", "flake8 (==3.9.2)", "PyYAML (==5.4.1)", "fire (==0.4.0)", "coloredlogs (==15.0.1)", "flask-talisman (==0.8.1)", "isort (==4.3.21)", "pylint (==1.9.5)", "mock (==3.0.5)", "virtualenv (==20.2.2)", "mock (==4.0.3)", "black (==21.6b0)", "pylint (==2.8.3)"]
-testing = ["pytest-sugar (>=0.9.4)", "lxml (>=4.6.2)", "selenium (>=3.141.0)", "percy (>=2.0.2)", "requests[security] (>=2.21.0)", "waitress (>=1.4.4)", "cryptography (<3.4)", "pytest (>=4.6,<5)", "pytest-mock (>=2.0.0,<3)", "beautifulsoup4 (>=4.8.2,<=4.9.3)", "pytest (>=6.0.2)", "pytest-mock (>=3.2.0)", "beautifulsoup4 (>=4.8.2)"]
+celery = ["redis (>=3.5.3)", "celery[redis] (>=5.1.2)"]
+ci = ["black (==21.6b0)", "dash-flow-example (==0.0.5)", "dash-dangerously-set-inner-html", "flake8 (==3.9.2)", "flaky (==3.7.0)", "flask-talisman (==0.8.1)", "mimesis", "mock (==4.0.3)", "numpy", "preconditions", "pylint (==2.10.2)", "pytest-mock (==3.2.0)", "pytest-sugar (==0.9.4)", "isort (==4.3.21)", "orjson (==3.5.4)", "pyarrow (<3)", "pandas (==1.1.5)", "xlrd (<2)", "orjson (==3.6.3)", "pyarrow", "openpyxl", "pandas (>=1.4.0)", "xlrd (>=2.0.1)"]
+dev = ["coloredlogs (>=15.0.1)", "fire (>=0.4.0)", "PyYAML (>=5.4.1)"]
+diskcache = ["diskcache (>=5.2.1)", "multiprocess (>=0.70.12)", "psutil (>=5.8.0)"]
+testing = ["beautifulsoup4 (>=4.8.2)", "lxml (>=4.6.2)", "percy (>=2.0.2)", "pytest (>=6.0.2)", "requests[security] (>=2.21.0)", "selenium (>=3.141.0)", "waitress (>=1.4.4)", "webdriver-manager (>=3.5.1)", "cryptography (<3.4)"]
 
 [[package]]
 name = "dash-bootstrap-components"
-version = "0.12.2"
+version = "1.0.3"
 description = "Bootstrap themed components for use in Plotly Dash"
 category = "main"
 optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=3.6, <4"
 
 [package.dependencies]
-dash = ">=1.9.0"
+dash = ">=2.0.0"
 
 [package.extras]
 pandas = ["numpy", "pandas"]
 
 [[package]]
 name = "dash-core-components"
-version = "1.17.1"
+version = "2.0.0"
 description = "Core component suite for Dash"
 category = "main"
 optional = true
@@ -496,7 +521,7 @@ python-versions = "*"
 
 [[package]]
 name = "dash-html-components"
-version = "1.1.4"
+version = "2.0.0"
 description = "Vanilla HTML components for Dash"
 category = "main"
 optional = true
@@ -504,7 +529,7 @@ python-versions = "*"
 
 [[package]]
 name = "dash-table"
-version = "4.12.0"
+version = "5.0.0"
 description = "Dash table"
 category = "main"
 optional = true
@@ -1013,14 +1038,6 @@ smb = ["smbprotocol"]
 ssh = ["paramiko"]
 
 [[package]]
-name = "future"
-version = "0.18.2"
-description = "Clean single-source support for Python 3 and 2"
-category = "main"
-optional = true
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
 name = "gdal"
 version = "3.4.1"
 description = "GDAL: Geospatial Data Abstraction Library"
@@ -1415,7 +1432,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "lxml"
-version = "4.7.1"
+version = "4.8.0"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 category = "main"
 optional = false
@@ -1859,15 +1876,15 @@ test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock 
 
 [[package]]
 name = "plotly"
-version = "4.14.3"
+version = "5.6.0"
 description = "An open-source, interactive data visualization library for Python"
 category = "main"
 optional = true
-python-versions = "*"
+python-versions = ">=3.6"
 
 [package.dependencies]
-retrying = ">=1.3.3"
 six = "*"
+tenacity = ">=6.2.0"
 
 [[package]]
 name = "pluggy"
@@ -2187,11 +2204,11 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-slugify"
-version = "5.0.2"
-description = "A Python Slugify application that handles Unicode"
+version = "6.0.1"
+description = "A Python slugify application that also handles Unicode"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
 text-unidecode = ">=1.3"
@@ -2292,17 +2309,6 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
-
-[[package]]
-name = "retrying"
-version = "1.3.3"
-description = "Retrying"
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-six = ">=1.7.0"
 
 [[package]]
 name = "rx"
@@ -2661,6 +2667,17 @@ python-versions = "*"
 widechars = ["wcwidth"]
 
 [[package]]
+name = "tenacity"
+version = "8.0.1"
+description = "Retry code until it succeeds"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.extras]
+doc = ["reno", "sphinx", "tornado (>=4.5)"]
+
+[[package]]
 name = "terminado"
 version = "0.13.1"
 description = "Tornado websocket backend for the Xterm.js Javascript terminal emulator library."
@@ -2908,6 +2925,19 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "webdriver-manager"
+version = "3.5.3"
+description = "Library provides the way to automatically manage drivers for different browsers"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+configparser = "*"
+crayons = "*"
+requests = "*"
+
+[[package]]
 name = "webencodings"
 version = "0.5.1"
 description = "Character encoding aliases for legacy web content"
@@ -3053,7 +3083,7 @@ sql = ["duckdb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "d8be58cfdeafdb9096e32b9b8f11fcacbd03843afcd35a4e2f7224c2834ac8e4"
+content-hash = "29a585b92fac0be6c498d472d9ee872477e77d4b683ab4bc667918f636133b9f"
 
 [metadata.files]
 aenum = [
@@ -3422,6 +3452,10 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+configparser = [
+    {file = "configparser-5.2.0-py3-none-any.whl", hash = "sha256:e8b39238fb6f0153a069aa253d349467c3c4737934f253ef6abac5fe0eca1e5d"},
+    {file = "configparser-5.2.0.tar.gz", hash = "sha256:1b35798fdf1713f1c3139016cfcbc461f09edbf099d1fb658d4b7479fcaa3daa"},
+]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},
     {file = "coverage-5.5-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b"},
@@ -3480,6 +3514,10 @@ crate = [
     {file = "crate-0.25.0-py2.py3-none-any.whl", hash = "sha256:2de19674271e3a2feae8380fd9418bae536f5d246e93cd68dbb7a932f52c9c19"},
     {file = "crate-0.25.0.tar.gz", hash = "sha256:23e525cfe83aa2e00c8c00bd2c4f7b3b7038bd65e27bd347d24491e42c42554a"},
 ]
+crayons = [
+    {file = "crayons-0.4.0-py2.py3-none-any.whl", hash = "sha256:e73ad105c78935d71fe454dd4b85c5c437ba199294e7ffd3341842bc683654b1"},
+    {file = "crayons-0.4.0.tar.gz", hash = "sha256:bd33b7547800f2cfbd26b38431f9e64b487a7de74a947b0fafc89b45a601813f"},
+]
 css-html-js-minify = [
     {file = "css-html-js-minify-2.5.5.zip", hash = "sha256:4a9f11f7e0496f5284d12111f3ba4ff5ff2023d12f15d195c9c48bd97013746c"},
     {file = "css_html_js_minify-2.5.5-py2.py3-none-any.whl", hash = "sha256:3da9d35ac0db8ca648c1b543e0e801d7ca0bab9e6bfd8418fee59d5ae001727a"},
@@ -3490,20 +3528,21 @@ cycler = [
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
 ]
 dash = [
-    {file = "dash-1.21.0.tar.gz", hash = "sha256:8b03a53e4f7a5f3eded8af099ff54d9981f7879d22d74c7970b9a27c8f698ebb"},
+    {file = "dash-2.1.0-py3-none-any.whl", hash = "sha256:5c19cddad8dcf473ce0cc9a8aa40f7fc8f2b7856f7daad1f8bcd992a8203b8c0"},
+    {file = "dash-2.1.0.tar.gz", hash = "sha256:b5b29a3e2862a6700cf50582d81bda4edfe57d47e1c71c519a6c87f9187587e5"},
 ]
 dash-bootstrap-components = [
-    {file = "dash-bootstrap-components-0.12.2.tar.gz", hash = "sha256:b3266967f16d542ce715fd8ea0ed082b56e64dfa623750bf8150b72fe7b303ff"},
-    {file = "dash_bootstrap_components-0.12.2-py3-none-any.whl", hash = "sha256:4f697a0996e458a17859614a429f093ab0e143ab359b825e7ac0c1625738c2c8"},
+    {file = "dash-bootstrap-components-1.0.3.tar.gz", hash = "sha256:d054aed4a162526810a86d80b8682ba2f2047d54baf12a6a28b4fddf45043243"},
+    {file = "dash_bootstrap_components-1.0.3-py3-none-any.whl", hash = "sha256:409e9db7c5013c7f3ce94dc91a00639623191d1f0835be7cbb204228625a452c"},
 ]
 dash-core-components = [
-    {file = "dash_core_components-1.17.1.tar.gz", hash = "sha256:7e503f5eddb63034dd20c23d218cc0d8a81ec88e9a15b7cbc60e266b0e2b60a9"},
+    {file = "dash_core_components-2.0.0.tar.gz", hash = "sha256:c6733874af975e552f95a1398a16c2ee7df14ce43fa60bb3718a3c6e0b63ffee"},
 ]
 dash-html-components = [
-    {file = "dash_html_components-1.1.4.tar.gz", hash = "sha256:dc4f423e13716d179d51a42b3c7e2a2ed02e05185c742f88214b58d59e24bbd4"},
+    {file = "dash_html_components-2.0.0.tar.gz", hash = "sha256:8703a601080f02619a6390998e0b3da4a5daabe97a1fd7a9cebc09d015f26e50"},
 ]
 dash-table = [
-    {file = "dash_table-4.12.0.tar.gz", hash = "sha256:4c99689a887bfd035278b14ecd5db70706023389e53735d5e3cccc416facdbe4"},
+    {file = "dash_table-5.0.0.tar.gz", hash = "sha256:18624d693d4c8ef2ddec99a6f167593437a7ea0bf153aa20f318c170c5bc7308"},
 ]
 dask = [
     {file = "dask-2022.2.0-py3-none-any.whl", hash = "sha256:feaf838faa23150faadaeb2483e8612cfb8fed51f62e635a1a6dd55d1d793ba4"},
@@ -3739,9 +3778,6 @@ fsspec = [
     {file = "fsspec-2021.7.0-py3-none-any.whl", hash = "sha256:86822ccf367da99957f49db64f7d5fd3d8d21444fac4dfdc8ebc38ee93d478c6"},
     {file = "fsspec-2021.7.0.tar.gz", hash = "sha256:792ebd3b54de0b30f1ce73f0ba0a8bcc864724f2d9f248cb8d0ece47db0cbde8"},
 ]
-future = [
-    {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
-]
 gdal = [
     {file = "GDAL-3.4.1.tar.gz", hash = "sha256:b19e8143bc2c0d3e222789a465d82b6874236eb78801aec608bf5c8c44d20fcf"},
 ]
@@ -3910,66 +3946,67 @@ locket = [
     {file = "locket-0.2.1.tar.gz", hash = "sha256:3e1faba403619fe201552f083f1ecbf23f550941bc51985ac6ed4d02d25056dd"},
 ]
 lxml = [
-    {file = "lxml-4.7.1-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:d546431636edb1d6a608b348dd58cc9841b81f4116745857b6cb9f8dadb2725f"},
-    {file = "lxml-4.7.1-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6308062534323f0d3edb4e702a0e26a76ca9e0e23ff99be5d82750772df32a9e"},
-    {file = "lxml-4.7.1-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f76dbe44e31abf516114f6347a46fa4e7c2e8bceaa4b6f7ee3a0a03c8eba3c17"},
-    {file = "lxml-4.7.1-cp27-cp27m-win32.whl", hash = "sha256:d5618d49de6ba63fe4510bdada62d06a8acfca0b4b5c904956c777d28382b419"},
-    {file = "lxml-4.7.1-cp27-cp27m-win_amd64.whl", hash = "sha256:9393a05b126a7e187f3e38758255e0edf948a65b22c377414002d488221fdaa2"},
-    {file = "lxml-4.7.1-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:50d3dba341f1e583265c1a808e897b4159208d814ab07530202b6036a4d86da5"},
-    {file = "lxml-4.7.1-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:44f552e0da3c8ee3c28e2eb82b0b784200631687fc6a71277ea8ab0828780e7d"},
-    {file = "lxml-4.7.1-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:e662c6266e3a275bdcb6bb049edc7cd77d0b0f7e119a53101d367c841afc66dc"},
-    {file = "lxml-4.7.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:4c093c571bc3da9ebcd484e001ba18b8452903cd428c0bc926d9b0141bcb710e"},
-    {file = "lxml-4.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:3e26ad9bc48d610bf6cc76c506b9e5ad9360ed7a945d9be3b5b2c8535a0145e3"},
-    {file = "lxml-4.7.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a5f623aeaa24f71fce3177d7fee875371345eb9102b355b882243e33e04b7175"},
-    {file = "lxml-4.7.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7b5e2acefd33c259c4a2e157119c4373c8773cf6793e225006a1649672ab47a6"},
-    {file = "lxml-4.7.1-cp310-cp310-win32.whl", hash = "sha256:67fa5f028e8a01e1d7944a9fb616d1d0510d5d38b0c41708310bd1bc45ae89f6"},
-    {file = "lxml-4.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:b1d381f58fcc3e63fcc0ea4f0a38335163883267f77e4c6e22d7a30877218a0e"},
-    {file = "lxml-4.7.1-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:38d9759733aa04fb1697d717bfabbedb21398046bd07734be7cccc3d19ea8675"},
-    {file = "lxml-4.7.1-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:dfd0d464f3d86a1460683cd742306d1138b4e99b79094f4e07e1ca85ee267fe7"},
-    {file = "lxml-4.7.1-cp35-cp35m-win32.whl", hash = "sha256:534e946bce61fd162af02bad7bfd2daec1521b71d27238869c23a672146c34a5"},
-    {file = "lxml-4.7.1-cp35-cp35m-win_amd64.whl", hash = "sha256:6ec829058785d028f467be70cd195cd0aaf1a763e4d09822584ede8c9eaa4b03"},
-    {file = "lxml-4.7.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:ade74f5e3a0fd17df5782896ddca7ddb998845a5f7cd4b0be771e1ffc3b9aa5b"},
-    {file = "lxml-4.7.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:41358bfd24425c1673f184d7c26c6ae91943fe51dfecc3603b5e08187b4bcc55"},
-    {file = "lxml-4.7.1-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6e56521538f19c4a6690f439fefed551f0b296bd785adc67c1777c348beb943d"},
-    {file = "lxml-4.7.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5b0f782f0e03555c55e37d93d7a57454efe7495dab33ba0ccd2dbe25fc50f05d"},
-    {file = "lxml-4.7.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:490712b91c65988012e866c411a40cc65b595929ececf75eeb4c79fcc3bc80a6"},
-    {file = "lxml-4.7.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:34c22eb8c819d59cec4444d9eebe2e38b95d3dcdafe08965853f8799fd71161d"},
-    {file = "lxml-4.7.1-cp36-cp36m-win32.whl", hash = "sha256:2a906c3890da6a63224d551c2967413b8790a6357a80bf6b257c9a7978c2c42d"},
-    {file = "lxml-4.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:36b16fecb10246e599f178dd74f313cbdc9f41c56e77d52100d1361eed24f51a"},
-    {file = "lxml-4.7.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:a5edc58d631170de90e50adc2cc0248083541affef82f8cd93bea458e4d96db8"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:87c1b0496e8c87ec9db5383e30042357b4839b46c2d556abd49ec770ce2ad868"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:0a5f0e4747f31cff87d1eb32a6000bde1e603107f632ef4666be0dc065889c7a"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:bf6005708fc2e2c89a083f258b97709559a95f9a7a03e59f805dd23c93bc3986"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc15874816b9320581133ddc2096b644582ab870cf6a6ed63684433e7af4b0d3"},
-    {file = "lxml-4.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:0b5e96e25e70917b28a5391c2ed3ffc6156513d3db0e1476c5253fcd50f7a944"},
-    {file = "lxml-4.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:ec9027d0beb785a35aa9951d14e06d48cfbf876d8ff67519403a2522b181943b"},
-    {file = "lxml-4.7.1-cp37-cp37m-win32.whl", hash = "sha256:9fbc0dee7ff5f15c4428775e6fa3ed20003140560ffa22b88326669d53b3c0f4"},
-    {file = "lxml-4.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:1104a8d47967a414a436007c52f533e933e5d52574cab407b1e49a4e9b5ddbd1"},
-    {file = "lxml-4.7.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:fc9fb11b65e7bc49f7f75aaba1b700f7181d95d4e151cf2f24d51bfd14410b77"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:317bd63870b4d875af3c1be1b19202de34c32623609ec803b81c99193a788c1e"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:610807cea990fd545b1559466971649e69302c8a9472cefe1d6d48a1dee97440"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:09b738360af8cb2da275998a8bf79517a71225b0de41ab47339c2beebfff025f"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6a2ab9d089324d77bb81745b01f4aeffe4094306d939e92ba5e71e9a6b99b71e"},
-    {file = "lxml-4.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:eed394099a7792834f0cb4a8f615319152b9d801444c1c9e1b1a2c36d2239f9e"},
-    {file = "lxml-4.7.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:735e3b4ce9c0616e85f302f109bdc6e425ba1670a73f962c9f6b98a6d51b77c9"},
-    {file = "lxml-4.7.1-cp38-cp38-win32.whl", hash = "sha256:772057fba283c095db8c8ecde4634717a35c47061d24f889468dc67190327bcd"},
-    {file = "lxml-4.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:13dbb5c7e8f3b6a2cf6e10b0948cacb2f4c9eb05029fe31c60592d08ac63180d"},
-    {file = "lxml-4.7.1-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:718d7208b9c2d86aaf0294d9381a6acb0158b5ff0f3515902751404e318e02c9"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:5bee1b0cbfdb87686a7fb0e46f1d8bd34d52d6932c0723a86de1cc532b1aa489"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:e410cf3a2272d0a85526d700782a2fa92c1e304fdcc519ba74ac80b8297adf36"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:585ea241ee4961dc18a95e2f5581dbc26285fcf330e007459688096f76be8c42"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a555e06566c6dc167fbcd0ad507ff05fd9328502aefc963cb0a0547cfe7f00db"},
-    {file = "lxml-4.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:adaab25be351fff0d8a691c4f09153647804d09a87a4e4ea2c3f9fe9e8651851"},
-    {file = "lxml-4.7.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:82d16a64236970cb93c8d63ad18c5b9f138a704331e4b916b2737ddfad14e0c4"},
-    {file = "lxml-4.7.1-cp39-cp39-win32.whl", hash = "sha256:59e7da839a1238807226f7143c68a479dee09244d1b3cf8c134f2fce777d12d0"},
-    {file = "lxml-4.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:a1bbc4efa99ed1310b5009ce7f3a1784698082ed2c1ef3895332f5df9b3b92c2"},
-    {file = "lxml-4.7.1-pp37-pypy37_pp73-macosx_10_14_x86_64.whl", hash = "sha256:0607ff0988ad7e173e5ddf7bf55ee65534bd18a5461183c33e8e41a59e89edf4"},
-    {file = "lxml-4.7.1-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:6c198bfc169419c09b85ab10cb0f572744e686f40d1e7f4ed09061284fc1303f"},
-    {file = "lxml-4.7.1-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a58d78653ae422df6837dd4ca0036610b8cb4962b5cfdbd337b7b24de9e5f98a"},
-    {file = "lxml-4.7.1-pp38-pypy38_pp73-macosx_10_14_x86_64.whl", hash = "sha256:e18281a7d80d76b66a9f9e68a98cf7e1d153182772400d9a9ce855264d7d0ce7"},
-    {file = "lxml-4.7.1-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:8e54945dd2eeb50925500957c7c579df3cd07c29db7810b83cf30495d79af267"},
-    {file = "lxml-4.7.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:447d5009d6b5447b2f237395d0018901dcc673f7d9f82ba26c1b9f9c3b444b60"},
-    {file = "lxml-4.7.1.tar.gz", hash = "sha256:a1613838aa6b89af4ba10a0f3a972836128801ed008078f8c1244e65958f1b24"},
+    {file = "lxml-4.8.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:e1ab2fac607842ac36864e358c42feb0960ae62c34aa4caaf12ada0a1fb5d99b"},
+    {file = "lxml-4.8.0-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28d1af847786f68bec57961f31221125c29d6f52d9187c01cd34dc14e2b29430"},
+    {file = "lxml-4.8.0-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b92d40121dcbd74831b690a75533da703750f7041b4bf951befc657c37e5695a"},
+    {file = "lxml-4.8.0-cp27-cp27m-win32.whl", hash = "sha256:e01f9531ba5420838c801c21c1b0f45dbc9607cb22ea2cf132844453bec863a5"},
+    {file = "lxml-4.8.0-cp27-cp27m-win_amd64.whl", hash = "sha256:6259b511b0f2527e6d55ad87acc1c07b3cbffc3d5e050d7e7bcfa151b8202df9"},
+    {file = "lxml-4.8.0-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1010042bfcac2b2dc6098260a2ed022968dbdfaf285fc65a3acf8e4eb1ffd1bc"},
+    {file = "lxml-4.8.0-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fa56bb08b3dd8eac3a8c5b7d075c94e74f755fd9d8a04543ae8d37b1612dd170"},
+    {file = "lxml-4.8.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:31ba2cbc64516dcdd6c24418daa7abff989ddf3ba6d3ea6f6ce6f2ed6e754ec9"},
+    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:31499847fc5f73ee17dbe1b8e24c6dafc4e8d5b48803d17d22988976b0171f03"},
+    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:5f7d7d9afc7b293147e2d506a4596641d60181a35279ef3aa5778d0d9d9123fe"},
+    {file = "lxml-4.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:a3c5f1a719aa11866ffc530d54ad965063a8cbbecae6515acbd5f0fae8f48eaa"},
+    {file = "lxml-4.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6268e27873a3d191849204d00d03f65c0e343b3bcb518a6eaae05677c95621d1"},
+    {file = "lxml-4.8.0-cp310-cp310-win32.whl", hash = "sha256:330bff92c26d4aee79c5bc4d9967858bdbe73fdbdbacb5daf623a03a914fe05b"},
+    {file = "lxml-4.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:b2582b238e1658c4061ebe1b4df53c435190d22457642377fd0cb30685cdfb76"},
+    {file = "lxml-4.8.0-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a2bfc7e2a0601b475477c954bf167dee6d0f55cb167e3f3e7cefad906e7759f6"},
+    {file = "lxml-4.8.0-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a1547ff4b8a833511eeaceacbcd17b043214fcdb385148f9c1bc5556ca9623e2"},
+    {file = "lxml-4.8.0-cp35-cp35m-win32.whl", hash = "sha256:a9f1c3489736ff8e1c7652e9dc39f80cff820f23624f23d9eab6e122ac99b150"},
+    {file = "lxml-4.8.0-cp35-cp35m-win_amd64.whl", hash = "sha256:530f278849031b0eb12f46cca0e5db01cfe5177ab13bd6878c6e739319bae654"},
+    {file = "lxml-4.8.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:078306d19a33920004addeb5f4630781aaeabb6a8d01398045fcde085091a169"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:86545e351e879d0b72b620db6a3b96346921fa87b3d366d6c074e5a9a0b8dadb"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:24f5c5ae618395ed871b3d8ebfcbb36e3f1091fd847bf54c4de623f9107942f3"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:bbab6faf6568484707acc052f4dfc3802bdb0cafe079383fbaa23f1cdae9ecd4"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7993232bd4044392c47779a3c7e8889fea6883be46281d45a81451acfd704d7e"},
+    {file = "lxml-4.8.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6d6483b1229470e1d8835e52e0ff3c6973b9b97b24cd1c116dca90b57a2cc613"},
+    {file = "lxml-4.8.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ad4332a532e2d5acb231a2e5d33f943750091ee435daffca3fec0a53224e7e33"},
+    {file = "lxml-4.8.0-cp36-cp36m-win32.whl", hash = "sha256:db3535733f59e5605a88a706824dfcb9bd06725e709ecb017e165fc1d6e7d429"},
+    {file = "lxml-4.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5f148b0c6133fb928503cfcdfdba395010f997aa44bcf6474fcdd0c5398d9b63"},
+    {file = "lxml-4.8.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:8a31f24e2a0b6317f33aafbb2f0895c0bce772980ae60c2c640d82caac49628a"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:719544565c2937c21a6f76d520e6e52b726d132815adb3447ccffbe9f44203c4"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:c0b88ed1ae66777a798dc54f627e32d3b81c8009967c63993c450ee4cbcbec15"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fa9b7c450be85bfc6cd39f6df8c5b8cbd76b5d6fc1f69efec80203f9894b885f"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e9f84ed9f4d50b74fbc77298ee5c870f67cb7e91dcdc1a6915cb1ff6a317476c"},
+    {file = "lxml-4.8.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:1d650812b52d98679ed6c6b3b55cbb8fe5a5460a0aef29aeb08dc0b44577df85"},
+    {file = "lxml-4.8.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:80bbaddf2baab7e6de4bc47405e34948e694a9efe0861c61cdc23aa774fcb141"},
+    {file = "lxml-4.8.0-cp37-cp37m-win32.whl", hash = "sha256:6f7b82934c08e28a2d537d870293236b1000d94d0b4583825ab9649aef7ddf63"},
+    {file = "lxml-4.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e1fd7d2fe11f1cb63d3336d147c852f6d07de0d0020d704c6031b46a30b02ca8"},
+    {file = "lxml-4.8.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:5045ee1ccd45a89c4daec1160217d363fcd23811e26734688007c26f28c9e9e7"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:0c1978ff1fd81ed9dcbba4f91cf09faf1f8082c9d72eb122e92294716c605428"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cbf2ff155b19dc4d4100f7442f6a697938bf4493f8d3b0c51d45568d5666b5"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:ce13d6291a5f47c1c8dbd375baa78551053bc6b5e5c0e9bb8e39c0a8359fd52f"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e11527dc23d5ef44d76fef11213215c34f36af1608074561fcc561d983aeb870"},
+    {file = "lxml-4.8.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:60d2f60bd5a2a979df28ab309352cdcf8181bda0cca4529769a945f09aba06f9"},
+    {file = "lxml-4.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:62f93eac69ec0f4be98d1b96f4d6b964855b8255c345c17ff12c20b93f247b68"},
+    {file = "lxml-4.8.0-cp38-cp38-win32.whl", hash = "sha256:20b8a746a026017acf07da39fdb10aa80ad9877046c9182442bf80c84a1c4696"},
+    {file = "lxml-4.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:891dc8f522d7059ff0024cd3ae79fd224752676447f9c678f2a5c14b84d9a939"},
+    {file = "lxml-4.8.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:b6fc2e2fb6f532cf48b5fed57567ef286addcef38c28874458a41b7837a57807"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:74eb65ec61e3c7c019d7169387d1b6ffcfea1b9ec5894d116a9a903636e4a0b1"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:627e79894770783c129cc5e89b947e52aa26e8e0557c7e205368a809da4b7939"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:545bd39c9481f2e3f2727c78c169425efbfb3fbba6e7db4f46a80ebb249819ca"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5a58d0b12f5053e270510bf12f753a76aaf3d74c453c00942ed7d2c804ca845c"},
+    {file = "lxml-4.8.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ec4b4e75fc68da9dc0ed73dcdb431c25c57775383fec325d23a770a64e7ebc87"},
+    {file = "lxml-4.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5804e04feb4e61babf3911c2a974a5b86f66ee227cc5006230b00ac6d285b3a9"},
+    {file = "lxml-4.8.0-cp39-cp39-win32.whl", hash = "sha256:aa0cf4922da7a3c905d000b35065df6184c0dc1d866dd3b86fd961905bbad2ea"},
+    {file = "lxml-4.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:dd10383f1d6b7edf247d0960a3db274c07e96cf3a3fc7c41c8448f93eac3fb1c"},
+    {file = "lxml-4.8.0-pp37-pypy37_pp73-macosx_10_14_x86_64.whl", hash = "sha256:2403a6d6fb61c285969b71f4a3527873fe93fd0abe0832d858a17fe68c8fa507"},
+    {file = "lxml-4.8.0-pp37-pypy37_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:986b7a96228c9b4942ec420eff37556c5777bfba6758edcb95421e4a614b57f9"},
+    {file = "lxml-4.8.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6fe4ef4402df0250b75ba876c3795510d782def5c1e63890bde02d622570d39e"},
+    {file = "lxml-4.8.0-pp38-pypy38_pp73-macosx_10_14_x86_64.whl", hash = "sha256:f10ce66fcdeb3543df51d423ede7e238be98412232fca5daec3e54bcd16b8da0"},
+    {file = "lxml-4.8.0-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:730766072fd5dcb219dd2b95c4c49752a54f00157f322bc6d71f7d2a31fecd79"},
+    {file = "lxml-4.8.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:8b99ec73073b37f9ebe8caf399001848fced9c08064effdbfc4da2b5a8d07b93"},
+    {file = "lxml-4.8.0.tar.gz", hash = "sha256:f63f62fc60e6228a4ca9abae28228f35e1bd3ce675013d1dfb828688d50c6e23"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
@@ -4419,8 +4456,8 @@ platformdirs = [
     {file = "platformdirs-2.5.0.tar.gz", hash = "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"},
 ]
 plotly = [
-    {file = "plotly-4.14.3-py2.py3-none-any.whl", hash = "sha256:d68fc15fcb49f88db27ab3e0c87110943e65fee02a47f33a8590f541b3042461"},
-    {file = "plotly-4.14.3.tar.gz", hash = "sha256:7d8aaeed392e82fb8e0e48899f2d3d957b12327f9d38cdd5802bc574a8a39d91"},
+    {file = "plotly-5.6.0-py2.py3-none-any.whl", hash = "sha256:20277d211ea0e00e2a86d31e9f865a1ab45a7b17576f3bb865992ecbf15db093"},
+    {file = "plotly-5.6.0.tar.gz", hash = "sha256:d86e44ebde38f4753dff982ab9b5e03cf872aab8fdf53a403e999ed378154331"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -4653,8 +4690,8 @@ python-dotenv = [
     {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
 ]
 python-slugify = [
-    {file = "python-slugify-5.0.2.tar.gz", hash = "sha256:f13383a0b9fcbe649a1892b9c8eb4f8eab1d6d84b84bb7a624317afa98159cab"},
-    {file = "python_slugify-5.0.2-py2.py3-none-any.whl", hash = "sha256:6d8c5df75cd4a7c3a2d21e257633de53f52ab0265cd2d1dc62a730e8194a7380"},
+    {file = "python-slugify-6.0.1.tar.gz", hash = "sha256:ba72aa9d9f0514c0c3dd4430442f698ccc27a24d19630473663a71e3ec606bc1"},
+    {file = "python_slugify-6.0.1-py2.py3-none-any.whl", hash = "sha256:89eec682c5180ba64811c9906a28184bbcc0a35792ba1bda3b5c2ab0cb2d0f67"},
 ]
 pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
@@ -4894,9 +4931,6 @@ requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
-retrying = [
-    {file = "retrying-1.3.3.tar.gz", hash = "sha256:08c039560a6da2fe4f2c426d0766e284d3b736e355f8dd24b37367b0bb41973b"},
-]
 rx = [
     {file = "Rx-3.2.0-py3-none-any.whl", hash = "sha256:922c5f4edb3aa1beaa47bf61d65d5380011ff6adcd527f26377d05cb73ed8ec8"},
     {file = "Rx-3.2.0.tar.gz", hash = "sha256:b657ca2b45aa485da2f7dcfd09fac2e554f7ac51ff3c2f8f2ff962ecd963d91c"},
@@ -5087,6 +5121,10 @@ tabulate = [
     {file = "tabulate-0.8.9-py3-none-any.whl", hash = "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4"},
     {file = "tabulate-0.8.9.tar.gz", hash = "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"},
 ]
+tenacity = [
+    {file = "tenacity-8.0.1-py3-none-any.whl", hash = "sha256:f78f4ea81b0fabc06728c11dc2a8c01277bfc5181b321a4770471902e3eb844a"},
+    {file = "tenacity-8.0.1.tar.gz", hash = "sha256:43242a20e3e73291a28bcbcacfd6e000b02d3857a9a9fff56b297a27afdc932f"},
+]
 terminado = [
     {file = "terminado-0.13.1-py3-none-any.whl", hash = "sha256:f446b522b50a7aa68b5def0a02893978fb48cb82298b0ebdae13003c6ee6f198"},
     {file = "terminado-0.13.1.tar.gz", hash = "sha256:5b82b5c6e991f0705a76f961f43262a7fb1e55b093c16dca83f16384a7f39b7b"},
@@ -5238,6 +5276,10 @@ validators = [
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+webdriver-manager = [
+    {file = "webdriver_manager-3.5.3-py2.py3-none-any.whl", hash = "sha256:ef4320064bec22df5b2d7ea0509d08a99d3cecd1ddabd190f26f871dfa52a362"},
+    {file = "webdriver_manager-3.5.3.tar.gz", hash = "sha256:33c86736c51839abdcdeed1bbfd1f0d55277411bae4f232fdc9ace0c518e04f4"},
 ]
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,9 +128,9 @@ uvicorn                         = { version = "^0.14", optional = true }
 wradlib                         = { version = "^1.13", optional = true }
 
 # Explorer UI service
-plotly                          = { version = "^4.14", optional = true }
-dash                            = { version = "^1.19", optional = true }
-dash-bootstrap-components       = { version = "^0.12", optional = true }
+plotly                          = { version = "^5.0", optional = true }
+dash                            = { version = "^2.0", optional = true }
+dash-bootstrap-components       = { version = "^1.0", optional = true }
 
 sphinx = { version = "^3.2", optional = true }
 sphinx-material = { version = "^0.0.30", optional = true }
@@ -187,6 +187,7 @@ pybufrkit = "^0.2"
 selenium = "^3.141"
 percy = "^2.0"
 h5py = "^3.1"
+webdriver-manager = "^3.5.3"
 
 # Coverage
 coverage = { version = "^5.3", extras = ["toml"] }

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,14 +19,16 @@ black==21.12b0; python_full_version >= "3.6.2"
 bleach==4.1.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 cached-property==1.5.2; python_version < "3.8" and python_version >= "3.7"
 cachetools==4.2.4; python_version >= "3.5" and python_version < "4.0"
-certifi==2021.10.8; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.5"
+certifi==2021.10.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 cffi==1.15.0; python_full_version >= "3.6.1" and python_version >= "3.7" and implementation_name == "pypy"
 charset-normalizer==2.0.12; python_full_version >= "3.6.0" and python_version >= "3.6"
 click-params==0.1.2; python_version >= "3.6" and python_version < "4.0"
 click==8.0.3; python_version >= "3.6"
 cloup==0.8.2; python_version >= "3.6"
 colorama==0.4.4; python_full_version >= "3.6.2" and platform_system == "Windows" and python_version >= "3.6" and sys_platform == "win32" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and python_version < "4.0" and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") or sys_platform == "win32" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6") and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
+configparser==5.2.0; python_version >= "3.6"
 coverage==5.5; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0" and python_version < "4")
+crayons==0.4.0; python_version >= "3.6"
 dateparser==1.1.0; python_version >= "3.5"
 decorator==5.1.1; python_version >= "3.6" and python_version < "4.0"
 defusedxml==0.7.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
@@ -76,7 +78,7 @@ jupyter-core==4.9.2; python_full_version >= "3.6.1" and python_version >= "3.7" 
 jupyter-server-mathjax==0.2.4; python_version >= "3.7"
 jupyter-server==1.13.5; python_version >= "3.7"
 livereload==2.6.3; python_version >= "3.6"
-lxml==4.7.1; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
+lxml==4.8.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 markupsafe==2.0.1; python_version >= "3.6"
 marshmallow==3.14.1; python_version >= "3.6"
 mccabe==0.6.1; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and python_version >= "3.7" and python_version < "4.0"
@@ -170,8 +172,9 @@ typing-extensions==4.1.1
 tzdata==2021.5; platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 tzlocal==4.1; python_version >= "3.6"
 untokenize==0.1.1
-urllib3==1.26.8; python_full_version >= "3.6.2" and python_version < "4" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.5")
+urllib3==1.26.8; python_full_version >= "3.6.2" and python_version < "4" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version < "4") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6")
 validators==0.18.2; python_version >= "3.6" and python_version < "4.0"
+webdriver-manager==3.5.3; python_version >= "3.6"
 webencodings==0.5.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 websocket-client==1.2.3; python_version >= "3.7"
 yarl==1.7.2; python_version >= "3.6"

--- a/tests/ui/explorer/test_explorer.py
+++ b/tests/ui/explorer/test_explorer.py
@@ -76,10 +76,29 @@ def test_app_data_stations_failed(wetterdienst_ui, dash_tre):
     """
     Verify if data for "stations" has been correctly propagated.
     """
+    # Select provider.
+    dash_tre.wait_for_element_by_id("select-provider")
+    dash_tre.select_dcc_dropdown("#select-provider", value="DWD")
+
+    # Select network.
+    dash_tre.wait_for_element_by_id("select-network")
+    dash_tre.select_dcc_dropdown("#select-network", value="OBSERVATION")
+
+    # Select resolution.
+    dash_tre.wait_for_element_by_id("select-resolution")
+    dash_tre.select_dcc_dropdown("#select-resolution", value="DAILY")
+
+    # Select dataset.
+    dash_tre.wait_for_element_by_id("select-dataset")
+    dash_tre.select_dcc_dropdown("#select-dataset", value="CLIMATE_SUMMARY")
 
     # Select parameter.
     dash_tre.wait_for_element_by_id("select-parameter")
-    dash_tre.select_dcc_dropdown("#select-parameter", value="extreme_wind")
+    dash_tre.select_dcc_dropdown("#select-parameter", value="PRECIPITATION_HEIGHT")
+
+    # Select period.
+    dash_tre.wait_for_element_by_id("select-period")
+    dash_tre.select_dcc_dropdown("#select-period", value="NOW")
 
     # Wait for data element.
     dash_tre.wait_for_element_by_id("dataframe-stations", timeout=5)
@@ -89,7 +108,49 @@ def test_app_data_stations_failed(wetterdienst_ui, dash_tre):
     dash_tre.wait_for_contains_text("#status-response-stations", "No data", timeout=2)
     dash_tre.wait_for_contains_text("#status-response-values", "No data", timeout=2)
     dash_tre.wait_for_contains_text("#map", "No data to display", timeout=2)
-    dash_tre.wait_for_contains_text("#graph", "No variable selected", timeout=2)
+
+
+@pytest.mark.slow
+@pytest.mark.cflake
+@pytest.mark.explorer
+def test_options_reset(wetterdienst_ui, dash_tre):
+    """
+    Verify if data for "stations" has been correctly propagated.
+    """
+    # Select provider.
+    dash_tre.wait_for_element_by_id("select-provider")
+    dash_tre.select_dcc_dropdown("#select-provider", value="DWD")
+
+    # Select network.
+    dash_tre.wait_for_element_by_id("select-network")
+    dash_tre.select_dcc_dropdown("#select-network", value="OBSERVATION")
+
+    # Select resolution.
+    dash_tre.wait_for_element_by_id("select-resolution")
+    dash_tre.select_dcc_dropdown("#select-resolution", value="DAILY")
+
+    # Select dataset.
+    dash_tre.wait_for_element_by_id("select-dataset")
+    dash_tre.select_dcc_dropdown("#select-dataset", value="CLIMATE_SUMMARY")
+
+    # Select parameter.
+    dash_tre.wait_for_element_by_id("select-parameter")
+    dash_tre.select_dcc_dropdown("#select-parameter", value="PRECIPITATION_HEIGHT")
+
+    # Select period.
+    dash_tre.wait_for_element_by_id("select-period")
+    dash_tre.select_dcc_dropdown("#select-period", value="HISTORICAL")
+
+    # Set another provider
+    dash_tre.wait_for_element_by_id("select-provider")
+    dash_tre.select_dcc_dropdown("#select-provider", value="ECCC")
+
+    # Check other options for reset
+    dash_tre.wait_for_contains_text("#select-network", "")
+    dash_tre.wait_for_contains_text("#select-resolution", "")
+    dash_tre.wait_for_contains_text("#select-dataset", "")
+    dash_tre.wait_for_contains_text("#select-parameter", "")
+    dash_tre.wait_for_contains_text("#select-period", "")
 
 
 @pytest.mark.slow
@@ -99,36 +160,43 @@ def test_app_data_values(wetterdienst_ui, dash_tre):
     """
     Verify if data for "values" has been correctly propagated.
     """
+    # Select provider.
+    dash_tre.wait_for_element_by_id("select-provider")
+    dash_tre.select_dcc_dropdown("#select-provider", value="DWD")
+
+    # Select network.
+    dash_tre.wait_for_element_by_id("select-network")
+    dash_tre.select_dcc_dropdown("#select-network", value="OBSERVATION")
+
+    # Select resolution.
+    dash_tre.wait_for_element_by_id("select-resolution")
+    dash_tre.select_dcc_dropdown("#select-resolution", value="HOURLY")
+
+    # Select dataset.
+    dash_tre.wait_for_element_by_id("select-dataset")
+    dash_tre.select_dcc_dropdown("#select-dataset", value="TEMPERATURE_AIR")
+    time.sleep(0.5)
 
     # Select parameter.
     dash_tre.wait_for_element_by_id("select-parameter")
-    dash_tre.select_dcc_dropdown("#select-parameter", value="air_temperature")
-
-    # Select time resolution.
-    dash_tre.wait_for_element_by_id("select-resolution")
-    dash_tre.select_dcc_dropdown("#select-resolution", value="hourly")
+    dash_tre.select_dcc_dropdown("#select-parameter", value="TEMPERATURE_AIR_MEAN_200")
 
     # Select period.
     dash_tre.wait_for_element_by_id("select-period")
-    dash_tre.select_dcc_dropdown("#select-period", value="recent")
+    dash_tre.select_dcc_dropdown("#select-period", value="RECENT")
 
     # Select weather station.
     dash_tre.wait_for_element_by_id("select-station")
     dash_tre.select_dcc_dropdown("#select-station", value="Anklam")
     time.sleep(0.5)
 
-    # Select variable.
-    dash_tre.wait_for_element_by_id("select-variable")
-    dash_tre.wait_for_element_by_id_clickable("select-variable")
-    dash_tre.select_dcc_dropdown("#select-variable", value="temperature_air_200")
-    time.sleep(0.25)
-
     # Wait for data element.
     dash_tre.wait_for_element_by_id("dataframe-values")
+    time.sleep(0.5)
 
     # Wait for status element.
-    dash_tre.wait_for_contains_text("#status-response", "Records", timeout=2)
-    dash_tre.wait_for_contains_text("#status-response", "Begin date", timeout=2)
+    dash_tre.wait_for_contains_text("#status-response", "Records", timeout=20)
+    dash_tre.wait_for_contains_text("#status-response", "Begin date", timeout=20)
 
     # Read payload from data element.
     dom: BeautifulSoup = dash_tre.dash_innerhtml_dom
@@ -136,12 +204,5 @@ def test_app_data_values(wetterdienst_ui, dash_tre):
     data = json.loads(data_element.text)
 
     # Verify data.
-    assert data["columns"] == [
-        "station_id",
-        "dataset",
-        "date",
-        "qn_9",
-        "temperature_air_mean_200",
-        "humidity",
-    ]
+    assert data["columns"] == ["station_id", "dataset", "parameter", "date", "value"]
     assert len(data["data"]) == 13200

--- a/wetterdienst/ui/explorer/app.py
+++ b/wetterdienst/ui/explorer/app.py
@@ -9,22 +9,15 @@ from typing import Optional
 
 import dash
 import dash_bootstrap_components as dbc
-import dash_core_components as dcc
-import dash_html_components as html
 import pandas as pd
 import plotly.graph_objects as go
 import requests
-from dash.dependencies import Input, Output, State
+from dash import Input, Output, State, dcc, html
 
-from wetterdienst import Settings
+from wetterdienst.api import ApiEndpoints
 from wetterdienst.exceptions import InvalidParameterCombination
 from wetterdienst.metadata.columns import Columns
-from wetterdienst.provider.dwd.observation import (
-    DwdObservationDataset,
-    DwdObservationPeriod,
-    DwdObservationRequest,
-    DwdObservationResolution,
-)
+from wetterdienst.ui.core import get_stations, get_values
 from wetterdienst.ui.explorer.layout.main import get_app_layout
 from wetterdienst.ui.explorer.library import add_annotation_no_data, default_figure
 from wetterdienst.ui.explorer.util import frame_summary
@@ -58,12 +51,15 @@ def toggle_about(n1, n2, is_open):
 @app.callback(
     Output("dataframe-stations", "children"),
     [
-        Input("select-parameter", "value"),
+        Input("select-provider", "value"),
+        Input("select-network", "value"),
         Input("select-resolution", "value"),
+        Input("select-dataset", "value"),
+        Input("select-parameter", "value"),
         Input("select-period", "value"),
     ],
 )
-def fetch_stations(parameter: str, resolution: str, period: str):
+def fetch_stations(provider: str, network: str, resolution: str, dataset: str, parameter: str, period: str):
     """
     Fetch "stations" data.
 
@@ -71,16 +67,38 @@ def fetch_stations(parameter: str, resolution: str, period: str):
 
     The data will be stored on a hidden within the browser DOM.
     """
-    log.info(f"Requesting stations for " f"parameter={parameter}, " f"resolution={resolution}, " f"period={period}")
+    if not (provider and network and resolution and dataset and parameter and period):
+        return empty_frame
+
+    api = ApiEndpoints[provider][network].value
+
+    if period == "ALL":
+        period = [*api._period_base]
+
+    log.info(f"Requesting stations for parameter={parameter}, resolution={resolution}, period={period}")
+
     try:
-        stations = DwdObservationRequest(
-            parameter=DwdObservationDataset(parameter),
-            resolution=DwdObservationResolution(resolution),
-            period=DwdObservationPeriod(period),
-        ).all()
+        stations = get_stations(
+            api=api,
+            parameter=parameter,
+            resolution=resolution,
+            period=period,
+            date=None,
+            issue="latest",
+            all_=True,
+            station_id=None,
+            name=None,
+            coordinates=None,
+            rank=None,
+            distance=None,
+            bbox=None,
+            sql=None,
+            si_units=True,
+            tidy=True,
+            humanize=True,
+        )
     except (requests.exceptions.ConnectionError, InvalidParameterCombination) as ex:
         log.warning(ex)
-        # raise PreventUpdate
         log.error("Unable to connect to data source")
         return empty_frame
 
@@ -94,13 +112,18 @@ def fetch_stations(parameter: str, resolution: str, period: str):
 @app.callback(
     Output("dataframe-values", "children"),
     [
-        Input("select-parameter", "value"),
+        Input("select-provider", "value"),
+        Input("select-network", "value"),
         Input("select-resolution", "value"),
+        Input("select-dataset", "value"),
+        Input("select-parameter", "value"),
         Input("select-period", "value"),
         Input("select-station", "value"),
     ],
 )
-def fetch_values(parameter: str, resolution: str, period: str, station_id: int):
+def fetch_values(
+    provider: str, network: str, resolution: str, dataset: str, parameter: str, period: str, station_id: int
+):
     """
     Fetch "values" data.
 
@@ -108,36 +131,51 @@ def fetch_values(parameter: str, resolution: str, period: str, station_id: int):
 
     The data will be stored on a hidden within the browser DOM.
     """
+    if not (provider and network and resolution and dataset and parameter and period):
+        return empty_frame
 
     # Sanity checks.
     if station_id is None:
         log.warning("Querying without station_id is rejected")
         return empty_frame
 
+    api = ApiEndpoints[provider][network].value
+
+    if period == "ALL":
+        period = [*api._period_base]
+
     log.info(
-        f"Requesting values for "
-        f"station_id={station_id}, "
-        f"parameter={parameter}, "
-        f"resolution={resolution}, "
+        f"Requesting values for station_id={station_id}, parameter={parameter}, resolution={resolution}, "
         f"period={period}"
     )
 
-    Settings.tidy = False
-    Settings.humanize = True
-
-    stations = DwdObservationRequest(
-        parameter=DwdObservationDataset(parameter),
-        resolution=DwdObservationResolution(resolution),
-        period=DwdObservationPeriod(period),
-    ).filter_by_station_id(station_id=(str(station_id),))
-
     try:
-        df = stations.values.all().df
+        values = get_values(
+            api=api,
+            parameter=parameter,
+            resolution=resolution,
+            period=period,
+            date=None,
+            issue="latest",
+            all_=None,
+            station_id=station_id,
+            name=None,
+            coordinates=None,
+            rank=None,
+            distance=None,
+            bbox=None,
+            sql=None,
+            sql_values=None,
+            si_units=True,
+            tidy=True,
+            humanize=True,
+        )
+        df = values.df
     except ValueError:
         log.exception("No data received")
         return empty_frame
 
-    df = df.dropna(axis=0)
+    df = df.drop(columns="quality").dropna(axis=0)
 
     log.info(f"Propagating values data frame with {frame_summary(df)}")
 
@@ -169,52 +207,37 @@ def render_navigation_stations(payload):
 
 
 @app.callback(
-    Output("select-variable", "options"),
-    [Input("dataframe-values", "children")],
-)
-def render_navigation_variables(payload):
-    """
-    Compute list of items from "values" data for populating the "variables"
-    chooser element.
-    """
-    climate_data = pd.read_json(payload, orient="split")
-    log.info(f"Rendering variable dropdown from {frame_summary(climate_data)}")
-
-    # Build list of columns to be selectable.
-    columns = []
-    for column in climate_data.columns:
-
-        # Skip some columns.
-        if column in ["station_id", "date"]:
-            continue
-
-        columns.append({"label": column, "value": column})
-
-    return columns
-
-
-@app.callback(
     Output("status-response-stations", "children"),
     [
-        Input("select-parameter", "value"),
+        Input("select-provider", "value"),
+        Input("select-network", "value"),
         Input("select-resolution", "value"),
+        Input("select-dataset", "value"),
+        Input("select-parameter", "value"),
         Input("select-period", "value"),
         Input("dataframe-stations", "children"),
     ],
 )
-def render_status_response_stations(parameter: str, resolution: str, period: str, payload: str):
+def render_status_response_stations(
+    provider: str, network: str, resolution: str, dataset: str, parameter: str, period: str, payload: str
+):
     """
     Report about the status of the query.
     """
 
     title = [dcc.Markdown("#### Stations")]
 
+    if not (provider and network and resolution and dataset and parameter and period):
+        empty_message = [dcc.Markdown("Choose from provider, network, resolution, dataset,  parameter and period.")]
+
+        return title + empty_message
+
     empty_message = [
         dcc.Markdown(
             f"""
-No data.
-Maybe the combination of "{parameter}", "{resolution}" and "{period}" is invalid.
-    """
+            No data. Maybe the combination of "{resolution}", "{dataset}", "{parameter}" and "{period}"
+            is invalid for provider "{provider}" and network "{network}".
+            """
         )
     ]
 
@@ -240,20 +263,24 @@ Maybe the combination of "{parameter}", "{resolution}" and "{period}" is invalid
     Output("status-response-values", "children"),
     [
         Input("dataframe-values", "children"),
-        State("select-parameter", "value"),
+        State("select-provider", "value"),
+        State("select-network", "value"),
         State("select-resolution", "value"),
+        State("select-dataset", "value"),
+        State("select-parameter", "value"),
         State("select-period", "value"),
         State("select-station", "value"),
-        State("select-variable", "value"),
     ],
 )
 def render_status_response_values(
     payload: str,
-    parameter: str,
+    provider: str,
+    network: str,
     resolution: str,
+    dataset: str,
+    parameter: str,
     period: str,
     station: str,
-    variable: str,
 ):
     """
     Report about the status of the query.
@@ -267,7 +294,7 @@ def render_status_response_values(
         # Main message.
         empty_message = [html.Span("No data. ")]
 
-        candidates = ["parameter", "resolution", "period", "station", "variable"]
+        candidates = ["provider", "network", "resolution", "dataset", "parameter", "period", "station"]
         missing = []
         for candidate in candidates:
             if locals().get(candidate) is None:
@@ -353,10 +380,9 @@ def render_map(payload):
 
 @app.callback(
     Output("graph-values", "figure"),
-    [Input("select-variable", "value")],
-    [Input("dataframe-values", "children")],
+    [Input("select-parameter", "value"), Input("dataframe-values", "children")],
 )
-def render_graph(variable, payload):
+def render_graph(parameter, payload):
     """
     Create a "graph" Figure element from "values" data.
     """
@@ -366,9 +392,9 @@ def render_graph(variable, payload):
     except ValueError:
         climate_data = pd.DataFrame()
 
-    log.info(f"Rendering graph for variable={variable} from {frame_summary(climate_data)}")
+    log.info(f"Rendering graph for parameter={parameter} from {frame_summary(climate_data)}")
 
-    fig = default_figure(climate_data, variable)
+    fig = default_figure(climate_data, parameter)
 
     fig.update_layout(
         margin=go.layout.Margin(
@@ -380,6 +406,140 @@ def render_graph(variable, payload):
     )
 
     return fig
+
+
+@app.callback(Output("select-network", "options"), Input("select-provider", "value"))
+def set_network_options(provider):
+    """Set network options based on provider"""
+    if not provider:
+        return []
+
+    return [{"label": network.name, "value": network.name} for network in ApiEndpoints[provider]]
+
+
+@app.callback(
+    Output("select-resolution", "options"),
+    [
+        Input("select-provider", "value"),
+        Input("select-network", "value"),
+    ],
+)
+def set_resolution_options(provider, network):
+    """Set resolution options based on provider and network"""
+    if not (provider and network):
+        return []
+
+    api = ApiEndpoints[provider][network].value
+
+    return [{"label": resolution.name, "value": resolution.name} for resolution in api._resolution_base]
+
+
+@app.callback(
+    Output("select-dataset", "options"),
+    [
+        Input("select-provider", "value"),
+        Input("select-network", "value"),
+        Input("select-resolution", "value"),
+    ],
+)
+def set_dataset_options(provider, network, resolution):
+    """Set dataset options based on provider network and resolution"""
+    if not (provider and network and resolution):
+        return []
+
+    api = ApiEndpoints[provider][network].value
+
+    if api._has_datasets and not api._unique_dataset:
+        # first dataset is placeholder for unique dataset with parameters combined from all datasets
+        datasets = [{"label": resolution, "value": resolution}]
+        for dataset in api._dataset_tree[resolution]:
+            datasets.append({"label": dataset, "value": dataset})
+        return datasets
+    else:
+        return [{"label": resolution, "value": resolution}]
+
+
+@app.callback(
+    [
+        Output("select-parameter", "options"),
+        Output("select-period", "options"),
+    ],
+    [
+        Input("select-provider", "value"),
+        Input("select-network", "value"),
+        Input("select-resolution", "value"),
+        Input("select-dataset", "value"),
+    ],
+)
+def set_parameter_options(provider, network, resolution, dataset):
+    """Set parameter options based on provider, network, resolution and dataset"""
+    if not (provider and network and resolution and dataset):
+        return [], []
+
+    api = ApiEndpoints[provider][network].value
+
+    if api._has_datasets and not api._unique_dataset:
+        if dataset == resolution:
+            # Return tidy parameters e.g. parameters grouped under one resolution
+            parameters = [
+                {"label": parameter.name, "value": parameter.name} for parameter in api._parameter_base[resolution]
+            ]
+        else:
+            # return individual parameters of one dataset e.g. climate_summary
+            parameters = [
+                {"label": parameter.name, "value": parameter.name}
+                for parameter in api._dataset_tree[resolution][dataset]
+            ]
+    else:
+        # If network only provides parameters but not datasets, just return them all as option
+        parameters = [{"label": parameter.name, "value": parameter.name} for parameter in api._dataset_tree[resolution]]
+
+    # Periods ALL placeholder, may use click options for multiple periods
+    periods = [{"label": "ALL", "value": "ALL"}]
+    for period in api._period_base:
+        periods.append({"label": period.name, "value": period.name})
+
+    return parameters, periods
+
+
+@app.callback(
+    [
+        Output("select-network", "value"),
+        Output("select-resolution", "value"),
+        Output("select-dataset", "value"),
+        Output("select-parameter", "value"),
+        Output("select-period", "value"),
+    ],
+    [
+        Input("select-provider", "value"),
+        Input("select-network", "value"),
+        Input("select-resolution", "value"),
+        Input("select-dataset", "value"),
+        Input("select-parameter", "value"),
+        Input("select-period", "value"),
+    ],
+)
+def reset_values(provider, network, resolution, dataset, parameter, period):
+    """Reset settings values if any previous parameter has been changed e.g.
+    when a new provider is selected, reset network, resolution, etc"""
+    last_triggered = dash.callback_context.triggered[0]["prop_id"].split(".")[0]
+
+    previous = ("select-provider", "select-network", "select-resolution", "select-dataset")
+
+    if last_triggered in previous[:1]:
+        network = None
+
+    if last_triggered in previous[:2]:
+        resolution = None
+
+    if last_triggered in previous[:3]:
+        dataset = None
+
+    if last_triggered in previous:
+        parameter = None
+        period = None
+
+    return network, resolution, dataset, parameter, period
 
 
 def start_service(listen_address: Optional[str] = None, reload: Optional[bool] = False):  # pragma: no cover
@@ -394,7 +554,8 @@ def start_service(listen_address: Optional[str] = None, reload: Optional[bool] =
 
     host, port = listen_address.split(":")
     port = int(port)
-    app.server.run(host=host, port=port, debug=reload)
+
+    app.run_server(host=host, port=port, debug=reload)
 
 
 if __name__ == "__main__":

--- a/wetterdienst/ui/explorer/layout/main.py
+++ b/wetterdienst/ui/explorer/layout/main.py
@@ -5,8 +5,7 @@
 Wetterdienst Explorer UI layout.
 """
 import dash_bootstrap_components as dbc
-import dash_core_components as dcc
-import dash_html_components as html
+from dash import dcc, html
 
 from wetterdienst.ui.explorer.layout.observations_germany import dashboard_layout
 

--- a/wetterdienst/ui/explorer/layout/observations_germany.py
+++ b/wetterdienst/ui/explorer/layout/observations_germany.py
@@ -1,31 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
-import operator
+from dash import dcc, html
 
-import dash_core_components as dcc
-import dash_html_components as html
-
-from wetterdienst.provider.dwd.observation import (
-    DwdObservationDataset,
-    DwdObservationPeriod,
-    DwdObservationResolution,
-)
+from wetterdienst.api import ApiEndpoints
 
 
-def get_parameters():
-    return sorted(
-        [{"label": param.value, "value": param.value} for param in DwdObservationDataset],
-        key=operator.itemgetter("label"),
-    )
-
-
-def get_resolutions():
-    return [{"label": param.value, "value": param.value} for param in DwdObservationResolution]
-
-
-def get_periods():
-    return [{"label": param.value, "value": param.value} for param in DwdObservationPeriod]
+def get_providers():
+    return [{"label": provider, "value": provider} for provider in ApiEndpoints]
 
 
 def dashboard_layout() -> html:
@@ -38,42 +20,55 @@ def dashboard_layout() -> html:
                 [
                     html.Div(
                         [
-                            html.Div("Parameter:"),
+                            html.Div("Provider:"),
                             dcc.Dropdown(
-                                id="select-parameter",
-                                options=get_parameters(),
-                                value=DwdObservationDataset.TEMPERATURE_AIR.value,
+                                id="select-provider",
+                                options=get_providers(),
+                                value=None,
+                                multi=False,
+                                className="dcc_control",
+                            ),
+                            html.Div("Network:"),
+                            dcc.Dropdown(
+                                id="select-network",
+                                value=None,
                                 multi=False,
                                 className="dcc_control",
                             ),
                             html.Div("Resolution:"),
                             dcc.Dropdown(
                                 id="select-resolution",
-                                options=get_resolutions(),
-                                value=DwdObservationResolution.HOURLY.value,
+                                value=None,
+                                multi=False,
+                                className="dcc_control",
+                            ),
+                            html.Div("Dataset:"),
+                            dcc.Dropdown(
+                                id="select-dataset",
+                                value=None,
+                                multi=False,
+                                className="dcc_control",
+                            ),
+                            html.Div("Parameter:"),
+                            dcc.Dropdown(
+                                id="select-parameter",
+                                value=None,
                                 multi=False,
                                 className="dcc_control",
                             ),
                             html.Div("Period:"),
                             dcc.Dropdown(
                                 id="select-period",
-                                options=get_periods(),
-                                value=DwdObservationPeriod.RECENT.value,
+                                value=None,
                                 multi=False,
                                 className="dcc_control",
                             ),
                             html.Div("Station:"),
-                            dcc.Dropdown(
-                                id="select-station",
-                                multi=False,
-                                className="dcc_control",
-                            ),
-                            html.Div("Variable:"),
                             dcc.Loading(
                                 id="loading-1",
                                 children=[
                                     dcc.Dropdown(
-                                        id="select-variable",
+                                        id="select-station",
                                         multi=False,
                                         className="dcc_control",
                                     ),

--- a/wetterdienst/ui/explorer/library.py
+++ b/wetterdienst/ui/explorer/library.py
@@ -20,26 +20,12 @@ def default_figure(climate_data: pd.DataFrame, column: str) -> go.Figure:
     Returns:
         plotly Figure object
     """
-
-    # Create a placeholder figure for empty data.
-    # https://community.plotly.com/t/replacing-an-empty-graph-with-a-message/31497/2
-    if column is None:
-        fig = go.Figure()
-        fig.add_annotation(
-            text="No variable selected",
-            xref="paper",
-            yref="paper",
-            showarrow=False,
-            font={"size": 28},
-        )
-        return fig
-
     if climate_data.empty:
         fig = go.Figure()
         add_annotation_no_data(fig)
         return fig
 
-    fig = go.Figure(data=[go.Scatter(x=climate_data.date, y=climate_data.loc[:, column], hoverinfo="x+y")])
+    fig = go.Figure(data=[go.Scatter(x=climate_data.date, y=climate_data.value, hoverinfo="x+y")])
     fig.update_layout(yaxis={"title": f"{column}"}, showlegend=False)
     return fig
 


### PR DESCRIPTION
With #503, we added a provider adapter for NOAA GHCN. This patch adjusts Wetterdienst Explorer accordingly, in order to be able to select both `provider` and `network` as new parameters.