### PR TITLE
Add details about time interval for NOAA GHCN stations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 Development
 ***********
 
+- Fix missing station ids within values result
+- Add details about time interval for NOAA GHCN stations
+
 0.26.0 (06.02.2022)
 *******************
 

--- a/tests/provider/eccc/test_api.py
+++ b/tests/provider/eccc/test_api.py
@@ -26,7 +26,7 @@ def test_eccc_api_stations():
         {
             "station_id": ["14"],
             "from_date": [pd.Timestamp("1984-01-01", tz=pytz.UTC)],
-            "to_date": [pd.Timestamp("1996-01-01", tz=pytz.UTC)],
+            "to_date": [pd.Timestamp("1996-12-31", tz=pytz.UTC)],
             "height": [4.0],
             "latitude": [48.87],
             "longitude": [-123.28],

--- a/tests/provider/noaa/ghcn/test_api_stations.py
+++ b/tests/provider/noaa/ghcn/test_api_stations.py
@@ -6,6 +6,7 @@ from wetterdienst.provider.noaa.ghcn import NoaaGhcnRequest
 
 def test_noaa_ghcn_stations():
     df = NoaaGhcnRequest("daily").all().df.iloc[:5, :]
+
     df_expected = pd.DataFrame(
         {
             "station_id": [
@@ -15,8 +16,24 @@ def test_noaa_ghcn_stations():
                 "AEM00041194",
                 "AEM00041217",
             ],
-            "from_date": pd.to_datetime([pd.NaT] * 5, utc=True),
-            "to_date": pd.to_datetime([pd.NaT] * 5, utc=True),
+            "from_date": pd.to_datetime(
+                [
+                    "1949-01-01 00:00:00+00:00",
+                    "1957-01-01 00:00:00+00:00",
+                    "1944-01-01 00:00:00+00:00",
+                    "1983-01-01 00:00:00+00:00",
+                    "1983-01-01 00:00:00+00:00",
+                ]
+            ),
+            "to_date": pd.to_datetime(
+                [
+                    "1949-12-31 00:00:00+00:00",
+                    "1970-12-31 00:00:00+00:00",
+                    "2022-12-31 00:00:00+00:00",
+                    "2022-12-31 00:00:00+00:00",
+                    "2022-12-31 00:00:00+00:00",
+                ]
+            ),
             "height": [10.1, 19.2, 34.0, 10.4, 26.8],
             "latitude": [17.1167, 17.1333, 25.333, 25.255, 24.433],
             "longitude": [-61.7833, -61.7833, 55.517, 55.364, 54.651],

--- a/wetterdienst/provider/dwd/mosmix/api.py
+++ b/wetterdienst/provider/dwd/mosmix/api.py
@@ -328,19 +328,6 @@ class DwdMosmixRequest(ScalarRequestCore):
 
     _url = "https://www.dwd.de/DE/leistungen/met_verfahren_mosmix/mosmix_stationskatalog.cfg?view=nasPublication"
 
-    _colspecs = [
-        (0, 5),
-        (6, 11),
-        (12, 17),
-        (18, 22),
-        (23, 44),
-        (45, 51),
-        (52, 58),
-        (59, 64),
-        (65, 71),
-        (72, 76),
-    ]
-
     @property
     def _dataset_accessor(self) -> str:
         """
@@ -487,7 +474,18 @@ class DwdMosmixRequest(ScalarRequestCore):
             StringIO(payload.decode(encoding="latin-1")),
             skiprows=4,
             skip_blank_lines=True,
-            colspecs=self._colspecs,
+            colspecs=[
+                (0, 5),
+                (6, 11),
+                (12, 17),
+                (18, 22),
+                (23, 44),
+                (45, 51),
+                (52, 58),
+                (59, 64),
+                (65, 71),
+                (72, 76),
+            ],
             na_values=["----"],
             header=None,
             dtype="str",
@@ -508,7 +506,6 @@ class DwdMosmixRequest(ScalarRequestCore):
 
         # Convert coordinates from degree minutes to decimal degrees
         df[Columns.LATITUDE.value] = df[Columns.LATITUDE.value].astype(float).apply(convert_dm_to_dd)
-
         df[Columns.LONGITUDE.value] = df[Columns.LONGITUDE.value].astype(float).apply(convert_dm_to_dd)
 
         return df.reindex(columns=self._base_columns)

--- a/wetterdienst/provider/eccc/observation/api.py
+++ b/wetterdienst/provider/eccc/observation/api.py
@@ -12,6 +12,7 @@ import pandas as pd
 import requests
 from fsspec.implementations.cached import WholeFileCacheFileSystem
 from fsspec.implementations.http import HTTPFileSystem
+from pandas._libs.tslibs.offsets import YearEnd
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
@@ -335,7 +336,11 @@ class EcccObservationRequest(ScalarRequestCore):
 
         df = df.drop(columns=["latitude", "longitude"])
 
-        return df.rename(columns=self._columns_mapping)
+        df = df.rename(columns=self._columns_mapping)
+
+        df[Columns.TO_DATE.value] = pd.to_datetime(df[Columns.TO_DATE.value]) + YearEnd()
+
+        return df
 
     @staticmethod
     def _download_stations() -> BytesIO:


### PR DESCRIPTION
Further data is added to the NOAA GHCN stations listing from http://noaa-ghcn-pds.s3.amazonaws.com/ghcnd-inventory.txt that contains start and end date of all elements of all stations.