### PR TITLE
Fix explorer to work with DWD Mosmix

### DIFF
--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -10849,7 +10849,7 @@ https://github.com/pickleshare/pickleshare
 UNKNOWN
 
 platformdirs
-2.5.0
+2.5.1
 MIT License
 UNKNOWN
 https://github.com/platformdirs/platformdirs

--- a/poetry.lock
+++ b/poetry.lock
@@ -1864,7 +1864,7 @@ test = ["docutils", "pytest-cov", "pytest-pycodestyle", "pytest-runner"]
 
 [[package]]
 name = "platformdirs"
-version = "2.5.0"
+version = "2.5.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
@@ -4438,8 +4438,8 @@ pip-licenses = [
     {file = "pip_licenses-3.5.3-py3-none-any.whl", hash = "sha256:59c148d6a03784bf945d232c0dc0e9de4272a3675acaa0361ad7712398ca86ba"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.5.0-py3-none-any.whl", hash = "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb"},
-    {file = "platformdirs-2.5.0.tar.gz", hash = "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"},
+    {file = "platformdirs-2.5.1-py3-none-any.whl", hash = "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"},
+    {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
 ]
 plotly = [
     {file = "plotly-5.6.0-py2.py3-none-any.whl", hash = "sha256:20277d211ea0e00e2a86d31e9f865a1ab45a7b17576f3bb865992ecbf15db093"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ pbr==5.8.1; python_version >= "3.7"
 percy==2.0.2
 pint==0.17; python_version >= "3.6"
 pip-licenses==3.5.3; python_version >= "3.6" and python_version < "4.0"
-platformdirs==2.5.0; python_version >= "3.7" and python_full_version >= "3.6.2"
+platformdirs==2.5.1; python_version >= "3.7" and python_full_version >= "3.6.2"
 pluggy==1.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 poethepoet==0.9.0; python_version >= "3.6" and python_version < "4.0"
 prometheus-client==0.13.1; python_version >= "3.7"

--- a/tests/ui/explorer/test_explorer.py
+++ b/tests/ui/explorer/test_explorer.py
@@ -208,3 +208,38 @@ def test_app_data_values(wetterdienst_ui, dash_tre):
     # Verify data.
     assert data["columns"] == ["station_id", "dataset", "parameter", "date", "value"]
     assert len(data["data"]) == 13200
+
+
+@pytest.mark.slow
+@pytest.mark.cflake
+@pytest.mark.explorer
+def test_dwd_mosmix_options(wetterdienst_ui, dash_tre):
+    """
+    Verify if data for "values" has been correctly propagated.
+    """
+    # Select provider.
+    dash_tre.wait_for_element_by_id("select-provider")
+    dash_tre.select_dcc_dropdown("#select-provider", value="DWD")
+
+    # Select network.
+    dash_tre.wait_for_element_by_id("select-network")
+    dash_tre.select_dcc_dropdown("#select-network", value="MOSMIX")
+
+    # Select resolution.
+    dash_tre.wait_for_element_by_id("select-resolution")
+    dash_tre.select_dcc_dropdown("#select-resolution", value="SMALL")
+
+    # Select dataset.
+    dash_tre.wait_for_element_by_id("select-dataset")
+    dash_tre.select_dcc_dropdown("#select-dataset", value="SMALL")
+    time.sleep(0.5)
+
+    # Select parameter.
+    dash_tre.wait_for_element_by_id("select-parameter")
+    dash_tre.select_dcc_dropdown("#select-parameter", value="TEMPERATURE_AIR_MEAN_200")
+    time.sleep(0.5)
+
+    # Select period.
+    dash_tre.wait_for_element_by_id("select-period")
+    dash_tre.select_dcc_dropdown("#select-period", value="FUTURE")
+    time.sleep(0.5)

--- a/wetterdienst/provider/dwd/mosmix/api.py
+++ b/wetterdienst/provider/dwd/mosmix/api.py
@@ -316,7 +316,7 @@ class DwdMosmixRequest(ScalarRequestCore):
     _resolution_type = ResolutionType.FIXED
     _resolution_base = Resolution  # use general Resolution for fixed Resolution
     _period_type = PeriodType.FIXED
-    _period_base = None
+    _period_base = Period.FUTURE
     _data_range = DataRange.FIXED
     _has_datasets = True
     _dataset_tree = DwdMosmixParameter

--- a/wetterdienst/ui/core.py
+++ b/wetterdienst/ui/core.py
@@ -12,7 +12,7 @@ from wetterdienst.core.scalar.result import StationsResult, ValuesResult
 from wetterdienst.metadata.datarange import DataRange
 from wetterdienst.metadata.period import PeriodType
 from wetterdienst.metadata.resolution import Resolution, ResolutionType
-from wetterdienst.provider.dwd.mosmix import DwdMosmixType
+from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
 from wetterdienst.settings import Settings
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 
@@ -95,7 +95,7 @@ def get_stations(
     start_date, end_date = None, None
     if date:
         # TODO: use rather network here
-        if api.provider == Provider.DWD and api.kind == Kind.FORECAST:
+        if api == DwdMosmixRequest:
             mosmix_type = DwdMosmixType[resolution.upper()]
 
             if mosmix_type == DwdMosmixType.SMALL:


### PR DESCRIPTION
The special case of DWD Mosmix which has no resolution but rather mosmix type was not taken into account by wetterdienst explorer. This PR fixes the issue and adds a test for the case.

Fixes #593 