### PR TITLE
Fix monthly and annual DWD observation data access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Fix monthly/annual data of DWD observations
+
 0.29.0 (27.02.2022)
 *******************
 


### PR DESCRIPTION
Monthly and annual data of DWD observations is fixed by dropping the "to_date" column leaving only the from date column as actual date column.

Fixes #603 