### PR TITLE
Optimize Docker images

### DIFF
--- a/.github/release/full/Dockerfile
+++ b/.github/release/full/Dockerfile
@@ -13,22 +13,21 @@ FROM python:3.8.8-slim as build-step
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
-RUN apt-get update
-
-
 # Install GDAL.
-RUN apt-get --yes install build-essential libgdal-dev libmariadbclient-dev git
+RUN apt-get update && \
+    apt-get --yes --no-install-recommends install build-essential libgdal-dev libmariadb-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 # Make sure you have numpy installed before you attempt to install the GDAL Python bindings.
 # https://gis.stackexchange.com/a/274328
-RUN pip install numpy
-RUN pip install GDAL==$(gdal-config --version)
+RUN pip install --no-cache-dir numpy
+RUN pip install --no-cache-dir GDAL==$(gdal-config --version)
 
 # Install wradlib.
-RUN pip install wradlib
+RUN pip --no-cache-dir install wradlib
 
 # Install database adapters
-RUN pip install mysqlclient
+RUN pip install --no-cache-dir mysqlclient
 
 
 # 2. Main
@@ -38,8 +37,9 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
 # Install libgdal.
-RUN apt-get update
-RUN apt-get --yes install libgdal20
+RUN apt-get update && \
+    apt-get --yes --no-install-recommends install libgdal20 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy build artefacts from first build step.
 COPY --from=build-step /usr/local/lib /usr/local/lib
@@ -50,7 +50,7 @@ COPY --from=build-step /usr/local/lib /usr/local/lib
 COPY dist/wetterdienst-*.whl /tmp/
 
 # Install latest wheel package.
-RUN pip install $(ls -c /tmp/wetterdienst-*-py3-none-any.whl)[sql,export,duckdb,influxdb,cratedb,mysql,postgresql,radar,bufr,restapi,explorer]
+RUN pip install --no-cache-dir $(ls -c /tmp/wetterdienst-*-py3-none-any.whl)[export,influxdb,cratedb,mysql,postgresql,radar,bufr,restapi,explorer]
 
 # Purge /tmp directory
 RUN rm /tmp/*

--- a/.github/release/standard/Dockerfile
+++ b/.github/release/standard/Dockerfile
@@ -3,14 +3,11 @@ FROM python:3.8.8-slim
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
-RUN apt-get update
-RUN apt-get --yes install git
-
 # Use "poetry build --format=wheel" to build wheel packages.
 COPY dist/wetterdienst-*.whl /tmp/
 
 # Install latest wheel package.
-RUN pip install $(ls -c /tmp/wetterdienst-*-py3-none-any.whl)[sql,export,restapi]
+RUN pip install --no-cache-dir $(ls -c /tmp/wetterdienst-*-py3-none-any.whl)[export,restapi]
 
 # Purge /tmp directory
 RUN rm /tmp/*


### PR DESCRIPTION
This PR reduces the size of the standard and full docker image

* Remove `sql` and `duckdb` for now since it causes problems
* Reduce the image size by removing apt/pip caches
* Removing `git` as it is not needed

Using Python 3.8.8 image both standard and full build fine on amd64 but crash on arm64.


I tried to update Python 3.8.8 to the newest Python 3.8 or Python 3.9 version which also changes the Debian version from 10 (buster) to 11 (bullseye). The following apt adjustments are needed then:
* Changing `libmariadbclient-dev` to `libmariadb-dev`
* `libgdal20` to `libgdal28`

Unfortunately the pip installation of gdal crahes then.