### PR TITLE
Fix EcccObservationResolution typo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Development
 
 - Fix acquisition of DWD weather phenomena data
 - Set default encoding when reading data from DWD with pandas to 'latin1'
+- Fix typo in `EcccObservationResolution`
 
 0.32.4 (14.05.2022)
 *******************
@@ -396,7 +397,7 @@ Bugfixes
 - establish code style black
 - setup nox session that can be used to run black via nox -s black for one of the supported
   Python versions
-- add option for data collection to tidy the DataFrame (properly reshape) with the 
+- add option for data collection to tidy the DataFrame (properly reshape) with the
   "tidy_data" keyword and set it to be used as default
 - fix integer type casting for cases with nans in the column/series
 - fix humanizing of column names for tidy data
@@ -419,7 +420,7 @@ Bugfixes
 - [cli] Add geospatial filtering by number of nearby stations.
 - Simplify release pipeline
 - small updates to readme
-- change updating "parallel" argument to be done after parameter parsing to prevent mistakenly not found 
+- change updating "parallel" argument to be done after parameter parsing to prevent mistakenly not found
   parameter
 - remove find_all_match_strings function and extract functionality to individual operations
 - parameter, time resolution and period type can now also be passed as strings of the enumerations e.g.

--- a/wetterdienst/provider/eccc/observation/api.py
+++ b/wetterdienst/provider/eccc/observation/api.py
@@ -31,7 +31,7 @@ from wetterdienst.provider.eccc.observation.metadata.parameter import (
     EcccObservationParameter,
 )
 from wetterdienst.provider.eccc.observation.metadata.resolution import (
-    EccObservationResolution,
+    EcccObservationResolution,
 )
 from wetterdienst.provider.eccc.observation.metadata.unit import EcccObservationUnit
 from wetterdienst.util.cache import CacheExpiry, cache_dir
@@ -241,7 +241,7 @@ class EcccObservationRequest(ScalarRequestCore):
 
     _tz = Timezone.UTC
 
-    _resolution_base = EccObservationResolution
+    _resolution_base = EcccObservationResolution
     _resolution_type = ResolutionType.MULTI
     _period_type = PeriodType.FIXED
     _period_base = Period.HISTORICAL
@@ -302,7 +302,7 @@ class EcccObservationRequest(ScalarRequestCore):
     def __init__(
         self,
         parameter: Tuple[Union[str, EcccObservationParameter]],
-        resolution: Union[EccObservationResolution, Resolution],
+        resolution: Union[EcccObservationResolution, Resolution],
         start_date: Optional[datetime] = None,
         end_date: Optional[datetime] = None,
     ):

--- a/wetterdienst/provider/eccc/observation/metadata/resolution.py
+++ b/wetterdienst/provider/eccc/observation/metadata/resolution.py
@@ -6,7 +6,7 @@ from enum import Enum
 from wetterdienst.metadata.resolution import Resolution
 
 
-class EccObservationResolution(Enum):
+class EcccObservationResolution(Enum):
     DAILY = Resolution.DAILY.value
     HOURLY = Resolution.HOURLY.value
     MONTHLY = Resolution.MONTHLY.value


### PR DESCRIPTION
The class `EcccObservationResolution` is missing a `c`.