### PR TITLE
CI/GHA: Run Windows tests on windows-2019 instead of windows-2022

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
         python-version: ["3.8", "3.9", "3.10"]
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
Might resolve those errors:

    OSError: [WinError 10013] An attempt was made to access a socket in a way forbidden by its access permissions

Spotted at, for example, https://github.com/earthobservations/wetterdienst/runs/6542666944#step:7:611

See also https://github.com/actions/virtual-environments/issues/4856.