### PR TITLE
Add options for handling missing data

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/cache@v2
       env:
         # Increase this value to reset cache if `poetry.lock` has not changed.
-        CACHE_NUMBER: 3
+        CACHE_NUMBER: 1
       with:
         path: .venv
         key: poetry-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-${{ env.CACHE_NUMBER }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,14 @@
 Changelog
 #########
 
+.. toctree::
+   :maxdepth: 0
+
 Development
 ***********
+
+- Add option to skip empty stations (option tidy must be set)
+- Add option to drop empty rows (value is NaN) (option tidy must be set)
 
 0.34.0 (22.05.2022)
 *******************

--- a/docs/usage/python-api.rst
+++ b/docs/usage/python-api.rst
@@ -164,6 +164,13 @@ Scalar arguments are:
 - `humanize` can be used to rename parameters to more meaningful
 names.
 - `si_units` can be used to convert values to SI units.
+- `skip_empty` (requires option `tidy`) can be used to skip empty stations
+    - empty stations are defined via `skip_threshold` which defaults to 0.95
+     and requires all parameters that are requested (for an entire dataset all of the dataset parameters)
+     to have at least 95 per cent of actual values (relative to start and end date if provided)
+- `skip_threshold` is used in combination with `skip_empty` to define when a station is empty, with 1.0 meaning no
+ values per parameter should be missing and e.g. 0.9 meaning 10 per cent of values can be missing
+- `dropna` (requires option `tidy`) is used to drop all empty entries thus reducing the workload
 
 All of `tidy`, `humanize` and `si_units` are defaulted to True.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -516,7 +516,7 @@ python-versions = "*"
 
 [[package]]
 name = "dask"
-version = "2022.5.0"
+version = "2022.5.2"
 description = "Parallel PyData with Task Scheduling"
 category = "main"
 optional = true
@@ -532,10 +532,10 @@ toolz = ">=0.8.2"
 
 [package.extras]
 array = ["numpy (>=1.18)"]
-complete = ["bokeh (>=2.4.2)", "distributed (==2022.05.0)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
+complete = ["bokeh (>=2.4.2)", "distributed (==2022.05.2)", "jinja2", "numpy (>=1.18)", "pandas (>=1.0)"]
 dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
 diagnostics = ["bokeh (>=2.4.2)", "jinja2"]
-distributed = ["distributed (==2022.05.0)"]
+distributed = ["distributed (==2022.05.2)"]
 test = ["pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
 
 [[package]]
@@ -1141,7 +1141,7 @@ packaging = "*"
 
 [[package]]
 name = "h5py"
-version = "3.6.0"
+version = "3.7.0"
 description = "Read and write HDF5 files from Python"
 category = "main"
 optional = false
@@ -1217,7 +1217,7 @@ test = ["nose", "nose-cov", "mock", "requests-mock"]
 
 [[package]]
 name = "influxdb-client"
-version = "1.29.0"
+version = "1.29.1"
 description = "InfluxDB 2.0 Python client library"
 category = "main"
 optional = true
@@ -1234,7 +1234,7 @@ urllib3 = ">=1.26.0"
 async = ["aiohttp (>=3.8.1)"]
 ciso = ["ciso8601 (>=2.1.1)"]
 extra = ["pandas (>=0.25.3)", "numpy"]
-test = ["coverage (>=4.0.3)", "nose (>=1.3.7)", "pluggy (>=0.3.1)", "py (>=1.4.31)", "randomize (>=0.13)", "pytest (>=5.0.0)", "httpretty (==1.0.5)", "psutil (>=5.6.3)"]
+test = ["coverage (>=4.0.3)", "nose (>=1.3.7)", "pluggy (>=0.3.1)", "py (>=1.4.31)", "randomize (>=0.13)", "pytest (>=5.0.0)", "httpretty (==1.0.5)", "psutil (>=5.6.3)", "aioresponses (>=0.7.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -1246,7 +1246,7 @@ python-versions = "*"
 
 [[package]]
 name = "ipython"
-version = "7.33.0"
+version = "7.34.0"
 description = "IPython: Productive Interactive Computing"
 category = "main"
 optional = true
@@ -2164,7 +2164,7 @@ diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pypdf2"
-version = "1.27.12"
+version = "1.28.3"
 description = "A pure-python PDF library capable of splitting, merging, cropping, and transforming PDF files"
 category = "main"
 optional = false
@@ -3063,13 +3063,14 @@ python-versions = "*"
 
 [[package]]
 name = "webdriver-manager"
-version = "3.5.4"
+version = "3.7.0"
 description = "Library provides the way to automatically manage drivers for different browsers"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
+python-dotenv = "*"
 requests = "*"
 
 [[package]]
@@ -3713,8 +3714,8 @@ dash-table = [
     {file = "dash_table-5.0.0.tar.gz", hash = "sha256:18624d693d4c8ef2ddec99a6f167593437a7ea0bf153aa20f318c170c5bc7308"},
 ]
 dask = [
-    {file = "dask-2022.5.0-py3-none-any.whl", hash = "sha256:1b168877673a3d12778e319a1a406bb33b5abe942d8b6fae70ed02cb6019868a"},
-    {file = "dask-2022.5.0.tar.gz", hash = "sha256:0afd69dd0cd9f838fc0710eda1f3e3333d6603b37e93ded7fac4a51d77566a0f"},
+    {file = "dask-2022.5.2-py3-none-any.whl", hash = "sha256:ecd0e8cd00802c2f684369f907e5ab9fbdc3ea0c0b4ebc1239da899f8d79cefb"},
+    {file = "dask-2022.5.2.tar.gz", hash = "sha256:d57061ccf37194907e65d62816c0fa6c1adaf2dcbc5785c6754bbdd3073f8898"},
 ]
 dateparser = [
     {file = "dateparser-1.1.1-py2.py3-none-any.whl", hash = "sha256:9600874312ff28a41f96ec7ccdc73be1d1c44435719da47fea3339d55ff5a628"},
@@ -4062,22 +4063,26 @@ h5netcdf = [
     {file = "h5netcdf-1.0.0.tar.gz", hash = "sha256:4bf07ac545e6e4ee372a8505ffcee5c83f2db8b9a5c4a510b9336d92c3d50fa6"},
 ]
 h5py = [
-    {file = "h5py-3.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a5320837c60870911645e9a935099bdb2be6a786fcf0dac5c860f3b679e2de55"},
-    {file = "h5py-3.6.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98646e659bf8591a2177e12a4461dced2cad72da0ba4247643fd118db88880d2"},
-    {file = "h5py-3.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:5996ff5adefd2d68c330a4265b6ef92e51b2fc674834a5990add5033bf109e20"},
-    {file = "h5py-3.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c9a5529343a619fea777b7caa27d493595b28b5af8b005e8d1817559fcccf493"},
-    {file = "h5py-3.6.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e2b49c48df05e19bb20b400b7ff7dc6f1ee36b84dc717c3771c468b33697b466"},
-    {file = "h5py-3.6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cd9447633b0bafaf82190d9a8d56f3cb2e8d30169483aee67d800816e028190a"},
-    {file = "h5py-3.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1c5acc660c458421e88c4c5fe092ce15923adfac4c732af1ac4fced683a5ea97"},
-    {file = "h5py-3.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:35ab552c6f0a93365b3cb5664a5305f3920daa0a43deb5b2c547c52815ec46b9"},
-    {file = "h5py-3.6.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:542781d50e1182b8fb619b1265dfe1c765e18215f818b0ab28b2983c28471325"},
-    {file = "h5py-3.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9f39242960b8d7f86f3056cc2546aa3047ff4835985f6483229af8f029e9c8db"},
-    {file = "h5py-3.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:8ecedf16c613973622a334701f67edcc0249469f9daa0576e994fb20ac0405db"},
-    {file = "h5py-3.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d8cacad89aa7daf3626fce106f7f2662ac35b14849df22d252d0d8fab9dc1c0b"},
-    {file = "h5py-3.6.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:dbaa1ed9768bf9ff04af0919acc55746e62b28333644f0251f38768313f31745"},
-    {file = "h5py-3.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:954c5c39a09b5302f69f752c3bbf165d368a65c8d200f7d5655e0fa6368a75e6"},
-    {file = "h5py-3.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:9fd8a14236fdd092a20c0bdf25c3aba3777718d266fabb0fdded4fcf252d1630"},
-    {file = "h5py-3.6.0.tar.gz", hash = "sha256:8752d2814a92aba4e2b2a5922d2782d0029102d99caaf3c201a566bc0b40db29"},
+    {file = "h5py-3.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d77af42cb751ad6cc44f11bae73075a07429a5cf2094dfde2b1e716e059b3911"},
+    {file = "h5py-3.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:63beb8b7b47d0896c50de6efb9a1eaa81dbe211f3767e7dd7db159cea51ba37a"},
+    {file = "h5py-3.7.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:04e2e1e2fc51b8873e972a08d2f89625ef999b1f2d276199011af57bb9fc7851"},
+    {file = "h5py-3.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f73307c876af49aa869ec5df1818e9bb0bdcfcf8a5ba773cc45a4fba5a286a5c"},
+    {file = "h5py-3.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:f514b24cacdd983e61f8d371edac8c1b780c279d0acb8485639e97339c866073"},
+    {file = "h5py-3.7.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:43fed4d13743cf02798a9a03a360a88e589d81285e72b83f47d37bb64ed44881"},
+    {file = "h5py-3.7.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c038399ce09a58ff8d89ec3e62f00aa7cb82d14f34e24735b920e2a811a3a426"},
+    {file = "h5py-3.7.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03d64fb86bb86b978928bad923b64419a23e836499ec6363e305ad28afd9d287"},
+    {file = "h5py-3.7.0-cp37-cp37m-win_amd64.whl", hash = "sha256:e5b7820b75f9519499d76cc708e27242ccfdd9dfb511d6deb98701961d0445aa"},
+    {file = "h5py-3.7.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:a9351d729ea754db36d175098361b920573fdad334125f86ac1dd3a083355e20"},
+    {file = "h5py-3.7.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6776d896fb90c5938de8acb925e057e2f9f28755f67ec3edcbc8344832616c38"},
+    {file = "h5py-3.7.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0a047fddbe6951bce40e9cde63373c838a978c5e05a011a682db9ba6334b8e85"},
+    {file = "h5py-3.7.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0798a9c0ff45f17d0192e4d7114d734cac9f8b2b2c76dd1d923c4d0923f27bb6"},
+    {file = "h5py-3.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:0d8de8cb619fc597da7cf8cdcbf3b7ff8c5f6db836568afc7dc16d21f59b2b49"},
+    {file = "h5py-3.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f084bbe816907dfe59006756f8f2d16d352faff2d107f4ffeb1d8de126fc5dc7"},
+    {file = "h5py-3.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1fcb11a2dc8eb7ddcae08afd8fae02ba10467753a857fa07a404d700a93f3d53"},
+    {file = "h5py-3.7.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ed43e2cc4f511756fd664fb45d6b66c3cbed4e3bd0f70e29c37809b2ae013c44"},
+    {file = "h5py-3.7.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e7535df5ee3dc3e5d1f408fdfc0b33b46bc9b34db82743c82cd674d8239b9ad"},
+    {file = "h5py-3.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:9e2ad2aa000f5b1e73b5dfe22f358ca46bf1a2b6ca394d9659874d7fc251731a"},
+    {file = "h5py-3.7.0.tar.gz", hash = "sha256:3fcf37884383c5da64846ab510190720027dca0768def34dd8dcb659dbe5cbf3"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -4100,16 +4105,16 @@ influxdb = [
     {file = "influxdb-5.3.1.tar.gz", hash = "sha256:46f85e7b04ee4b3dee894672be6a295c94709003a7ddea8820deec2ac4d8b27a"},
 ]
 influxdb-client = [
-    {file = "influxdb_client-1.29.0-py3-none-any.whl", hash = "sha256:c118a129d1eed4d3eafad664c907303bd66109f6727098734074606e7084230c"},
-    {file = "influxdb_client-1.29.0.tar.gz", hash = "sha256:4f56622d9f63f3eea22859f3a53564f803f422a10fdd421d839abc13e3fe36f7"},
+    {file = "influxdb_client-1.29.1-py3-none-any.whl", hash = "sha256:2145a33cd80325c390832361a274975901a4f462c7e158dc24bb45a97a91deeb"},
+    {file = "influxdb_client-1.29.1.tar.gz", hash = "sha256:8e354aae9a7cce1e8125636228ecc7bd1df2a8cb0100399d2024f7fc1fdad73f"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 ipython = [
-    {file = "ipython-7.33.0-py3-none-any.whl", hash = "sha256:916a3126896e4fd78dd4d9cf3e21586e7fd93bae3f1cd751588b75524b64bf94"},
-    {file = "ipython-7.33.0.tar.gz", hash = "sha256:bcffb865a83b081620301ba0ec4d95084454f26b91d6d66b475bff3dfb0218d4"},
+    {file = "ipython-7.34.0-py3-none-any.whl", hash = "sha256:c175d2440a1caff76116eb719d40538fbb316e214eda85c5515c303aacbfb23e"},
+    {file = "ipython-7.34.0.tar.gz", hash = "sha256:af3bdb46aa292bce5615b1b2ebc76c2080c5f77f54bda2ec72461317273e7cd6"},
 ]
 ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
@@ -4910,8 +4915,8 @@ pyparsing = [
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
 ]
 pypdf2 = [
-    {file = "PyPDF2-1.27.12-py3-none-any.whl", hash = "sha256:9416c347b4c03391caf7562486bec0fd129bbb6a3359eefe4a0b758d0e3dc20c"},
-    {file = "PyPDF2-1.27.12.tar.gz", hash = "sha256:20929fad10a3b4890862f65f3a46f563cfdf53132faae5193b54e18658467a60"},
+    {file = "PyPDF2-1.28.3-py3-none-any.whl", hash = "sha256:2e342532caec6faabbee0ae43d9c0fed9e0d77bf65d86d11b87e9e560088426e"},
+    {file = "PyPDF2-1.28.3.tar.gz", hash = "sha256:a7dd99f933207c3dc1b3cfdb9905fdcd1c11e8ab68b9600c50734bb5439c2fed"},
 ]
 pyproj = [
     {file = "pyproj-3.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:473961faef7a9fd723c5d432f65220ea6ab3854e606bf84b4d409a75a4261c78"},
@@ -5608,8 +5613,8 @@ wcwidth = [
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 webdriver-manager = [
-    {file = "webdriver_manager-3.5.4-py2.py3-none-any.whl", hash = "sha256:b5b91b5df83181e002263fe27296967a5b19cb1ebe8e4a63ee83538394037df4"},
-    {file = "webdriver_manager-3.5.4.tar.gz", hash = "sha256:2eb7c2fe38ec5b06e2090164923e4dfb7c3ac4e7140333a3de9c7956f5047858"},
+    {file = "webdriver_manager-3.7.0-py2.py3-none-any.whl", hash = "sha256:ee09f7c5d9c61ca9cf2b78a036355f617f5dede2d68b7d2d77877d1d48df1361"},
+    {file = "webdriver_manager-3.7.0.tar.gz", hash = "sha256:4a7247086b181d3a077a7f0be71b2f8e297d213ddd563ecea263dcb17e4e865f"},
 ]
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},

--- a/tests/core/scalar/test_api.py
+++ b/tests/core/scalar/test_api.py
@@ -1,0 +1,88 @@
+import pytest
+
+from wetterdienst import Settings
+from wetterdienst.exceptions import NoParametersFound
+from wetterdienst.provider.dwd.observation import (
+    DwdObservationDataset,
+    DwdObservationRequest,
+    DwdObservationResolution,
+)
+
+
+def test_api_skip_empty_stations():
+    start_date = "2021-01-01"
+    end_date = "2021-12-31"
+
+    with Settings:
+        Settings.skip_empty = True
+
+        stations = DwdObservationRequest(
+            parameter=[
+                DwdObservationDataset.TEMPERATURE_AIR,
+                DwdObservationDataset.PRECIPITATION,
+            ],
+            resolution=DwdObservationResolution.MINUTE_10,
+            start_date=start_date,
+            end_date=end_date,
+        ).filter_by_rank(49.19780976647141, 8.135207205143768, 20)
+
+    values = next(stations.values.query())
+
+    assert (
+        values.df.station_id.iloc[0] != stations.df.station_id.iloc[0]
+    )  # not supposed to be the first station of the list
+    assert values.df.station_id.iloc[0] == "05426"
+
+
+def test_api_dropna():
+    start_date = "2021-01-01"
+    end_date = "2021-12-31"
+
+    with Settings:
+        Settings.dropna = True
+
+        stations = DwdObservationRequest(
+            parameter=[
+                DwdObservationDataset.TEMPERATURE_AIR,
+                DwdObservationDataset.PRECIPITATION,
+            ],
+            resolution=DwdObservationResolution.MINUTE_10,
+            start_date=start_date,
+            end_date=end_date,
+        ).filter_by_rank(49.19780976647141, 8.135207205143768, 20)
+
+    values = next(stations.values.query())
+
+    assert values.df.shape[0] == 51971
+
+
+def test_api_no_valid_parameters():
+    with pytest.raises(NoParametersFound):
+        DwdObservationRequest(
+            parameter=[
+                DwdObservationDataset.TEMPERATURE_AIR,
+            ],
+            resolution=DwdObservationResolution.DAILY,
+        )
+
+
+def test_api_partly_valid_parameters(caplog):
+    request = DwdObservationRequest(
+        parameter=[
+            DwdObservationDataset.TEMPERATURE_AIR,
+            DwdObservationDataset.WIND,
+            DwdObservationDataset.PRECIPITATION,
+            DwdObservationDataset.SOLAR,
+        ],
+        resolution=DwdObservationResolution.DAILY,
+    )
+
+    assert "dataset WIND is not a valid dataset for resolution DAILY" in caplog.text
+    assert "dataset PRECIPITATION is not a valid dataset for resolution DAILY" in caplog.text
+
+    assert request.parameter == [
+        (
+            DwdObservationDataset.SOLAR,
+            DwdObservationDataset.SOLAR,
+        )
+    ]

--- a/wetterdienst/core/scalar/result.py
+++ b/wetterdienst/core/scalar/result.py
@@ -94,6 +94,18 @@ class StationsResult(ExportMixin):
         return self.stations.si_units
 
     @property
+    def skip_empty(self) -> bool:
+        return self.stations.skip_empty
+
+    @property
+    def skip_threshold(self) -> float:
+        return self.stations.skip_threshold
+
+    @property
+    def dropna(self) -> float:
+        return self.stations.dropna
+
+    @property
     def _has_tidy_data(self) -> bool:
         return self.stations._has_tidy_data
 

--- a/wetterdienst/settings.py
+++ b/wetterdienst/settings.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2018-2022, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
 from contextvars import ContextVar
 from dataclasses import dataclass
 
@@ -20,6 +23,9 @@ class Settings:
             humanize: bool = env.bool("HUMANIZE", True)
             tidy: bool = env.bool("TIDY", True)
             si_units: bool = env.bool("SI_UNITS", True)
+            skip_empty: bool = env.bool("SKIP_EMPTY", False)
+            skip_threshold: bool = env.float("SKIP_THRESHOLD", 0.95)
+            dropna: bool = env.bool("DROPNA", False)
 
     @classmethod
     def reset(cls):

--- a/wetterdienst/ui/cli.py
+++ b/wetterdienst/ui/cli.py
@@ -129,13 +129,13 @@ def cli():
         wetterdienst stations_result --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --bbox=<left,lower,right,top> [--target=<target>] [--format=<format>] [--pretty=<pretty>] [--debug=<debug>]
         wetterdienst stations_result --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --sql=<sql> [--target=<target>] [--format=<format>] [--pretty=<pretty>] [--debug=<debug>]
 
-        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --all=<all> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--pretty=<pretty>] [--debug=<debug>]
-        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --station=<station> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--pretty=<pretty>] [--debug=<debug>]
-        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --name=<name> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--pretty=<pretty>] [--debug=<debug>]
-        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --coordinates=<latitude,longitude> --rank=<rank>  [--sql=<sql>] [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--pretty=<pretty>] [--debug=<debug>]
-        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --coordinates=<latitude,longitude> --distance=<distance> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--pretty=<pretty>] [--debug=<debug>]
-        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --bbox=<left,lower,right,top> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--pretty=<pretty>] [--debug=<debug>]
-        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --sql=<sql> [--target=<target>] [--format=<format>] [--humanize=<humanize>] [--tidy=<tidy>] [--si-units=<si-units>] [--pretty=<pretty>] [--debug=<debug>]
+        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --all=<all> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--skip_empty=<skip_empty>] [--skip_threshold=<skip_threshold>] [--dropna=<dropna>] [--pretty=<pretty>] [--debug=<debug>]
+        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --station=<station> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--skip_empty=<skip_empty>] [--skip_threshold=<skip_threshold>] [--dropna=<dropna>] [--pretty=<pretty>] [--debug=<debug>]
+        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --name=<name> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--skip_empty=<skip_empty>] [--skip_threshold=<skip_threshold>] [--dropna=<dropna>] [--pretty=<pretty>] [--debug=<debug>]
+        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --coordinates=<latitude,longitude> --rank=<rank>  [--sql=<sql>] [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--skip_empty=<skip_empty>] [--skip_threshold=<skip_threshold>] [--dropna=<dropna>] [--pretty=<pretty>] [--debug=<debug>]
+        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --coordinates=<latitude,longitude> --distance=<distance> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--skip_empty=<skip_empty>] [--skip_threshold=<skip_threshold>] [--dropna=<dropna>] [--pretty=<pretty>] [--debug=<debug>]
+        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --bbox=<left,lower,right,top> [--target=<target>] [--format=<format>] [--tidy=<tidy>] [--humanize=<humanize>] [--si-units=<si-units>] [--skip_empty=<skip_empty>] [--skip_threshold=<skip_threshold>] [--dropna=<dropna>] [--pretty=<pretty>] [--debug=<debug>]
+        wetterdienst values --provider=<provider> --network=<network> --parameter=<parameter> --resolution=<resolution> [--period=<period>] --sql=<sql> [--target=<target>] [--format=<format>] [--humanize=<humanize>] [--tidy=<tidy>] [--si-units=<si-units>] [--skip_empty=<skip_empty>] [--skip_threshold=<skip_threshold>] [--dropna=<dropna>] [--pretty=<pretty>] [--debug=<debug>]
 
     Options:
         --parameter=<parameter>               Parameter Set/Parameter, e.g. "kl" or "precipitation_height", etc.
@@ -158,6 +158,9 @@ def cli():
         --tidy                                Tidy DataFrame
         --humanize                            Humanize parameters
         --si-units                            Convert to SI units
+        --skip_empty                          Skip empty stations according to skip_threshold
+        --skip_threshold                      Skip threshold for a station to be empty (0 < skip_threshold <= 1)
+        --dropna                              Whether to drop nan values from the result
         --pretty                              Pretty json with indent 4
         --debug                               Enable debug messages
         --listen=<listen>                     HTTP server listen address.
@@ -507,6 +510,9 @@ def stations(
         tidy=False,
         si_units=False,
         humanize=False,
+        skip_empty=False,
+        skip_threshold=0.95,
+        dropna=False,
     )
 
     if stations_.df.empty:
@@ -550,6 +556,9 @@ def stations(
 @cloup.option("--si-units", type=click.BOOL, default=True)
 @cloup.option("--humanize", type=click.BOOL, default=True)
 @cloup.option("--pretty", is_flag=True)
+@cloup.option("--skip_empty", type=click.BOOL, default=False)
+@cloup.option("--skip_threshold", type=click.FloatRange(min=0, min_open=True, max=1), default=0.95)
+@cloup.option("--dropna", type=click.BOOL, default=False)
 @debug_opt
 def values(
     provider: str,
@@ -573,6 +582,9 @@ def values(
     tidy: bool,
     si_units: bool,
     humanize: bool,
+    skip_empty: bool,
+    skip_threshold: float,
+    dropna: bool,
     pretty: bool,
     debug: bool,
 ):
@@ -600,6 +612,9 @@ def values(
             si_units=si_units,
             tidy=tidy,
             humanize=humanize,
+            skip_empty=skip_empty,
+            skip_threshold=skip_threshold,
+            dropna=dropna,
         )
     except ValueError as ex:
         log.exception(ex)

--- a/wetterdienst/ui/core.py
+++ b/wetterdienst/ui/core.py
@@ -67,6 +67,9 @@ def get_stations(
     si_units: bool,
     tidy: bool,
     humanize: bool,
+    skip_empty: bool,
+    skip_threshold: float,
+    dropna: bool,
 ) -> StationsResult:
     """
     Core function for querying stations_result via cli and restapi
@@ -89,6 +92,9 @@ def get_stations(
     :param si_units:
     :param tidy:
     :param humanize:
+    :param skip_empty:
+    :param skip_threshold:
+    :param dropna:
     :return:
     """
     # TODO: move this into Request core
@@ -137,6 +143,9 @@ def get_stations(
         Settings.tidy = tidy
         Settings.humanize = humanize
         Settings.si_units = si_units
+        Settings.skip_empty = skip_empty
+        Settings.skip_threshold = skip_threshold
+        Settings.dropna = dropna
 
         r = api(**kwargs)
 
@@ -215,6 +224,9 @@ def get_values(
     si_units: bool,
     tidy: bool,
     humanize: bool,
+    skip_empty: bool,
+    skip_threshold: float,
+    dropna: bool,
 ) -> ValuesResult:
     """
     Core function for querying values via cli and restapi
@@ -237,6 +249,9 @@ def get_values(
     :param si_units:
     :param tidy:
     :param humanize:
+    :param skip_empty:
+    :param skip_threshold:
+    :param dropna:
     :return:
     """
     stations_ = get_stations(
@@ -257,6 +272,9 @@ def get_values(
         si_units=si_units,
         tidy=tidy,
         humanize=humanize,
+        skip_empty=skip_empty,
+        skip_threshold=skip_threshold,
+        dropna=dropna,
     )
 
     try:

--- a/wetterdienst/ui/explorer/app.py
+++ b/wetterdienst/ui/explorer/app.py
@@ -98,6 +98,9 @@ def fetch_stations(provider: str, network: str, resolution: str, dataset: str, p
             si_units=True,
             tidy=True,
             humanize=True,
+            skip_empty=False,
+            skip_threshold=0.95,
+            dropna=False,
         )
     except (requests.exceptions.ConnectionError, InvalidParameterCombination) as ex:
         log.warning(ex)
@@ -169,6 +172,9 @@ def fetch_values(
             sql=None,
             sql_values=None,
             si_units=True,
+            skip_empty=False,
+            skip_threshold=0.95,
+            dropna=False,
             tidy=True,
             humanize=True,
         )

--- a/wetterdienst/ui/restapi.py
+++ b/wetterdienst/ui/restapi.py
@@ -175,6 +175,9 @@ def stations(
             tidy=False,
             si_units=False,
             humanize=False,
+            skip_empty=False,
+            skip_threshold=0.95,
+            dropna=False,
         )
     except (KeyError, ValueError) as e:
         return HTTPException(status_code=404, detail=str(e))
@@ -225,6 +228,9 @@ def values(
     humanize: bool = Query(default=True),
     tidy: bool = Query(default=True),
     si_units: bool = Query(alias="si-units", default=True),
+    skip_empty: bool = Query(alias="skip-empty", default=False),
+    skip_threshold: float = Query(alias="skip-threshold", default=0.95, gt=0, le=1),
+    dropna: bool = Query(alias="dropna", default=False),
     pretty: bool = Query(default=False),
     debug: bool = Query(default=False),
 ):
@@ -311,6 +317,9 @@ def values(
             sql=sql,
             sql_values=sql_values,
             si_units=si_units,
+            skip_empty=skip_empty,
+            skip_threshold=skip_threshold,
+            dropna=dropna,
             tidy=tidy,
             humanize=humanize,
         )


### PR DESCRIPTION
Dear all,

this PR adds two options to wetterdienst:

- `skip_empty`can be used to skip stations whose values are empty according to a given threshold `skip_threshold? which is defaulted to 95% meaning a station is seen as empty if of each parameter requested the values have less then 95 % actual values
- `dropna` can be used to drop values which are NaN from the returned values DataFrame

Cheers
Benjamin