### PR TITLE
CI: Use `pytest-xdist` for Windows on GHA

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,16 +54,8 @@ jobs:
     - name: Install project
       run: .github/workflows/install.sh testing
 
-    - name: Install jupyter kernel
+    - name: Install Jupyter kernel
       run: poetry run python -m ipykernel install --name "python3" --user
 
-    - name: Run tests (Windows, sequential)
-      run: |
-        if [ "$RUNNER_OS" == "Windows" ]; then 
-          poetry run poe test-slow
-        fi
-    - name: Run tests (Linux/macOS, parallel)
-      run: |
-        if [ "$RUNNER_OS" != "Windows" ]; then
-          poetry run poe test
-        fi
+    - name: Run tests
+      run: poetry run poe test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,4 +58,6 @@ jobs:
       run: poetry run python -m ipykernel install --name "python3" --user
 
     - name: Run tests
-      run: poetry run poe test
+      run: |
+        poetry run pytest -vvv --numprocesses=auto -m "not (explorer or cflake)" tests
+        poetry run pytest -vvv -m cflake tests

--- a/tests/provider/dwd/observation/test_io.py
+++ b/tests/provider/dwd/observation/test_io.py
@@ -220,7 +220,7 @@ def test_export_unknown():
 
 
 @pytest.mark.remote
-def test_export_spreadsheet(tmpdir_factory):
+def test_export_spreadsheet(tmp_path):
     """Test export of DataFrame to spreadsheet"""
     Settings.tidy = False
     Settings.humanize = True
@@ -238,7 +238,7 @@ def test_export_spreadsheet(tmpdir_factory):
 
     df = request.values.all().df
 
-    filename = tmpdir_factory.mktemp("data").join("observations.xlsx")
+    filename = tmp_path.joinpath("observations.xlsx")
     ExportMixin(df=df).to_target(f"file://{filename}")
 
     workbook = openpyxl.load_workbook(filename=filename)
@@ -323,7 +323,7 @@ def test_export_spreadsheet(tmpdir_factory):
 
 
 @pytest.mark.remote
-def test_export_parquet(tmpdir_factory):
+def test_export_parquet(tmp_path):
     """Test export of DataFrame to parquet"""
 
     pq = pytest.importorskip("pyarrow.parquet")
@@ -345,7 +345,7 @@ def test_export_parquet(tmpdir_factory):
     df = request.values.all().df
 
     # Save to Parquet file.
-    filename = tmpdir_factory.mktemp("data").join("observation.parquet")
+    filename = tmp_path.joinpath("observation.parquet")
     ExportMixin(df=df).to_target(f"file://{filename}")
 
     # Read back Parquet file.
@@ -390,7 +390,7 @@ def test_export_parquet(tmpdir_factory):
 
 
 @pytest.mark.remote
-def test_export_zarr(tmpdir_factory):
+def test_export_zarr(tmp_path):
     """Test export of DataFrame to zarr"""
 
     zarr = pytest.importorskip("zarr")
@@ -412,7 +412,7 @@ def test_export_zarr(tmpdir_factory):
     df = request.values.all().df
 
     # Save to Zarr group.
-    filename = tmpdir_factory.mktemp("data").join("observation.zarr")
+    filename = tmp_path.joinpath("observation.zarr")
     ExportMixin(df=df).to_target(f"file://{filename}")
 
     # Read back Zarr group.
@@ -458,7 +458,7 @@ def test_export_zarr(tmpdir_factory):
 
 
 @pytest.mark.remote
-def test_export_feather(tmpdir_factory):
+def test_export_feather(tmp_path):
     """Test export of DataFrame to feather"""
     feather = pytest.importorskip("pyarrow.feather")
 
@@ -479,7 +479,7 @@ def test_export_feather(tmpdir_factory):
     df = request.values.all().df
 
     # Save to Feather file.
-    filename = tmpdir_factory.mktemp("data").join("observation.feather")
+    filename = tmp_path.joinpath("observation.feather")
     ExportMixin(df=df).to_target(f"file://{filename}")
 
     # Read back Feather file.
@@ -524,7 +524,7 @@ def test_export_feather(tmpdir_factory):
 
 
 @pytest.mark.remote
-def test_export_sqlite(tmpdir_factory):
+def test_export_sqlite(tmp_path):
     """Test export of DataFrame to sqlite db"""
     Settings.tidy = False
     Settings.humanize = True
@@ -539,7 +539,7 @@ def test_export_sqlite(tmpdir_factory):
         station_id=[1048],
     )
 
-    filename = tmpdir_factory.mktemp("data").join("observation.sqlite")
+    filename = tmp_path.joinpath("observation.sqlite")
 
     df = request.values.all().df
     ExportMixin(df=df).to_target(f"sqlite:///{filename}?table=testdrive")


### PR DESCRIPTION
## About
In order to speed up test execution on CI, let's also use `pytest-xdist` for running the test suite on Windows.

## Problem
When running the tests in parallel with `pytest-xdist`, using `poe test-parallel`, it croaks on Windows.
