### PR TITLE
Fix access of DWD observation solar daily data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Fix correct mapping of periods for solar daily data which should also have Period.HISTORICAL besides Period.RECENT
+
 0.41.0 (24.07.2022)
 *******************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 Development
 ***********
 
+0.41.1 (04.08.2022)
+*******************
+
 - Fix correct mapping of periods for solar daily data which should also have Period.HISTORICAL besides Period.RECENT
 
 0.41.0 (24.07.2022)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wetterdienst"
-version = "0.41.0"
+version = "0.41.1"
 description = "Open weather data for humans"
 authors = [
     "Benjamin Gutzmann <gutzemann@gmail.com>",

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -989,3 +989,20 @@ def test_dwd_observation_not_tidy_empty_df_no_start_end_date():
         period=DwdObservationPeriod.NOW,
     ).filter_by_station_id("01736")
     assert request.values.all().df.empty
+
+
+def test_dwd_observation_solar_daily():
+    """Test DWD observation solar daily data"""
+    Settings.tidy = True
+    Settings.humanize = True
+    Settings.si_units = True
+
+    # Snippet provided by https://github.com/pedroalencar1
+    request = DwdObservationRequest(
+        parameter=DwdObservationDataset.SOLAR,
+        resolution=DwdObservationResolution.DAILY,
+        start_date=datetime(1950, 1, 1),
+        end_date=datetime(2021, 12, 31),
+    ).filter_by_station_id(station_id=[3987])
+
+    assert not request.values.all().df.value.dropna().empty

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -84,7 +84,7 @@ def test_dwd_stations_basic():
     assert response.status_code == 200
     assert response.json()["data"][0]["station_id"] == "00011"
     assert response.json()["data"][0]["name"] == "Donaueschingen (Landeplatz)"
-    assert response.json()["data"][0]["latitude"] == 47.9737
+    assert response.json()["data"][0]["latitude"] == 47.9736
     assert response.json()["data"][0]["longitude"] == 8.5205
 
 

--- a/wetterdienst/provider/dwd/observation/metadata/dataset.py
+++ b/wetterdienst/provider/dwd/observation/metadata/dataset.py
@@ -196,7 +196,7 @@ RESOLUTION_DATASET_MAPPING: Dict[Resolution, Dict[DwdObservationDataset, List[Pe
             Period.HISTORICAL,
             Period.RECENT,
         ],
-        DwdObservationDataset.SOLAR: [Period.RECENT],
+        DwdObservationDataset.SOLAR: [Period.HISTORICAL, Period.RECENT],
         DwdObservationDataset.WATER_EQUIVALENT: [
             Period.HISTORICAL,
             Period.RECENT,


### PR DESCRIPTION
Dear all,

after @pedroalencar1 has handed in an issue requesting daily solar data of DWD observations I spotted a mistake in our dwd observation period mapping. This has been figured out correctly for hourly solar data however for the daily dataset the mapping did only contain period recent and not period historical which would also account for the provided data.

After adding the period to the mapping everything works as expected. I also added a test for this scenario.

Cheers
Benjamin

Fixes #690 