### PR TITLE
Move cache settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Move cache settings to core wetterdienst Settings object
+
 0.41.1 (04.08.2022)
 *******************
 

--- a/docs/usage/python-api.rst
+++ b/docs/usage/python-api.rst
@@ -603,9 +603,9 @@ FSSPEC_CLIENT_KWARGS to pass your very own client kwargs to fsspec e.g.
 
 .. ipython:: python
 
-    from wetterdienst.util.cache import FSSPEC_CLIENT_KWARGS
+    from wetterdienst import Settings
 
-    FSSPEC_CLIENT_KWARGS["trust_env"] = True  # use proxy from environment variables
+    Settings.fsspec_client_kwargs["trust_env"] = True  # use proxy from environment variables
 
 
 .. _wradlib: https://wradlib.org/

--- a/poetry.lock
+++ b/poetry.lock
@@ -547,6 +547,21 @@ distributed = ["distributed (==2022.8.0)"]
 test = ["pandas", "pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
 
 [[package]]
+name = "dataclass-wizard"
+version = "0.22.1"
+description = "Marshal dataclasses to/from JSON. Use field properties with initial values. Construct a dataclass schema with JSON input."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.7.4.2", markers = "python_version <= \"3.9\""}
+
+[package.extras]
+timedelta = ["pytimeparse (>=1.1.7)"]
+yaml = ["PyYAML (>=5.3)"]
+
+[[package]]
 name = "dateparser"
 version = "1.1.1"
 description = "Date parsing library designed to parse dates from HTML pages"
@@ -3304,7 +3319,7 @@ sql = ["duckdb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "3a78a527f27904231f809b5daf988489abbbc5461bca88693f2208bd56ed653f"
+content-hash = "4f8d61abd0d8fa04a325fc4486cde3154e16e3e469d47b072ce14cc48a94d180"
 
 [metadata.files]
 aenum = [
@@ -3706,6 +3721,10 @@ dash-table = [
 dask = [
     {file = "dask-2022.8.0-py3-none-any.whl", hash = "sha256:f4e4575b33179ed5c5b16992d2a786c578dd771c78acbd23d8a332b89eabac4f"},
     {file = "dask-2022.8.0.tar.gz", hash = "sha256:a14c1c5143081701d4fe62283e09cc5ad5336dff3a152de64eb77ee3180e9792"},
+]
+dataclass-wizard = [
+    {file = "dataclass-wizard-0.22.1.tar.gz", hash = "sha256:77a6584a758788ca0d32cf9d09ebbd3cb12e5eb5dcded4d846e358257f5fc3a0"},
+    {file = "dataclass_wizard-0.22.1-py2.py3-none-any.whl", hash = "sha256:e2cef176cbfac9f5adc812a8957d67aafc0c9c85b8c72ac7ca0ae0e7e692db38"},
 ]
 dateparser = [
     {file = "dateparser-1.1.1-py2.py3-none-any.whl", hash = "sha256:9600874312ff28a41f96ec7ccdc73be1d1c44435719da47fea3339d55ff5a628"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ timezonefinder = "^5.2"
 diskcache = "^5.4.0"
 environs = "^9.4.0"
 scikit-learn = "^1.0.2"
+dataclass-wizard = "^0.22.1"
 
 [tool.poetry.dev-dependencies]
 poethepoet = "^0.9"

--- a/tests/provider/dwd/observation/test_available_datasets.py
+++ b/tests/provider/dwd/observation/test_available_datasets.py
@@ -17,7 +17,8 @@ from wetterdienst.provider.dwd.observation.metadata.dataset import (
 from wetterdienst.provider.dwd.observation.metadata.parameter import (
     DwdObservationParameter,
 )
-from wetterdienst.util.cache import FSSPEC_CLIENT_KWARGS, CacheExpiry, cache_dir
+from wetterdienst.settings import Settings
+from wetterdienst.util.cache import CacheExpiry
 
 SKIP_DATASETS = (
     ("10_minutes", "wind_test"),
@@ -42,8 +43,8 @@ def test_compare_available_dwd_datasets():
         use_listings_cache=True,
         listings_expiry_time=CacheExpiry.TWELVE_HOURS.value,
         listings_cache_type="filedircache",
-        listings_cache_location=cache_dir,
-        client_kwargs=FSSPEC_CLIENT_KWARGS,
+        listings_cache_location=Settings.cache_dir,
+        client_kwargs=Settings.fsspec_client_kwargs,
     )
 
     base_url = "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -6,15 +6,27 @@ from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 import pytest
 
-from wetterdienst import Settings
-
 
 @pytest.mark.cflake
-def test_settings():
+def test_settings(caplog):
     """Check Settings object"""
+    from wetterdienst import Settings
+
     Settings.default()
 
     assert not Settings.cache_disable
+    assert caplog.messages[0] == "Wetterdienst cache is enabled"
+
+    Settings.cache_disable = True
+
+    assert Settings.cache_disable
+    assert caplog.messages[-1] == "Wetterdienst cache is disabled"
+
+    Settings.cache_disable = False
+
+    assert not Settings.cache_disable
+    assert caplog.messages[-1] == "Wetterdienst cache is enabled"
+
     assert Settings.tidy
     assert Settings.humanize
     assert Settings.si_units
@@ -35,6 +47,7 @@ def test_settings():
 
 def test_settings_concurrent():
     """Check leaking of Settings through threads"""
+    from wetterdienst import Settings
 
     def settings_tidy_concurrent(tidy: bool):
         with Settings:

--- a/wetterdienst/__init__.py
+++ b/wetterdienst/__init__.py
@@ -22,7 +22,6 @@ from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.provider import Provider
 from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.settings import Settings
-from wetterdienst.util.cache import cache_dir
 
 try:
     __version__ = version(__appname__)
@@ -37,7 +36,7 @@ def info() -> None:
         "authors": "Benjamin Gutzmann <gutzemann@gmail.com>, " "Andreas Motl <andreas.motl@panodata.org>",
         "documentation": "https://wetterdienst.readthedocs.io/",
         "repository": "https://github.com/earthobservations/wetterdienst",
-        "cache_dir": cache_dir,
+        "cache_dir": Settings.cache_dir,
     }
 
     text = "Wetterdienst - Open weather data for humans-------------------------------------------"

--- a/wetterdienst/settings.py
+++ b/wetterdienst/settings.py
@@ -1,14 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2022, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
+import logging
+import pathlib
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
+import appdirs
+from dataclass_wizard import property_wizard
 from environs import Env
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
-class Settings:
+class Settings(metaclass=property_wizard):
     """Wetterdienst class for general settings"""
 
     env = Env()
@@ -16,7 +22,16 @@ class Settings:
 
     with env.prefixed("WD_"):
         # cache
+        # for initial printout we need to work with _cache_disable and
+        # Check out this: https://florimond.dev/en/posts/2018/10/reconciling-dataclasses-and-properties-in-python/
         cache_disable: bool = env.bool("CACHE_DISABLE", False)
+        _cache_disable: bool = field(init=False, repr=False)
+
+        cache_dir: pathlib.Path = env.path("CACHE_DIR", appdirs.user_cache_dir(appname="wetterdienst"))
+
+        # FSSPEC aiohttp client kwargs, may be used to pass extra arguments
+        # such as proxies to aiohttp
+        fsspec_client_kwargs: dict = env.dict("FSSPEC_CLIENT_KWARGS", {}) or field(default_factory=dict)
 
         with env.prefixed("SCALAR_"):
             # scalar
@@ -27,18 +42,26 @@ class Settings:
             skip_threshold: bool = env.float("SKIP_THRESHOLD", 0.95)
             dropna: bool = env.bool("DROPNA", False)
 
-    @classmethod
-    def reset(cls):
-        """Reset Wetterdienst Settings to start"""
-        cls.env.read_env()
-        cls.__init__(cls)
+    @property
+    def cache_disable(self) -> bool:
+        return self._cache_disable
 
-    @classmethod
-    def default(cls):
+    @cache_disable.setter
+    def cache_disable(self, value: bool) -> None:
+        self._cache_disable = value
+        status = "disabled" if value else "enabled"
+        log.warning(f"Wetterdienst cache is {status}")
+
+    def reset(self):
+        """Reset Wetterdienst Settings to start"""
+        self.env.read_env()
+        self.__init__()
+
+    def default(self):
         """Ignore environmental variables and use all default arguments as defined above"""
         # Put empty env to force using the given defaults
-        cls.env = Env()
-        cls.__init__(cls)
+        self.env = Env()
+        self.__init__()
 
     _local_settings = ContextVar("local_settings")
     _local_settings_token = None
@@ -52,7 +75,7 @@ class Settings:
     def __exit__(self, type_, value, traceback):
         self._local_settings.reset(self._local_settings_token)
         # this is not the same object as the original one
-        return Settings.__init__(self)
+        return Settings.__init__()
 
 
 Settings = Settings()

--- a/wetterdienst/util/cache.py
+++ b/wetterdienst/util/cache.py
@@ -1,28 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
-import os
-import sys
 from enum import Enum
-
-import appdirs
-
-# FSSPEC aiohttp client kwargs, may be used to pass extra arguments
-# such as proxies etc to aiohttp
-FSSPEC_CLIENT_KWARGS = {}
-
-# Whether caching should be disabled at all.
-WD_CACHE_DISABLE = "WD_CACHE_DISABLE" in os.environ
-
-# Configure cache directory.
-try:
-    cache_dir = os.environ["WD_CACHE_DIR"]
-except KeyError:
-    cache_dir = appdirs.user_cache_dir(appname="wetterdienst")
-
-# Early reporting.
-if WD_CACHE_DISABLE:
-    sys.stderr.write("INFO: Wetterdienst cache is disabled\n")
 
 
 class CacheExpiry(Enum):

--- a/wetterdienst/util/network.py
+++ b/wetterdienst/util/network.py
@@ -8,12 +8,8 @@ from typing import List, Optional, Union
 from fsspec.implementations.cached import WholeFileCacheFileSystem
 from fsspec.implementations.http import HTTPFileSystem
 
-from wetterdienst.util.cache import (
-    FSSPEC_CLIENT_KWARGS,
-    WD_CACHE_DISABLE,
-    CacheExpiry,
-    cache_dir,
-)
+from wetterdienst.settings import Settings
+from wetterdienst.util.cache import CacheExpiry
 
 
 class NetworkFilesystemManager:
@@ -39,9 +35,9 @@ class NetworkFilesystemManager:
     def register(cls, ttl=CacheExpiry.NO_CACHE):
         ttl_name, ttl_value = cls.resolve_ttl(ttl)
         key = f"ttl-{ttl_name}"
-        real_cache_dir = os.path.join(cache_dir, "fsspec", key)
-        filesystem_real = HTTPFileSystem(use_listings_cache=True, client_kwargs=FSSPEC_CLIENT_KWARGS)
-        if WD_CACHE_DISABLE or ttl is CacheExpiry.NO_CACHE:
+        real_cache_dir = os.path.join(Settings.cache_dir, "fsspec", key)
+        filesystem_real = HTTPFileSystem(use_listings_cache=True, client_kwargs=Settings.fsspec_client_kwargs)
+        if Settings.cache_disable or ttl is CacheExpiry.NO_CACHE:
             filesystem_effective = filesystem_real
         else:
             filesystem_effective = WholeFileCacheFileSystem(
@@ -70,10 +66,10 @@ def list_remote_files_fsspec(url: str, ttl: CacheExpiry = CacheExpiry.FILEINDEX)
     """
     fs = HTTPFileSystem(
         use_listings_cache=True,
-        listings_expiry_time=not WD_CACHE_DISABLE and ttl.value,
+        listings_expiry_time=not Settings.cache_disable and ttl.value,
         listings_cache_type="filedircache",
-        listings_cache_location=cache_dir,
-        client_kwargs=FSSPEC_CLIENT_KWARGS,
+        listings_cache_location=Settings.cache_dir,
+        client_kwargs=Settings.fsspec_client_kwargs,
     )
 
     return fs.find(url)


### PR DESCRIPTION
Dear all,

this PR moves the cache settings to the global wetterdienst Settings object. I am currently not happy with the situation around the `cache_disable` attribute, which should have an initial printout so that the user knows if the cache is disabled but also throughout enabling/disabling again inform the user about the current mode of cache.

Apparently using a property on a dataclass field is quite complicated however the thread at [1] had a working solution.

@amotl Do you have any suggestions on this?

Cheers
Benjamin

[1] https://florimond.dev/en/posts/2018/10/reconciling-dataclasses-and-properties-in-python/