### PR TITLE
Fix two parameter names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Development
 ***********
 
 - Move cache settings to core wetterdienst Settings object
+- Fix two parameter names
 
 0.41.1 (04.08.2022)
 *******************

--- a/wetterdienst/metadata/parameter.py
+++ b/wetterdienst/metadata/parameter.py
@@ -480,9 +480,9 @@ class Parameter(Enum):
     # VISIBILITY
     # ---- distance ----
     VISIBILITY_RANGE_INDICATOR = "VISIBILITY_INDICATOR"
-    VISIBILITY_RANGE = "VISIBILITY"  # through clouds, fog, etc
+    VISIBILITY_RANGE = "VISIBILITY_RANGE"  # through clouds, fog, etc
     # ---- probability ----
-    PROBABILITY_VISIBILITY_BELOW_1000_M = "vv10"
+    PROBABILITY_VISIBILITY_BELOW_1000_M = "PROBABILITY_VISIBILITY_BELOW_1000_M"
 
     # WATER EQUIVALENT
     # ---- aggregated ----


### PR DESCRIPTION
Parameters `VISIBILITY_RANGE` and `PROBABILITY_VISIBILITY_BELOW_1000_M` had wrong values. Although this shouldn't be of a big deal, they should follow the general mapping scheme.