### PR TITLE
Cleanup some code blocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Slightly adapt the conversion function to satisfy linter
+
 0.43.0 (05.09.2022)
 *******************
 

--- a/wetterdienst/provider/eccc/observation/api.py
+++ b/wetterdienst/provider/eccc/observation/api.py
@@ -115,17 +115,12 @@ class EcccObservationValues(ScalarValuesCore):
         """
         meta = self.sr.df[self.sr.df[Columns.STATION_ID.value] == station_id]
 
-        name, from_date, to_date = (
-            meta[
-                [
-                    Columns.NAME.value,
-                    Columns.FROM_DATE.value,
-                    Columns.TO_DATE.value,
-                ]
+        from_date, to_date = meta[
+            [
+                Columns.FROM_DATE.value,
+                Columns.TO_DATE.value,
             ]
-            .values.flatten()
-            .tolist()
-        )
+        ].values.flatten()
 
         # start and end year from station
         start_year = None if pd.isna(from_date) else from_date.year

--- a/wetterdienst/util/network.py
+++ b/wetterdienst/util/network.py
@@ -3,8 +3,9 @@
 # Distributed under the MIT License. See LICENSE for more info.
 import os
 from io import BytesIO
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
+from fsspec import AbstractFileSystem
 from fsspec.implementations.cached import WholeFileCacheFileSystem
 from fsspec.implementations.http import HTTPFileSystem
 
@@ -17,10 +18,10 @@ class NetworkFilesystemManager:
     Manage multiple FSSPEC instances keyed by cache expiration time.
     """
 
-    filesystems = {}
+    filesystems: Dict[str, AbstractFileSystem] = {}
 
     @staticmethod
-    def resolve_ttl(ttl: Union[int, CacheExpiry]):
+    def resolve_ttl(ttl: Union[int, CacheExpiry]) -> Tuple[str, int]:
 
         ttl_name = ttl
         ttl_value = ttl
@@ -46,8 +47,8 @@ class NetworkFilesystemManager:
         cls.filesystems[key] = filesystem_effective
 
     @classmethod
-    def get(cls, ttl=CacheExpiry.NO_CACHE):
-        ttl_name, ttl_value = cls.resolve_ttl(ttl)
+    def get(cls, ttl=CacheExpiry.NO_CACHE) -> AbstractFileSystem:
+        ttl_name, _ = cls.resolve_ttl(ttl)
         key = f"ttl-{ttl_name}"
         if key not in cls.filesystems:
             cls.register(ttl=ttl)


### PR DESCRIPTION
Dear all,

this is to satisfy linters and adjust some smaller code blocks accordingly. Previously for the conversion of units a local-global variable was created from which the conversion function drew its factors and operands. Now this object is passed directly to the function to clarify the use.

Few other small changes were done, where previously certain objects were created but not used.

Fixes #713 