### PR TITLE
Make explorer work again

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Development
     - global radiation was mistakenly named radiation_short_wave_direct at certain points, now it is named correctly
 - Adjust Docker images to fix build problems, now use python 3.10 as base
 - Adjust NOAA sources to AWS as NCEI sources currently are not available
+- Make explorer work again for all services setting up Period enum classes instead of single instances of Period for
+  period base
 
 0.43.0 (05.09.2022)
 *******************

--- a/tests/ui/test_cli.py
+++ b/tests/ui/test_cli.py
@@ -206,19 +206,6 @@ def test_no_network(caplog):
     assert "No API available for provider DWD and network abc" in caplog.text
 
 
-def test_data_range():
-    runner = CliRunner()
-
-    result = runner.invoke(
-        cli,
-        "values --provider=eccc --network=observation --parameter=precipitation_height "
-        "--resolution=daily --name=toronto",
-    )
-
-    assert isinstance(result.exception, TypeError)
-    assert "Combination of provider ECCC and network OBSERVATION requires start and end date" in str(result.exception)
-
-
 @pytest.mark.parametrize(
     "provider,network,setting,station_id,expected_dict,coordinates",
     SETTINGS_STATIONS,

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -52,22 +52,6 @@ def test_no_network():
     assert "Choose provider and network from /restapi/coverage" in response.text
 
 
-def test_data_range(capsys):
-    response = client.get(
-        "/restapi/values",
-        params={
-            "provider": "eccc",
-            "network": "observation",
-            "parameter": "precipitation_height",
-            "resolution": "daily",
-            "period": "historical",
-            "name": "toronto",
-        },
-    )
-
-    assert "Combination of provider ECCC and network OBSERVATION requires start and end date" in response.text
-
-
 def test_dwd_stations_basic():
 
     response = client.get(

--- a/wetterdienst/provider/eccc/observation/api.py
+++ b/wetterdienst/provider/eccc/observation/api.py
@@ -35,6 +35,10 @@ from wetterdienst.util.network import download_file
 log = logging.getLogger(__name__)
 
 
+class EcccObservationPeriod(Enum):
+    HISTORICAL = Period.HISTORICAL.value
+
+
 class EcccObservationValues(ScalarValuesCore):
 
     _string_parameters = ()
@@ -231,9 +235,9 @@ class EcccObservationRequest(ScalarRequestCore):
     _resolution_base = EcccObservationResolution
     _resolution_type = ResolutionType.MULTI
     _period_type = PeriodType.FIXED
-    _period_base = Period.HISTORICAL
+    _period_base = EcccObservationPeriod
     _parameter_base = EcccObservationParameter  # replace with parameter enumeration
-    _data_range = DataRange.LOOSELY
+    _data_range = DataRange.FIXED
     _has_datasets = True
     _dataset_base = EcccObservationDataset
     _unique_dataset = True

--- a/wetterdienst/provider/noaa/ghcn/api.py
+++ b/wetterdienst/provider/noaa/ghcn/api.py
@@ -36,6 +36,10 @@ class NoaaGhcnResolution(Enum):
     DAILY = Resolution.DAILY.value
 
 
+class NoaaGhcnPeriod(Enum):
+    HISTORICAL = Period.HISTORICAL.value
+
+
 class NoaaGhcnValues(ScalarValuesCore):
     _string_parameters = ()
     _irregular_parameters = ()
@@ -118,7 +122,7 @@ class NoaaGhcnRequest(ScalarRequestCore):
     _resolution_type = ResolutionType.FIXED
     _resolution_base = NoaaGhcnResolution
     _period_type = PeriodType.FIXED
-    _period_base = Period.HISTORICAL
+    _period_base = NoaaGhcnPeriod
     _data_range = DataRange.FIXED
 
     _has_datasets = True

--- a/wetterdienst/provider/wsv/pegel/api.py
+++ b/wetterdienst/provider/wsv/pegel/api.py
@@ -90,6 +90,10 @@ class WsvPegelResolution(Enum):
     DYNAMIC = Resolution.DYNAMIC.value
 
 
+class WsvPegelPeriod(Enum):
+    RECENT = Period.RECENT.value
+
+
 class WsvPegelDataset(Enum):
     DYNAMIC = "DYNAMIC"
 
@@ -166,7 +170,7 @@ class WsvPegelRequest(ScalarRequestCore):
     _resolution_base = WsvPegelResolution
 
     _period_type = PeriodType.FIXED
-    _period_base = Period.RECENT
+    _period_base = WsvPegelPeriod
 
     _data_range = DataRange.FIXED
 


### PR DESCRIPTION
The explorer previously didn't work for some weather services which had a fixed period and for which we set an instance as period base rather than an enum with a single value. Now with an enum class set as period base they work once again.

Also for ECCC Observation the date range was previously set to loosely which would require setting start date and end date. However the data provided actually is given in chunked files and setting was changed to date range fixed. This now also works once again.