### PR TITLE
Providing `settings` instance via DI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Development
 - CLI: Add command line options ``wetterdienst --version`` and ``wetterdienst -v``
   to display version number
 - Further cleanups
+- Change Settings to be provided via initialization instead of having a singleton
 
 0.52.0 (19.01.2023)
 *******************

--- a/README.rst
+++ b/README.rst
@@ -288,14 +288,17 @@ Library
     >>> pd.options.display.max_columns = 8
     >>> from wetterdienst import Settings
     >>> from wetterdienst.provider.dwd.observation import DwdObservationRequest
-    >>> Settings.tidy = True  # default, tidy data
-    >>> Settings.humanize = True  # default, humanized parameters
-    >>> Settings.si_units = True  # default, convert values to SI units
+    >>> settings = Settings( # default
+    ...     tidy=True,  # tidy data
+    ...     humanize=True,  # humanized parameters
+    ...     si_units=True  # convert values to SI units
+    ... )
     >>> request = DwdObservationRequest(
     ...    parameter=["climate_summary"],
     ...    resolution="daily",
     ...    start_date="1990-01-01",  # if not given timezone defaulted to UTC
     ...    end_date="2020-01-01",  # if not given timezone defaulted to UTC
+    ...    settings=settings
     ... ).filter_by_station_id(station_id=(1048, 4411))
     >>> request.df.head()  # station list
         station_id                 from_date                   to_date  height  \

--- a/example/mosmix_forecasts.py
+++ b/example/mosmix_forecasts.py
@@ -25,13 +25,13 @@ from wetterdienst.util.cli import setup_logging
 def mosmix_example():
     """Retrieve Mosmix mosmix data by DWD."""
     # A. MOSMIX-L -- Specific stations_result - each station with own file
-    Settings.tidy = True
-    Settings.humanize = True
+    settings = Settings(tidy=True, humanize=True)
 
     request = DwdMosmixRequest(
         parameter=["DD", "ww"],
         start_issue=DwdForecastDate.LATEST,  # automatically set if left empty
         mosmix_type=DwdMosmixType.LARGE,
+        settings=settings,
     )
 
     stations = request.filter_by_station_id(

--- a/example/observations_sql.py
+++ b/example/observations_sql.py
@@ -30,15 +30,14 @@ log = logging.getLogger()
 
 def sql_example():
     """Retrieve temperature data by DWD and filter by sql statement."""
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = False
+    settings = Settings(tidy=True, humanize=True, si_units=False)
 
     request = DwdObservationRequest(
         parameter=[DwdObservationDataset.TEMPERATURE_AIR],
         resolution=DwdObservationResolution.HOURLY,
         start_date="2019-01-01",
         end_date="2020-01-01",
+        settings=settings,
     )
 
     stations = request.filter_by_station_id(station_id=(1048,))

--- a/example/wetterdienst_notebook.ipynb
+++ b/example/wetterdienst_notebook.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false,
     "inputHidden": false,
@@ -39,6 +39,7 @@
    "source": [
     "from pprint import pprint\n",
     "\n",
+    "from wetterdienst import Settings\n",
     "from wetterdienst.provider.dwd.observation import (\n",
     "    DwdObservationRequest,\n",
     "    DwdObservationPeriod,\n",
@@ -54,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -65,11 +66,43 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "Wetterdienst default settings"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{'cache_disable': False,\n 'cache_dir': 'abc',\n 'fsspec_client_kwargs': {},\n 'humanize': True,\n 'tidy': True,\n 'si_units': True,\n 'skip_empty': False,\n 'skip_threshold': 0.95,\n 'dropna': False,\n 'interp_use_nearby_station_until_km': 1}"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# don't display real cache_dir, which might contain sensible information\n",
+    "s = Settings.default().to_dict()\n",
+    "s.update({\"cache_dir\": \"abc\"})\n",
+    "s"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false
    },
    "source": [
-    "Which parameters are available?"
+    "## Which parameters are available?"
    ]
   },
   {

--- a/poetry.lock
+++ b/poetry.lock
@@ -282,6 +282,24 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
+name = "asteval"
+version = "0.9.28"
+description = "Safe, minimalistic evaluator of python expression using ast module"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "asteval-0.9.28-py3-none-any.whl", hash = "sha256:c263d25bcc76d5fbeae68b7954b6f7bb16067232b515e4da01e3653e2ec01341"},
+    {file = "asteval-0.9.28.tar.gz", hash = "sha256:91bc7d7826bb9c33f4a5a3ef0a8a50fbd5a4695001944ff1d4e0163c413c0a91"},
+]
+
+[package.extras]
+all = ["Sphinx", "build", "coverage", "pytest", "pytest-cov", "twine"]
+dev = ["build", "twine"]
+doc = ["Sphinx"]
+test = ["coverage", "pytest", "pytest-cov"]
+
+[[package]]
 name = "asttokens"
 version = "2.2.1"
 description = "Annotate AST trees with source code positions"
@@ -1775,6 +1793,17 @@ sphinx = ">=5.0,<7.0"
 sphinx-basic-ng = "*"
 
 [[package]]
+name = "future"
+version = "0.18.3"
+description = "Clean single-source support for Python 3 and 2"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "future-0.18.3.tar.gz", hash = "sha256:34a17436ed1e96697a86f9de3d15a3b0be01d8bc8de9c1dffd59fb8234ed5307"},
+]
+
+[[package]]
 name = "gdal"
 version = "3.6.2"
 description = "GDAL: Geospatial Data Abstraction Library"
@@ -2716,6 +2745,30 @@ six = "*"
 tornado = {version = "*", markers = "python_version > \"2.7\""}
 
 [[package]]
+name = "lmfit"
+version = "1.1.0"
+description = "Least-Squares Minimization with Bounds and Constraints"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "lmfit-1.1.0-py3-none-any.whl", hash = "sha256:29f0540f94b3969a23db2b51abf309f327af8ea3667443ac4cd93d07fdfdb14f"},
+    {file = "lmfit-1.1.0.tar.gz", hash = "sha256:a2755b708ad7bad010178da28f082f55cbee7a084a625b452632e2d77b5391fb"},
+]
+
+[package.dependencies]
+asteval = ">=0.9.28"
+numpy = ">=1.19"
+scipy = ">=1.6"
+uncertainties = ">=3.1.4"
+
+[package.extras]
+all = ["Pillow", "Sphinx", "build", "cairosvg", "check-wheel-contents", "codecov", "corner", "coverage", "dill", "emcee (>=3.0.0)", "flaky", "jupyter-sphinx (>=0.2.4)", "matplotlib", "numdifftools", "pandas", "pre-commit", "pycairo", "pytest", "pytest-cov", "sphinx-gallery (>=0.10)", "sphinxcontrib-svg2pdfconverter", "sympy", "twine"]
+dev = ["build", "check-wheel-contents", "pre-commit", "twine"]
+doc = ["Pillow", "Sphinx", "cairosvg", "corner", "dill", "emcee (>=3.0.0)", "jupyter-sphinx (>=0.2.4)", "matplotlib", "numdifftools", "pandas", "pycairo", "sphinx-gallery (>=0.10)", "sphinxcontrib-svg2pdfconverter", "sympy"]
+test = ["codecov", "coverage", "flaky", "pytest", "pytest-cov"]
+
+[[package]]
 name = "locket"
 version = "1.0.0"
 description = "File-based locks for Python on Linux and Windows"
@@ -3533,40 +3586,40 @@ zfpy = ["zfpy (>=1.0.0)"]
 
 [[package]]
 name = "numpy"
-version = "1.24.1"
+version = "1.24.2"
 description = "Fundamental package for array computing in Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "numpy-1.24.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:179a7ef0889ab769cc03573b6217f54c8bd8e16cef80aad369e1e8185f994cd7"},
-    {file = "numpy-1.24.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b09804ff570b907da323b3d762e74432fb07955701b17b08ff1b5ebaa8cfe6a9"},
-    {file = "numpy-1.24.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1b739841821968798947d3afcefd386fa56da0caf97722a5de53e07c4ccedc7"},
-    {file = "numpy-1.24.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e3463e6ac25313462e04aea3fb8a0a30fb906d5d300f58b3bc2c23da6a15398"},
-    {file = "numpy-1.24.1-cp310-cp310-win32.whl", hash = "sha256:b31da69ed0c18be8b77bfce48d234e55d040793cebb25398e2a7d84199fbc7e2"},
-    {file = "numpy-1.24.1-cp310-cp310-win_amd64.whl", hash = "sha256:b07b40f5fb4fa034120a5796288f24c1fe0e0580bbfff99897ba6267af42def2"},
-    {file = "numpy-1.24.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7094891dcf79ccc6bc2a1f30428fa5edb1e6fb955411ffff3401fb4ea93780a8"},
-    {file = "numpy-1.24.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e418681372520c992805bb723e29d69d6b7aa411065f48216d8329d02ba032"},
-    {file = "numpy-1.24.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e274f0f6c7efd0d577744f52032fdd24344f11c5ae668fe8d01aac0422611df1"},
-    {file = "numpy-1.24.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0044f7d944ee882400890f9ae955220d29b33d809a038923d88e4e01d652acd9"},
-    {file = "numpy-1.24.1-cp311-cp311-win32.whl", hash = "sha256:442feb5e5bada8408e8fcd43f3360b78683ff12a4444670a7d9e9824c1817d36"},
-    {file = "numpy-1.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:de92efa737875329b052982e37bd4371d52cabf469f83e7b8be9bb7752d67e51"},
-    {file = "numpy-1.24.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b162ac10ca38850510caf8ea33f89edcb7b0bb0dfa5592d59909419986b72407"},
-    {file = "numpy-1.24.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:26089487086f2648944f17adaa1a97ca6aee57f513ba5f1c0b7ebdabbe2b9954"},
-    {file = "numpy-1.24.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caf65a396c0d1f9809596be2e444e3bd4190d86d5c1ce21f5fc4be60a3bc5b36"},
-    {file = "numpy-1.24.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0677a52f5d896e84414761531947c7a330d1adc07c3a4372262f25d84af7bf7"},
-    {file = "numpy-1.24.1-cp38-cp38-win32.whl", hash = "sha256:dae46bed2cb79a58d6496ff6d8da1e3b95ba09afeca2e277628171ca99b99db1"},
-    {file = "numpy-1.24.1-cp38-cp38-win_amd64.whl", hash = "sha256:6ec0c021cd9fe732e5bab6401adea5a409214ca5592cd92a114f7067febcba0c"},
-    {file = "numpy-1.24.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:28bc9750ae1f75264ee0f10561709b1462d450a4808cd97c013046073ae64ab6"},
-    {file = "numpy-1.24.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84e789a085aabef2f36c0515f45e459f02f570c4b4c4c108ac1179c34d475ed7"},
-    {file = "numpy-1.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e669fbdcdd1e945691079c2cae335f3e3a56554e06bbd45d7609a6cf568c700"},
-    {file = "numpy-1.24.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef85cf1f693c88c1fd229ccd1055570cb41cdf4875873b7728b6301f12cd05bf"},
-    {file = "numpy-1.24.1-cp39-cp39-win32.whl", hash = "sha256:87a118968fba001b248aac90e502c0b13606721b1343cdaddbc6e552e8dfb56f"},
-    {file = "numpy-1.24.1-cp39-cp39-win_amd64.whl", hash = "sha256:ddc7ab52b322eb1e40521eb422c4e0a20716c271a306860979d450decbb51b8e"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ed5fb71d79e771ec930566fae9c02626b939e37271ec285e9efaf1b5d4370e7d"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad2925567f43643f51255220424c23d204024ed428afc5aad0f86f3ffc080086"},
-    {file = "numpy-1.24.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:cfa1161c6ac8f92dea03d625c2d0c05e084668f4a06568b77a25a89111621566"},
-    {file = "numpy-1.24.1.tar.gz", hash = "sha256:2386da9a471cc00a1f47845e27d916d5ec5346ae9696e01a8a34760858fe9dd2"},
+    {file = "numpy-1.24.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eef70b4fc1e872ebddc38cddacc87c19a3709c0e3e5d20bf3954c147b1dd941d"},
+    {file = "numpy-1.24.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8d2859428712785e8a8b7d2b3ef0a1d1565892367b32f915c4a4df44d0e64f5"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6524630f71631be2dabe0c541e7675db82651eb998496bbe16bc4f77f0772253"},
+    {file = "numpy-1.24.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a51725a815a6188c662fb66fb32077709a9ca38053f0274640293a14fdd22978"},
+    {file = "numpy-1.24.2-cp310-cp310-win32.whl", hash = "sha256:2620e8592136e073bd12ee4536149380695fbe9ebeae845b81237f986479ffc9"},
+    {file = "numpy-1.24.2-cp310-cp310-win_amd64.whl", hash = "sha256:97cf27e51fa078078c649a51d7ade3c92d9e709ba2bfb97493007103c741f1d0"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7de8fdde0003f4294655aa5d5f0a89c26b9f22c0a58790c38fae1ed392d44a5a"},
+    {file = "numpy-1.24.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4173bde9fa2a005c2c6e2ea8ac1618e2ed2c1c6ec8a7657237854d42094123a0"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4cecaed30dc14123020f77b03601559fff3e6cd0c048f8b5289f4eeabb0eb281"},
+    {file = "numpy-1.24.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a23f8440561a633204a67fb44617ce2a299beecf3295f0d13c495518908e910"},
+    {file = "numpy-1.24.2-cp311-cp311-win32.whl", hash = "sha256:e428c4fbfa085f947b536706a2fc349245d7baa8334f0c5723c56a10595f9b95"},
+    {file = "numpy-1.24.2-cp311-cp311-win_amd64.whl", hash = "sha256:557d42778a6869c2162deb40ad82612645e21d79e11c1dc62c6e82a2220ffb04"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d0a2db9d20117bf523dde15858398e7c0858aadca7c0f088ac0d6edd360e9ad2"},
+    {file = "numpy-1.24.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:c72a6b2f4af1adfe193f7beb91ddf708ff867a3f977ef2ec53c0ffb8283ab9f5"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c29e6bd0ec49a44d7690ecb623a8eac5ab8a923bce0bea6293953992edf3a76a"},
+    {file = "numpy-1.24.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2eabd64ddb96a1239791da78fa5f4e1693ae2dadc82a76bc76a14cbb2b966e96"},
+    {file = "numpy-1.24.2-cp38-cp38-win32.whl", hash = "sha256:e3ab5d32784e843fc0dd3ab6dcafc67ef806e6b6828dc6af2f689be0eb4d781d"},
+    {file = "numpy-1.24.2-cp38-cp38-win_amd64.whl", hash = "sha256:76807b4063f0002c8532cfeac47a3068a69561e9c8715efdad3c642eb27c0756"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a"},
+    {file = "numpy-1.24.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb"},
+    {file = "numpy-1.24.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780"},
+    {file = "numpy-1.24.2-cp39-cp39-win32.whl", hash = "sha256:63e45511ee4d9d976637d11e6c9864eae50e12dc9598f531c035265991910468"},
+    {file = "numpy-1.24.2-cp39-cp39-win_amd64.whl", hash = "sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:92011118955724465fb6853def593cf397b4a1367495e0b59a7e69d40c4eb71d"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa"},
+    {file = "numpy-1.24.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:150947adbdfeceec4e5926d956a06865c1c690f2fd902efede4ca6fe2e657c3f"},
+    {file = "numpy-1.24.2.tar.gz", hash = "sha256:003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22"},
 ]
 
 [[package]]
@@ -6084,6 +6137,27 @@ devenv = ["black", "pyroma", "pytest-cov", "zest.releaser"]
 test = ["pytest (>=4.3)", "pytest-mock (>=3.3)"]
 
 [[package]]
+name = "uncertainties"
+version = "3.1.7"
+description = "Transparent calculations with uncertainties on the quantities involved (aka error propagation); fast calculation of derivatives"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "uncertainties-3.1.7-py2.py3-none-any.whl", hash = "sha256:4040ec64d298215531922a68fa1506dc6b1cb86cd7cca8eca848fcfe0f987151"},
+    {file = "uncertainties-3.1.7.tar.gz", hash = "sha256:80111e0839f239c5b233cb4772017b483a0b7a1573a581b92ab7746a35e6faab"},
+]
+
+[package.dependencies]
+future = "*"
+
+[package.extras]
+all = ["nose", "numpy", "sphinx"]
+docs = ["sphinx"]
+optional = ["numpy"]
+tests = ["nose", "numpy"]
+
+[[package]]
 name = "untokenize"
 version = "0.1.1"
 description = "Transforms tokens into original source code (while preserving whitespace)."
@@ -6268,14 +6342,14 @@ files = [
 
 [[package]]
 name = "websocket-client"
-version = "1.5.0"
+version = "1.5.1"
 description = "WebSocket client for Python with low level API options"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "websocket-client-1.5.0.tar.gz", hash = "sha256:561ca949e5bbb5d33409a37235db55c279235c78ee407802f1d2314fff8a8536"},
-    {file = "websocket_client-1.5.0-py3-none-any.whl", hash = "sha256:fb5d81b95d350f3a54838ebcb4c68a5353bbd1412ae8f068b1e5280faeb13074"},
+    {file = "websocket-client-1.5.1.tar.gz", hash = "sha256:3f09e6d8230892547132177f575a4e3e73cfdf06526e20cc02aa1c3b47184d40"},
+    {file = "websocket_client-1.5.1-py3-none-any.whl", hash = "sha256:cdf5877568b7e83aa7cf2244ab56a3213de587bbe0ce9d8b9600fc77b455d89e"},
 ]
 
 [package.extras]
@@ -6508,14 +6582,14 @@ jupyter = ["ipytree (>=0.2.2)", "ipywidgets (>=8.0.0)", "notebook"]
 
 [[package]]
 name = "zipp"
-version = "3.12.0"
+version = "3.12.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "zipp-3.12.0-py3-none-any.whl", hash = "sha256:9eb0a4c5feab9b08871db0d672745b53450d7f26992fd1e4653aa43345e97b86"},
-    {file = "zipp-3.12.0.tar.gz", hash = "sha256:73efd63936398aac78fd92b6f4865190119d6c91b531532e798977ea8dd402eb"},
+    {file = "zipp-3.12.1-py3-none-any.whl", hash = "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3"},
+    {file = "zipp-3.12.1.tar.gz", hash = "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"},
 ]
 
 [package.extras]
@@ -6542,4 +6616,4 @@ sql = ["duckdb"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8,<3.12"
-content-hash = "5746946ed7b9f89a61dc2ba268f9f77a4e4f0718679d8db53b2eb0c267e7e906"
+content-hash = "9e998af78536fc5f89c676ea24fc019610df0f246b746ac2c841a4f4cc760508"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,7 @@ freezegun = "^1.2"
 h5py = { version = "^3.1", optional = true}
 ipykernel = "^6.19.4"
 jupyter = "^1.0.0"
+lmfit = "^1.1.0"  # required for example observations_station_gaussian_model.py
 percy = "^2.0"
 pybufrkit = "^0.2"
 pytest = "^7.2"
@@ -212,7 +213,7 @@ explorer            = ["dash", "dash-bootstrap-components", "dash-leaflet", "geo
 export              = ["openpyxl", "pyarrow", "sqlalchemy", "xarray", "zarr"]
 influxdb            = ["influxdb", "influxdb-client"]
 interpolation       = ["scipy", "shapely", "utm"]
-ipython             = ["ipython", "matplotlib", "jsonschema"]
+ipython             = ["ipython", "matplotlib"]
 mpl                 = ["matplotlib"]
 mysql               = ["mysqlclient"]
 postgresql          = ["psycopg2-binary"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,55 @@
+import pytest
+
+from wetterdienst import Settings
+
+
+@pytest.fixture
+def default_settings():
+    return Settings.default()
+
+
+# True settings
+@pytest.fixture
+def settings_skip_empty_true():
+    return Settings(skip_empty=True, ignore_env=True)
+
+
+@pytest.fixture
+def settings_dropna_true():
+    return Settings(dropna=True, ignore_env=True)
+
+
+# False settings
+@pytest.fixture
+def settings_humanize_false():
+    return Settings(humanize=False, ignore_env=True)
+
+
+@pytest.fixture
+def settings_humanize_si_false():
+    return Settings(humanize=False, si_units=False, ignore_env=True)
+
+
+@pytest.fixture
+def settings_humanize_si_tidy_false():
+    return Settings(tidy=False, humanize=False, si_units=False, ignore_env=True)
+
+
+@pytest.fixture
+def settings_humanize_tidy_false():
+    return Settings(tidy=False, humanize=False, ignore_env=True)
+
+
+@pytest.fixture
+def settings_si_false():
+    return Settings(si_units=False, ignore_env=True)
+
+
+@pytest.fixture
+def settings_si_tidy_false():
+    return Settings(tidy=False, si_units=False, ignore_env=True)
+
+
+@pytest.fixture
+def settings_tidy_false():
+    return Settings(tidy=False, ignore_env=True)

--- a/tests/core/scalar/test_api.py
+++ b/tests/core/scalar/test_api.py
@@ -12,13 +12,14 @@ from wetterdienst.provider.dwd.observation import (
 )
 
 
-def test_api_skip_empty_stations():
+# TODO: Apply dependency injection for `settings` here.
+def test_api_skip_empty_stations(settings):
     start_date = "2021-01-01"
     end_date = "2021-12-31"
 
-    with Settings:
-        Settings.skip_empty = True
+    settings.skip_empty = True
 
+    if True:
         stations = DwdObservationRequest(
             parameter=[
                 DwdObservationDataset.TEMPERATURE_AIR,

--- a/tests/core/scalar/test_interpolation.py
+++ b/tests/core/scalar/test_interpolation.py
@@ -24,12 +24,13 @@ pytestmark = pytest.mark.slow
 
 
 @pytest.mark.remote
-def test_interpolation_temperature_air_mean_200_hourly_by_coords():
+def test_interpolation_temperature_air_mean_200_hourly_by_coords(default_settings):
     stations = DwdObservationRequest(
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.HOURLY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
+        settings=default_settings,
     )
 
     result = stations.interpolate(latlon=(50.0, 8.9))
@@ -53,12 +54,13 @@ def test_interpolation_temperature_air_mean_200_hourly_by_coords():
 
 
 @pytest.mark.remote
-def test_interpolation_temperature_air_mean_200_daily_by_station_id():
+def test_interpolation_temperature_air_mean_200_daily_by_station_id(default_settings):
     stations = DwdObservationRequest(
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
         start_date=datetime(1986, 10, 31),
         end_date=datetime(1986, 11, 1),
+        settings=default_settings,
     )
     for result in (
         stations.interpolate(latlon=(48.2156, 8.9784)),
@@ -83,12 +85,13 @@ def test_interpolation_temperature_air_mean_200_daily_by_station_id():
 
 
 @pytest.mark.remote
-def test_interpolation_precipitation_height_minute_10():
+def test_interpolation_precipitation_height_minute_10(default_settings):
     stations = DwdObservationRequest(
         parameter=Parameter.PRECIPITATION_HEIGHT,
         resolution=DwdObservationResolution.MINUTE_10,
         start_date=datetime(2021, 10, 1),
         end_date=datetime(2021, 10, 5),
+        settings=default_settings,
     )
 
     result = stations.interpolate(latlon=(50.0, 8.9))
@@ -112,12 +115,13 @@ def test_interpolation_precipitation_height_minute_10():
     assert_frame_equal(test_df, expected_df)
 
 
-def test_not_interpolatable_parameter():
+def test_not_interpolatable_parameter(default_settings):
     stations = DwdObservationRequest(
         parameter=Parameter.WIND_DIRECTION,
         resolution=DwdObservationResolution.HOURLY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
+        settings=default_settings,
     )
 
     result = stations.interpolate(latlon=(50.0, 8.9))
@@ -144,12 +148,13 @@ def test_not_interpolatable_parameter():
     )
 
 
-def test_not_interpolatable_dataset():
+def test_not_interpolatable_dataset(default_settings):
     stations = DwdObservationRequest(
         parameter=DwdObservationDataset.TEMPERATURE_AIR,
         resolution=DwdObservationResolution.HOURLY,
         start_date=datetime(2022, 1, 1),
         end_date=datetime(2022, 1, 2),
+        settings=default_settings,
     )
 
     result = stations.interpolate(latlon=(50.0, 8.9))
@@ -177,36 +182,39 @@ def test_not_interpolatable_dataset():
     )
 
 
-def not_supported_provider_dwd_mosmix(caplog):
+def test_not_supported_provider_dwd_mosmix(default_settings, caplog):
     request = DwdMosmixRequest(
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
         parameter=["DD", "ww"],
         mosmix_type=DwdMosmixType.SMALL,
+        settings=default_settings,
     )
     result = request.interpolate(latlon=(50.0, 8.9))
     assert result.df.empty
     assert "Interpolation currently only works for DwdObservationRequest" in caplog.text
 
 
-def test_not_supported_provider_ecc(caplog):
+def test_not_supported_provider_ecc(default_settings, caplog):
     station = EcccObservationRequest(
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=EcccObservationResolution.DAILY,
+        settings=default_settings,
     )
     result = station.interpolate(latlon=(50.0, 8.9))
     assert result.df.empty
     assert "Interpolation currently only works for DwdObservationRequest" in caplog.text
 
 
-def test_interpolation_temperature_air_mean_200_daily_three_floats():
+def test_interpolation_temperature_air_mean_200_daily_three_floats(default_settings):
     stations = DwdObservationRequest(
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
+        settings=default_settings,
     )
     with pytest.raises(ValueError) as excinfo:
         stations.interpolate(latlon=(0, 1, 2))
@@ -214,12 +222,13 @@ def test_interpolation_temperature_air_mean_200_daily_three_floats():
     assert str(excinfo.value).startswith("too many values to unpack")
 
 
-def test_interpolation_temperature_air_mean_200_daily_one_floats():
+def test_interpolation_temperature_air_mean_200_daily_one_floats(default_settings):
     stations = DwdObservationRequest(
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
+        settings=default_settings,
     )
     with pytest.raises(ValueError) as excinfo:
         stations.interpolate(latlon=(0,))
@@ -227,12 +236,13 @@ def test_interpolation_temperature_air_mean_200_daily_one_floats():
     assert str(excinfo.value).startswith("not enough values to unpack")
 
 
-def test_interpolation_temperature_air_mean_200_daily_no_station_found():
+def test_interpolation_temperature_air_mean_200_daily_no_station_found(default_settings):
     stations = DwdObservationRequest(
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
+        settings=default_settings,
     )
     with pytest.raises(StationNotFoundError) as excinfo:
         stations.interpolate_by_station_id(station_id="00")

--- a/tests/core/scalar/test_summary.py
+++ b/tests/core/scalar/test_summary.py
@@ -20,12 +20,13 @@ from wetterdienst.provider.eccc.observation.metadata.resolution import (
 
 
 @pytest.mark.xfail
-def test_summary_temperature_air_mean_200_daily():
+def test_summary_temperature_air_mean_200_daily(default_settings):
     stations = DwdObservationRequest(
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
         start_date=datetime(1934, 1, 1),
         end_date=datetime(1965, 12, 31),
+        settings=default_settings,
     )
     for result in (stations.summarize(latlon=(51.0221, 13.8470)), stations.summarize_by_station_id(station_id="1050")):
         summarized_df = result.df
@@ -48,12 +49,13 @@ def test_summary_temperature_air_mean_200_daily():
         assert_frame_equal(given, expected)
 
 
-def test_not_summarizable_dataset():
+def test_not_summarizable_dataset(default_settings):
     stations = DwdObservationRequest(
         parameter=DwdObservationDataset.TEMPERATURE_AIR,
         resolution=DwdObservationResolution.HOURLY,
         start_date=datetime(2022, 1, 1),
         end_date=datetime(2022, 1, 2),
+        settings=default_settings,
     )
 
     result = stations.summarize(latlon=(50.0, 8.9))
@@ -81,25 +83,27 @@ def test_not_summarizable_dataset():
     )
 
 
-def not_supported_provider_dwd_mosmix(caplog):
+def test_not_supported_provider_dwd_mosmix(default_settings, caplog):
     request = DwdMosmixRequest(
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
         parameter=["DD", "ww"],
         mosmix_type=DwdMosmixType.SMALL,
+        settings=default_settings,
     )
     result = request.summarize(latlon=(50.0, 8.9))
     assert result.df.empty
-    assert "Interpolation currently only works for DwdObservationRequest" in caplog.text
+    assert "Summary currently only works for DwdObservationRequest" in caplog.text
 
 
-def test_not_supported_provider_ecc(caplog):
+def test_not_supported_provider_ecc(default_settings, caplog):
     station = EcccObservationRequest(
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=EcccObservationResolution.DAILY,
+        settings=default_settings,
     )
     result = station.summarize(latlon=(50.0, 8.9))
     assert result.df.empty
-    assert "Interpolation currently only works for DwdObservationRequest" in caplog.text
+    assert "Summary currently only works for DwdObservationRequest" in caplog.text

--- a/tests/example/test_notebook_examples.py
+++ b/tests/example/test_notebook_examples.py
@@ -12,7 +12,7 @@ EXAMPLE_DIR = Path(__file__).parent.parent.parent / "example"
 
 @pytest.mark.slow
 @pytest.mark.remote
-def test_jupyter_example():
+def test_wetterdienst_notebook():
     """Test for climate_observations jupyter notebook"""
     fixture = NBRegressionFixture(
         exec_notebook=True,

--- a/tests/example/test_regular_examples.py
+++ b/tests/example/test_regular_examples.py
@@ -9,6 +9,7 @@ from example import (
     dwd_describe_fields,
     mosmix_forecasts,
     observations_sql,
+    observations_station_gaussian_model,
     observations_stations,
 )
 
@@ -19,6 +20,7 @@ EXAMPLES = (
     mosmix_forecasts,
     observations_sql,
     observations_stations,
+    observations_station_gaussian_model,
     dwd_describe_fields,
 )
 

--- a/tests/provider/dwd/mosmix/test_api_data.py
+++ b/tests/provider/dwd/mosmix/test_api_data.py
@@ -7,20 +7,16 @@ import pytest
 import pytz
 
 from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
-from wetterdienst.settings import Settings
 
 
-# TODO: Apply dependency injection for `settings` here.
 @pytest.mark.remote
-def test_dwd_mosmix_l(settings):
+def test_dwd_mosmix_l(settings_humanize_false):
     """
     Test some details of a typical MOSMIX-L response.
     """
-    settings.tidy = True
-    settings.humanize = False
-    settings.si_units = True
-
-    request = DwdMosmixRequest(parameter="large", mosmix_type=DwdMosmixType.LARGE).filter_by_station_id(
+    request = DwdMosmixRequest(
+        parameter="large", mosmix_type=DwdMosmixType.LARGE, settings=settings_humanize_false
+    ).filter_by_station_id(
         station_id=["01001"],
     )
     response = next(request.values.query())
@@ -166,13 +162,11 @@ def test_dwd_mosmix_l(settings):
 
 @pytest.mark.remote
 @pytest.mark.slow
-def test_dwd_mosmix_s():
+def test_dwd_mosmix_s(settings_humanize_false):
     """Test some details of a typical MOSMIX-S response."""
-    Settings.tidy = True
-    Settings.humanize = False
-    Settings.si_units = True
-
-    request = DwdMosmixRequest(parameter="small", mosmix_type=DwdMosmixType.SMALL,).filter_by_station_id(
+    request = DwdMosmixRequest(
+        parameter="small", mosmix_type=DwdMosmixType.SMALL, settings=settings_humanize_false
+    ).filter_by_station_id(
         station_id=["01028"],
     )
     response = next(request.values.query())
@@ -243,7 +237,7 @@ def test_dwd_mosmix_s():
 
 
 @pytest.mark.remote
-def test_mosmix_date_filter():
+def test_mosmix_date_filter(default_settings):
     now = datetime.now(tz=pytz.utc)
 
     stations = DwdMosmixRequest(
@@ -252,6 +246,7 @@ def test_mosmix_date_filter():
         start_date=now - timedelta(hours=1),
         end_date=now,
         start_issue=now - timedelta(hours=5),
+        settings=default_settings,
     )
 
     nearest_station = stations.filter_by_rank(latlon=(52.122050, 11.619845), rank=1)
@@ -261,15 +256,13 @@ def test_mosmix_date_filter():
 
 
 @pytest.mark.remote
-def test_mosmix_l_parameters():
+def test_mosmix_l_parameters(settings_humanize_false):
     """
     Test some details of a MOSMIX-L response when queried for specific parameters.
     """
-    Settings.tidy = True
-    Settings.humanize = False
-    Settings.si_units = True
-
-    request = DwdMosmixRequest(mosmix_type=DwdMosmixType.LARGE, parameter=["DD", "ww"],).filter_by_station_id(
+    request = DwdMosmixRequest(
+        mosmix_type=DwdMosmixType.LARGE, parameter=["DD", "ww"], settings=settings_humanize_false
+    ).filter_by_station_id(
         station_id=("01001", "123"),
     )
     response = next(request.values.query())

--- a/tests/provider/dwd/mosmix/test_api_data.py
+++ b/tests/provider/dwd/mosmix/test_api_data.py
@@ -10,14 +10,15 @@ from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
 from wetterdienst.settings import Settings
 
 
+# TODO: Apply dependency injection for `settings` here.
 @pytest.mark.remote
-def test_dwd_mosmix_l():
+def test_dwd_mosmix_l(settings):
     """
     Test some details of a typical MOSMIX-L response.
     """
-    Settings.tidy = True
-    Settings.humanize = False
-    Settings.si_units = True
+    settings.tidy = True
+    settings.humanize = False
+    settings.si_units = True
 
     request = DwdMosmixRequest(parameter="large", mosmix_type=DwdMosmixType.LARGE).filter_by_station_id(
         station_id=["01001"],

--- a/tests/provider/dwd/mosmix/test_api_stations.py
+++ b/tests/provider/dwd/mosmix/test_api_stations.py
@@ -20,13 +20,13 @@ from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
 
 
 @pytest.mark.remote
-def test_dwd_mosmix_stations_success():
+def test_dwd_mosmix_stations_success(default_settings):
     """
     Verify full MOSMIX station list.
     """
 
     # Acquire data.
-    df = DwdMosmixRequest(parameter="small", mosmix_type=DwdMosmixType.LARGE).all().df
+    df = DwdMosmixRequest(parameter="small", mosmix_type=DwdMosmixType.LARGE, settings=default_settings).all().df
     assert not df.empty
 
     # Verify size of dataframe with all records.
@@ -69,13 +69,13 @@ def test_dwd_mosmix_stations_success():
 
 
 @pytest.mark.remote
-def test_dwd_mosmix_stations_filtered():
+def test_dwd_mosmix_stations_filtered(default_settings):
     """
     Verify MOSMIX station list filtering by station identifier.
     """
 
     # Acquire data.
-    request = DwdMosmixRequest(parameter="small", mosmix_type=DwdMosmixType.LARGE)
+    request = DwdMosmixRequest(parameter="small", mosmix_type=DwdMosmixType.LARGE, settings=default_settings)
     df = request.all().df
     assert not df.empty
 

--- a/tests/provider/dwd/observation/test_api_stations.py
+++ b/tests/provider/dwd/observation/test_api_stations.py
@@ -30,13 +30,14 @@ EXPECTED_DF = pd.DataFrame(
 
 
 @pytest.mark.remote
-def test_dwd_observations_stations_filter():
+def test_dwd_observations_stations_filter(default_settings):
 
     # Existing combination of parameters
     request = DwdObservationRequest(
         DwdObservationDataset.CLIMATE_SUMMARY,
         DwdObservationResolution.DAILY,
         DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     )
 
     df = request.filter_by_station_id(station_id=("00001",)).df
@@ -47,21 +48,24 @@ def test_dwd_observations_stations_filter():
 
 
 @pytest.mark.remote
-def test_dwd_observations_urban_stations():
+def test_dwd_observations_urban_stations(default_settings):
     """Test DWD Observation urban stations"""
-    stations = DwdObservationRequest(parameter="urban_air_temperature", resolution="hourly", period="historical").all()
+    stations = DwdObservationRequest(
+        parameter="urban_air_temperature", resolution="hourly", period="historical", settings=default_settings
+    ).all()
 
     assert stations.station_id.tolist() == ["00399", "13667", "15811", "15818"]
 
 
 @pytest.mark.remote
-def test_dwd_observations_stations_filter_name():
+def test_dwd_observations_stations_filter_name(default_settings):
 
     # Existing combination of parameters
     request = DwdObservationRequest(
         DwdObservationDataset.CLIMATE_SUMMARY,
         DwdObservationResolution.DAILY,
         DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     )
 
     df = request.filter_by_name(name="Aach").df
@@ -72,13 +76,14 @@ def test_dwd_observations_stations_filter_name():
 
 
 @pytest.mark.remote
-def test_dwd_observations_stations_filter_empty():
+def test_dwd_observations_stations_filter_empty(default_settings):
 
     # Existing combination of parameters
     request = DwdObservationRequest(
         DwdObservationDataset.CLIMATE_SUMMARY,
         DwdObservationResolution.DAILY,
         DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     )
 
     df = request.filter_by_station_id(station_id=("FizzBuzz",)).df
@@ -87,13 +92,14 @@ def test_dwd_observations_stations_filter_empty():
 
 
 @pytest.mark.remote
-def test_dwd_observations_stations_filter_name_empty():
+def test_dwd_observations_stations_filter_name_empty(default_settings):
 
     # Existing combination of parameters
     request = DwdObservationRequest(
         DwdObservationDataset.CLIMATE_SUMMARY,
         DwdObservationResolution.DAILY,
         DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     )
 
     df = request.filter_by_name(name="FizzBuzz").df
@@ -102,21 +108,23 @@ def test_dwd_observations_stations_filter_name_empty():
 
 
 @pytest.mark.remote
-def test_dwd_observations_multiple_datasets_tidy():
+def test_dwd_observations_multiple_datasets_tidy(default_settings):
     request = DwdObservationRequest(
         [DwdObservationDataset.CLIMATE_SUMMARY, DwdObservationDataset.PRECIPITATION_MORE],
         DwdObservationResolution.DAILY,
         DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     ).all()
     assert request.tidy
 
 
-def test_dwd_observations_stations_fail():
+def test_dwd_observations_stations_fail(default_settings):
     with pytest.raises(TypeError):
         DwdObservationRequest(
             DwdObservationDataset.CLIMATE_SUMMARY,
             DwdObservationResolution.DAILY,
             DwdObservationPeriod.HISTORICAL,
+            settings=default_settings,
         ).filter_by_station_id(name="FizzBuzz")
 
     with pytest.raises(TypeError):
@@ -124,17 +132,19 @@ def test_dwd_observations_stations_fail():
             DwdObservationDataset.CLIMATE_SUMMARY,
             DwdObservationResolution.DAILY,
             DwdObservationPeriod.HISTORICAL,
+            settings=default_settings,
         ).filter_by_name(name=123)
 
 
 @pytest.mark.remote
-def test_dwd_observations_stations_geojson():
+def test_dwd_observations_stations_geojson(default_settings):
 
     # Existing combination of parameters
     request = DwdObservationRequest(
         DwdObservationDataset.CLIMATE_SUMMARY,
         DwdObservationResolution.DAILY,
         DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     )
 
     results = request.filter_by_station_id(station_id=("00001",))

--- a/tests/provider/dwd/observation/test_api_stations_geo.py
+++ b/tests/provider/dwd/observation/test_api_stations_geo.py
@@ -56,7 +56,7 @@ EXPECTED_STATIONS_DF = pd.DataFrame.from_records(
 
 
 @pytest.mark.remote
-def test_dwd_observation_stations_nearby_number_single():
+def test_dwd_observation_stations_nearby_number_single(default_settings):
 
     # Test for one nearest station
     request = DwdObservationRequest(
@@ -65,6 +65,7 @@ def test_dwd_observation_stations_nearby_number_single():
         DwdObservationPeriod.HISTORICAL,
         datetime(2020, 1, 1),
         datetime(2020, 1, 20),
+        settings=default_settings,
     )
 
     nearby_station = request.filter_by_rank(
@@ -77,13 +78,14 @@ def test_dwd_observation_stations_nearby_number_single():
 
 
 @pytest.mark.remote
-def test_dwd_observation_stations_nearby_number_multiple():
+def test_dwd_observation_stations_nearby_number_multiple(default_settings):
     request = DwdObservationRequest(
         DwdObservationDataset.TEMPERATURE_AIR,
         DwdObservationResolution.HOURLY,
         DwdObservationPeriod.HISTORICAL,
         datetime(2020, 1, 1),
         datetime(2020, 1, 20),
+        settings=default_settings,
     )
     nearby_station = request.filter_by_rank(
         latlon=(50.0, 8.9),
@@ -95,13 +97,14 @@ def test_dwd_observation_stations_nearby_number_multiple():
 
 
 @pytest.mark.remote
-def test_dwd_observation_stations_nearby_distance():
+def test_dwd_observation_stations_nearby_distance(default_settings):
     request = DwdObservationRequest(
         DwdObservationDataset.TEMPERATURE_AIR,
         DwdObservationResolution.HOURLY,
         DwdObservationPeriod.HISTORICAL,
         datetime(2020, 1, 1),
         datetime(2020, 1, 20),
+        settings=default_settings,
     )
     # Kilometers
     nearby_station = request.filter_by_distance(latlon=(50.0, 8.9), distance=16.13, unit="km")
@@ -117,13 +120,14 @@ def test_dwd_observation_stations_nearby_distance():
 
 
 @pytest.mark.remote
-def test_dwd_observation_stations_bbox():
+def test_dwd_observation_stations_bbox(default_settings):
     request = DwdObservationRequest(
         DwdObservationDataset.TEMPERATURE_AIR,
         DwdObservationResolution.HOURLY,
         DwdObservationPeriod.HISTORICAL,
         datetime(2020, 1, 1),
         datetime(2020, 1, 20),
+        settings=default_settings,
     )
     nearby_station = request.filter_by_bbox(left=8.7862, bottom=49.9195, right=8.993, top=50.0900)
     nearby_station = nearby_station.df.drop("to_date", axis="columns")
@@ -132,13 +136,14 @@ def test_dwd_observation_stations_bbox():
 
 
 @pytest.mark.remote
-def test_dwd_observation_stations_empty():
+def test_dwd_observation_stations_empty(default_settings):
     request = DwdObservationRequest(
         DwdObservationDataset.TEMPERATURE_AIR,
         DwdObservationResolution.HOURLY,
         DwdObservationPeriod.HISTORICAL,
         datetime(2020, 1, 1),
         datetime(2020, 1, 20),
+        settings=default_settings,
     )
 
     # Bbox
@@ -151,7 +156,7 @@ def test_dwd_observation_stations_empty():
 
 
 @pytest.mark.remote
-def test_dwd_observation_stations_fail():
+def test_dwd_observation_stations_fail(default_settings):
     # Number
     with pytest.raises(ValueError):
         DwdObservationRequest(
@@ -160,6 +165,7 @@ def test_dwd_observation_stations_fail():
             DwdObservationPeriod.HISTORICAL,
             datetime(2020, 1, 1),
             datetime(2020, 1, 20),
+            settings=default_settings,
         ).filter_by_rank(
             latlon=(51.4, 9.3),
             rank=0,
@@ -172,6 +178,7 @@ def test_dwd_observation_stations_fail():
             DwdObservationPeriod.HISTORICAL,
             datetime(2020, 1, 1),
             datetime(2020, 1, 20),
+            settings=default_settings,
         ).filter_by_distance(
             latlon=(51.4, 9.3),
             distance=-1,
@@ -184,6 +191,7 @@ def test_dwd_observation_stations_fail():
             DwdObservationPeriod.HISTORICAL,
             datetime(2020, 1, 1),
             datetime(2020, 1, 20),
+            settings=default_settings,
         ).filter_by_bbox(left=10, bottom=10, right=5, top=5)
 
 

--- a/tests/provider/dwd/observation/test_available_datasets.py
+++ b/tests/provider/dwd/observation/test_available_datasets.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
+import pytest
+
 from wetterdienst import boot
 
 boot.monkeypatch()
@@ -17,7 +19,6 @@ from wetterdienst.provider.dwd.observation.metadata.dataset import (
 from wetterdienst.provider.dwd.observation.metadata.parameter import (
     DwdObservationParameter,
 )
-from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 
@@ -36,7 +37,8 @@ SKIP_DATASETS = (
 )
 
 
-def test_compare_available_dwd_datasets():
+@pytest.mark.remote
+def test_compare_available_dwd_datasets(default_settings):
     """Test to compare the datasets made available with wetterdienst with the ones actually availabel on the DWD CDC
     server instance"""
     # similar to func list_remote_files_fsspec, but we don't want to get full depth
@@ -44,8 +46,8 @@ def test_compare_available_dwd_datasets():
         use_listings_cache=True,
         listings_expiry_time=CacheExpiry.TWELVE_HOURS.value,
         listings_cache_type="filedircache",
-        listings_cache_location=Settings.cache_dir,
-        client_kwargs=Settings.fsspec_client_kwargs,
+        listings_cache_location=default_settings.cache_dir,
+        client_kwargs=default_settings.fsspec_client_kwargs,
     )
 
     base_url = "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/"

--- a/tests/provider/dwd/observation/test_fileindex.py
+++ b/tests/provider/dwd/observation/test_fileindex.py
@@ -19,13 +19,14 @@ from wetterdienst.provider.dwd.observation.fileindex import (
 
 
 @pytest.mark.remote
-def test_file_index_creation_success():
+def test_file_index_creation_success(default_settings):
 
     # Existing combination of parameters
     file_index = create_file_index_for_climate_observations(
         DwdObservationDataset.CLIMATE_SUMMARY,
         DwdObservationResolution.DAILY,
         DwdObservationPeriod.RECENT,
+        settings=default_settings,
     )
 
     assert not file_index.empty
@@ -40,23 +41,21 @@ def test_file_index_creation_success():
 
 
 @pytest.mark.remote
-def test_file_index_creation_failure():
-
+def test_file_index_creation_failure(default_settings):
     with pytest.raises(FileNotFoundError):
         create_file_index_for_climate_observations(
-            DwdObservationDataset.CLIMATE_SUMMARY,
-            Resolution.MINUTE_1,
-            Period.HISTORICAL,
+            DwdObservationDataset.CLIMATE_SUMMARY, Resolution.MINUTE_1, Period.HISTORICAL, settings=default_settings
         )
 
 
 @pytest.mark.remote
-def test_create_file_list_for_dwd_server():
+def test_create_file_list_for_dwd_server(default_settings):
     remote_file_path = create_file_list_for_climate_observations(
         station_id="01048",
         dataset=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.RECENT,
+        settings=default_settings,
     )
     assert remote_file_path == [
         "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/"
@@ -70,6 +69,7 @@ def test_create_file_list_for_dwd_server():
         resolution=Resolution.MINUTE_10,
         period=Period.HISTORICAL,
         date_range="19930428_19991231",
+        settings=default_settings,
     )
 
     assert remote_file_path == [

--- a/tests/provider/dwd/observation/test_io.py
+++ b/tests/provider/dwd/observation/test_io.py
@@ -178,16 +178,13 @@ def test_format_csv():
 
 
 @pytest.mark.remote
-def test_request():
+def test_request(default_settings):
     """Test general data request"""
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = True
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.RECENT,
+        settings=default_settings,
     ).filter_by_station_id(station_id=[1048])
 
     df = request.values.all().df
@@ -196,16 +193,13 @@ def test_request():
 
 
 @pytest.mark.remote
-def test_export_unknown():
+def test_export_unknown(default_settings):
     """Test export of DataFrame to unknown format"""
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = True
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.RECENT,
+        settings=default_settings,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -219,18 +213,15 @@ def test_export_unknown():
 
 
 @pytest.mark.remote
-def test_export_spreadsheet(tmp_path):
+def test_export_spreadsheet(tmp_path, settings_si_tidy_false):
     """Test export of DataFrame to spreadsheet"""
-    Settings.tidy = False
-    Settings.humanize = True
-    Settings.si_units = False
-
     # 1. Request data and save to .xlsx file.
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         start_date="2019",
         end_date="2020",
+        settings=settings_si_tidy_false,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -322,14 +313,9 @@ def test_export_spreadsheet(tmp_path):
 
 
 @pytest.mark.remote
-def test_export_parquet(tmp_path):
+def test_export_parquet(tmp_path, settings_si_tidy_false):
     """Test export of DataFrame to parquet"""
-
     pq = pytest.importorskip("pyarrow.parquet")
-
-    Settings.tidy = False
-    Settings.humanize = True
-    Settings.si_units = False
 
     # Request data.
     request = DwdObservationRequest(
@@ -337,6 +323,7 @@ def test_export_parquet(tmp_path):
         resolution=DwdObservationResolution.DAILY,
         start_date="2019",
         end_date="2020",
+        settings=settings_si_tidy_false,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -389,14 +376,10 @@ def test_export_parquet(tmp_path):
 
 
 @pytest.mark.remote
-def test_export_zarr(tmp_path):
+def test_export_zarr(tmp_path, settings_si_tidy_false):
     """Test export of DataFrame to zarr"""
 
     zarr = pytest.importorskip("zarr")
-
-    Settings.tidy = False
-    Settings.humanize = True
-    Settings.si_units = False
 
     # Request data.
     request = DwdObservationRequest(
@@ -404,6 +387,7 @@ def test_export_zarr(tmp_path):
         resolution=DwdObservationResolution.DAILY,
         start_date="2019",
         end_date="2020",
+        settings=settings_si_tidy_false,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -457,13 +441,9 @@ def test_export_zarr(tmp_path):
 
 
 @pytest.mark.remote
-def test_export_feather(tmp_path):
+def test_export_feather(tmp_path, settings_si_tidy_false):
     """Test export of DataFrame to feather"""
     feather = pytest.importorskip("pyarrow.feather")
-
-    Settings.tidy = False
-    Settings.humanize = True
-    Settings.si_units = False
 
     # Request data
     request = DwdObservationRequest(
@@ -471,6 +451,7 @@ def test_export_feather(tmp_path):
         resolution=DwdObservationResolution.DAILY,
         start_date="2019",
         end_date="2020",
+        settings=settings_si_tidy_false,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -523,17 +504,14 @@ def test_export_feather(tmp_path):
 
 
 @pytest.mark.remote
-def test_export_sqlite(tmp_path):
+def test_export_sqlite(tmp_path, settings_si_tidy_false):
     """Test export of DataFrame to sqlite db"""
-    Settings.tidy = False
-    Settings.humanize = True
-    Settings.si_units = False
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         start_date="2019",
         end_date="2020",
+        settings=settings_si_tidy_false,
     ).filter_by_station_id(
         station_id=[1048],
     )
@@ -629,16 +607,13 @@ def test_export_cratedb():
 
 @surrogate("duckdb.connect")
 @pytest.mark.remote
-def test_export_duckdb():
+def test_export_duckdb(settings_si_false):
     """Test export of DataFrame to duckdb"""
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = False
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.RECENT,
+        settings=settings_si_false,
     ).filter_by_station_id(station_id=[1048])
 
     mock_connection = mock.MagicMock()
@@ -656,16 +631,13 @@ def test_export_duckdb():
 
 @surrogate("influxdb.InfluxDBClient")
 @pytest.mark.remote
-def test_export_influxdb1_tabular():
+def test_export_influxdb1_tabular(settings_si_tidy_false):
     """Test export of DataFrame to influxdb v1"""
-    Settings.tidy = False
-    Settings.humanize = True
-    Settings.si_units = False
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.RECENT,
+        settings=settings_si_tidy_false,
     ).filter_by_station_id(station_id=[1048])
 
     mock_client = mock.MagicMock()
@@ -722,16 +694,13 @@ def test_export_influxdb1_tabular():
 
 @surrogate("influxdb.InfluxDBClient")
 @pytest.mark.remote
-def test_export_influxdb1_tidy():
+def test_export_influxdb1_tidy(settings_si_false):
     """Test export of DataFrame to influxdb v1"""
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = False
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.RECENT,
+        settings=settings_si_false,
     ).filter_by_station_id(station_id=[1048])
 
     mock_client = mock.MagicMock()
@@ -777,16 +746,13 @@ def test_export_influxdb1_tidy():
 @surrogate("influxdb_client.Point")
 @surrogate("influxdb_client.client.write_api.SYNCHRONOUS")
 @pytest.mark.remote
-def test_export_influxdb2_tabular():
+def test_export_influxdb2_tabular(settings_si_false):
     """Test export of DataFrame to influxdb v2"""
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = False
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.RECENT,
+        settings=settings_si_false,
     ).filter_by_station_id(station_id=[1048])
 
     mock_client = mock.MagicMock()
@@ -811,16 +777,13 @@ def test_export_influxdb2_tabular():
 @surrogate("influxdb_client.Point")
 @surrogate("influxdb_client.client.write_api.SYNCHRONOUS")
 @pytest.mark.remote
-def test_export_influxdb2_tidy():
+def test_export_influxdb2_tidy(settings_si_false):
     """Test export of DataFrame to influxdb v2"""
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = False
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.CLIMATE_SUMMARY,
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.RECENT,
+        settings=settings_si_false,
     ).filter_by_station_id(station_id=[1048])
 
     mock_client = mock.MagicMock()

--- a/tests/provider/dwd/observation/test_metaindex.py
+++ b/tests/provider/dwd/observation/test_metaindex.py
@@ -14,36 +14,30 @@ from wetterdienst.provider.dwd.observation.metaindex import (
 
 
 @pytest.mark.remote
-def test_meta_index_creation_success():
+def test_meta_index_creation_success(default_settings):
 
     # Existing combination of parameters
     meta_index = create_meta_index_for_climate_observations(
-        DwdObservationDataset.CLIMATE_SUMMARY,
-        Resolution.DAILY,
-        Period.HISTORICAL,
+        DwdObservationDataset.CLIMATE_SUMMARY, Resolution.DAILY, Period.HISTORICAL, settings=default_settings
     )
 
     assert not meta_index.empty
 
 
 @pytest.mark.remote
-def test_meta_index_creation_failure():
+def test_meta_index_creation_failure(default_settings):
 
     with pytest.raises(FileNotFoundError):
         create_meta_index_for_climate_observations(
-            DwdObservationDataset.CLIMATE_SUMMARY,
-            Resolution.MINUTE_1,
-            Period.HISTORICAL,
+            DwdObservationDataset.CLIMATE_SUMMARY, Resolution.MINUTE_1, Period.HISTORICAL, settings=default_settings
         )
 
 
 @pytest.mark.remote
-def test_meta_index_1mph_creation():
+def test_meta_index_1mph_creation(default_settings):
 
     meta_index_1mph = create_meta_index_for_climate_observations(
-        DwdObservationDataset.PRECIPITATION,
-        Resolution.MINUTE_1,
-        Period.HISTORICAL,
+        DwdObservationDataset.PRECIPITATION, Resolution.MINUTE_1, Period.HISTORICAL, settings=default_settings
     )
 
     assert meta_index_1mph.loc[meta_index_1mph[Columns.STATION_ID.value] == "00003", :].values.tolist() == [

--- a/tests/provider/dwd/observation/test_parameters.py
+++ b/tests/provider/dwd/observation/test_parameters.py
@@ -33,7 +33,7 @@ parameters_reference = [
 ]
 
 
-def test_dwd_observation_parameters_constants():
+def test_dwd_observation_parameters_constants(default_settings):
     request = DwdObservationRequest(
         parameter=[
             DwdObservationParameter.DAILY.TEMPERATURE_AIR_MEAN_200,  # tmk
@@ -44,12 +44,13 @@ def test_dwd_observation_parameters_constants():
         ],
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     )
 
     assert request.parameter == parameters_reference
 
 
-def test_dwd_observation_parameters_strings_lowercase():
+def test_dwd_observation_parameters_strings_lowercase(default_settings):
     request = DwdObservationRequest(
         parameter=[
             "tmk",
@@ -60,12 +61,13 @@ def test_dwd_observation_parameters_strings_lowercase():
         ],
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     )
 
     assert request.parameter == parameters_reference
 
 
-def test_dwd_observation_parameters_strings_uppercase():
+def test_dwd_observation_parameters_strings_uppercase(default_settings):
     request = DwdObservationRequest(
         parameter=[
             "TMK",
@@ -76,6 +78,7 @@ def test_dwd_observation_parameters_strings_uppercase():
         ],
         resolution=DwdObservationResolution.DAILY,
         period=DwdObservationPeriod.HISTORICAL,
+        settings=default_settings,
     )
 
     assert request.parameter == parameters_reference

--- a/tests/provider/dwd/radar/test_api_current.py
+++ b/tests/provider/dwd/radar/test_api_current.py
@@ -19,7 +19,7 @@ h5py = pytest.importorskip("h5py", reason="h5py not installed")
 
 
 @pytest.mark.remote
-def test_radar_request_site_current_sweep_pcp_v_hdf5():
+def test_radar_request_site_current_sweep_pcp_v_hdf5(default_settings):
     """
     Example for testing radar sites full current SWEEP_PCP,
     this time in OPERA HDF5 (ODIM_H5) format.
@@ -31,6 +31,7 @@ def test_radar_request_site_current_sweep_pcp_v_hdf5():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -62,7 +63,7 @@ def test_radar_request_site_current_sweep_pcp_v_hdf5():
 
 
 @pytest.mark.remote
-def test_radar_request_site_current_sweep_vol_v_hdf5_full():
+def test_radar_request_site_current_sweep_vol_v_hdf5_full(default_settings):
     """
     Example for testing radar sites full current SWEEP_VOL,
     this time in OPERA HDF5 (ODIM_H5) format.
@@ -74,6 +75,7 @@ def test_radar_request_site_current_sweep_vol_v_hdf5_full():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -105,7 +107,7 @@ def test_radar_request_site_current_sweep_vol_v_hdf5_full():
 
 
 @pytest.mark.remote
-def test_radar_request_site_current_sweep_vol_v_hdf5_single():
+def test_radar_request_site_current_sweep_vol_v_hdf5_single(default_settings):
     """
     Example for testing radar sites single current SWEEP_VOL,
     this time in OPERA HDF5 (ODIM_H5) format.
@@ -118,6 +120,7 @@ def test_radar_request_site_current_sweep_vol_v_hdf5_single():
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
         elevation=1,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -144,7 +147,7 @@ def test_radar_request_site_current_sweep_vol_v_hdf5_single():
         DwdRadarResolution.HOURLY,
     ],
 )
-def test_radar_request_radolan_cdc_current(resolution):
+def test_radar_request_radolan_cdc_current(resolution, default_settings):
     """
     Verify data acquisition for current RADOLAN_CDC/daily+hourly.
 
@@ -157,6 +160,7 @@ def test_radar_request_radolan_cdc_current(resolution):
         start_date=DwdRadarDate.CURRENT,
         resolution=resolution,
         period=DwdRadarPeriod.RECENT,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -168,7 +172,7 @@ def test_radar_request_radolan_cdc_current(resolution):
 
 
 @pytest.mark.remote
-def test_radar_request_radolan_cdc_current_5min():
+def test_radar_request_radolan_cdc_current_5min(default_settings):
     """
     Verify failure for RADOLAN_CDC/5 minutes.
 
@@ -178,4 +182,5 @@ def test_radar_request_radolan_cdc_current_5min():
             parameter=DwdRadarParameter.RADOLAN_CDC,
             resolution=DwdRadarResolution.MINUTE_5,
             start_date=DwdRadarDate.CURRENT,
+            settings=default_settings,
         )

--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -26,7 +26,7 @@ h5py = pytest.importorskip("h5py", reason="h5py not installed")
 wrl = pytest.importorskip("wradlib", reason="wradlib not installed")
 
 
-def test_radar_request_radolan_cdc_hourly_alignment_1():
+def test_radar_request_radolan_cdc_hourly_alignment_1(default_settings):
     """
     Verify the alignment of RADOLAN_CDC timestamps
     to designated interval marks of HH:50.
@@ -40,12 +40,13 @@ def test_radar_request_radolan_cdc_hourly_alignment_1():
         resolution=DwdRadarResolution.HOURLY,
         period=DwdRadarPeriod.HISTORICAL,
         start_date="2019-08-08 00:53:53",
+        settings=default_settings,
     )
 
     assert request.start_date == datetime(year=2019, month=8, day=8, hour=0, minute=50, second=0)
 
 
-def test_radar_request_radolan_cdc_hourly_alignment_2():
+def test_radar_request_radolan_cdc_hourly_alignment_2(default_settings):
     """
     Verify the alignment of RADOLAN_CDC timestamps
     to designated interval marks of HH:50.
@@ -59,13 +60,14 @@ def test_radar_request_radolan_cdc_hourly_alignment_2():
         resolution=DwdRadarResolution.HOURLY,
         period=DwdRadarPeriod.HISTORICAL,
         start_date="2019-08-08 00:42:42",
+        settings=default_settings,
     )
 
     assert request.start_date == datetime(year=2019, month=8, day=7, hour=23, minute=50, second=0)
 
 
 @pytest.mark.remote
-def test_radar_request_radolan_cdc_historic_hourly_data():
+def test_radar_request_radolan_cdc_historic_hourly_data(default_settings):
     """
     Verify data acquisition for RADOLAN_CDC/hourly/historical.
     """
@@ -75,6 +77,7 @@ def test_radar_request_radolan_cdc_historic_hourly_data():
         resolution=DwdRadarResolution.HOURLY,
         period=DwdRadarPeriod.HISTORICAL,
         start_date="2019-08-08 00:50:00",
+        settings=default_settings,
     )
 
     assert request == DwdRadarValues(
@@ -82,6 +85,7 @@ def test_radar_request_radolan_cdc_historic_hourly_data():
         resolution=DwdRadarResolution.HOURLY,
         period=DwdRadarPeriod.HISTORICAL,
         start_date=datetime(year=2019, month=8, day=8, hour=0, minute=50, second=0),
+        settings=default_settings,
     )
 
     radolan_hourly_backup_url = (
@@ -100,7 +104,7 @@ def test_radar_request_radolan_cdc_historic_hourly_data():
 
 
 @pytest.mark.remote
-def test_radar_request_radolan_cdc_historic_daily_data():
+def test_radar_request_radolan_cdc_historic_daily_data(default_settings):
     """
     Verify data acquisition for RADOLAN_CDC/daily/historical.
     """
@@ -109,6 +113,7 @@ def test_radar_request_radolan_cdc_historic_daily_data():
         resolution=DwdRadarResolution.DAILY,
         period=DwdRadarPeriod.HISTORICAL,
         start_date="2019-08-08 00:50:00",
+        settings=default_settings,
     )
 
     assert request == DwdRadarValues(
@@ -116,6 +121,7 @@ def test_radar_request_radolan_cdc_historic_daily_data():
         resolution=DwdRadarResolution.DAILY,
         period=DwdRadarPeriod.HISTORICAL,
         start_date=datetime(year=2019, month=8, day=8, hour=0, minute=50, second=0),
+        settings=default_settings,
     )
 
     radolan_daily_backup_url = (
@@ -134,7 +140,7 @@ def test_radar_request_radolan_cdc_historic_daily_data():
 
 
 @pytest.mark.remote
-def test_radar_request_composite_historic_hg_yesterday(prefixed_radar_locations):
+def test_radar_request_composite_historic_hg_yesterday(prefixed_radar_locations, default_settings):
     """
     Example for testing radar/composite FX for a specific date.
     """
@@ -142,8 +148,7 @@ def test_radar_request_composite_historic_hg_yesterday(prefixed_radar_locations)
     timestamp = datetime.utcnow() - timedelta(days=1)
 
     request = DwdRadarValues(
-        parameter=DwdRadarParameter.HG_REFLECTIVITY,
-        start_date=timestamp,
+        parameter=DwdRadarParameter.HG_REFLECTIVITY, start_date=timestamp, settings=default_settings
     )
 
     results = list(request.query())
@@ -185,7 +190,7 @@ def test_radar_request_composite_historic_hg_yesterday(prefixed_radar_locations)
 
 
 @pytest.mark.remote
-def test_radar_request_composite_historic_hg_timerange():
+def test_radar_request_composite_historic_hg_timerange(default_settings):
     """
     Example for testing radar/composite FX for a timerange.
     """
@@ -196,6 +201,7 @@ def test_radar_request_composite_historic_hg_timerange():
         parameter=DwdRadarParameter.HG_REFLECTIVITY,
         start_date=timestamp,
         end_date=timedelta(minutes=10),
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -213,7 +219,7 @@ def test_radar_request_composite_historic_hg_timerange():
 
 
 @pytest.mark.remote
-def test_radar_request_composite_historic_radolan_rw_yesterday(radar_locations):
+def test_radar_request_composite_historic_radolan_rw_yesterday(radar_locations, default_settings):
     """
     Verify acquisition of radar/composite/radolan_rw data works
     when using a specific date.
@@ -222,8 +228,7 @@ def test_radar_request_composite_historic_radolan_rw_yesterday(radar_locations):
     timestamp = datetime.utcnow() - timedelta(days=1)
 
     request = DwdRadarValues(
-        parameter=DwdRadarParameter.RW_REFLECTIVITY,
-        start_date=timestamp,
+        parameter=DwdRadarParameter.RW_REFLECTIVITY, start_date=timestamp, settings=default_settings
     )
 
     results = list(request.query())
@@ -259,7 +264,7 @@ def test_radar_request_composite_historic_radolan_rw_yesterday(radar_locations):
 
 
 @pytest.mark.remote
-def test_radar_request_composite_historic_radolan_rw_timerange(radar_locations):
+def test_radar_request_composite_historic_radolan_rw_timerange(radar_locations, default_settings):
     """
     Verify acquisition of radar/composite/radolan_rw data works
     when using a specific date, with timerange.
@@ -271,6 +276,7 @@ def test_radar_request_composite_historic_radolan_rw_timerange(radar_locations):
         parameter=DwdRadarParameter.RW_REFLECTIVITY,
         start_date=timestamp,
         end_date=timedelta(hours=3),
+        settings=default_settings,
     )
     results = list(request.query())
 
@@ -305,7 +311,7 @@ def test_radar_request_composite_historic_radolan_rw_timerange(radar_locations):
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_dx_yesterday():
+def test_radar_request_site_historic_dx_yesterday(default_settings):
     """
     Verify acquisition of radar/site/DX data works
     when using a specific date.
@@ -317,6 +323,7 @@ def test_radar_request_site_historic_dx_yesterday():
         parameter=DwdRadarParameter.DX_REFLECTIVITY,
         start_date=timestamp,
         site=DwdRadarSite.BOO,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -349,7 +356,7 @@ def test_radar_request_site_historic_dx_yesterday():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_dx_timerange():
+def test_radar_request_site_historic_dx_timerange(default_settings):
     """
     Verify acquisition of radar/site/DX data works
     when using a specific date, with timerange.
@@ -362,6 +369,7 @@ def test_radar_request_site_historic_dx_timerange():
         start_date=timestamp,
         end_date=timedelta(hours=0.5),
         site=DwdRadarSite.BOO,
+        settings=default_settings,
     )
 
     # Verify number of elements.
@@ -397,7 +405,7 @@ def test_radar_request_site_historic_dx_timerange():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_pe_binary_yesterday():
+def test_radar_request_site_historic_pe_binary_yesterday(default_settings):
     """
     Verify acquisition of radar/site/PE_ECHO_TOP data works
     when using a specific date.
@@ -413,6 +421,7 @@ def test_radar_request_site_historic_pe_binary_yesterday():
         start_date=timestamp,
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.BINARY,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -436,7 +445,7 @@ def test_radar_request_site_historic_pe_binary_yesterday():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_pe_bufr():
+def test_radar_request_site_historic_pe_bufr(default_settings):
     """
     Verify acquisition of radar/site/PE_ECHO_TOP data works
     when using a specific date.
@@ -452,6 +461,7 @@ def test_radar_request_site_historic_pe_bufr():
         start_date=timestamp,
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.BUFR,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -480,7 +490,7 @@ def test_radar_request_site_historic_pe_bufr():
         DwdRadarDataFormat.BUFR,
     ],
 )
-def test_radar_request_site_historic_pe_timerange(fmt):
+def test_radar_request_site_historic_pe_timerange(fmt, default_settings):
     """
     Verify acquisition of radar/site/PE_ECHO_TOP data works
     when using date ranges.
@@ -499,6 +509,7 @@ def test_radar_request_site_historic_pe_timerange(fmt):
         end_date=end_date,
         site=DwdRadarSite.BOO,
         fmt=fmt,
+        settings=default_settings,
     )
 
     assert request.start_date.minute % 5 == 0
@@ -524,7 +535,7 @@ def test_radar_request_site_historic_pe_timerange(fmt):
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_px250_bufr_yesterday():
+def test_radar_request_site_historic_px250_bufr_yesterday(default_settings):
     """
     Example for testing radar/site PX250 for a specific date.
     """
@@ -535,6 +546,7 @@ def test_radar_request_site_historic_px250_bufr_yesterday():
         parameter=DwdRadarParameter.PX250_REFLECTIVITY,
         start_date=timestamp,
         site=DwdRadarSite.BOO,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -566,7 +578,7 @@ def test_radar_request_site_historic_px250_bufr_yesterday():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_px250_bufr_timerange():
+def test_radar_request_site_historic_px250_bufr_timerange(default_settings):
     """
     Example for testing radar/site PX250 for a specific date, with timerange.
     """
@@ -578,6 +590,7 @@ def test_radar_request_site_historic_px250_bufr_timerange():
         start_date=timestamp,
         end_date=timedelta(hours=1),
         site=DwdRadarSite.BOO,
+        settings=default_settings,
     )
 
     # Verify number of elements.
@@ -590,7 +603,7 @@ def test_radar_request_site_historic_px250_bufr_timerange():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_sweep_pcp_v_bufr_yesterday():
+def test_radar_request_site_historic_sweep_pcp_v_bufr_yesterday(default_settings):
     """
     Example for testing radar/site sweep-precipitation for a specific date,
     this time in BUFR format.
@@ -603,6 +616,7 @@ def test_radar_request_site_historic_sweep_pcp_v_bufr_yesterday():
         start_date=timestamp,
         site=DwdRadarSite.ASB,
         fmt=DwdRadarDataFormat.BUFR,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -630,7 +644,7 @@ def test_radar_request_site_historic_sweep_pcp_v_bufr_yesterday():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_sweep_pcp_v_bufr_timerange():
+def test_radar_request_site_historic_sweep_pcp_v_bufr_timerange(default_settings):
     """
     Example for testing radar/site sweep-precipitation for a specific date,
     this time in BUFR format, with timerange.
@@ -644,6 +658,7 @@ def test_radar_request_site_historic_sweep_pcp_v_bufr_timerange():
         end_date=timedelta(hours=1),
         site=DwdRadarSite.ASB,
         fmt=DwdRadarDataFormat.BUFR,
+        settings=default_settings,
     )
 
     # Verify number of elements.
@@ -665,7 +680,7 @@ def test_radar_request_site_historic_sweep_pcp_v_bufr_timerange():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_sweep_vol_v_bufr_yesterday():
+def test_radar_request_site_historic_sweep_vol_v_bufr_yesterday(default_settings):
     """
     Example for testing radar/site sweep_vol_v for a specific date,
     this time in BUFR format.
@@ -678,6 +693,7 @@ def test_radar_request_site_historic_sweep_vol_v_bufr_yesterday():
         start_date=timestamp,
         site=DwdRadarSite.ASB,
         fmt=DwdRadarDataFormat.BUFR,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -705,7 +721,7 @@ def test_radar_request_site_historic_sweep_vol_v_bufr_yesterday():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_sweep_vol_v_bufr_timerange():
+def test_radar_request_site_historic_sweep_vol_v_bufr_timerange(default_settings):
     """
     Example for testing radar/site sweep_vol_v for a specific date,
     this time in BUFR format, with timerange.
@@ -719,6 +735,7 @@ def test_radar_request_site_historic_sweep_vol_v_bufr_timerange():
         end_date=timedelta(hours=0.5),
         site=DwdRadarSite.ASB,
         fmt=DwdRadarDataFormat.BUFR,
+        settings=default_settings,
     )
 
     # Verify number of elements.
@@ -740,7 +757,7 @@ def test_radar_request_site_historic_sweep_vol_v_bufr_timerange():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_sweep_pcp_v_hdf5_yesterday():
+def test_radar_request_site_historic_sweep_pcp_v_hdf5_yesterday(default_settings):
     """
     Example for testing radar/site sweep-precipitation for a specific date,
     this time in HDF5 format.
@@ -754,6 +771,7 @@ def test_radar_request_site_historic_sweep_pcp_v_hdf5_yesterday():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
     results = list(request.query())
 
@@ -790,7 +808,7 @@ def test_radar_request_site_historic_sweep_pcp_v_hdf5_yesterday():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_sweep_pcp_v_hdf5_timerange():
+def test_radar_request_site_historic_sweep_pcp_v_hdf5_timerange(default_settings):
     """
     Example for testing radar/site sweep-precipitation for a specific date,
     this time in HDF5 format, with timerange.
@@ -805,6 +823,7 @@ def test_radar_request_site_historic_sweep_pcp_v_hdf5_timerange():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     # Verify number of elements.
@@ -826,7 +845,7 @@ def test_radar_request_site_historic_sweep_pcp_v_hdf5_timerange():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_sweep_vol_v_hdf5_yesterday():
+def test_radar_request_site_historic_sweep_vol_v_hdf5_yesterday(default_settings):
     """
     Example for testing radar/site sweep-precipitation for a specific date,
     this time in HDF5 format.
@@ -840,6 +859,7 @@ def test_radar_request_site_historic_sweep_vol_v_hdf5_yesterday():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
     results = list(request.query())
 
@@ -886,7 +906,7 @@ def test_radar_request_site_historic_sweep_vol_v_hdf5_yesterday():
 
 
 @pytest.mark.remote
-def test_radar_request_site_historic_sweep_vol_v_hdf5_timerange():
+def test_radar_request_site_historic_sweep_vol_v_hdf5_timerange(default_settings):
     """
     Example for testing radar/site sweep-precipitation for a specific date,
     this time in HDF5 format, with timerange.
@@ -901,6 +921,7 @@ def test_radar_request_site_historic_sweep_vol_v_hdf5_timerange():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     # Verify number of elements.
@@ -922,7 +943,7 @@ def test_radar_request_site_historic_sweep_vol_v_hdf5_timerange():
 
 
 @pytest.mark.remote
-def test_radar_request_radvor_re_yesterday(prefixed_radar_locations):
+def test_radar_request_radvor_re_yesterday(prefixed_radar_locations, default_settings):
     """
     Verify acquisition of radar/radvor/re data works
     when using a specific date. Querying one point
@@ -935,8 +956,7 @@ def test_radar_request_radvor_re_yesterday(prefixed_radar_locations):
     timestamp = datetime.utcnow() - timedelta(days=1)
 
     request = DwdRadarValues(
-        parameter=DwdRadarParameter.RE_REFLECTIVITY,
-        start_date=timestamp,
+        parameter=DwdRadarParameter.RE_REFLECTIVITY, start_date=timestamp, settings=default_settings
     )
 
     results = list(request.query())
@@ -978,7 +998,7 @@ def test_radar_request_radvor_re_yesterday(prefixed_radar_locations):
 
 
 @pytest.mark.remote
-def test_radar_request_radvor_re_timerange(station_reference_pattern_sorted_prefixed):
+def test_radar_request_radvor_re_timerange(default_settings, station_reference_pattern_sorted_prefixed):
     """
     Verify acquisition of radar/radvor/re data works
     when using a specific date. Querying for 15 minutes
@@ -993,6 +1013,7 @@ def test_radar_request_radvor_re_timerange(station_reference_pattern_sorted_pref
         parameter=DwdRadarParameter.RE_REFLECTIVITY,
         start_date=timestamp,
         end_date=timedelta(minutes=3 * 5),
+        settings=default_settings,
     )
 
     # Verify number of elements.
@@ -1015,7 +1036,7 @@ def test_radar_request_radvor_re_timerange(station_reference_pattern_sorted_pref
 
 
 @pytest.mark.remote
-def test_radar_request_radvor_rq_yesterday(radar_locations):
+def test_radar_request_radvor_rq_yesterday(radar_locations, default_settings):
     """
     Verify acquisition of radar/radvor/rq data works
     when using a specific date. Querying one point
@@ -1028,8 +1049,7 @@ def test_radar_request_radvor_rq_yesterday(radar_locations):
     timestamp = datetime.utcnow() - timedelta(days=1)
 
     request = DwdRadarValues(
-        parameter=DwdRadarParameter.RQ_REFLECTIVITY,
-        start_date=timestamp,
+        parameter=DwdRadarParameter.RQ_REFLECTIVITY, start_date=timestamp, settings=default_settings
     )
 
     results = list(request.query())
@@ -1069,7 +1089,7 @@ def test_radar_request_radvor_rq_yesterday(radar_locations):
 
 
 @pytest.mark.remote
-def test_radar_request_radvor_rq_timerange(radar_locations):
+def test_radar_request_radvor_rq_timerange(radar_locations, default_settings):
     """
     Verify acquisition of radar/radvor/rq data works
     when using a specific date. Querying for 45 minutes
@@ -1084,6 +1104,7 @@ def test_radar_request_radvor_rq_timerange(radar_locations):
         parameter=DwdRadarParameter.RQ_REFLECTIVITY,
         start_date=timestamp,
         end_date=timedelta(minutes=3 * 15),
+        settings=default_settings,
     )
 
     # Verify number of elements.

--- a/tests/provider/dwd/radar/test_api_invalid.py
+++ b/tests/provider/dwd/radar/test_api_invalid.py
@@ -16,7 +16,7 @@ from wetterdienst.provider.dwd.radar.metadata import (
 from wetterdienst.provider.dwd.radar.sites import DwdRadarSite
 
 
-def test_radar_request_site_historic_pe_wrong_parameters():
+def test_radar_request_site_historic_pe_wrong_parameters(default_settings):
     """
     Verify acquisition of radar/site/PE_ECHO_TOP data croaks
     when omitting RadarDataFormat.
@@ -27,6 +27,7 @@ def test_radar_request_site_historic_pe_wrong_parameters():
             parameter=DwdRadarParameter.PE_ECHO_TOP,
             site=DwdRadarSite.BOO,
             start_date=datetime.utcnow(),
+            settings=default_settings,
         )
         next(request.query())
 
@@ -34,7 +35,10 @@ def test_radar_request_site_historic_pe_wrong_parameters():
     assert str(excinfo.value).startswith("Argument 'format' is missing")
 
 
-def test_radar_request_site_historic_pe_future(caplog):
+def test_radar_request_site_historic_pe_future(
+    default_settings,
+    caplog,
+):
     """
     Verify that ``DWDRadarRequest`` will properly emit
     log messages when hitting empty results.
@@ -47,6 +51,7 @@ def test_radar_request_site_historic_pe_future(caplog):
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.BUFR,
         start_date="2099-01-01 00:00:00",
+        settings=default_settings,
     )
     results = list(request.query())
     assert results == []
@@ -55,7 +60,7 @@ def test_radar_request_site_historic_pe_future(caplog):
     assert "No radar file found" in caplog.text
 
 
-def test_radar_request_site_latest_sweep_pcp_v_hdf5():
+def test_radar_request_site_latest_sweep_pcp_v_hdf5(default_settings):
     """
     Verify requesting latest HDF5 data croaks.
     """
@@ -66,6 +71,7 @@ def test_radar_request_site_latest_sweep_pcp_v_hdf5():
             site=DwdRadarSite.BOO,
             fmt=DwdRadarDataFormat.HDF5,
             start_date=DwdRadarDate.LATEST,
+            settings=default_settings,
         )
 
         list(request.query())
@@ -74,7 +80,7 @@ def test_radar_request_site_latest_sweep_pcp_v_hdf5():
     assert str(excinfo.value).startswith("HDF5 data has no '-latest-' files")
 
 
-def test_radar_request_site_latest_sweep_pcp_v_hdf5_wrong_parameters():
+def test_radar_request_site_latest_sweep_pcp_v_hdf5_wrong_parameters(default_settings):
     """
     Verify requesting HDF5 data without RadarDataFormat croaks.
     """
@@ -84,6 +90,7 @@ def test_radar_request_site_latest_sweep_pcp_v_hdf5_wrong_parameters():
             parameter=DwdRadarParameter.SWEEP_PCP_VELOCITY_H,
             site=DwdRadarSite.BOO,
             start_date=DwdRadarDate.CURRENT,
+            settings=default_settings,
         )
 
         list(request.query())
@@ -92,15 +99,14 @@ def test_radar_request_site_latest_sweep_pcp_v_hdf5_wrong_parameters():
     assert str(excinfo.value).startswith("Argument 'format' is missing")
 
 
-def test_radar_request_site_without_site():
+def test_radar_request_site_without_site(default_settings):
     """
     Verify requesting site data without site croaks.
     """
 
     with pytest.raises(ValueError) as excinfo:
         request = DwdRadarValues(
-            parameter=DwdRadarParameter.SWEEP_PCP_VELOCITY_H,
-            start_date=DwdRadarDate.LATEST,
+            parameter=DwdRadarParameter.SWEEP_PCP_VELOCITY_H, start_date=DwdRadarDate.LATEST, settings=default_settings
         )
 
         list(request.query())
@@ -109,7 +115,7 @@ def test_radar_request_site_without_site():
     assert str(excinfo.value).startswith("Argument 'site' is missing")
 
 
-def test_radar_request_hdf5_without_subset():
+def test_radar_request_hdf5_without_subset(default_settings):
     """
     Verify requesting HDF5 data without "subset" croaks.
     """
@@ -120,6 +126,7 @@ def test_radar_request_hdf5_without_subset():
             site=DwdRadarSite.BOO,
             fmt=DwdRadarDataFormat.HDF5,
             start_date=DwdRadarDate.MOST_RECENT,
+            settings=default_settings,
         )
 
         list(request.query())
@@ -136,7 +143,7 @@ def test_radar_request_hdf5_without_subset():
         DwdRadarResolution.HOURLY,
     ],
 )
-def test_radar_request_radolan_cdc_latest(time_resolution):
+def test_radar_request_radolan_cdc_latest(time_resolution, default_settings):
     """
     Verify requesting latest RADOLAN_CDC croaks.
     """
@@ -146,6 +153,7 @@ def test_radar_request_radolan_cdc_latest(time_resolution):
             parameter=DwdRadarParameter.RADOLAN_CDC,
             resolution=time_resolution,
             start_date=DwdRadarDate.LATEST,
+            settings=default_settings,
         )
 
         list(request.query())
@@ -154,7 +162,7 @@ def test_radar_request_radolan_cdc_latest(time_resolution):
     assert str(excinfo.value).startswith("RADOLAN_CDC data has no '-latest-' files")
 
 
-def test_radar_request_radolan_cdc_invalid_time_resolution():
+def test_radar_request_radolan_cdc_invalid_time_resolution(default_settings):
     """
     Verify requesting 1-minute RADOLAN_CDC croaks.
     """
@@ -165,11 +173,12 @@ def test_radar_request_radolan_cdc_invalid_time_resolution():
             resolution="minute_1",
             period=DwdRadarPeriod.RECENT,
             start_date="2019-08-08 00:50:00",
+            settings=default_settings,
         )
 
 
 @pytest.mark.remote
-def test_radar_request_radolan_cdc_future(caplog):
+def test_radar_request_radolan_cdc_future(default_settings, caplog):
     """
     Verify that ``DWDRadarRequest`` will properly emit
     log messages when hitting empty results.
@@ -181,6 +190,7 @@ def test_radar_request_radolan_cdc_future(caplog):
         resolution="daily",
         period=DwdRadarPeriod.RECENT,
         start_date="2099-01-01 00:50:00",
+        settings=default_settings,
     )
 
     results = list(request.query())

--- a/tests/provider/dwd/radar/test_api_latest.py
+++ b/tests/provider/dwd/radar/test_api_latest.py
@@ -14,14 +14,13 @@ from wetterdienst.provider.dwd.radar.sites import DwdRadarSite
 
 
 @pytest.mark.remote
-def test_radar_request_composite_latest_rv_reflectivity(station_reference_pattern_sorted_prefixed):
+def test_radar_request_composite_latest_rv_reflectivity(default_settings, station_reference_pattern_sorted_prefixed):
     """
     Example for testing radar COMPOSITES latest.
     """
 
     request = DwdRadarValues(
-        parameter=DwdRadarParameter.RV_REFLECTIVITY,
-        start_date=DwdRadarDate.LATEST,
+        parameter=DwdRadarParameter.RV_REFLECTIVITY, start_date=DwdRadarDate.LATEST, settings=default_settings
     )
 
     buffer = next(request.query())[1]
@@ -36,7 +35,7 @@ def test_radar_request_composite_latest_rv_reflectivity(station_reference_patter
 
 
 @pytest.mark.remote
-def test_radar_request_composite_latest_rw_reflectivity(radar_locations):
+def test_radar_request_composite_latest_rw_reflectivity(default_settings, radar_locations):
     """
     Example for testing radar COMPOSITES (RADOLAN) latest.
     """
@@ -44,8 +43,7 @@ def test_radar_request_composite_latest_rw_reflectivity(radar_locations):
     wrl = pytest.importorskip("wradlib", reason="wradlib not installed")
 
     request = DwdRadarValues(
-        parameter=DwdRadarParameter.RW_REFLECTIVITY,
-        start_date=DwdRadarDate.LATEST,
+        parameter=DwdRadarParameter.RW_REFLECTIVITY, start_date=DwdRadarDate.LATEST, settings=default_settings
     )
 
     results = list(request.query())
@@ -80,7 +78,7 @@ def test_radar_request_composite_latest_rw_reflectivity(radar_locations):
 
 
 @pytest.mark.remote
-def test_radar_request_site_latest_dx_reflectivity():
+def test_radar_request_site_latest_dx_reflectivity(default_settings):
     """
     Example for testing radar SITES latest.
     """
@@ -91,6 +89,7 @@ def test_radar_request_site_latest_dx_reflectivity():
         parameter=DwdRadarParameter.DX_REFLECTIVITY,
         start_date=DwdRadarDate.LATEST,
         site=DwdRadarSite.BOO,
+        settings=default_settings,
     )
 
     buffer = next(request.query())[1]

--- a/tests/provider/dwd/radar/test_api_most_recent.py
+++ b/tests/provider/dwd/radar/test_api_most_recent.py
@@ -19,7 +19,7 @@ from wetterdienst.provider.dwd.radar.sites import DwdRadarSite
 
 
 @pytest.mark.remote
-def test_radar_request_site_most_recent_sweep_pcp_v_hdf5():
+def test_radar_request_site_most_recent_sweep_pcp_v_hdf5(default_settings):
     """
     Example for testing radar sites most recent full SWEEP_PCP,
     this time in OPERA HDF5 (ODIM_H5) format.
@@ -32,6 +32,7 @@ def test_radar_request_site_most_recent_sweep_pcp_v_hdf5():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -64,7 +65,7 @@ def test_radar_request_site_most_recent_sweep_pcp_v_hdf5():
 
 
 @pytest.mark.remote
-def test_radar_request_site_most_recent_sweep_vol_v_hdf5():
+def test_radar_request_site_most_recent_sweep_vol_v_hdf5(default_settings):
     """
     Example for testing radar sites most recent full SWEEP_VOL,
     this time in OPERA HDF5 (ODIM_H5) format.
@@ -77,6 +78,7 @@ def test_radar_request_site_most_recent_sweep_vol_v_hdf5():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -115,7 +117,7 @@ def test_radar_request_site_most_recent_sweep_vol_v_hdf5():
 
 
 @pytest.mark.remote
-def test_radar_request_radolan_cdc_most_recent(radar_locations):
+def test_radar_request_radolan_cdc_most_recent(default_settings, radar_locations):
     """
     Example for testing radar sites most recent RADOLAN_CDC.
     """
@@ -127,6 +129,7 @@ def test_radar_request_radolan_cdc_most_recent(radar_locations):
         resolution=DwdRadarResolution.DAILY,
         period=DwdRadarPeriod.RECENT,
         start_date=DwdRadarDate.MOST_RECENT,
+        settings=default_settings,
     )
 
     results = list(request.query())

--- a/tests/provider/dwd/radar/test_api_recent.py
+++ b/tests/provider/dwd/radar/test_api_recent.py
@@ -16,7 +16,7 @@ h5py = pytest.importorskip("h5py", reason="h5py not installed")
 
 
 @pytest.mark.remote
-def test_radar_request_site_recent_sweep_pcp_v_hdf5():
+def test_radar_request_site_recent_sweep_pcp_v_hdf5(default_settings):
     """
     Example for testing radar sites SWEEP_PCP with timerange.
     """
@@ -27,6 +27,7 @@ def test_radar_request_site_recent_sweep_pcp_v_hdf5():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     results = list(request.query())
@@ -59,7 +60,7 @@ def test_radar_request_site_recent_sweep_pcp_v_hdf5():
 
 
 @pytest.mark.remote
-def test_radar_request_site_recent_sweep_vol_v_hdf5():
+def test_radar_request_site_recent_sweep_vol_v_hdf5(default_settings):
     """
     Example for testing radar sites SWEEP_VOL with timerange.
     """
@@ -70,6 +71,7 @@ def test_radar_request_site_recent_sweep_vol_v_hdf5():
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     results = list(request.query())

--- a/tests/provider/dwd/radar/test_index.py
+++ b/tests/provider/dwd/radar/test_index.py
@@ -16,32 +16,28 @@ from wetterdienst.provider.dwd.radar.metadata import (
 from wetterdienst.provider.dwd.radar.sites import DwdRadarSite
 
 
-def test_radar_fileindex_composite_pg_reflectivity_bin():
+def test_radar_fileindex_composite_pg_reflectivity_bin(default_settings):
 
     file_index = create_fileindex_radar(
-        parameter=DwdRadarParameter.PG_REFLECTIVITY,
-        fmt=DwdRadarDataFormat.BINARY,
+        parameter=DwdRadarParameter.PG_REFLECTIVITY, fmt=DwdRadarDataFormat.BINARY, settings=default_settings
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
     assert all(PurePath(url).match("*/weather/radar/composit/pg/*---bin") for url in urls)
 
 
-def test_radar_fileindex_composite_pg_reflectivity_bufr():
+def test_radar_fileindex_composite_pg_reflectivity_bufr(default_settings):
 
     file_index = create_fileindex_radar(
-        parameter=DwdRadarParameter.PG_REFLECTIVITY,
-        fmt=DwdRadarDataFormat.BUFR,
+        parameter=DwdRadarParameter.PG_REFLECTIVITY, fmt=DwdRadarDataFormat.BUFR, settings=default_settings
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
     assert all(PurePath(url).match("*/weather/radar/composit/pg/*---bufr") for url in urls)
 
 
-def test_radar_fileindex_composite_rv_reflectivity_bin():
-    file_index = create_fileindex_radar(
-        parameter=DwdRadarParameter.RV_REFLECTIVITY,
-    )
+def test_radar_fileindex_composite_rv_reflectivity_bin(default_settings):
+    file_index = create_fileindex_radar(parameter=DwdRadarParameter.RV_REFLECTIVITY, settings=default_settings)
     urls = file_index[DwdColumns.FILENAME.value].tolist()
     assert all(PurePath(url).match("*/weather/radar/composit/rv/*.tar.bz2") for url in urls)
 
@@ -54,11 +50,9 @@ def test_radar_fileindex_composite_rv_reflectivity_bin():
         DwdRadarParameter.SF_REFLECTIVITY,
     ],
 )
-def test_radar_fileindex_radolan_reflectivity_bin(parameter):
+def test_radar_fileindex_radolan_reflectivity_bin(parameter, default_settings):
 
-    file_index = create_fileindex_radar(
-        parameter=parameter,
-    )
+    file_index = create_fileindex_radar(parameter=parameter, settings=default_settings)
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
     assert all(
@@ -68,60 +62,63 @@ def test_radar_fileindex_radolan_reflectivity_bin(parameter):
     )
 
 
-def test_radar_fileindex_sites_px_reflectivity_bin():
+def test_radar_fileindex_sites_px_reflectivity_bin(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.PX_REFLECTIVITY,
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.BINARY,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
     assert all(PurePath(url).match("*/weather/radar/sites/px/boo/*---bin") for url in urls)
 
 
-def test_radar_fileindex_sites_px_reflectivity_bufr():
+def test_radar_fileindex_sites_px_reflectivity_bufr(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.PX_REFLECTIVITY,
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.BUFR,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
     assert all(PurePath(url).match("*/weather/radar/sites/px/boo/*---buf") for url in urls)
 
 
-def test_radar_fileindex_sites_px250_reflectivity_bufr():
+def test_radar_fileindex_sites_px250_reflectivity_bufr(default_settings):
 
     file_index = create_fileindex_radar(
-        parameter=DwdRadarParameter.PX250_REFLECTIVITY,
-        site=DwdRadarSite.BOO,
+        parameter=DwdRadarParameter.PX250_REFLECTIVITY, site=DwdRadarSite.BOO, settings=default_settings
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
     assert all("/weather/radar/sites/px250/boo" in url for url in urls)
 
 
-def test_radar_fileindex_sites_sweep_bufr():
+def test_radar_fileindex_sites_sweep_bufr(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.SWEEP_VOL_VELOCITY_H,
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.BUFR,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
     assert all(PurePath(url).match("*/weather/radar/sites/sweep_vol_v/boo/*--buf.bz2") for url in urls)
 
 
-def test_radar_fileindex_sites_sweep_vol_v_hdf5_simple():
+def test_radar_fileindex_sites_sweep_vol_v_hdf5_simple(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.SWEEP_VOL_VELOCITY_H,
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.SIMPLE,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
@@ -129,13 +126,14 @@ def test_radar_fileindex_sites_sweep_vol_v_hdf5_simple():
     assert all("/weather/radar/sites/sweep_vol_v/boo/hdf5/filter_simple" in url for url in urls)
 
 
-def test_radar_fileindex_sites_sweep_vol_v_hdf5_polarimetric():
+def test_radar_fileindex_sites_sweep_vol_v_hdf5_polarimetric(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.SWEEP_VOL_VELOCITY_H,
         site=DwdRadarSite.BOO,
         fmt=DwdRadarDataFormat.HDF5,
         subset=DwdRadarDataSubset.POLARIMETRIC,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
@@ -143,12 +141,13 @@ def test_radar_fileindex_sites_sweep_vol_v_hdf5_polarimetric():
     assert all("/weather/radar/sites/sweep_vol_v/boo/hdf5/filter_polarimetric" in url for url in urls)
 
 
-def test_radar_fileindex_radolan_cdc_daily_recent():
+def test_radar_fileindex_radolan_cdc_daily_recent(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.RADOLAN_CDC,
         resolution=Resolution.DAILY,
         period=Period.RECENT,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
@@ -159,12 +158,13 @@ def test_radar_fileindex_radolan_cdc_daily_recent():
     )
 
 
-def test_radar_fileindex_radolan_cdc_daily_historical():
+def test_radar_fileindex_radolan_cdc_daily_historical(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.RADOLAN_CDC,
         resolution=Resolution.DAILY,
         period=Period.HISTORICAL,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
@@ -175,12 +175,13 @@ def test_radar_fileindex_radolan_cdc_daily_historical():
     )
 
 
-def test_radar_fileindex_radolan_cdc_hourly_recent():
+def test_radar_fileindex_radolan_cdc_hourly_recent(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.RADOLAN_CDC,
         resolution=Resolution.HOURLY,
         period=Period.RECENT,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
@@ -191,12 +192,13 @@ def test_radar_fileindex_radolan_cdc_hourly_recent():
     )
 
 
-def test_radar_fileindex_radolan_cdc_hourly_historical():
+def test_radar_fileindex_radolan_cdc_hourly_historical(default_settings):
 
     file_index = create_fileindex_radar(
         parameter=DwdRadarParameter.RADOLAN_CDC,
         resolution=Resolution.HOURLY,
         period=Period.HISTORICAL,
+        settings=default_settings,
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()
@@ -207,11 +209,10 @@ def test_radar_fileindex_radolan_cdc_hourly_historical():
     )
 
 
-def test_radar_fileindex_radolan_cdc_5minutes():
+def test_radar_fileindex_radolan_cdc_5minutes(default_settings):
 
     file_index = create_fileindex_radar(
-        parameter=DwdRadarParameter.RADOLAN_CDC,
-        resolution=Resolution.MINUTE_5,
+        parameter=DwdRadarParameter.RADOLAN_CDC, resolution=Resolution.MINUTE_5, settings=default_settings
     )
 
     urls = file_index[DwdColumns.FILENAME.value].tolist()

--- a/tests/provider/dwd/test_index.py
+++ b/tests/provider/dwd/test_index.py
@@ -13,6 +13,7 @@ from wetterdienst.provider.dwd.observation import (
     DwdObservationPeriod,
     DwdObservationResolution,
 )
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.network import list_remote_files_fsspec
 
@@ -30,7 +31,8 @@ def test_build_index_path():
 def test_list_files_of_climate_observations():
     files_server = list_remote_files_fsspec(
         "https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/annual/kl/recent",
-        CacheExpiry.NO_CACHE,
+        settings=Settings.default(),
+        ttl=CacheExpiry.NO_CACHE,
     )
 
     assert (
@@ -39,13 +41,14 @@ def test_list_files_of_climate_observations():
     )
 
 
-def test_fileindex():
+def test_fileindex(default_settings):
 
     file_index = _create_file_index_for_dwd_server(
         DwdObservationDataset.CLIMATE_SUMMARY,
         DwdObservationResolution.DAILY,
         DwdObservationPeriod.RECENT,
         "observations_germany/climate/",
+        settings=default_settings,
     )
 
     assert "daily/kl/recent" in file_index.iloc[0][DwdColumns.FILENAME.value]

--- a/tests/provider/dwd/test_util.py
+++ b/tests/provider/dwd/test_util.py
@@ -6,7 +6,6 @@ import pandas as pd
 import pytest
 from pandas._testing import assert_frame_equal
 
-from wetterdienst import Settings
 from wetterdienst.exceptions import InvalidEnumeration
 from wetterdienst.provider.dwd.observation import (
     DwdObservationDataset,
@@ -33,20 +32,17 @@ def test_parse_enumeration_from_template():
         parse_enumeration_from_template("climate", DwdObservationDataset)
 
 
-def test_coerce_field_types():
+def test_coerce_field_types(settings_humanize_tidy_false):
     """Test coercion of fields"""
     # Special cases
     # We require a stations_result object with hourly resolution in order to accurately parse
     # the hourly timestamp (pandas would fail parsing it because it has a strange
     # format)
-    Settings.tidy = False
-    Settings.humanize = False
-    Settings.si_units = True
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.SOLAR,  # RS_IND_01,
         resolution=DwdObservationResolution.HOURLY,
         period=DwdObservationPeriod.RECENT,
+        settings=settings_humanize_tidy_false,
     ).all()
 
     # Here we don't query the actual data because it takes too long
@@ -82,16 +78,13 @@ def test_coerce_field_types():
     assert_frame_equal(df, expected_df, check_categorical=False)
 
 
-def test_coerce_field_types_with_nans():
+def test_coerce_field_types_with_nans(settings_humanize_tidy_false):
     """Test field coercion with NaNs"""
-    Settings.tidy = False
-    Settings.humanize = False
-    Settings.si_units = True
-
     request = DwdObservationRequest(
         parameter=DwdObservationDataset.SOLAR,  # RS_IND_01,
         resolution=DwdObservationResolution.HOURLY,
         period=DwdObservationPeriod.RECENT,
+        settings=settings_humanize_tidy_false,
     ).all()
 
     df = pd.DataFrame(

--- a/tests/provider/eccc/test_api.py
+++ b/tests/provider/eccc/test_api.py
@@ -8,20 +8,16 @@ import pytz
 from pandas._testing import assert_frame_equal
 
 from wetterdienst.provider.eccc.observation import EcccObservationRequest
-from wetterdienst.settings import Settings
 
 
 @pytest.mark.remote
-def test_eccc_api_stations():
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = False
-
+def test_eccc_api_stations(settings_si_false):
     request = EcccObservationRequest(
         parameter="DAILY",
         resolution="DAILY",
         start_date="1990-01-01",
         end_date="1990-01-02",
+        settings=settings_si_false,
     ).filter_by_station_id(station_id=(14,))
 
     expected = pd.DataFrame(
@@ -41,16 +37,13 @@ def test_eccc_api_stations():
 
 
 @pytest.mark.remote
-def test_eccc_api_values():
-    Settings.tidy = True
-    Settings.humanize = True
-    Settings.si_units = False
-
+def test_eccc_api_values(settings_si_false):
     request = EcccObservationRequest(
         parameter="DAILY",
         resolution="DAILY",
         start_date="1980-01-01",
         end_date="1980-01-02",
+        settings=settings_si_false,
     ).filter_by_station_id(station_id=(1652,))
 
     values = request.values.all().df

--- a/tests/provider/noaa/ghcn/test_api_data.py
+++ b/tests/provider/noaa/ghcn/test_api_data.py
@@ -5,7 +5,6 @@ import pandas as pd
 import pytest
 from pandas._testing import assert_frame_equal
 
-from wetterdienst import Settings
 from wetterdienst.provider.noaa.ghcn import NoaaGhcnParameter, NoaaGhcnRequest
 
 
@@ -18,17 +17,13 @@ from wetterdienst.provider.noaa.ghcn import NoaaGhcnParameter, NoaaGhcnRequest
         (dt.datetime(2015, 1, 1, 1, 1, 1), dt.datetime(2022, 1, 1, 1, 1, 1)),
     ],
 )
-def test_api_amsterdam(start_date, end_date):
-    with Settings:
-        Settings.tidy = True
-        Settings.si_units = True
-        Settings.humanize = True
-
-        request = NoaaGhcnRequest(
-            parameter=[NoaaGhcnParameter.DAILY.TEMPERATURE_AIR_MEAN_200],
-            start_date=start_date,
-            end_date=end_date,
-        ).filter_by_name("DE BILT")
+def test_api_amsterdam(start_date, end_date, default_settings):
+    request = NoaaGhcnRequest(
+        parameter=[NoaaGhcnParameter.DAILY.TEMPERATURE_AIR_MEAN_200],
+        start_date=start_date,
+        end_date=end_date,
+        settings=default_settings,
+    ).filter_by_name("DE BILT")
     values = request.values.all().df
     assert not values.value.dropna().empty
     assert_frame_equal(

--- a/tests/provider/noaa/ghcn/test_api_stations.py
+++ b/tests/provider/noaa/ghcn/test_api_stations.py
@@ -9,8 +9,8 @@ from wetterdienst.provider.noaa.ghcn import NoaaGhcnRequest
 
 
 @pytest.mark.remote
-def test_noaa_ghcn_stations():
-    df = NoaaGhcnRequest("daily").all().df.iloc[:5, :]
+def test_noaa_ghcn_stations(default_settings):
+    df = NoaaGhcnRequest("daily", settings=default_settings).all().df.iloc[:5, :]
 
     df_expected = pd.DataFrame(
         {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,7 +29,7 @@ from wetterdienst import Settings, Wetterdienst
         # EA Hydrology
         ("ea", "hydrology", {"parameter": "flow", "resolution": "daily"}, None),
         # NWS Observation
-        ("nws", "observation", {"parameter": "precipitation_height"}, "KBHM"),
+        ("nws", "observation", {"parameter": "temperature_air_mean_200"}, "KBHM"),
         # Eaufrance Hubeau
         ("eaufrance", "hubeau", {"parameter": "flow"}, None),  # noqa: E800
         # ZAMG Observation
@@ -46,13 +46,13 @@ def test_api(provider, network, kwargs, si_units, station_id):
     # Discover parameters
     assert api.discover()
 
-    Settings.si_units = si_units
+    settings = Settings(si_units=si_units, ignore_env=True)
 
     # All stations_result
     if station_id:
-        request = api(**kwargs).filter_by_station_id(station_id=station_id)
+        request = api(**kwargs, settings=settings).filter_by_station_id(station_id=station_id)
     else:
-        request = api(**kwargs).all()
+        request = api(**kwargs, settings=settings).all()
 
     stations = request.df
 
@@ -77,7 +77,4 @@ def test_api(provider, network, kwargs, si_units, station_id):
     values = next(request.values.query()).df
 
     assert set(values.columns).issuperset({"station_id", "parameter", "date", "value", "quality"})
-
-    values = values.drop(columns="quality").dropna(axis=0)
-
-    assert not values.empty
+    assert not values.dropna(subset="value").empty

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -248,7 +248,6 @@ def test_dwd_values_sql_tabular(dicts_are_same):
 @pytest.mark.remote
 @pytest.mark.sql
 def test_dwd_values_sql_tidy(dicts_are_same):
-
     response = client.get(
         "/restapi/values",
         params={

--- a/tests/util/test_network.py
+++ b/tests/util/test_network.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.network import NetworkFilesystemManager
 
 
 def test_create_fsspec_filesystem():
-    fs1 = NetworkFilesystemManager.get(ttl=CacheExpiry.METAINDEX)
-    fs2 = NetworkFilesystemManager.get(ttl=CacheExpiry.METAINDEX)
+    fs1 = NetworkFilesystemManager.get(settings=Settings.default(), ttl=CacheExpiry.METAINDEX)
+    fs2 = NetworkFilesystemManager.get(settings=Settings.default(), ttl=CacheExpiry.METAINDEX)
 
     assert id(fs1) == id(fs2)

--- a/wetterdienst/boot.py
+++ b/wetterdienst/boot.py
@@ -28,7 +28,7 @@ def info() -> None:
         "authors": "Benjamin Gutzmann <gutzemann@gmail.com>, Andreas Motl <andreas.motl@panodata.org>",
         "documentation": "https://wetterdienst.readthedocs.io/",
         "repository": "https://github.com/earthobservations/wetterdienst",
-        "cache_dir": Settings.cache_dir,
+        "cache_dir (default)": Settings().cache_dir,
     }
 
     text = get_title("Wetterdienst - Open weather data for humans")

--- a/wetterdienst/core/scalar/request.py
+++ b/wetterdienst/core/scalar/request.py
@@ -343,6 +343,7 @@ class ScalarRequestCore(Core):
 
     def __init__(
         self,
+        settings: Settings,
         parameter: Tuple[Union[str, Enum]],
         resolution: Resolution,
         period: Period,
@@ -357,7 +358,10 @@ class ScalarRequestCore(Core):
         :param start_date: Start date for filtering stations_result for their available data
         :param end_date:   End date for filtering stations_result for their available data
         """
-        settings = copy(Settings)
+
+        # settings = copy(Settings)
+        self.settings = settings
+
         super().__init__()
 
         self.resolution = parse_enumeration_from_template(resolution, self._resolution_base, Resolution)

--- a/wetterdienst/core/scalar/request.py
+++ b/wetterdienst/core/scalar/request.py
@@ -3,7 +3,6 @@
 # Distributed under the MIT License. See LICENSE for more info.
 import logging
 from abc import abstractmethod
-from copy import copy
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional, Tuple, Union
@@ -343,12 +342,12 @@ class ScalarRequestCore(Core):
 
     def __init__(
         self,
-        settings: Settings,
         parameter: Tuple[Union[str, Enum]],
         resolution: Resolution,
         period: Period,
         start_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
         end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
+        settings: Optional[Settings] = None,
     ) -> None:
         """
 
@@ -358,8 +357,7 @@ class ScalarRequestCore(Core):
         :param start_date: Start date for filtering stations_result for their available data
         :param end_date:   End date for filtering stations_result for their available data
         """
-
-        # settings = copy(Settings)
+        settings = settings or Settings.default()
         self.settings = settings
 
         super().__init__()
@@ -875,7 +873,7 @@ class ScalarRequestCore(Core):
             log.warning("Summary might be slow for high resolutions due to mass of data")
 
         if not isinstance(self, DwdObservationRequest):
-            log.error("Interpolation currently only works for DwdObservationRequest")
+            log.error("Summary currently only works for DwdObservationRequest")
             return SummarizedValuesResult(df=pd.DataFrame(), stations=self)
         lat, lon = latlon
         lat, lon = float(lat), float(lon)

--- a/wetterdienst/provider/dwd/index.py
+++ b/wetterdienst/provider/dwd/index.py
@@ -10,15 +10,13 @@ from wetterdienst.provider.dwd.observation.metadata.dataset import (
     DWD_URBAN_DATASETS,
     DwdObservationDataset,
 )
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.network import list_remote_files_fsspec
 
 
 def _create_file_index_for_dwd_server(
-    dataset: DwdObservationDataset,
-    resolution: Resolution,
-    period: Period,
-    cdc_base: str,
+    dataset: DwdObservationDataset, resolution: Resolution, period: Period, cdc_base: str, settings: Settings
 ) -> pd.DataFrame:
     """
     Function to create a file index of the DWD station data, which usually is shipped as
@@ -35,7 +33,7 @@ def _create_file_index_for_dwd_server(
 
     url = f"https://opendata.dwd.de/climate_environment/CDC/{cdc_base}/{parameter_path}"
 
-    files_server = list_remote_files_fsspec(url, ttl=CacheExpiry.TWELVE_HOURS)
+    files_server = list_remote_files_fsspec(url, settings=settings, ttl=CacheExpiry.TWELVE_HOURS)
 
     if not files_server:
         raise FileNotFoundError(f"url {url} does not have a list of files")

--- a/wetterdienst/provider/dwd/mosmix/access.py
+++ b/wetterdienst/provider/dwd/mosmix/access.py
@@ -15,6 +15,7 @@ from lxml.etree import iterparse  # noqa: S410
 from pandas import DatetimeIndex
 from tqdm import tqdm
 
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.io import read_in_chunks
 from wetterdienst.util.logging import TqdmToLogger
@@ -24,11 +25,7 @@ log = logging.getLogger(__name__)
 
 
 class KMLReader:
-    def __init__(
-        self,
-        station_ids: List[str],
-        parameters: List[str],
-    ) -> None:
+    def __init__(self, station_ids: List[str], parameters: List[str], settings: Settings) -> None:
         self.station_ids = station_ids
         self.parameters = parameters
         self.metadata = {}
@@ -36,7 +33,7 @@ class KMLReader:
         self.nsmap = None
         self.iter_elems = None
 
-        self.dwdfs = NetworkFilesystemManager.get(ttl=CacheExpiry.FIVE_MINUTES)
+        self.dwdfs = NetworkFilesystemManager.get(settings=settings, ttl=CacheExpiry.FIVE_MINUTES)
 
     def download(self, url: str) -> BytesIO:
         """Download kml file as bytes.

--- a/wetterdienst/provider/dwd/observation/download.py
+++ b/wetterdienst/provider/dwd/observation/download.py
@@ -2,6 +2,7 @@
 # Copyright (C) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from io import BytesIO
 from typing import List, Tuple
 from zipfile import BadZipFile
@@ -10,12 +11,13 @@ from fsspec.implementations.zip import ZipFileSystem
 from requests.exceptions import InvalidURL
 
 from wetterdienst.exceptions import FailedDownload, ProductFileNotFound
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.network import download_file
 
 
 def download_climate_observations_data_parallel(
-    remote_files: List[str],
+    remote_files: List[str], settings: Settings
 ) -> List[Tuple[str, BytesIO]]:
     """
     Wrapper for ``_download_dwd_data`` to provide a multiprocessing feature.
@@ -24,12 +26,12 @@ def download_climate_observations_data_parallel(
     :return:                List of downloaded files
     """
     with ThreadPoolExecutor() as p:
-        files_in_bytes = p.map(_download_climate_observations_data, remote_files)
+        files_in_bytes = p.map(partial(_download_climate_observations_data, settings=settings), remote_files)
 
     return list(zip(remote_files, files_in_bytes))
 
 
-def _download_climate_observations_data(remote_file: str) -> BytesIO:
+def _download_climate_observations_data(remote_file: str, settings: Settings) -> BytesIO:
     """
     This function downloads the station data for which the link is
     provided by the 'select_dwd' function. It checks the shortened filepath (just
@@ -44,13 +46,13 @@ def _download_climate_observations_data(remote_file: str) -> BytesIO:
         stores data on local file system
 
     """
-    return BytesIO(__download_climate_observations_data(remote_file=remote_file))
+    return BytesIO(__download_climate_observations_data(remote_file=remote_file, settings=settings))
 
 
-def __download_climate_observations_data(remote_file: str) -> bytes:
+def __download_climate_observations_data(remote_file: str, settings: Settings) -> bytes:
 
     try:
-        file = download_file(remote_file, ttl=CacheExpiry.FIVE_MINUTES)
+        file = download_file(remote_file, settings=settings, ttl=CacheExpiry.FIVE_MINUTES)
     except InvalidURL as e:
         raise InvalidURL(f"Error: the station data {remote_file} could not be reached.") from e
     except Exception as ex:

--- a/wetterdienst/provider/dwd/observation/fileindex.py
+++ b/wetterdienst/provider/dwd/observation/fileindex.py
@@ -17,6 +17,7 @@ from wetterdienst.provider.dwd.observation.metadata.dataset import (
     DwdObservationDataset,
 )
 from wetterdienst.provider.dwd.observation.metadata.resolution import HIGH_RESOLUTIONS
+from wetterdienst.settings import Settings
 
 STATION_ID_REGEX = r"(?<!\d)\d{3,5}(?!\d)"
 DATE_RANGE_REGEX = r"(?<!\d)\d{8}_\d{8}(?!\d)"
@@ -27,6 +28,7 @@ def create_file_list_for_climate_observations(
     dataset: DwdObservationDataset,
     resolution: Resolution,
     period: Period,
+    settings: Settings,
     date_range: Optional[str] = None,
 ) -> List[str]:
     """
@@ -43,7 +45,7 @@ def create_file_list_for_climate_observations(
     Returns:
         List of path's to file
     """
-    file_index = create_file_index_for_climate_observations(dataset, resolution, period)
+    file_index = create_file_index_for_climate_observations(dataset, resolution, period, settings)
 
     file_index = file_index[file_index[DwdColumns.STATION_ID.value] == station_id]
 
@@ -54,9 +56,7 @@ def create_file_list_for_climate_observations(
 
 
 def create_file_index_for_climate_observations(
-    dataset: DwdObservationDataset,
-    resolution: Resolution,
-    period: Period,
+    dataset: DwdObservationDataset, resolution: Resolution, period: Period, settings: Settings
 ) -> pd.DataFrame:
     """
     Function (cached) to create a file index of the DWD station data. The file index
@@ -72,10 +72,12 @@ def create_file_index_for_climate_observations(
 
     if dataset in DWD_URBAN_DATASETS:
         file_index = _create_file_index_for_dwd_server(
-            dataset, resolution, Period.RECENT, "observations_germany/climate_urban"
+            dataset, resolution, Period.RECENT, "observations_germany/climate_urban", settings
         )
     else:
-        file_index = _create_file_index_for_dwd_server(dataset, resolution, period, "observations_germany/climate")
+        file_index = _create_file_index_for_dwd_server(
+            dataset, resolution, period, "observations_germany/climate", settings
+        )
 
     file_index = file_index.loc[file_index[DwdColumns.FILENAME.value].str.endswith(Extension.ZIP.value), :]
 

--- a/wetterdienst/provider/environment_agency/hydrology/api.py
+++ b/wetterdienst/provider/environment_agency/hydrology/api.py
@@ -19,6 +19,7 @@ from wetterdienst.metadata.provider import Provider
 from wetterdienst.metadata.resolution import Resolution, ResolutionType
 from wetterdienst.metadata.timezone import Timezone
 from wetterdienst.metadata.unit import OriginUnit, SIUnit
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.network import download_file
 from wetterdienst.util.parameter import DatasetTreeCore
@@ -76,7 +77,7 @@ class EaHydrologyValues(ScalarValuesCore):
 
     def _collect_station_parameter(self, station_id: str, parameter: Enum, dataset: Enum) -> pd.DataFrame:
         endpoint = self._base_url.format(station_id=station_id)
-        payload = download_file(endpoint, CacheExpiry.NO_CACHE)
+        payload = download_file(endpoint, self.sr.stations.settings, CacheExpiry.NO_CACHE)
 
         measures_list = json.loads(payload.read())["items"][0]["measures"]
 
@@ -135,6 +136,7 @@ class EaHydrologyRequest(ScalarRequestCore):
         resolution: EaHydrologyResolution,
         start_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
         end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
+        settings: Optional[Settings] = None,
     ):
         super(EaHydrologyRequest, self).__init__(
             parameter=parameter,
@@ -142,6 +144,7 @@ class EaHydrologyRequest(ScalarRequestCore):
             period=Period.HISTORICAL,
             start_date=start_date,
             end_date=end_date,
+            settings=settings,
         )
 
         if self.resolution == Resolution.MINUTE_15:
@@ -174,7 +177,7 @@ class EaHydrologyRequest(ScalarRequestCore):
 
         log.info(f"Acquiring station listing from {self.endpoint}")
 
-        response = download_file(self.endpoint, CacheExpiry.FIVE_MINUTES)
+        response = download_file(self.endpoint, self.settings, CacheExpiry.FIVE_MINUTES)
 
         payload = json.loads(response.read())["items"]
 

--- a/wetterdienst/provider/wsv/pegel/api.py
+++ b/wetterdienst/provider/wsv/pegel/api.py
@@ -18,6 +18,7 @@ from wetterdienst.metadata.provider import Provider
 from wetterdienst.metadata.resolution import Resolution, ResolutionType
 from wetterdienst.metadata.timezone import Timezone
 from wetterdienst.metadata.unit import OriginUnit, SIUnit
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.network import download_file
 from wetterdienst.util.parameter import DatasetTreeCore
@@ -125,7 +126,7 @@ class WsvPegelValues(ScalarValuesCore):
         url = self._endpoint.format(station_id=station_id, parameter=parameter.value)
 
         try:
-            response = download_file(url, CacheExpiry.NO_CACHE)
+            response = download_file(url, self.sr.stations.settings, CacheExpiry.NO_CACHE)
         except FileNotFoundError:
             return pd.DataFrame()
 
@@ -148,7 +149,7 @@ class WsvPegelValues(ScalarValuesCore):
         """
         url = self._station_endpoint.format(station_id=station_id, parameter=parameter.value)
 
-        response = download_file(url)
+        response = download_file(url, self.sr.stations.settings)
 
         station_dict = json.load(response)
 
@@ -206,6 +207,7 @@ class WsvPegelRequest(ScalarRequestCore):
         parameter,
         start_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
         end_date: Optional[Union[str, datetime, pd.Timestamp]] = None,
+        settings: Optional[Settings] = None,
     ):
         super(WsvPegelRequest, self).__init__(
             parameter=parameter,
@@ -213,6 +215,7 @@ class WsvPegelRequest(ScalarRequestCore):
             period=Period.RECENT,
             start_date=start_date,
             end_date=end_date,
+            settings=settings,
         )
 
     def _all(self):
@@ -261,7 +264,7 @@ class WsvPegelRequest(ScalarRequestCore):
 
             return gauge_datum, m_i, m_ii, m_iii, mnw, mw, mhw, hhw, hsw
 
-        response = download_file(self._endpoint, CacheExpiry.ONE_HOUR)
+        response = download_file(self._endpoint, self.settings, CacheExpiry.ONE_HOUR)
 
         df = pd.read_json(response)
 

--- a/wetterdienst/settings.py
+++ b/wetterdienst/settings.py
@@ -81,4 +81,13 @@ class Settings:
         return Settings.__init__()
 
 
-Settings = Settings()
+class DefaultSettings(Settings):
+    # TODO: Implement all default loading here.
+    pass
+
+
+# FIXME: GLOBAL VARIABLE. Not thread-safe.
+# Settings = Settings()
+
+
+# TODO: Create sweet thing which is mutable and acts like a context manager.

--- a/wetterdienst/ui/core.py
+++ b/wetterdienst/ui/core.py
@@ -3,7 +3,6 @@
 # Distributed under the MIT License. See LICENSE for more info.
 import logging
 import sys
-import typing
 from typing import List, Optional, Tuple, Union
 
 from wetterdienst import Kind, Provider
@@ -13,8 +12,7 @@ from wetterdienst.core.scalar.result import StationsResult, ValuesResult
 from wetterdienst.metadata.datarange import DataRange
 from wetterdienst.metadata.period import PeriodType
 from wetterdienst.metadata.resolution import Resolution, ResolutionType
-from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
-from wetterdienst.settings import Settings, DefaultSettings
+from wetterdienst.settings import Settings
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 
 log = logging.getLogger(__name__)
@@ -74,7 +72,7 @@ def _get_stations_request(
         skip_empty=skip_empty,
         skip_threshold=skip_threshold,
         dropna=dropna,
-        interp_use_nearby_station_until_km=use_nearby_station_until_km
+        interp_use_nearby_station_until_km=use_nearby_station_until_km,
     )
 
     # TODO: move this into Request core
@@ -378,7 +376,7 @@ def get_interpolate(
         tidy=True,
         humanize=humanize,
         skip_empty=False,
-        skip_threshold=False,
+        skip_threshold=0,
         dropna=False,
         use_nearby_station_until_km=use_nearby_station_until_km,
     )
@@ -450,7 +448,7 @@ def get_summarize(
         tidy=True,
         humanize=humanize,
         skip_empty=False,
-        skip_threshold=False,
+        skip_threshold=0,
         dropna=False,
         use_nearby_station_until_km=0,
     )

--- a/wetterdienst/ui/core.py
+++ b/wetterdienst/ui/core.py
@@ -3,6 +3,7 @@
 # Distributed under the MIT License. See LICENSE for more info.
 import logging
 import sys
+import typing
 from typing import List, Optional, Tuple, Union
 
 from wetterdienst import Kind, Provider
@@ -12,7 +13,8 @@ from wetterdienst.core.scalar.result import StationsResult, ValuesResult
 from wetterdienst.metadata.datarange import DataRange
 from wetterdienst.metadata.period import PeriodType
 from wetterdienst.metadata.resolution import Resolution, ResolutionType
-from wetterdienst.settings import Settings
+from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
+from wetterdienst.settings import Settings, DefaultSettings
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 
 log = logging.getLogger(__name__)
@@ -65,6 +67,16 @@ def _get_stations_request(
 ):
     from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
 
+    settings = Settings(
+        si_units=si_units,
+        tidy=tidy,
+        humanize=humanize,
+        skip_empty=skip_empty,
+        skip_threshold=skip_threshold,
+        dropna=dropna,
+        interp_use_nearby_station_until_km=use_nearby_station_until_km
+    )
+
     # TODO: move this into Request core
     start_date, end_date = None, None
     if date:
@@ -107,16 +119,7 @@ def _get_stations_request(
     if api._period_type == PeriodType.MULTI:
         kwargs["period"] = period
 
-    with Settings:
-        Settings.tidy = tidy
-        Settings.humanize = humanize
-        Settings.si_units = si_units
-        Settings.skip_empty = skip_empty
-        Settings.skip_threshold = skip_threshold
-        Settings.dropna = dropna
-        Settings.interp_use_nearby_station_until_km = use_nearby_station_until_km
-
-        return api(**kwargs)
+    return api(**kwargs, settings=settings)
 
 
 def get_stations(

--- a/wetterdienst/util/network.py
+++ b/wetterdienst/util/network.py
@@ -32,8 +32,9 @@ class NetworkFilesystemManager:
 
         return ttl_name, ttl_value
 
+    # TODO: Apply dependency injection for `wetterdienst_settings` here.
     @classmethod
-    def register(cls, ttl=CacheExpiry.NO_CACHE):
+    def register(cls, wetterdienst_settings, ttl=CacheExpiry.NO_CACHE):
         ttl_name, ttl_value = cls.resolve_ttl(ttl)
         key = f"ttl-{ttl_name}"
         real_cache_dir = os.path.join(Settings.cache_dir, "fsspec", key)

--- a/wetterdienst/util/pdf.py
+++ b/wetterdienst/util/pdf.py
@@ -5,16 +5,17 @@ from io import StringIO
 
 import PyPDF2
 
+from wetterdienst.settings import Settings
 from wetterdienst.util.cache import CacheExpiry
 from wetterdienst.util.network import download_file
 
 
 def read_pdf(url):
     text = StringIO()
-    response = download_file(url, CacheExpiry.NO_CACHE)
+    response = download_file(url, settings=Settings.default(), ttl=CacheExpiry.NO_CACHE)
     pdf = PyPDF2.PdfReader(response)
-    for page_number in range(pdf.numPages):
+    for page_number in range(len(pdf.pages)):
         page = pdf.pages[page_number]
-        result = page.extractText()
+        result = page.extract_text()
         text.write(result)
     return text.getvalue()


### PR DESCRIPTION
### About
We have a need to get rid of the global `Settings` singleton. It is not thread-safe and whatnot.

### Proposal
Like `pytest` heavily uses dependency injection for providing test fixtures to test case functions, `wetterdienst` should be able to do it equally well for its `settings` instance.

### References
- https://python-dependency-injector.ets-labs.org/introduction/di_in_python.html
- https://stackoverflow.com/questions/2461702/why-is-ioc-di-not-common-in-python

### Notes
_This patch will fail CI. It is not correctly implemented or functional in any way and really just a sketch coming from a discussion between @gutzbenj and me about #707 ff._
