### PR TITLE
CI: Modernize GHA action recipes and fix dependency caching issue

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,14 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Check code coverage
     steps:
-    - name: Acquire sources
-      uses: actions/checkout@v2
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-        architecture: x64
+    - name: Acquire sources
+      uses: actions/checkout@v3
 
     - name: Setup Poetry
       uses: snok/install-poetry@v1
@@ -24,31 +19,25 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Get Poetry cache directory
-      id: poetry-cache-dir
-      run: |
-        echo "::set-output name=dir::$(poetry config cache-dir)"
-
-    - name: Apply cache
-      id: poetry-cache-flag
-      uses: actions/cache@v2
-      env:
-        # Increase this value to reset cache if `poetry.lock` has not changed.
-        CACHE_NUMBER: 1
+    - name: Setup Python
+      id: python-setup
+      uses: actions/setup-python@v4
       with:
-        path: ${{ steps.poetry-cache-dir.outputs.dir }}
-        key: poetry-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-${{ env.CACHE_NUMBER }}
+        python-version: "3.10"
+        architecture: x64
+        cache: poetry
 
-    - name: Install library
+    - name: Install project
+      if: steps.python-setup.outputs.cache-hit != 'true'
       run: .github/workflows/install.sh testing
 
-    - name: Generate coverage report
+    - name: Run tests, with coverage
       run: |
         poetry run pytest --cov=wetterdienst tests/
         poetry run coverage xml
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+    - name: Upload coverage report to Codecov
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
         flags: unittests

--- a/.github/workflows/docker-publish-full.yml
+++ b/.github/workflows/docker-publish-full.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -55,10 +55,10 @@ jobs:
 
     steps:
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/docker-publish-standard.yml
+++ b/.github/workflows/docker-publish-standard.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
@@ -55,10 +55,10 @@ jobs:
 
     steps:
       - name: Acquire sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,11 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Build documentation
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-        architecture: x64
+
+    - name: Acquire sources
+      uses: actions/checkout@v3
 
     - name: Setup Poetry
       uses: snok/install-poetry@v1
@@ -21,22 +19,15 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Get Poetry cache directory
-      id: poetry-cache-dir
-      run: |
-        echo "::set-output name=dir::$(poetry config cache-dir)"
-
-    - name: Apply cache
-      id: poetry-cache-flag
-      uses: actions/cache@v2
-      env:
-        # Increase this value to reset cache if `poetry.lock` has not changed.
-        CACHE_NUMBER: 1
+    - name: Setup Python
+      id: python-setup
+      uses: actions/setup-python@v4
       with:
-        path: ${{ steps.poetry-cache-dir.outputs.dir }}
-        key: poetry-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-${{ env.CACHE_NUMBER }}
+        python-version: "3.10"
+        architecture: x64
+        cache: poetry
 
-    - name: Install library
+    - name: Install project tooling
       run: .github/workflows/install.sh docs
 
     - name: Build docs

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -9,13 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Code style checks
     steps:
+
     - name: Acquire sources
-      uses: actions/checkout@v2
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-        architecture: x64
+      uses: actions/checkout@v3
 
     - name: Setup Poetry
       uses: snok/install-poetry@v1
@@ -23,23 +19,16 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Get Poetry cache directory
-      id: poetry-cache-dir
-      run: |
-        echo "::set-output name=dir::$(poetry config cache-dir)"
-
-    - name: Apply cache
-      id: poetry-cache-flag
-      uses: actions/cache@v2
-      env:
-        # Increase this value to reset cache if `poetry.lock` has not changed.
-        CACHE_NUMBER: 1
+    - name: Setup Python
+      id: python-setup
+      uses: actions/setup-python@v4
       with:
-        path: ${{ steps.poetry-cache-dir.outputs.dir }}
-        key: poetry-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-${{ env.CACHE_NUMBER }}
+        python-version: "3.10"
+        architecture: x64
+        cache: poetry
 
-    - name: Install library
-      run: poetry install --no-root
+    - name: Install project tooling
+      run: poetry install --no-interaction --no-root
 
-    - name: Run lint on code
+    - name: Run code-style checks
       run: poetry run poe lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: "3.10"
-        architecture: x64
+
+    - name: Acquire sources
+      uses: actions/checkout@v3
 
     - name: Setup Poetry
       uses: snok/install-poetry@v1
@@ -18,22 +16,16 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Get Poetry cache directory
-      id: poetry-cache-dir
-      run: |
-        echo "::set-output name=dir::$(poetry config cache-dir)"
-
-    - name: Apply cache
-      id: poetry-cache-flag
-      uses: actions/cache@v2
-      env:
-        # Increase this value to reset cache if `poetry.lock` has not changed.
-        CACHE_NUMBER: 2
+    - name: Setup Python
+      id: python-setup
+      uses: actions/setup-python@v4
       with:
-        path: ${{ steps.poetry-cache-dir.outputs.dir }}
-        key: poetry-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-${{ env.CACHE_NUMBER }}
+        python-version: "3.10"
+        architecture: x64
+        cache: poetry
 
-    - name: Install library
+    - name: Install project
+      if: steps.python-setup.outputs.cache-hit != 'true'
       run: .github/workflows/install.sh testing
 
     - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,13 +23,7 @@ jobs:
     steps:
 
     - name: Acquire sources
-      uses: actions/checkout@v2
-
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        architecture: x64
+      uses: actions/checkout@v3
 
     - name: Setup Poetry
       uses: snok/install-poetry@v1
@@ -37,26 +31,24 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Apply cache
-      id: poetry-cache-flag
-      uses: actions/cache@v2
-      env:
-        # Increase this value to reset cache if `poetry.lock` has not changed.
-        CACHE_NUMBER: 2
+    - name: Setup Python
+      id: python-setup
+      uses: actions/setup-python@v4
       with:
-        path: .venv
-        key: poetry-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}-${{ env.CACHE_NUMBER }}
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+        cache: poetry
 
-    - name: Install dependencies
+    - name: Install project
+      if: steps.python-setup.outputs.cache-hit != 'true'
       run: .github/workflows/install.sh testing
-      if: steps.poetry-cache-flag.outputs.cache-hit != 'true'
 
-    - name: Test (Windows) - single core
+    - name: Run tests (Windows, sequential)
       run: |
         if [ "$RUNNER_OS" == "Windows" ]; then 
           poetry run poe test-slow
         fi
-    - name: Test (Linux/Mac) - multi core
+    - name: Run tests (Linux/macOS, parallel)
       run: |
         if [ "$RUNNER_OS" != "Windows" ]; then
           poetry run poe test

--- a/tests/provider/dwd/radar/test_api_current.py
+++ b/tests/provider/dwd/radar/test_api_current.py
@@ -56,7 +56,7 @@ def test_radar_request_site_current_sweep_pcp_v_hdf5():
 
     shape = hdf["/dataset1/data1/data"].shape
 
-    assert shape == (360, 600) or shape == (361, 600)
+    assert shape in ((360, 600), (361, 600), (359, 600))
 
 
 @pytest.mark.remote
@@ -99,7 +99,7 @@ def test_radar_request_site_current_sweep_vol_v_hdf5_full():
 
     shape = hdf["/dataset1/data1/data"].shape
 
-    assert shape == (360, 180) or shape == (360, 720) or shape == (361, 720)
+    assert shape in ((360, 180), (360, 720), (361, 720), (358, 720))
 
 
 @pytest.mark.remote

--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -823,7 +823,7 @@ def test_radar_request_site_historic_sweep_pcp_v_hdf5_yesterday():
     assert hdf["/how"].attrs.get("scan_count") == 1
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape == (360, 600)
+    assert hdf["/dataset1/data1/data"].shape in ((360, 600), (358, 600))
 
     timestamp = round_minutes(request.start_date, 5)
     assert hdf["/what"].attrs.get("date") == bytes(timestamp.strftime("%Y%m%d"), encoding="ascii")
@@ -909,7 +909,7 @@ def test_radar_request_site_historic_sweep_vol_v_hdf5_yesterday():
     assert hdf["/how"].attrs.get("scan_count") == 10
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape in ((360, 180), (360, 720), (361, 720))
+    assert hdf["/dataset1/data1/data"].shape in ((360, 180), (360, 720), (361, 720), (358, 720))
 
     timestamp = round_minutes(request.start_date, 5)
     assert hdf["/what"].attrs.get("date") == bytes(timestamp.strftime("%Y%m%d"), encoding="ascii")

--- a/tests/provider/dwd/radar/test_api_most_recent.py
+++ b/tests/provider/dwd/radar/test_api_most_recent.py
@@ -105,7 +105,7 @@ def test_radar_request_site_most_recent_sweep_vol_v_hdf5():
     assert hdf["/how"].attrs.get("scan_count") == 10
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape in ((360, 720), (361, 720))
+    assert hdf["/dataset1/data1/data"].shape in ((360, 720), (361, 720), (358, 720))
 
     # Verify that the second file is the second scan / elevation level.
     buffer = results[1].data


### PR DESCRIPTION
### About
This patch is another stab at #730. `actions/setup-python@v4` already implements caching for dependencies, so we can get rid of `actions/cache@v2`. Even if it might increase runtime, I think a _stable_ test harness is more important.

### Runtime comparison
- Beforehand: ~12-30 minutes total runtime, with ~5-13 minutes runtime per test matrix slot. [1]
- On the change: 24 minutes total runtime, with 9-23 minutes total runtime per test matrix slot, 2-4 minutes for installing the project dependencies. Caches ~250-325 MB worth of data. [2]
- Subsequent run [^1]: 19 minutes total runtime, with 7-13 minutes total runtime per test matrix slot on Linux/macOS and 13-18 minutes on Windows. 15-45 seconds for setting up Python including cached dependencies, 0 seconds for _installing_ the project dependencies.

[1] https://github.com/earthobservations/wetterdienst/actions/workflows/tests.yml?page=2 ff.
[2] https://github.com/earthobservations/wetterdienst/actions/runs/3122993288

[^1]: with warm cache