### PR TITLE
Tests: Do not strongly depend on `wradlib`

### DIFF
--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -10,7 +10,6 @@ import h5py
 import pybufrkit
 import pytest
 import requests
-import wradlib as wrl
 
 from wetterdienst.provider.dwd.radar import (
     DwdRadarDataFormat,
@@ -22,6 +21,8 @@ from wetterdienst.provider.dwd.radar import (
 )
 from wetterdienst.provider.dwd.radar.sites import DwdRadarSite
 from wetterdienst.util.datetime import round_minutes
+
+wrl = pytest.importorskip("wradlib", reason="wradlib not installed")
 
 HERE = Path(__file__).parent
 

--- a/tests/provider/dwd/radar/test_api_latest.py
+++ b/tests/provider/dwd/radar/test_api_latest.py
@@ -5,7 +5,6 @@ import re
 from datetime import datetime
 
 import pytest
-import wradlib as wrl
 
 from tests.provider.dwd.radar import station_reference_pattern_unsorted
 from wetterdienst.provider.dwd.radar import DwdRadarValues
@@ -43,6 +42,8 @@ def test_radar_request_composite_latest_rw_reflectivity():
     """
     Example for testing radar COMPOSITES (RADOLAN) latest.
     """
+
+    wrl = pytest.importorskip("wradlib", reason="wradlib not installed")
 
     request = DwdRadarValues(
         parameter=DwdRadarParameter.RW_REFLECTIVITY,
@@ -108,6 +109,8 @@ def test_radar_request_site_latest_dx_reflectivity():
     """
     Example for testing radar SITES latest.
     """
+
+    wrl = pytest.importorskip("wradlib", reason="wradlib not installed")
 
     request = DwdRadarValues(
         parameter=DwdRadarParameter.DX_REFLECTIVITY,

--- a/tests/provider/dwd/radar/test_api_most_recent.py
+++ b/tests/provider/dwd/radar/test_api_most_recent.py
@@ -2,7 +2,6 @@
 # Copyright (C) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
 import pytest
-import wradlib as wrl
 
 from wetterdienst.provider.dwd.radar import (
     DwdRadarParameter,
@@ -118,6 +117,8 @@ def test_radar_request_radolan_cdc_most_recent():
     """
     Example for testing radar sites most recent RADOLAN_CDC.
     """
+
+    wrl = pytest.importorskip("wradlib", reason="wradlib not installed")
 
     request = DwdRadarValues(
         parameter=DwdRadarParameter.RADOLAN_CDC,


### PR DESCRIPTION
### About
Skip corresponding tests when `wradlib` is not installed. This fixes #734 on my machine and will make parts of the test suite easier to run, specifically for all people who observe similar problems when having `wradlib` installed.