### PR TITLE
Tests: Improve tests wrt. temporary file creation

### DIFF
--- a/tests/provider/dwd/radar/test_api_latest.py
+++ b/tests/provider/dwd/radar/test_api_latest.py
@@ -64,7 +64,7 @@ def test_radar_request_composite_latest_rw_reflectivity(radar_locations):
     attrs = IsDict(
         {
             "datasize": 1620000,
-            "datetime": IsDatetime(approx=datetime.utcnow(), delta=timedelta(minutes=65)),
+            "datetime": IsDatetime(approx=datetime.utcnow(), delta=timedelta(minutes=90)),
             "formatversion": 3,
             "intervalseconds": 3600,
             "maxrange": "150 km",

--- a/tests/ui/test_cli.py
+++ b/tests/ui/test_cli.py
@@ -282,7 +282,7 @@ def test_cli_stations_excel(provider, network, setting, station_id, expected_dic
         target=f"file://{filename}",
     )
 
-    df = pd.read_excel(filename, sheet_name="Sheet1", dtype=str)
+    df = pd.read_excel(str(filename), sheet_name="Sheet1", dtype=str)
 
     assert "name" in df
     assert expected_dict["name"] in df["name"].values
@@ -382,7 +382,7 @@ def test_cli_values_excel(provider, network, setting, station_id, station_name, 
         target=f"file://{filename}",
     )
 
-    df = pd.read_excel(filename, sheet_name="Sheet1", dtype=str)
+    df = pd.read_excel(str(filename), sheet_name="Sheet1", dtype=str)
 
     assert "station_id" in df
     assert station_id in df["station_id"].values

--- a/tests/ui/test_cli.py
+++ b/tests/ui/test_cli.py
@@ -269,10 +269,10 @@ def test_cli_stations_csv(provider, network, setting, station_id, expected_dict,
     "provider,network,setting,station_id,expected_dict,coordinates",
     SETTINGS_STATIONS,
 )
-def test_cli_stations_excel(provider, network, setting, station_id, expected_dict, coordinates, tmpdir_factory):
+def test_cli_stations_excel(provider, network, setting, station_id, expected_dict, coordinates, tmp_path):
 
     # filename = tmpdir_factory.mktemp("data").join("stations_result.xlsx")  # Noqa:E800
-    filename = "stations.xlsx"
+    filename = tmp_path.joinpath("stations_result.xlsx")
 
     _ = invoke_wetterdienst_stations_export(
         provider=provider,
@@ -282,7 +282,7 @@ def test_cli_stations_excel(provider, network, setting, station_id, expected_dic
         target=f"file://{filename}",
     )
 
-    df = pd.read_excel("stations.xlsx", sheet_name="Sheet1", dtype=str)
+    df = pd.read_excel(filename, sheet_name="Sheet1", dtype=str)
 
     assert "name" in df
     assert expected_dict["name"] in df["name"].values
@@ -370,13 +370,9 @@ def test_cli_values_csv(provider, network, setting, station_id, station_name):
     "provider,network,setting,station_id,station_name",
     SETTINGS_VALUES,
 )
-def test_cli_values_excel(provider, network, setting, station_id, station_name, tmpdir_factory):
+def test_cli_values_excel(provider, network, setting, station_id, station_name, tmp_path):
 
-    # TODO: Why doesn't this work?
-    # filename = tmpdir_factory.mktemp("data").join("values.xlsx") # Noqa:E800
-
-    # FIXME: This will concurrently access the file with `pytest-xdist`, so it will croak.
-    filename = "values.xlsx"
+    filename = tmp_path.joinpath("values.xlsx")
 
     _ = invoke_wetterdienst_values_export(
         provider=provider,
@@ -386,7 +382,7 @@ def test_cli_values_excel(provider, network, setting, station_id, station_name, 
         target=f"file://{filename}",
     )
 
-    df = pd.read_excel("values.xlsx", sheet_name="Sheet1", dtype=str)
+    df = pd.read_excel(filename, sheet_name="Sheet1", dtype=str)
 
     assert "station_id" in df
     assert station_id in df["station_id"].values

--- a/tests/util/test_url.py
+++ b/tests/util/test_url.py
@@ -25,3 +25,11 @@ def test_connectionstring_table_from_query_param():
     cs = ConnectionString(url)
 
     assert cs.get_table() == "tablename"
+
+
+def test_connectionstring_temporary_file(tmp_path):
+    filepath = tmp_path.joinpath("foobar.txt")
+    url = f"file://{filepath}"
+    cs = ConnectionString(url)
+
+    assert cs.get_path() == str(filepath)


### PR DESCRIPTION
This patch may improve the situation when running the test suite in parallel with `pytest-xdist`, where a test case may otherwise try to access the same resource concurrently. Closes #739.