### PR TITLE
Fix passing an empty DataFrame through unit conversion

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Fix passing an empty DataFrame through unit conversion and ensure set of columns
+
 0.45.0 (22.09.2022)
 *******************
 

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -52,6 +52,26 @@ def test_dwd_observation_data_api():
 
 
 @pytest.mark.remote
+def test_dwd_observation_data_empty():
+    with Settings:
+        stations = DwdObservationRequest(
+            parameter=[
+                DwdObservationDataset.TEMPERATURE_AIR,
+                DwdObservationDataset.WIND,
+                DwdObservationDataset.PRECIPITATION,
+            ],
+            resolution=DwdObservationResolution.MINUTE_10,
+            period=DwdObservationPeriod.NOW,
+        )
+
+    nearest_station = stations.filter_by_rank(rank=1, latitude=52.384630, longitude=9.733908)
+
+    values = nearest_station.values.all()
+
+    assert values.df.station_id.unique() == ["02011"]
+
+
+@pytest.mark.remote
 def test_dwd_observation_data_dataset():
     """Request a parameter set"""
     expected = DwdObservationRequest(

--- a/tests/provider/dwd/radar/test_api_current.py
+++ b/tests/provider/dwd/radar/test_api_current.py
@@ -56,7 +56,7 @@ def test_radar_request_site_current_sweep_pcp_v_hdf5():
 
     shape = hdf["/dataset1/data1/data"].shape
 
-    assert shape in ((360, 600), (361, 600), (359, 600))
+    assert shape in ((361, 600), (360, 600), (359, 600), (358, 600))
 
 
 @pytest.mark.remote

--- a/tests/provider/dwd/radar/test_api_most_recent.py
+++ b/tests/provider/dwd/radar/test_api_most_recent.py
@@ -59,7 +59,7 @@ def test_radar_request_site_most_recent_sweep_pcp_v_hdf5():
     assert hdf["/how"].attrs.get("scan_count") == 1
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape in ((360, 600), (359, 600))
+    assert hdf["/dataset1/data1/data"].shape in ((360, 600), (359, 600), (358, 600))
 
 
 @pytest.mark.remote

--- a/tests/provider/dwd/radar/test_api_recent.py
+++ b/tests/provider/dwd/radar/test_api_recent.py
@@ -100,7 +100,7 @@ def test_radar_request_site_recent_sweep_vol_v_hdf5():
     assert hdf["/how"].attrs.get("scan_count") == 10
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape in ((360, 720), (358, 720))
+    assert hdf["/dataset1/data1/data"].shape in ((361, 720), (360, 720), (359, 720), (358, 720))
 
     # Verify that the second file is the second scan / elevation level.
     buffer = results[1].data

--- a/wetterdienst/core/scalar/values.py
+++ b/wetterdienst/core/scalar/values.py
@@ -253,9 +253,9 @@ class ScalarValuesCore(metaclass=ABCMeta):
                 )
                 data.append(group)
             try:
-                return pd.concat(data)
+                return pd.concat(data, axis=0)
             except ValueError:
-                return pd.DataFrame()
+                return df
 
         return df.apply(_convert_values_to_si, axis=0, conv_factors=conversion_factors)
 

--- a/wetterdienst/provider/dwd/observation/api.py
+++ b/wetterdienst/provider/dwd/observation/api.py
@@ -465,7 +465,10 @@ class DwdObservationRequest(ScalarRequestCore):
 
     def __init__(
         self,
-        parameter: Union[str, DwdObservationDataset],
+        parameter: Union[
+            Union[str, DwdObservationDataset, DwdObservationParameter],
+            List[Union[str, DwdObservationDataset, DwdObservationParameter]],
+        ],
         resolution: Union[str, Resolution, DwdObservationResolution],
         period: Optional[Union[str, Period, DwdObservationPeriod]] = None,
         start_date: Optional[Union[str, datetime, pd.Timestamp]] = None,


### PR DESCRIPTION
At #754 @TheAnalystx has seen an error with empty data. Originally when converting units and the passed dataframe was empty, a new empty dataframe without any specifications was returned. This PR changes the behaviour to just pass the original dataframe with existing columns if the dataframe is empty so to prevent the returning of an completely empty dataframe.