### PR TITLE
Add support for reading DWD Mosmix-L all stations files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Add support for reading DWD Mosmix-L all stations files
+
 0.46.0 (14.10.2022)
 *******************
 

--- a/docs/usage/python-api.rst
+++ b/docs/usage/python-api.rst
@@ -656,7 +656,7 @@ Get stations for Mosmix:
 Mosmix forecasts require us to define ``station_ids`` and ``mosmix_type``. Furthermore
 we can also define explicitly the requested parameters.
 
-Get Mosmix-L data:
+Get Mosmix-L data (single station file):
 
 .. ipython:: python
     :okwarning:
@@ -666,6 +666,23 @@ Get Mosmix-L data:
     stations = DwdMosmixRequest(
         parameter="large",
         mosmix_type=DwdMosmixType.LARGE
+    ).filter_by_station_id(station_id=["01001", "01008"])
+    response =  next(stations.values.query())
+
+    print(response.stations.df)
+    print(response.df)
+
+Get Mosmix-L data (all stations file):
+
+.. ipython:: python
+    :okwarning:
+
+    from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
+
+    stations = DwdMosmixRequest(
+        parameter="large",
+        mosmix_type=DwdMosmixType.LARGE,
+        station_group="all_stations"
     ).filter_by_station_id(station_id=["01001", "01008"])
     response =  next(stations.values.query())
 

--- a/example/mosmix_forecasts.py
+++ b/example/mosmix_forecasts.py
@@ -44,7 +44,28 @@ def mosmix_example():
     output_section("Metadata", response.stations.df)
     output_section("Forecasts", response.df)
 
-    # B. MOSMIX-S -- All stations_result - specified stations_result are extracted.
+    # B. MOSMIX-L -- All stations_result - specified stations_result are extracted.
+    Settings.tidy = True
+    Settings.humanize = True
+
+    request = DwdMosmixRequest(
+        parameter=["DD", "ww"],
+        start_issue=DwdForecastDate.LATEST,  # automatically set if left empty
+        mosmix_type=DwdMosmixType.LARGE,
+        station_group="all_stations",
+    )
+
+    stations = request.filter_by_station_id(
+        station_id=["01001", "01008"],
+    )
+
+    response = next(stations.values.query())
+
+    # meta data enriched with information from metadata_for_forecasts()
+    output_section("Metadata", response.stations.df)
+    output_section("Forecasts", response.df)
+
+    # C. MOSMIX-S -- All stations_result - specified stations_result are extracted.
 
     request = DwdMosmixRequest(
         parameter=["DD", "ww"],

--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -168,8 +168,8 @@ def test_radar_request_composite_historic_hg_yesterday():
     assert dt_delta.seconds / 60 < 10
     assert requested_attrs["radarid"] == "10000"
     assert requested_attrs["datasize"] == 5280000
-    assert requested_attrs["maxrange"] == "150 km"
-    assert requested_attrs["radolanversion"] == "P300003H"
+    assert requested_attrs["maxrange"] == "100 km"
+    assert requested_attrs["radolanversion"] == "P300001H"
     assert requested_attrs["precision"] == 1.0
     assert requested_attrs["intervalseconds"] == 300
     assert requested_attrs["nrow"] == 1200
@@ -824,7 +824,7 @@ def test_radar_request_site_historic_sweep_pcp_v_hdf5_yesterday():
     assert hdf["/how"].attrs.get("scan_count") == 1
     assert hdf["/dataset1/how"].attrs.get("scan_index") == 1
 
-    assert hdf["/dataset1/data1/data"].shape in ((360, 600), (359, 600), (358, 600))
+    assert hdf["/dataset1/data1/data"].shape in ((360, 600), (359, 600), (358, 600), (357, 600))
 
     timestamp = round_minutes(request.start_date, 5)
     assert hdf["/what"].attrs.get("date") == bytes(timestamp.strftime("%Y%m%d"), encoding="ascii")
@@ -998,7 +998,7 @@ def test_radar_request_radvor_re_yesterday():
         "producttype": "RE",
         "datetime": request.start_date.to_pydatetime(),
         "precision": 0.001,
-        "formatversion": 3,
+        "formatversion": 5,
         "intervalseconds": 3600,
         "nrow": 900,
         "ncol": 900,
@@ -1109,7 +1109,7 @@ def test_radar_request_radvor_rq_yesterday():
         "producttype": "RQ",
         "datetime": request.start_date.to_pydatetime(),
         "precision": 0.1,
-        "formatversion": 3,
+        "formatversion": 5,
         "intervalseconds": 3600,
         "nrow": 900,
         "ncol": 900,
@@ -1192,9 +1192,9 @@ def test_radar_request_radvor_rq_timerange():
     attrs = {
         "producttype": "RQ",
         "datetime": request.start_date.to_pydatetime(),
-        "formatversion": 3,
+        "formatversion": 5,
         "datasize": 1620000,
-        "maxrange": "150 km",
+        "maxrange": "100 km",
         "precision": 0.1,
         "intervalseconds": 3600,
         "nrow": 900,

--- a/wetterdienst/provider/dwd/metadata/constants.py
+++ b/wetterdienst/provider/dwd/metadata/constants.py
@@ -8,7 +8,7 @@ DWD_CDC_PATH = "climate_environment/CDC/"
 
 DWD_MOSMIX_S_PATH = "weather/local_forecasts/mos/MOSMIX_S/all_stations/kml/"
 DWD_MOSMIX_L_PATH = "weather/local_forecasts/mos/MOSMIX_L/all_stations/kml/"
-DWD_MOSMIX_L_SINGLE_PATH = "weather/local_forecasts/mos/MOSMIX_L/single_stations/"
+DWD_MOSMIX_L_SINGLE_PATH = "weather/local_forecasts/mos/MOSMIX_L/single_stations/{station_id}/kml/"
 
 
 class DWDCDCBase(Enum):


### PR DESCRIPTION
DWD Mosmix-L all stations is finally back and apparently with the new stream parser it works as fluent as it could.

Fixes #586 