### PR TITLE
CI: Add support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,10 +20,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         exclude:
           - os: "windows-latest"
             python-version: "3.11"
+          - os: "windows-latest"
+            python-version: "3.12-dev"
+
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
     "Development Status :: 4 - Beta",
     "Environment :: Console",


### PR DESCRIPTION
Just out of curiosity. It will probably fail on CI, because not everything may be ready to support Python 3.12, yet.
Python 3.12.0 final will be released on 2023-10-02, so there is plenty of time to address this.