### PR TITLE
Fix bug with dropping duplicates of acquired data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Fix bug where duplicates of acquired data would be dropped regarding only the date but not the parameter
+
 0.48.0 (11.11.2022)
 *******************
 

--- a/wetterdienst/core/scalar/values.py
+++ b/wetterdienst/core/scalar/values.py
@@ -462,7 +462,7 @@ class ScalarValuesCore(metaclass=ABCMeta):
                 if parameter_df.empty:
                     parameter_df = self._create_empty_station_parameter_df(station_id, parameter, dataset)
 
-                parameter_df = parameter_df.drop_duplicates(subset=[Columns.DATE.value])
+                parameter_df = parameter_df.drop_duplicates()
 
                 # set dynamic resolution for services that have no fixed resolutions
                 if self.sr.resolution == Resolution.DYNAMIC:


### PR DESCRIPTION
Dear all,

apparently there was a bug with dropping duplicates of acquired data. The duplicates where detected only based on the date column however this would cause a dataset with multiple parameters to return only data for the first appearing parameter with this date. 

Now data is dropped according to all columns.

Cheers,
Benjamin