### PR TITLE
NWS API: Adjust `User-Agent` header

### DIFF
--- a/wetterdienst/provider/nws/observation/api.py
+++ b/wetterdienst/provider/nws/observation/api.py
@@ -20,7 +20,7 @@ from wetterdienst.util.network import download_file
 from wetterdienst.util.parameter import DatasetTreeCore
 
 Settings.fsspec_client_kwargs["headers"] = {
-    "User-Agent": "wetterdienst/gutzemann@gmail.com",
+    "User-Agent": "wetterdienst/0.48.0",
     "Content-Type": "application/json",
 }
 


### PR DESCRIPTION
Coming from https://github.com/earthobservations/wetterdienst/pull/781#discussion_r1027381956, this is hopefully a minor, but sensible improvement. Please let me know if you think it's not.