### PR TITLE
Allow querying an existing station via interpolate/summarize

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 Development
 ***********
 
+- Interpolation/Summary: Now the queried point can be an existing station laying on the border of the polygon that it's
+  being checked against
+
 0.49.0 (28.11.2022)
 *******************
 

--- a/wetterdienst/core/scalar/interpolate.py
+++ b/wetterdienst/core/scalar/interpolate.py
@@ -158,7 +158,7 @@ def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float):
     for station_group in combinations(stations_dict.keys(), 4):
         coords = [(stations_dict[s][0], stations_dict[s][1]) for s in station_group]
         pol = Polygon(coords)
-        if pol.contains(point):
+        if pol.covers(point):
             valid_groups.put(station_group)
 
     return valid_groups


### PR DESCRIPTION
Dear all,

beforehand when using `interpolate/summarize`, we were not able to query an existing station because it would not lay INSIDE one of the station group polygons:
https://github.com/earthobservations/wetterdienst/blob/d54e0f0c19758e15829aac6bb606b4151b3c62e2/wetterdienst/core/scalar/interpolate.py#L161

With this small change now an existing station location can be queried. This will allow us (in a further step) to simply take those stations values instead of interpolating/summarizing and ONLY interpolate/summarize where this station has no values.

Basically with the current workflow of `summarize` this is already happening because the nearest station would be the one the values are taken from but for `interpolate` we will have to do some approximation like `distance < 500m` to decide whether to take the bare values instead.

CC / @neumann-nico 