### PR TITLE
Change geo function signature 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Development
 
 - Interpolation/Summary: Now the queried point can be an existing station laying on the border of the polygon that it's
   being checked against
+- Geo: Change function signatures to use latlon tuple instead of latitude and longitude
 
 0.49.0 (28.11.2022)
 *******************

--- a/benchmarks/interpolation.py
+++ b/benchmarks/interpolation.py
@@ -58,7 +58,7 @@ def request_weather_data(
     )
 
     # request the nearest weather stations
-    request = stations.filter_by_distance(latitude=lat, longitude=lon, distance=distance)
+    request = stations.filter_by_distance(latlon=(lat, lon), distance=distance)
     print(request.df)
     station_ids = request.df["station_id"].values.tolist()
     latitudes = request.df["latitude"].values.tolist()
@@ -120,7 +120,7 @@ def visualize_points(data: Data):
 
 
 def main():
-    parameter = Parameter.TEMPERATURE_AIR_MEAN_200.name
+    parameter = Parameter.TEMPERATURE_AIR_MEAN_200
     latitude = 50.0
     longitude = 8.9
     distance = 21.0

--- a/benchmarks/interpolation_over_time.py
+++ b/benchmarks/interpolation_over_time.py
@@ -20,7 +20,7 @@ def get_interpolated_df(start_date: datetime, end_date: datetime) -> pd.DataFram
         start_date=start_date,
         end_date=end_date,
     )
-    return stations.interpolate(latitude=50.0, longitude=8.9).df
+    return stations.interpolate(latlon=(50.0, 8.9)).df
 
 
 def get_regular_df(start_date: datetime, end_date: datetime, exclude_stations: list) -> pd.DataFrame:
@@ -30,7 +30,7 @@ def get_regular_df(start_date: datetime, end_date: datetime, exclude_stations: l
         start_date=start_date,
         end_date=end_date,
     )
-    request = stations.filter_by_distance(latitude=50.0, longitude=8.9, distance=30)
+    request = stations.filter_by_distance(latlon=(50.0, 8.9), distance=30)
     df = request.values.all().df.dropna()
     station_ids = df.station_id.tolist()
     first_station_id = set(station_ids).difference(set(exclude_stations)).pop()

--- a/benchmarks/interpolation_precipitation_difference.py
+++ b/benchmarks/interpolation_precipitation_difference.py
@@ -13,7 +13,7 @@ def get_interpolated_df(start_date: datetime, end_date: datetime) -> pd.DataFram
         start_date=start_date,
         end_date=end_date,
     )
-    return stations.interpolate(latitude=50.0, longitude=8.9).df
+    return stations.interpolate(latlon=(50.0, 8.9)).df
 
 
 def get_regular_df(start_date: datetime, end_date: datetime, exclude_stations: list) -> pd.DataFrame:
@@ -23,7 +23,7 @@ def get_regular_df(start_date: datetime, end_date: datetime, exclude_stations: l
         start_date=start_date,
         end_date=end_date,
     )
-    request = stations.filter_by_distance(latitude=50.0, longitude=8.9, distance=30)
+    request = stations.filter_by_distance(latlon=(50.0, 8.9), distance=30)
     df = request.values.all().df.dropna()
     station_ids = df.station_id.tolist()
     first_station_id = set(station_ids).difference(set(exclude_stations)).pop()

--- a/docs/usage/python-api.rst
+++ b/docs/usage/python-api.rst
@@ -361,8 +361,7 @@ Distance with default (kilometers)
     )
 
     df = stations.filter_by_distance(
-        latitude=50.0,
-        longitude=8.9,
+        latlon=(50.0, 8.9),
         distance=30,
         unit="km"
     ).df
@@ -386,8 +385,7 @@ Distance with miles
     )
 
     df = stations.filter_by_distance(
-        latitude=50.0,
-        longitude=8.9,
+        latlon=(50.0, 8.9),
         distance=30,
         unit="mi"
     ).df
@@ -411,8 +409,7 @@ Rank selection
     )
 
     df = stations.filter_by_rank(
-        latitude=50.0,
-        longitude=8.9,
+        latlon=(50.0, 8.9),
         rank=5
     ).df
 
@@ -459,8 +456,7 @@ Again from here we can jump to the corresponding data:
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2020, 1, 20)
     ).filter_by_distance(
-        latitude=50.0,
-        longitude=8.9,
+        latlon=(50.0, 8.9),
         distance=30
     )
 
@@ -544,7 +540,7 @@ Currently the following parameters are supported (more will be added if useful):
         end_date=datetime(2022, 1, 20),
     )
 
-    result = stations.interpolate(latitude=50.0, longitude=8.9)
+    result = stations.interpolate(latlon=(50.0, 8.9))
     df = result.df
     print(df.head())
 
@@ -570,7 +566,7 @@ Currently the following parameters are supported (more will be added if useful):
         end_date=datetime(2022, 1, 20),
     )
 
-    result = stations.summarize(latitude=50.0, longitude=8.9)
+    result = stations.summarize(latlon=(50.0, 8.9))
     df = result.df
     print(df.head())
 

--- a/example/observations_stations.py
+++ b/example/observations_stations.py
@@ -31,7 +31,7 @@ def station_example():
         end_date=datetime(2020, 1, 20),
     )
 
-    result = stations.filter_by_distance(latitude=50.0, longitude=8.9, distance=30)
+    result = stations.filter_by_distance(latlon=(50.0, 8.9), distance=30)
 
     print(result.df)
 

--- a/tests/core/scalar/test_api.py
+++ b/tests/core/scalar/test_api.py
@@ -27,7 +27,7 @@ def test_api_skip_empty_stations():
             resolution=DwdObservationResolution.MINUTE_10,
             start_date=start_date,
             end_date=end_date,
-        ).filter_by_rank(49.19780976647141, 8.135207205143768, 20)
+        ).filter_by_rank(latlon=(49.19780976647141, 8.135207205143768), rank=20)
 
     values = next(stations.values.query())
 
@@ -52,7 +52,7 @@ def test_api_dropna():
             resolution=DwdObservationResolution.MINUTE_10,
             start_date=start_date,
             end_date=end_date,
-        ).filter_by_rank(49.19780976647141, 8.135207205143768, 20)
+        ).filter_by_rank(latlon=(49.19780976647141, 8.135207205143768), rank=20)
 
     values = next(stations.values.query())
 

--- a/tests/core/scalar/test_interpolation.py
+++ b/tests/core/scalar/test_interpolation.py
@@ -22,13 +22,13 @@ pytest.importorskip("shapely")
 
 def test_interpolation_temperature_air_mean_200_hourly():
     stations = DwdObservationRequest(
-        parameter=Parameter.TEMPERATURE_AIR_MEAN_200.name,
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.HOURLY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
     )
 
-    result = stations.interpolate(latitude=50.0, longitude=8.9)
+    result = stations.interpolate(latlon=(50.0, 8.9))
     interpolated_df = result.df
     assert interpolated_df.shape[0] == 18001
     assert interpolated_df.dropna().shape[0] == 18001
@@ -51,13 +51,13 @@ def test_interpolation_temperature_air_mean_200_hourly():
 @pytest.mark.slow
 def test_interpolation_precipitation_height_minute_10():
     stations = DwdObservationRequest(
-        parameter=Parameter.PRECIPITATION_HEIGHT.name,
+        parameter=Parameter.PRECIPITATION_HEIGHT,
         resolution=DwdObservationResolution.MINUTE_10,
         start_date=datetime(2021, 10, 1),
         end_date=datetime(2021, 10, 5),
     )
 
-    result = stations.interpolate(latitude=50.0, longitude=8.9)
+    result = stations.interpolate(latlon=(50.0, 8.9))
     interpolated_df = result.df
 
     assert interpolated_df.shape[0] == 577
@@ -80,13 +80,13 @@ def test_interpolation_precipitation_height_minute_10():
 
 def test_not_interpolatable_parameter():
     stations = DwdObservationRequest(
-        parameter=Parameter.WIND_DIRECTION.name,
+        parameter=Parameter.WIND_DIRECTION,
         resolution=DwdObservationResolution.HOURLY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
     )
 
-    result = stations.interpolate(latitude=50.0, longitude=8.9)
+    result = stations.interpolate(latlon=(50.0, 8.9))
     interpolated_df = result.df
     assert interpolated_df.shape[0] == 0
     assert interpolated_df.dropna().shape[0] == 0
@@ -112,13 +112,13 @@ def test_not_interpolatable_parameter():
 
 def test_not_interpolatable_dataset():
     stations = DwdObservationRequest(
-        parameter=DwdObservationDataset.TEMPERATURE_AIR.name,
+        parameter=DwdObservationDataset.TEMPERATURE_AIR,
         resolution=DwdObservationResolution.HOURLY,
         start_date=datetime(2022, 1, 1),
         end_date=datetime(2022, 1, 2),
     )
 
-    result = stations.interpolate(latitude=50.0, longitude=8.9)
+    result = stations.interpolate(latlon=(50.0, 8.9))
     interpolated_df = result.df
     assert interpolated_df.shape[0] == 0
     assert interpolated_df.dropna().shape[0] == 0
@@ -150,7 +150,7 @@ def not_supported_provider_dwd_mosmix(caplog):
         parameter=["DD", "ww"],
         mosmix_type=DwdMosmixType.SMALL,
     )
-    result = request.interpolate(latitude=50.0, longitude=8.9)
+    result = request.interpolate(latlon=(50.0, 8.9))
     assert result.df.empty
     assert "Interpolation currently only works for DwdObservationRequest" in caplog.text
 
@@ -159,9 +159,9 @@ def test_not_supported_provider_ecc(caplog):
     station = EcccObservationRequest(
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
-        parameter=Parameter.TEMPERATURE_AIR_MEAN_200.name,
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=EcccObservationResolution.DAILY,
     )
-    result = station.interpolate(latitude=50.0, longitude=8.9)
+    result = station.interpolate(latlon=(50.0, 8.9))
     assert result.df.empty
     assert "Interpolation currently only works for DwdObservationRequest" in caplog.text

--- a/tests/core/scalar/test_summary.py
+++ b/tests/core/scalar/test_summary.py
@@ -24,7 +24,7 @@ from wetterdienst.provider.eccc.observation.metadata.resolution import (
 @pytest.mark.skipif(
     os.getenv("CI") == "true" and sys.platform == "darwin", reason="FIXME: Produces different result on GHA/macOS"
 )
-def test_interpolation_temperature_air_mean_200_daily():
+def test_summary_temperature_air_mean_200_daily():
     stations = DwdObservationRequest(
         parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
@@ -32,7 +32,7 @@ def test_interpolation_temperature_air_mean_200_daily():
         end_date=datetime(1965, 12, 31),
     )
 
-    result = stations.summarize(latitude=51.0221, longitude=13.8470)
+    result = stations.summarize(latlon=(51.0221, 13.8470))
     summarized_df = result.df
     selected_dates = [
         datetime(1934, 1, 1, tzinfo=pytz.UTC),
@@ -55,13 +55,13 @@ def test_interpolation_temperature_air_mean_200_daily():
 
 def test_not_summarizable_dataset():
     stations = DwdObservationRequest(
-        parameter=DwdObservationDataset.TEMPERATURE_AIR.name,
+        parameter=DwdObservationDataset.TEMPERATURE_AIR,
         resolution=DwdObservationResolution.HOURLY,
         start_date=datetime(2022, 1, 1),
         end_date=datetime(2022, 1, 2),
     )
 
-    result = stations.summarize(latitude=50.0, longitude=8.9)
+    result = stations.summarize(latlon=(50.0, 8.9))
     summarized_df = result.df
     assert summarized_df.shape[0] == 0
     assert summarized_df.dropna().shape[0] == 0
@@ -93,7 +93,7 @@ def not_supported_provider_dwd_mosmix(caplog):
         parameter=["DD", "ww"],
         mosmix_type=DwdMosmixType.SMALL,
     )
-    result = request.summarize(latitude=50.0, longitude=8.9)
+    result = request.summarize(latlon=(50.0, 8.9))
     assert result.df.empty
     assert "Interpolation currently only works for DwdObservationRequest" in caplog.text
 
@@ -102,9 +102,9 @@ def test_not_supported_provider_ecc(caplog):
     station = EcccObservationRequest(
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
-        parameter=Parameter.TEMPERATURE_AIR_MEAN_200.name,
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=EcccObservationResolution.DAILY,
     )
-    result = station.summarize(latitude=50.0, longitude=8.9)
+    result = station.summarize(latlon=(50.0, 8.9))
     assert result.df.empty
     assert "Interpolation currently only works for DwdObservationRequest" in caplog.text

--- a/tests/provider/dwd/mosmix/test_api_data.py
+++ b/tests/provider/dwd/mosmix/test_api_data.py
@@ -253,7 +253,7 @@ def test_mosmix_date_filter():
         start_issue=now - timedelta(hours=5),
     )
 
-    nearest_station = stations.filter_by_rank(rank=1, latitude=52.122050, longitude=11.619845)
+    nearest_station = stations.filter_by_rank(latlon=(52.122050, 11.619845), rank=1)
     df = nearest_station.values.all().df
 
     assert len(df) == 40

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -64,7 +64,7 @@ def test_dwd_observation_data_empty():
             period=DwdObservationPeriod.NOW,
         )
 
-    nearest_station = stations.filter_by_rank(rank=1, latitude=52.384630, longitude=9.733908)
+    nearest_station = stations.filter_by_rank(latlon=(52.384630, 9.733908), rank=1)
 
     values = nearest_station.values.all()
 

--- a/tests/provider/dwd/observation/test_api_stations_geo.py
+++ b/tests/provider/dwd/observation/test_api_stations_geo.py
@@ -68,9 +68,8 @@ def test_dwd_observation_stations_nearby_number_single():
     )
 
     nearby_station = request.filter_by_rank(
-        50.0,
-        8.9,
-        1,
+        latlon=(50.0, 8.9),
+        rank=1,
     )
     nearby_station = nearby_station.df.drop("to_date", axis="columns")
 
@@ -87,9 +86,8 @@ def test_dwd_observation_stations_nearby_number_multiple():
         datetime(2020, 1, 20),
     )
     nearby_station = request.filter_by_rank(
-        50.0,
-        8.9,
-        3,
+        latlon=(50.0, 8.9),
+        rank=3,
     )
     nearby_station = nearby_station.df.drop("to_date", axis="columns")
 
@@ -106,13 +104,13 @@ def test_dwd_observation_stations_nearby_distance():
         datetime(2020, 1, 20),
     )
     # Kilometers
-    nearby_station = request.filter_by_distance(50.0, 8.9, 16.13, "km")
+    nearby_station = request.filter_by_distance(latlon=(50.0, 8.9), distance=16.13, unit="km")
     nearby_station = nearby_station.df.drop("to_date", axis="columns")
 
     assert_frame_equal(nearby_station, EXPECTED_STATIONS_DF)
 
     # Miles
-    nearby_station = request.filter_by_distance(50.0, 8.9, 10.03, "mi")
+    nearby_station = request.filter_by_distance(latlon=(50.0, 8.9), distance=10.03, unit="mi")
     nearby_station = nearby_station.df.drop(columns="to_date")
 
     assert_frame_equal(nearby_station, EXPECTED_STATIONS_DF)
@@ -163,9 +161,8 @@ def test_dwd_observation_stations_fail():
             datetime(2020, 1, 1),
             datetime(2020, 1, 20),
         ).filter_by_rank(
-            51.4,
-            9.3,
-            0,
+            latlon=(51.4, 9.3),
+            rank=0,
         )
     # Distance
     with pytest.raises(ValueError):
@@ -176,9 +173,8 @@ def test_dwd_observation_stations_fail():
             datetime(2020, 1, 1),
             datetime(2020, 1, 20),
         ).filter_by_distance(
-            51.4,
-            9.3,
-            -1,
+            latlon=(51.4, 9.3),
+            distance=-1,
         )
     # Bbox
     with pytest.raises(ValueError):

--- a/wetterdienst/core/scalar/interpolate.py
+++ b/wetterdienst/core/scalar/interpolate.py
@@ -42,7 +42,7 @@ def request_stations(
     stations_dict = {}
     hard_distance_km_limit = 40
 
-    stations_ranked = request.filter_by_rank(latitude=latitude, longitude=longitude, rank=20)
+    stations_ranked = request.filter_by_rank(latlon=(latitude, longitude), rank=20)
     stations_ranked_df = stations_ranked.df.dropna()
 
     for (_, station), result in zip(stations_ranked_df.iterrows(), stations_ranked.values.query()):

--- a/wetterdienst/core/scalar/summarize.py
+++ b/wetterdienst/core/scalar/summarize.py
@@ -28,7 +28,7 @@ def request_stations(request: "ScalarRequestCore", latitude: float, longitude: f
     stations_dict = {}
     hard_distance_km_limit = 40
 
-    stations_ranked = request.filter_by_rank(latitude=latitude, longitude=longitude, rank=20)
+    stations_ranked = request.filter_by_rank(latlon=(latitude, longitude), rank=20)
     stations_ranked_df = stations_ranked.df.dropna()
 
     for (_, station), result in zip(stations_ranked_df.iterrows(), stations_ranked.values.query()):

--- a/wetterdienst/ui/core.py
+++ b/wetterdienst/ui/core.py
@@ -163,8 +163,7 @@ def get_stations(
         lat, lon = coordinates.split(",")
 
         return r.filter_by_rank(
-            latitude=float(lat),
-            longitude=float(lon),
+            latlon=(float(lat), float(lon)),
             rank=rank,
         )
 
@@ -172,8 +171,7 @@ def get_stations(
         lat, lon = coordinates.split(",")
 
         return r.filter_by_distance(
-            latitude=float(lat),
-            longitude=float(lon),
+            latlon=(float(lat), float(lon)),
             distance=distance,
         )
 


### PR DESCRIPTION
Dear all,

this changes the function signatures where we query points (latitude, longitude) to use a latlon tuple instead.
This makes it easier to handle alternative input.

Especially we plan to let the user ask for summary/interpolation for an already given station id, assuming that its data is not complete.