### PR TITLE
Enable querying station id instead of latlon in interpolate/summary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Development
 - Interpolation/Summary: Now the queried point can be an existing station laying on the border of the polygon that it's
   being checked against
 - Geo: Change function signatures to use latlon tuple instead of latitude and longitude
+- Geo: Enable querying station id instead of latlon within interpolate and summarize
 
 0.49.0 (28.11.2022)
 *******************

--- a/docs/usage/python-api.rst
+++ b/docs/usage/python-api.rst
@@ -544,6 +544,27 @@ Currently the following parameters are supported (more will be added if useful):
     df = result.df
     print(df.head())
 
+Instead of a latlon you may alternatively use an existing station id for which to interpolate values in a manner of
+getting a more complete dataset:
+
+.. ipython:: python
+    :okwarning:
+
+    from wetterdienst.provider.dwd.observation import DwdObservationRequest
+    from wetterdienst import Parameter, Resolution
+
+    stations = DwdObservationRequest(
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
+        resolution=Resolution.HOURLY,
+        start_date=datetime(2022, 1, 1),
+        end_date=datetime(2022, 1, 20),
+    )
+
+    result = stations.interpolate_by_station_id(station_id="02480")
+    df = result.df
+    print(df.head())
+
+
 Summary
 -------
 
@@ -570,6 +591,25 @@ Currently the following parameters are supported (more will be added if useful):
     df = result.df
     print(df.head())
 
+Instead of a latlon you may alternatively use an existing station id for which to summarize values in a manner of
+getting a more complete dataset:
+
+.. ipython:: python
+    :okwarning:
+
+    from wetterdienst.provider.dwd.observation import DwdObservationRequest
+    from wetterdienst import Parameter, Resolution
+
+    stations = DwdObservationRequest(
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
+        resolution=Resolution.HOURLY,
+        start_date=datetime(2022, 1, 1),
+        end_date=datetime(2022, 1, 20),
+    )
+
+    result = stations.summarize_by_station_id(station_id="02480")
+    df = result.df
+    print(df.head())
 
 SQL support
 -----------

--- a/wetterdienst/core/scalar/interpolate.py
+++ b/wetterdienst/core/scalar/interpolate.py
@@ -41,7 +41,6 @@ def request_stations(
     param_dict = {}
     stations_dict = {}
     hard_distance_km_limit = 40
-
     stations_ranked = request.filter_by_rank(latlon=(latitude, longitude), rank=20)
     stations_ranked_df = stations_ranked.df.dropna()
 
@@ -120,7 +119,6 @@ def apply_station_values_per_parameter(
                 .set_index(Columns.DATE.value)
                 .astype("datetime64")
             )
-
         extract_station_values(param_dict[parameter_name], result_series_param, valid_station_groups_exists)
 
 
@@ -175,7 +173,6 @@ def get_station_group_ids(valid_station_groups: Queue, vals_index: frozenset) ->
 def apply_interpolation(row, stations_dict: dict, valid_station_groups, parameter, utm_x: float, utm_y: float):
     vals_state = ~pd.isna(row.values)
     vals = row[vals_state].astype(float)
-
     station_group_ids = get_station_group_ids(valid_station_groups, frozenset(vals.index))
 
     if station_group_ids:

--- a/wetterdienst/core/scalar/tools.py
+++ b/wetterdienst/core/scalar/tools.py
@@ -16,7 +16,6 @@ def extract_station_values(
     # 1. only add further stations if not a minimum of 4 stations is reached OR
     # 2. a gain of 10% of timestamps with at least 4 existing values over all stations is seen OR
     # 3. an additional counter is below 3 (used if a station has really no or few values)
-
     cond1 = param_data.values.shape[1] < 4
     cond2 = not cond1 and gain_of_value_pairs(param_data.values, result_series_param) > 0.10
     if (

--- a/wetterdienst/exceptions.py
+++ b/wetterdienst/exceptions.py
@@ -47,3 +47,7 @@ class InvalidTimeInterval(ValueError):
 
 class ProviderError(Exception):
     pass
+
+
+class StationNotFoundError(Exception):
+    pass


### PR DESCRIPTION
Dear all,

this PR enables us to query for a already given station within the setting of `.interpolate` and `.summarize`.

We often have users that want values for a specific station but then realize that the station has actually no values for their specified date range. The users can now simply submit their station id but within the given methods to receive a more complete dataset.

Instead of 

```python
request = Request(...).filter_by_station_id("1048")
```

one can now call

```python
request = Request(...).summarize_by_station_id("1048")
```

which will automatically fill in values from neighbouring stations where 1048 has no values.