### PR TITLE
Chore: Sort dependency packages in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3485,8 +3485,8 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 bufr = ["pdbufr"]
 cratedb = []
 duckdb = ["duckdb"]
-explorer = ["plotly", "dash", "dash-bootstrap-components"]
-export = ["openpyxl", "sqlalchemy", "pyarrow", "xarray", "zarr"]
+explorer = ["dash", "dash-bootstrap-components", "plotly"]
+export = ["openpyxl", "pyarrow", "sqlalchemy", "xarray", "zarr"]
 influxdb = ["influxdb", "influxdb-client"]
 interpolation = ["scipy", "shapely", "utm"]
 ipython = ["matplotlib"]
@@ -3494,14 +3494,14 @@ mpl = ["matplotlib"]
 mysql = ["mysqlclient"]
 postgresql = ["psycopg2-binary"]
 radar = ["h5py"]
-radarplus = ["wradlib", "pdbufr"]
+radarplus = ["pdbufr", "wradlib"]
 restapi = ["fastapi", "uvicorn"]
 sql = ["duckdb"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.12"
-content-hash = "57fac5b94a7de96d4924182e23f09ff2f270d00d88e8cfab3c06f83f2cefae20"
+content-hash = "c4dcafb6da3590da3c89733da0a09a25dae4756bf3958a5638030367ce53e699"
 
 [metadata.files]
 aenum = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,85 +97,64 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8,<3.12"
-pandas = "^1.3"
-numpy = "^1.22"
-cachetools = "^5.2"
-dateparser = "^1.0"
-beautifulsoup4 = "^4.9"
-requests = "^2.20"
-python-dateutil = "^2.8"
-platformdirs = "^2"
-lxml = "^4.9.1"
-tqdm = "^4.47"
-PyPDF2 = "^1.26"
-tabulate = "^0.8"
-deprecation = "^2.1"
-measurement = "^3.2"
-rapidfuzz = "^2.1"
-Pint = "^0.17"
+
 aenum = "^3.0"
+aiohttp = "^3.8.1"
+beautifulsoup4 = "^4.9"
+cachetools = "^5.2"
 click = "^8.0"
 click-params = "^0.4"
 cloup = "^1.0"
-fsspec = "^2022.02"
-aiohttp = "^3.8.1"
-timezonefinder = "^6.1"
+dash                            = { version = "^2.7", optional = true }  # Explorer UI feature.
+dash-bootstrap-components       = { version = "^1.2", optional = true }  # Explorer UI feature.
+dateparser = "^1.0"
+deprecation = "^2.1"
 diskcache = "^5.4.0"
-environs = "^9.4.0"
-scikit-learn = "^1.0.2"
-
-# Optional dependencies aka. "extras"
-matplotlib                      = { version = "^3.3", optional = true }
-
-openpyxl                        = { version = "^3.0", optional = true }
-pyarrow                         = { version = "^10.0", python = "<3.11", optional = true}
 duckdb                          = { version = "^0.6.0", optional = true }
+eccodes                         = { version = "1.2.0", optional = true }  # Radar feature.
+environs = "^9.4.0"
+fastapi                         = { version = "^0.65", optional = true }  # HTTP REST API feature.
+fsspec = "^2022.02"
+h5py                            = { version = "^3.1", optional = true, extras = ["radar"], python = "<3.11" }  # Radar feature.
 influxdb                        = { version = "^5.3", optional = true }
 influxdb-client                 = { version = "^1.18", optional = true }
-sqlalchemy                      = { version = "^1.4", optional = true }
+lxml = "^4.9.1"
+matplotlib                      = { version = "^3.3", optional = true }
+measurement = "^3.2"
 mysqlclient                     = { version = "^2.0", optional = true }
+numpy = "^1.22"
+openpyxl                        = { version = "^3.0", optional = true }
+pandas = "^1.3"
+pdbufr                          = { version = "^0.9.0", optional = true, extras = ["eccodes"] }  # Radar feature.
+Pint = "^0.17"
+platformdirs = "^2"
+plotly                          = { version = "^5.11", optional = true }  # Explorer UI feature.
 psycopg2-binary                 = { version = "^2.8", optional = true }
-
-# HTTP REST API service
-fastapi                         = { version = "^0.65", optional = true }
-uvicorn                         = { version = "^0.14", optional = true }
-
-# Radar
-eccodes                         = { version = "1.2.0", optional = true }
-h5py                            = { version = "^3.1", optional = true, extras = ["radar"], python = "<3.11" }
-pdbufr                          = { version = "^0.9.0", optional = true, extras = ["eccodes"] }
-wradlib                         = { version = "^1.13", optional = true }
-
-# Explorer UI service
-plotly                          = { version = "^5.11", optional = true }
-dash                            = { version = "^2.7", optional = true }
-dash-bootstrap-components       = { version = "^1.2", optional = true }
-
-# Interpolation
-utm = { version = "^0.7", optional = true }
-scipy = { version = "^1.9", optional = true }
-shapely = { version = "^1.8", optional = true }
-
-zarr = { version = "^2.13", python = "<3.11", optional = true }
-xarray = { version = "^2022.11", optional = true }
-
+pyarrow                         = { version = "^10.0", python = "<3.11", optional = true}
+PyPDF2 = "^1.26"
+python-dateutil = "^2.8"
+rapidfuzz = "^2.1"
+requests = "^2.20"
+scikit-learn = "^1.0.2"
+scipy                           = { version = "^1.9", optional = true }  # Interpolation feature.
+shapely                         = { version = "^1.8", optional = true }  # Interpolation feature.
+sqlalchemy                      = { version = "^1.4", optional = true }
+tabulate = "^0.8"
+timezonefinder = "^6.1"
+tqdm = "^4.47"
+utm                             = { version = "^0.7", optional = true }  # Interpolation feature.
+uvicorn                         = { version = "^0.14", optional = true }  # HTTP REST API feature.
+wradlib                         = { version = "^1.13", optional = true }  # Radar feature.
+xarray                          = { version = "^2022.11", optional = true }
+zarr                            = { version = "^2.13", python = "<3.11", optional = true }
 
 [tool.poetry.group.dev]
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-
-poethepoet = "^0.16"
-pip-licenses = "^3.3"
-
-# Formatting
-black = "^22.10.0"
-isort = "^5.10"
-
-# Linting
-flakeheaven = "^3.0"
-flake8-bandit = "^3.0"
 bandit = "^1.7.4"
+black = "^22.10.0"
+flake8-bandit = "^3.0"
 flake8-black = "^0.3"
 flake8-bugbear = "^22.1"
 flake8-builtins = "^1.5"
@@ -187,67 +166,62 @@ flake8-isort = "^4.1"
 flake8-print = "^5.0"
 flake8-return = "^1.1"
 flake8-2020 = "^1.6"
+flakeheaven = "^3.0"
+isort = "^5.10"
+pip-licenses = "^3.3"
+poethepoet = "^0.16"
 ruff = "^0.0.135"
-
 
 [tool.poetry.group.test]
 optional = true
 
 [tool.poetry.group.test.dependencies]
-
+coverage = { version = "^6.0", extras = ["toml"] }
+dash = { version = "^2.6", extras = ["testing"] }
 freezegun = "^1.2"
+h5py = { version = "^3.1", python = "<3.11", optional = true}
+percy = "^2.0"
+pybufrkit = "^0.2"
 pytest = "^7.2"
 pytest-cov = "^3.0"
 pytest-dictsdiff = "^0.5"
 pytest-notebook = "^0.8"
 pytest-xdist = "^3"
-
-# Test required libraries
-surrogate = "^0.1"
-pybufrkit = "^0.2"
 selenium = "^4.0"
-percy = "^2.0"
-h5py = { version = "^3.1", python = "<3.11", optional = true}
+surrogate = "^0.1"
 webdriver-manager = "^3.5.3"
-dash = { version = "^2.6", extras = ["testing"] }
-
-# Coverage
-coverage = { version = "^6.0", extras = ["toml"] }
-
 
 [tool.poetry.group.docs]
 optional = true
 
 [tool.poetry.group.docs.dependencies]
-
 docformatter = "^1.4"
-ipython = "^8.5"
 furo = "^2022.9.15"
+ipython = "^8.5"
+matplotlib = "^3.3"
 sphinx = "^5.2"
 sphinx-autodoc-typehints = "^1.11"
 sphinx-autobuild = "^2021.3"
 sphinx_design = "^0.3.0"
 sphinxcontrib-svg2pdfconverter = "^1.1"
 tomlkit = "^0.7"
-matplotlib = "^3.3"
-
 
 [tool.poetry.extras]
-mpl = ["matplotlib"]
-ipython = ["ipython", "matplotlib"]
-restapi = ["fastapi", "uvicorn"]
-explorer = ["plotly", "dash", "dash-bootstrap-components"]
-sql = ["duckdb"]
-export = ["openpyxl", "sqlalchemy", "pyarrow", "xarray", "zarr"]
-duckdb = ["duckdb"]
-influxdb = ["influxdb", "influxdb-client"]
-cratedb = ["crate"]
-mysql = ["mysqlclient"]
-postgresql = ["psycopg2-binary"]
-radar = ["h5py"]
-radarplus = ["wradlib", "pybufrkit", "pdbufr"]
-bufr = ["pybufrkit", "pdbufr"]
-interpolation = ["scipy", "shapely", "utm"]
+bufr                = ["pdbufr", "pybufrkit"]
+cratedb             = ["crate"]
+duckdb              = ["duckdb"]
+explorer            = ["dash", "dash-bootstrap-components", "plotly"]
+export              = ["openpyxl", "pyarrow", "sqlalchemy", "xarray", "zarr"]
+influxdb            = ["influxdb", "influxdb-client"]
+interpolation       = ["scipy", "shapely", "utm"]
+ipython             = ["ipython", "matplotlib"]
+mpl                 = ["matplotlib"]
+mysql               = ["mysqlclient"]
+postgresql          = ["psycopg2-binary"]
+radar               = ["h5py"]
+radarplus           = ["pdbufr", "pybufrkit", "wradlib"]
+restapi             = ["fastapi", "uvicorn"]
+sql                 = ["duckdb"]
 
 [tool.poetry.scripts]
 wetterdienst = 'wetterdienst.ui.cli:cli'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,48 +105,49 @@ cachetools = "^5.2"
 click = "^8.0"
 click-params = "^0.4"
 cloup = "^1.0"
-dash                            = { version = "^2.7", optional = true }  # Explorer UI feature.
-dash-bootstrap-components       = { version = "^1.2", optional = true }  # Explorer UI feature.
 dateparser = "^1.0"
 deprecation = "^2.1"
 diskcache = "^5.4.0"
-duckdb                          = { version = "^0.6.0", optional = true }
-eccodes                         = { version = "1.2.0", optional = true }  # Radar feature.
 environs = "^9.4.0"
-fastapi                         = { version = "^0.65", optional = true }  # HTTP REST API feature.
 fsspec = "^2022.02"
-h5py                            = { version = "^3.1", optional = true, extras = ["radar"], python = "<3.11" }  # Radar feature.
-influxdb                        = { version = "^5.3", optional = true }
-influxdb-client                 = { version = "^1.18", optional = true }
 lxml = "^4.9.1"
-matplotlib                      = { version = "^3.3", optional = true }
 measurement = "^3.2"
-mysqlclient                     = { version = "^2.0", optional = true }
 numpy = "^1.22"
-openpyxl                        = { version = "^3.0", optional = true }
 pandas = "^1.3"
-pdbufr                          = { version = "^0.9.0", optional = true, extras = ["eccodes"] }  # Radar feature.
 Pint = "^0.17"
 platformdirs = "^2"
-plotly                          = { version = "^5.11", optional = true }  # Explorer UI feature.
-psycopg2-binary                 = { version = "^2.8", optional = true }
-pyarrow                         = { version = "^10.0", python = "<3.11", optional = true}
 PyPDF2 = "^1.26"
 python-dateutil = "^2.8"
 rapidfuzz = "^2.1"
 requests = "^2.20"
 scikit-learn = "^1.0.2"
-scipy                           = { version = "^1.9", optional = true }  # Interpolation feature.
-shapely                         = { version = "^1.8", optional = true }  # Interpolation feature.
-sqlalchemy                      = { version = "^1.4", optional = true }
 tabulate = "^0.8"
 timezonefinder = "^6.1"
 tqdm = "^4.47"
+
+dash                            = { version = "^2.7", optional = true }  # Explorer UI feature.
+dash-bootstrap-components       = { version = "^1.2", optional = true }  # Explorer UI feature.
+duckdb                          = { version = "^0.6.0", optional = true }  # Export feature.
+eccodes                         = { version = "1.2.0", optional = true }  # Radar feature.
+fastapi                         = { version = "^0.65", optional = true }  # HTTP REST API feature.
+h5py                            = { version = "^3.1", optional = true, extras = ["radar"], python = "<3.11" }  # Radar feature.
+influxdb                        = { version = "^5.3", optional = true }  # Export feature.
+influxdb-client                 = { version = "^1.18", optional = true }  # Export feature.
+matplotlib                      = { version = "^3.3", optional = true }
+mysqlclient                     = { version = "^2.0", optional = true }  # Export feature.
+openpyxl                        = { version = "^3.0", optional = true }
+pdbufr                          = { version = "^0.9.0", optional = true, extras = ["eccodes"] }  # Radar feature.
+plotly                          = { version = "^5.11", optional = true }  # Explorer UI feature.
+psycopg2-binary                 = { version = "^2.8", optional = true }  # Export feature.
+pyarrow                         = { version = "^10.0", python = "<3.11", optional = true}
+scipy                           = { version = "^1.9", optional = true }  # Interpolation feature.
+shapely                         = { version = "^1.8", optional = true }  # Interpolation feature.
+sqlalchemy                      = { version = "^1.4", optional = true }  # Export feature.
 utm                             = { version = "^0.7", optional = true }  # Interpolation feature.
 uvicorn                         = { version = "^0.14", optional = true }  # HTTP REST API feature.
 wradlib                         = { version = "^1.13", optional = true }  # Radar feature.
 xarray                          = { version = "^2022.11", optional = true }
-zarr                            = { version = "^2.13", python = "<3.11", optional = true }
+zarr                            = { version = "^2.13", python = "<3.11", optional = true }  # Export feature.
 
 [tool.poetry.group.dev]
 optional = true


### PR DESCRIPTION
Hi,

@xylar recommended at https://github.com/conda-forge/wetterdienst-feedstock/pull/76#issuecomment-1330346041:

> One thing you could do there to make things easier here would be to alphabetize the dependencies (other than python, which should stay at the top). That is a pretty standard practice for python packages.

This patch implements his suggestion. Thank you very much.

With kind regards,
Andreas.
