### PR TITLE
Chore: Remove `eccodes` and `pdbufr` dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -690,19 +690,6 @@ python-versions = "*"
 numpy = ">=1.14"
 
 [[package]]
-name = "eccodes"
-version = "1.2.0"
-description = "Python interface to the ecCodes GRIB and BUFR decoder/encoder"
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-attrs = "*"
-cffi = "*"
-numpy = "*"
-
-[[package]]
 name = "entrypoints"
 version = "0.4"
 description = "Discover and load entry points from installed packages."
@@ -1991,22 +1978,6 @@ description = "Python Build Reasonableness"
 category = "dev"
 optional = false
 python-versions = ">=2.6"
-
-[[package]]
-name = "pdbufr"
-version = "0.9.0"
-description = "Pandas reader for the BUFR format using ecCodes."
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-attrs = "*"
-eccodes = "*"
-pandas = "*"
-
-[package.extras]
-tests = ["flake8", "pytest", "pytest-cov"]
 
 [[package]]
 name = "percy"
@@ -3482,7 +3453,7 @@ docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-bufr = ["pdbufr"]
+bufr = []
 cratedb = []
 duckdb = ["duckdb"]
 explorer = ["dash", "dash-bootstrap-components", "plotly"]
@@ -3494,14 +3465,14 @@ mpl = ["matplotlib"]
 mysql = ["mysqlclient"]
 postgresql = ["psycopg2-binary"]
 radar = ["h5py"]
-radarplus = ["pdbufr", "wradlib"]
+radarplus = ["wradlib"]
 restapi = ["fastapi", "uvicorn"]
 sql = ["duckdb"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.12"
-content-hash = "c4dcafb6da3590da3c89733da0a09a25dae4756bf3958a5638030367ce53e699"
+content-hash = "040d55fc1224d9663c85d08ba211225ef78854053ba314be267286025d0c65b6"
 
 [metadata.files]
 aenum = [
@@ -4124,10 +4095,6 @@ duckdb = [
     {file = "duckdb-0.6.0-cp39-cp39-win32.whl", hash = "sha256:253c1c68635462811f1bef3d10fac36b5907461ee387ba441b7d5dc03844b31e"},
     {file = "duckdb-0.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:5f11a9cd5f860db3ec66dae6f3c5b21df21b82fcbe1a6622acca14c16c0a0cc2"},
     {file = "duckdb-0.6.0.tar.gz", hash = "sha256:74e0e4cd1b77aaec9f76e3a0b4cf8535d80f2282f38c6248d4ec826a9606fe81"},
-]
-eccodes = [
-    {file = "eccodes-1.2.0-py3-none-any.whl", hash = "sha256:8d9ac25c7769659cf56f7c8f2aa1afca3d20e0b3f342e0f406da6b84c244f539"},
-    {file = "eccodes-1.2.0.tar.gz", hash = "sha256:813a861e4e26efc494fef091d1127ff44c7e055e5ed1de68bf36bb1e509c5ecf"},
 ]
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
@@ -5136,9 +5103,6 @@ pathspec = [
 pbr = [
     {file = "pbr-5.11.0-py2.py3-none-any.whl", hash = "sha256:db2317ff07c84c4c63648c9064a79fe9d9f5c7ce85a9099d4b6258b3db83225a"},
     {file = "pbr-5.11.0.tar.gz", hash = "sha256:b97bc6695b2aff02144133c2e7399d5885223d42b7912ffaec2ca3898e673bfe"},
-]
-pdbufr = [
-    {file = "pdbufr-0.9.0.tar.gz", hash = "sha256:c9f9e19ebae7d27e86166d72a088c699044917a66c800cfccfa72005a1cda945"},
 ]
 percy = [
     {file = "percy-2.0.2-py2.py3-none-any.whl", hash = "sha256:c1647b768810e9453220a7721a5d52cec560dee913d13c1e29b713703f4f223e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,6 @@ tqdm = "^4.47"
 dash                            = { version = "^2.7", optional = true }  # Explorer UI feature.
 dash-bootstrap-components       = { version = "^1.2", optional = true }  # Explorer UI feature.
 duckdb                          = { version = "^0.6.0", optional = true }  # Export feature.
-eccodes                         = { version = "1.2.0", optional = true }  # Radar feature.
 fastapi                         = { version = "^0.65", optional = true }  # HTTP REST API feature.
 h5py                            = { version = "^3.1", optional = true, extras = ["radar"], python = "<3.11" }  # Radar feature.
 influxdb                        = { version = "^5.3", optional = true }  # Export feature.
@@ -136,7 +135,6 @@ influxdb-client                 = { version = "^1.18", optional = true }  # Expo
 matplotlib                      = { version = "^3.3", optional = true }
 mysqlclient                     = { version = "^2.0", optional = true }  # Export feature.
 openpyxl                        = { version = "^3.0", optional = true }
-pdbufr                          = { version = "^0.9.0", optional = true, extras = ["eccodes"] }  # Radar feature.
 plotly                          = { version = "^5.11", optional = true }  # Explorer UI feature.
 psycopg2-binary                 = { version = "^2.8", optional = true }  # Export feature.
 pyarrow                         = { version = "^10.0", python = "<3.11", optional = true}
@@ -208,7 +206,7 @@ sphinxcontrib-svg2pdfconverter = "^1.1"
 tomlkit = "^0.7"
 
 [tool.poetry.extras]
-bufr                = ["pdbufr", "pybufrkit"]
+bufr                = ["pybufrkit"]
 cratedb             = ["crate"]
 duckdb              = ["duckdb"]
 explorer            = ["dash", "dash-bootstrap-components", "plotly"]
@@ -220,7 +218,7 @@ mpl                 = ["matplotlib"]
 mysql               = ["mysqlclient"]
 postgresql          = ["psycopg2-binary"]
 radar               = ["h5py"]
-radarplus           = ["pdbufr", "pybufrkit", "wradlib"]
+radarplus           = ["pybufrkit", "wradlib"]
 restapi             = ["fastapi", "uvicorn"]
 sql                 = ["duckdb"]
 


### PR DESCRIPTION
Apparently, `eccodes` and `pdbufr` are used no where in the code, so let's remove them from the project metadata.

Reference:
- #813

/cc @xylar