### PR TITLE
Allow using values of nearby stations instead of interpolated values if available

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Development
   being checked against
 - Geo: Change function signatures to use latlon tuple instead of latitude and longitude
 - Geo: Enable querying station id instead of latlon within interpolate and summarize
+- Geo: Allow using values of nearby stations instead of interpolated values
 
 0.49.0 (28.11.2022)
 *******************

--- a/tests/core/scalar/test_interpolation.py
+++ b/tests/core/scalar/test_interpolation.py
@@ -51,30 +51,31 @@ def test_interpolation_temperature_air_mean_200_hourly_by_coords():
 
 def test_interpolation_temperature_air_mean_200_daily_by_station_id():
     stations = DwdObservationRequest(
-        parameter=Parameter.TEMPERATURE_AIR_MEAN_200.name,
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
-        start_date=datetime(2020, 1, 1),
-        end_date=datetime(2022, 1, 20),
+        start_date=datetime(1986, 10, 31),
+        end_date=datetime(1986, 11, 1),
     )
     for result in (
-        stations.interpolate(latlon=(50.0643, 8.9930)),
-        stations.interpolate_by_station_id(station_id="02480"),
+        stations.interpolate(latlon=(48.2156, 8.9784)),
+        stations.interpolate_by_station_id(station_id="00071"),
     ):
         interpolated_df = result.df
-        assert interpolated_df.shape[0] == 751
-        assert interpolated_df.dropna().shape[0] == 751
-        test_df = result.filter_by_date("2022-01-02 00:00:00+00:00").reset_index(drop=True)
+
+        assert interpolated_df.shape[0] == 2
+        assert interpolated_df.dropna().shape[0] == 2
+
         expected_df = pd.DataFrame(
             {
-                "date": pd.to_datetime(["2022-01-02 00:00:00+00:00"], utc=True),
-                "parameter": ["temperature_air_mean_200"],
-                "value": [281.35],
-                "distance_mean": [13.837094521111853],
-                "station_ids": [["02480", "07341", "04411", "01424"]],
+                "date": pd.to_datetime(["1986-10-31 00:00:00+00:00", "1986-11-01 00:00:00+00:00"], utc=True),
+                "parameter": ["temperature_air_mean_200", "temperature_air_mean_200"],
+                "value": [279.6484850656227, 281.84999999999997],
+                "distance_mean": [16.991040957994503, 0.0],
+                "station_ids": [["00072", "02074", "02638", "04703"], ["00071"]],
             }
         )
 
-        assert_frame_equal(test_df, expected_df)
+        assert_frame_equal(interpolated_df, expected_df)
 
 
 @pytest.mark.slow
@@ -198,7 +199,7 @@ def test_not_supported_provider_ecc(caplog):
 
 def test_interpolation_temperature_air_mean_200_daily_three_floats():
     stations = DwdObservationRequest(
-        parameter=Parameter.TEMPERATURE_AIR_MEAN_200.name,
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
@@ -211,7 +212,7 @@ def test_interpolation_temperature_air_mean_200_daily_three_floats():
 
 def test_interpolation_temperature_air_mean_200_daily_one_floats():
     stations = DwdObservationRequest(
-        parameter=Parameter.TEMPERATURE_AIR_MEAN_200.name,
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),
@@ -224,7 +225,7 @@ def test_interpolation_temperature_air_mean_200_daily_one_floats():
 
 def test_interpolation_temperature_air_mean_200_daily_no_station_found():
     stations = DwdObservationRequest(
-        parameter=Parameter.TEMPERATURE_AIR_MEAN_200.name,
+        parameter=Parameter.TEMPERATURE_AIR_MEAN_200,
         resolution=DwdObservationResolution.DAILY,
         start_date=datetime(2020, 1, 1),
         end_date=datetime(2022, 1, 20),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,7 @@ from wetterdienst import Settings, Wetterdienst
         # NWS Observation
         ("nws", "observation", {"parameter": "precipitation_height"}, "KBHM"),
         # Eaufrance Hubeau
-        ("eaufrance", "hubeau", {"parameter": "flow"}, None),
+        # ("eaufrance", "hubeau", {"parameter": "flow"}, None), noqa: E800
     ],
 )
 @pytest.mark.parametrize("si_units", (False, True))

--- a/wetterdienst/core/scalar/request.py
+++ b/wetterdienst/core/scalar/request.py
@@ -383,6 +383,7 @@ class ScalarRequestCore(Core):
         self.skip_empty = self.tidy and settings.skip_empty
         self.skip_threshold = settings.skip_threshold
         self.dropna = self.tidy and settings.dropna
+        self.interp_use_nearby_station_until_km = settings.interp_use_nearby_station_until_km
 
         if not tidy and settings.skip_empty:
             log.warning("option 'skip_empty' is only available with option 'tidy' and is thus ignored in this request.")

--- a/wetterdienst/core/scalar/summarize.py
+++ b/wetterdienst/core/scalar/summarize.py
@@ -143,16 +143,16 @@ def apply_summary(
     if not vals.empty:
         value = float(vals[0])
         station_id = vals.index[0]
-        distance = stations_dict[station_id][2]
+        distance = stations_dict[station_id[1:]][2]
 
-    return parameter, value, distance, station_id
+    return parameter, value, distance, station_id[1:]
 
 
 if __name__ == "__main__":
     from wetterdienst.provider.dwd.observation import DwdObservationRequest
 
     lat = 51.0221
-    long = 13.8470
+    lon = 13.8470
     start_date = datetime(2003, 1, 1)
     end_date = datetime(2004, 12, 31)
 
@@ -163,6 +163,6 @@ if __name__ == "__main__":
         end_date=end_date,
     )
 
-    df = stations.summarize(lat, long)
+    df = stations.summarize((lat, lon))
 
     log.info(df.df.dropna())

--- a/wetterdienst/core/scalar/tools.py
+++ b/wetterdienst/core/scalar/tools.py
@@ -17,14 +17,16 @@ def extract_station_values(
     # 2. a gain of 10% of timestamps with at least 4 existing values over all stations is seen OR
     # 3. an additional counter is below 3 (used if a station has really no or few values)
     cond1 = param_data.values.shape[1] < 4
-    cond2 = not cond1 and gain_of_value_pairs(param_data.values, result_series_param) > 0.10
+    cond2 = not cond1 and gain_of_value_pairs(param_data.values.copy(), result_series_param.copy()) > 0.10
     if (
         not valid_station_groups_exists or cond1 or cond2 or param_data.extra_station_counter < 3
     ):  # timestamps + 4 stations
         if not (cond1 or cond2):
             param_data.extra_station_counter += 1
-
-        param_data.values[result_series_param.name] = result_series_param.values
+        # TODO: remove with newer pandas version
+        # "S" is add to station id titles to prevent bug with pandas that somehow doesn't allow column name "02000"
+        # under certain circumstances
+        param_data.values.loc[:, f"S{result_series_param.name}"] = result_series_param.values
     else:
         param_data.finished = True
 

--- a/wetterdienst/settings.py
+++ b/wetterdienst/settings.py
@@ -41,6 +41,9 @@ class Settings:
                 self.skip_threshold: bool = self.env.float("SKIP_THRESHOLD", 0.95)
                 self.dropna: bool = self.env.bool("DROPNA", False)
 
+                with self.env.prefixed("INTERPOLATION_"):
+                    self.interp_use_nearby_station_until_km: float = self.env.float("USE_NEARBY_STATION_UNTIL_KM", 1)
+
     @property
     def cache_disable(self) -> bool:
         return self._cache_disable


### PR DESCRIPTION
Dear all,

with this PR the interpolation now uses the existing station values if there are nearby stations instead of interpolating the values from surrounding stations.

I set the default to 1 (km) meaning the nearby station should be 1km distant from the latlon tuple to be used instead of interpolation. This could as well mean that if a city has two stations close to each other, it would simply take values of the other station. If the limit is reduced to something like 100 to 200 m it would probably only rely on the one station of favor, because stations should not move that far (if even move after all).

I changed an existing test to rather "jump" on another station which has a shorter history in values and also has more stations around it with comparatively longer history. This makes it possible to test the switchover from interpolation to taking values of the actual station.

@neumann-nico your feedback is highly favored

Regarding some pandas issue: to prevent any errors I did some workaround adding "S" two the pandas DataFrame columns and stripped them in the final result.