### PR TITLE
Fix error with numeric column names in method gain_of_value_pairs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Development
 
 - Update wetterdienst explorer with clickable stations and slighly changed layout
 - Improve radar tests and certain dict comparisons
+- Fix problem with numeric column names in method gain_of_value_pairs
 
 0.50.0 (03.12.2022)
 *******************

--- a/wetterdienst/core/scalar/summarize.py
+++ b/wetterdienst/core/scalar/summarize.py
@@ -142,10 +142,10 @@ def apply_summary(
 
     if not vals.empty:
         value = float(vals[0])
-        station_id = vals.index[0]
-        distance = stations_dict[station_id[1:]][2]
+        station_id = vals.index[0][1:]
+        distance = stations_dict[station_id][2]
 
-    return parameter, value, distance, station_id[1:]
+    return parameter, value, distance, station_id
 
 
 if __name__ == "__main__":

--- a/wetterdienst/core/scalar/tools.py
+++ b/wetterdienst/core/scalar/tools.py
@@ -33,6 +33,6 @@ def extract_station_values(
 
 def gain_of_value_pairs(old_values: pd.DataFrame, new_values: pd.Series) -> float:
     old_score = old_values.apply(lambda row: row.dropna().size >= 4).sum()  # 5: dates plus 4 values
-    old_values[new_values.name] = new_values.values  # Add new column
+    old_values[f"S{new_values.name}"] = new_values.values  # Add new column
     new_score = old_values.apply(lambda row: row.dropna().size >= 4).sum()  # 5: dates plus 4 values
     return new_score / old_score - 1


### PR DESCRIPTION
Dear all,

the same problem we've seen with numeric column names at the interpolation/summary DataFrame appears in the method gain_of_value_pairs. We can circumvent the problem by adding any character at the beginning e.g. S000001.

Cheers,
Benjamin