### PR TITLE
Defer module loading to improve startup speed and memory use

### DIFF
--- a/wetterdienst/api.py
+++ b/wetterdienst/api.py
@@ -8,110 +8,114 @@ from wetterdienst.util.parameter import DatasetTreeCore
 
 
 class RequestRegistry(DatasetTreeCore):
+    """
+    Manage all weather data providers.
+
+    Provide their main API request factories lazily on request.
+    """
+
     class DWD(DatasetTreeCore):
-        @staticmethod
-        @property
-        def OBSERVATION():
-            from wetterdienst.provider.dwd.observation import DwdObservationRequest
+        class OBSERVATION(DatasetTreeCore):
+            @staticmethod
+            def load() -> "DwdObservationRequest":  # noqa: F821
+                from wetterdienst.provider.dwd.observation import DwdObservationRequest
 
-            return DwdObservationRequest
+                return DwdObservationRequest
 
-        @staticmethod
-        @property
-        def MOSMIX():
-            from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
+        class MOSMIX(DatasetTreeCore):
+            @staticmethod
+            def load() -> "DwdMosmixRequest":  # noqa: F821
+                from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
 
-            return DwdMosmixRequest
+                return DwdMosmixRequest
 
-        @staticmethod
-        @property
-        def RADAR():
-            from wetterdienst.provider.dwd.radar import DwdRadarValues
+        class RADAR(DatasetTreeCore):
+            @staticmethod
+            def load() -> "DwdRadarValues":  # noqa: F821
+                from wetterdienst.provider.dwd.radar import DwdRadarValues
 
-            return DwdRadarValues
+                return DwdRadarValues
 
     class ECCC(DatasetTreeCore):
-        @staticmethod
-        @property
-        def OBSERVATION():
-            from wetterdienst.provider.eccc.observation import EcccObservationRequest
+        class OBSERVATION(DatasetTreeCore):
+            @staticmethod
+            def load() -> "EcccObservationRequest":  # noqa: F821
+                from wetterdienst.provider.eccc.observation import (
+                    EcccObservationRequest,
+                )
 
-            return EcccObservationRequest
+                return EcccObservationRequest
 
     class NOAA(DatasetTreeCore):
-        @staticmethod
-        @property
-        def GHCN():
-            from wetterdienst.provider.noaa.ghcn import NoaaGhcnRequest
+        class GHCN(DatasetTreeCore):
+            @staticmethod
+            def load() -> "NoaaGhcnRequest":  # noqa: F821
+                from wetterdienst.provider.noaa.ghcn import NoaaGhcnRequest
 
-            return NoaaGhcnRequest
+                return NoaaGhcnRequest
 
     class WSV(DatasetTreeCore):
-        @staticmethod
-        @property
-        def PEGEL():
-            from wetterdienst.provider.wsv.pegel import WsvPegelRequest
+        class PEGEL(DatasetTreeCore):
+            @staticmethod
+            def load() -> "WsvPegelRequest":  # noqa: F821
+                from wetterdienst.provider.wsv.pegel import WsvPegelRequest
 
-            return WsvPegelRequest
+                return WsvPegelRequest
 
     class EA(DatasetTreeCore):
-        @staticmethod
-        @property
-        def HYDROLOGY():
-            from wetterdienst.provider.environment_agency.hydrology import (
-                EaHydrologyRequest,
-            )
+        class HYDROLOGY(DatasetTreeCore):
+            @staticmethod
+            def load() -> "EaHydrologyRequest":  # noqa: F821
+                from wetterdienst.provider.environment_agency.hydrology import (
+                    EaHydrologyRequest,
+                )
 
-            return EaHydrologyRequest
+                return EaHydrologyRequest
 
     class NWS(DatasetTreeCore):
-        @staticmethod
-        @property
-        def OBSERVATION():
-            from wetterdienst.provider.nws.observation import NwsObservationRequest
+        class OBSERVATION(DatasetTreeCore):
+            @staticmethod
+            def load() -> "NwsObservationRequest":  # noqa: F821
+                from wetterdienst.provider.nws.observation import NwsObservationRequest
 
-            return NwsObservationRequest
+                return NwsObservationRequest
 
     class EAUFRANCE(DatasetTreeCore):
-        @staticmethod
-        @property
-        def HUBEAU():
-            from wetterdienst.provider.eaufrance.hubeau import HubeauRequest
+        class HUBEAU(DatasetTreeCore):
+            @staticmethod
+            def load() -> "HubeauRequest":  # noqa: F821
+                from wetterdienst.provider.eaufrance.hubeau import HubeauRequest
 
-            return HubeauRequest
+                return HubeauRequest
 
     class GEOSPHERE(DatasetTreeCore):
-        @staticmethod
-        @property
-        def OBSERVATION():
-            from wetterdienst.provider.geosphere.observation import (
-                GeosphereObservationRequest,
-            )
+        class OBSERVATION(DatasetTreeCore):
+            @staticmethod
+            def load() -> "GeosphereObservationRequest":  # noqa: F821
+                from wetterdienst.provider.geosphere.observation import (
+                    GeosphereObservationRequest,
+                )
 
-            return GeosphereObservationRequest
+                return GeosphereObservationRequest
 
     @classmethod
     def discover(cls):
-        api_endpoints = {}
-        for provider in cls:
-            api_endpoints[provider.__name__] = [network.fget.__name__ for network in cls[provider.__name__]]
-        return api_endpoints
+        return {provider.name: [network.name for network in cls[provider.name]] for provider in cls}
 
     @classmethod
     def resolve(cls, provider: str, network: str):
         try:
-            # `.fget()` is needed to access the <property> instance.
-            return cls[provider][network.upper()].fget()
+            return cls[provider][network.upper()].load()
         except AttributeError as ex:
             raise KeyError(ex)
 
     @classmethod
     def get_provider_names(cls):
-        return [provider.__name__ for provider in cls]
+        return [provider.name for provider in cls]
 
     @classmethod
     def get_network_names(cls, provider):
-        return [network.fget.__name__ for network in cls[provider]]
+        return [network.name for network in cls[provider]]
 
 
 class Wetterdienst:

--- a/wetterdienst/api.py
+++ b/wetterdienst/api.py
@@ -1,56 +1,123 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
-from enum import Enum
-
 from wetterdienst.exceptions import InvalidEnumeration, ProviderError
 from wetterdienst.metadata.provider import Provider
-from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
-from wetterdienst.provider.dwd.observation import DwdObservationRequest
-from wetterdienst.provider.dwd.radar import DwdRadarValues
-from wetterdienst.provider.eaufrance.hubeau import HubeauRequest
-from wetterdienst.provider.eccc.observation import EcccObservationRequest
-from wetterdienst.provider.environment_agency.hydrology.api import EaHydrologyRequest
-from wetterdienst.provider.geosphere.observation import GeosphereObservationRequest
-from wetterdienst.provider.noaa.ghcn.api import NoaaGhcnRequest
-from wetterdienst.provider.nws.observation.api import NwsObservationRequest
-from wetterdienst.provider.wsv.pegel.api import WsvPegelRequest
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 from wetterdienst.util.parameter import DatasetTreeCore
 
 
-class ApiEndpoints(DatasetTreeCore):
-    class DWD(Enum):
-        OBSERVATION = DwdObservationRequest  # generic name
-        MOSMIX = DwdMosmixRequest
-        RADAR = DwdRadarValues
+class RequestRegistry(DatasetTreeCore):
+    class DWD(DatasetTreeCore):
+        @staticmethod
+        @property
+        def OBSERVATION():
+            from wetterdienst.provider.dwd.observation import DwdObservationRequest
 
-    class ECCC(Enum):
-        OBSERVATION = EcccObservationRequest  # generic name
+            return DwdObservationRequest
 
-    class NOAA(Enum):
-        GHCN = NoaaGhcnRequest
+        @staticmethod
+        @property
+        def MOSMIX():
+            from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
 
-    class WSV(Enum):
-        PEGEL = WsvPegelRequest
+            return DwdMosmixRequest
 
-    class EA(Enum):
-        HYDROLOGY = EaHydrologyRequest
+        @staticmethod
+        @property
+        def RADAR():
+            from wetterdienst.provider.dwd.radar import DwdRadarValues
 
-    class NWS(Enum):
-        OBSERVATION = NwsObservationRequest
+            return DwdRadarValues
 
-    class EAUFRANCE(Enum):
-        HUBEAU = HubeauRequest
+    class ECCC(DatasetTreeCore):
+        @staticmethod
+        @property
+        def OBSERVATION():
+            from wetterdienst.provider.eccc.observation import EcccObservationRequest
 
-    class GEOSPHERE(Enum):
-        OBSERVATION = GeosphereObservationRequest
+            return EcccObservationRequest
+
+    class NOAA(DatasetTreeCore):
+        @staticmethod
+        @property
+        def GHCN():
+            from wetterdienst.provider.noaa.ghcn import NoaaGhcnRequest
+
+            return NoaaGhcnRequest
+
+    class WSV(DatasetTreeCore):
+        @staticmethod
+        @property
+        def PEGEL():
+            from wetterdienst.provider.wsv.pegel import WsvPegelRequest
+
+            return WsvPegelRequest
+
+    class EA(DatasetTreeCore):
+        @staticmethod
+        @property
+        def HYDROLOGY():
+            from wetterdienst.provider.environment_agency.hydrology import (
+                EaHydrologyRequest,
+            )
+
+            return EaHydrologyRequest
+
+    class NWS(DatasetTreeCore):
+        @staticmethod
+        @property
+        def OBSERVATION():
+            from wetterdienst.provider.nws.observation import NwsObservationRequest
+
+            return NwsObservationRequest
+
+    class EAUFRANCE(DatasetTreeCore):
+        @staticmethod
+        @property
+        def HUBEAU():
+            from wetterdienst.provider.eaufrance.hubeau import HubeauRequest
+
+            return HubeauRequest
+
+    class GEOSPHERE(DatasetTreeCore):
+        @staticmethod
+        @property
+        def OBSERVATION():
+            from wetterdienst.provider.geosphere.observation import (
+                GeosphereObservationRequest,
+            )
+
+            return GeosphereObservationRequest
+
+    @classmethod
+    def discover(cls):
+        api_endpoints = {}
+        for provider in cls:
+            api_endpoints[provider.__name__] = [network.fget.__name__ for network in cls[provider.__name__]]
+        return api_endpoints
+
+    @classmethod
+    def resolve(cls, provider: str, network: str):
+        try:
+            # `.fget()` is needed to access the <property> instance.
+            return cls[provider][network.upper()].fget()
+        except AttributeError as ex:
+            raise KeyError(ex)
+
+    @classmethod
+    def get_provider_names(cls):
+        return [provider.__name__ for provider in cls]
+
+    @classmethod
+    def get_network_names(cls, provider):
+        return [network.fget.__name__ for network in cls[provider]]
 
 
 class Wetterdienst:
     """Wetterdienst top-level API with links to the different available APIs"""
 
-    endpoints = ApiEndpoints
+    endpoints = RequestRegistry
 
     def __new__(cls, provider: str, network: str):
         """
@@ -62,7 +129,7 @@ class Wetterdienst:
         try:
             provider_ = parse_enumeration_from_template(provider, Provider)
 
-            api = cls.endpoints[provider_.name][network.upper()].value
+            api = cls.endpoints.resolve(provider_.name, network)
 
             if not api:
                 raise KeyError
@@ -75,8 +142,4 @@ class Wetterdienst:
     @classmethod
     def discover(cls) -> dict:
         """Display available API endpoints"""
-        api_endpoints = {}
-        for provider in cls.endpoints:
-            api_endpoints[provider.__name__] = [network.name for network in cls.endpoints[provider.__name__]]
-
-        return api_endpoints
+        return cls.endpoints.discover()

--- a/wetterdienst/core/scalar/request.py
+++ b/wetterdienst/core/scalar/request.py
@@ -37,7 +37,6 @@ from wetterdienst.metadata.provider import Provider
 from wetterdienst.metadata.resolution import Frequency, Resolution, ResolutionType
 from wetterdienst.settings import Settings
 from wetterdienst.util.enumeration import parse_enumeration_from_template
-from wetterdienst.util.geo import Coordinates, derive_nearest_neighbours
 
 log = logging.getLogger(__name__)
 
@@ -702,6 +701,8 @@ class ScalarRequestCore(Core):
         :param rank: number of stations_result to be returned, greater 0
         :return: pandas.DataFrame with station information for the selected stations_result
         """
+        from wetterdienst.util.geo import Coordinates, derive_nearest_neighbours
+
         rank = int(rank)
 
         if rank <= 0:

--- a/wetterdienst/ui/cli.py
+++ b/wetterdienst/ui/cli.py
@@ -16,8 +16,6 @@ from cloup.constraints import If, RequireExactly, accept_none
 
 from wetterdienst import Provider, Wetterdienst, __appname__, __version__
 from wetterdienst.exceptions import ProviderError
-from wetterdienst.provider.dwd.radar.api import DwdRadarSites
-from wetterdienst.provider.eumetnet.opera.sites import OperaRadarSites
 from wetterdienst.ui.core import (
     get_interpolate,
     get_stations,
@@ -879,6 +877,9 @@ def radar(
     wmo_code: str,
     country_name: str,
 ):
+    from wetterdienst.provider.dwd.radar.api import DwdRadarSites
+    from wetterdienst.provider.eumetnet.opera.sites import OperaRadarSites
+
     if dwd:
         data = DwdRadarSites().all()
     else:

--- a/wetterdienst/ui/core.py
+++ b/wetterdienst/ui/core.py
@@ -12,7 +12,6 @@ from wetterdienst.core.scalar.result import StationsResult, ValuesResult
 from wetterdienst.metadata.datarange import DataRange
 from wetterdienst.metadata.period import PeriodType
 from wetterdienst.metadata.resolution import Resolution, ResolutionType
-from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
 from wetterdienst.settings import Settings
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 
@@ -64,6 +63,8 @@ def _get_stations_request(
     dropna: bool,
     use_nearby_station_until_km: float,
 ):
+    from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest, DwdMosmixType
+
     # TODO: move this into Request core
     start_date, end_date = None, None
     if date:

--- a/wetterdienst/ui/explorer/layout/observations_germany.py
+++ b/wetterdienst/ui/explorer/layout/observations_germany.py
@@ -4,11 +4,11 @@
 import dash_leaflet as dl
 from dash import dcc, html
 
-from wetterdienst.api import ApiEndpoints
+from wetterdienst.api import RequestRegistry
 
 
 def get_providers():
-    return [{"label": provider.__name__, "value": provider.__name__} for provider in ApiEndpoints]
+    return [{"label": provider, "value": provider} for provider in RequestRegistry.get_provider_names()]
 
 
 def dashboard_layout() -> html:

--- a/wetterdienst/util/parameter.py
+++ b/wetterdienst/util/parameter.py
@@ -3,6 +3,8 @@
 # Distributed under the MIT License. See LICENSE for more info.
 import types
 
+from wetterdienst.util.python import classproperty
+
 
 class _GetAttrMeta(type):
     # https://stackoverflow.com/questions/33727217/subscriptable-objects-in-class
@@ -18,4 +20,6 @@ class _GetAttrMeta(type):
 
 
 class DatasetTreeCore(metaclass=_GetAttrMeta):
-    pass
+    @classproperty
+    def name(cls):
+        return cls.__name__

--- a/wetterdienst/util/parameter.py
+++ b/wetterdienst/util/parameter.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) 2018-2021, earthobservations developers.
 # Distributed under the MIT License. See LICENSE for more info.
+import types
+
+
 class _GetAttrMeta(type):
     # https://stackoverflow.com/questions/33727217/subscriptable-objects-in-class
     def __getitem__(cls, x):
@@ -9,8 +12,9 @@ class _GetAttrMeta(type):
     def __iter__(cls):
         """Getting subclasses which usually represent resolutions"""
         for attr in vars(cls):
-            if not attr.startswith("_"):
-                yield cls[attr]
+            slot = cls[attr]
+            if not attr.startswith("_") and not isinstance(slot, types.MethodType):
+                yield slot
 
 
 class DatasetTreeCore(metaclass=_GetAttrMeta):

--- a/wetterdienst/util/python.py
+++ b/wetterdienst/util/python.py
@@ -1,0 +1,14 @@
+class classproperty(property):
+    """
+    A decorator that behaves like @property except that operates
+    on classes rather than instances.
+
+    From SQLAlchemy's `sqlalchemy.util.langhelpers`.
+    """
+
+    def __init__(self, fget, *arg, **kw):
+        super(classproperty, self).__init__(fget, *arg, **kw)
+        self.__doc__ = fget.__doc__
+
+    def __get__(desc, self, cls):
+        return desc.fget(cls)


### PR DESCRIPTION
### About
This patch intends to improve startup speed and memory use, see GH-791.

### Details
The `RequestRegistry` (ex. `ApiEndpoints`) class now provides their members lazily. While the implementation is not optimal, it does not break its interface too much. Access to its internals is encapsulated using appropriate methods now (`discover`, `resolve`, `get_provider_names`, `get_network_names`), to make subsequent refactoring easier.

Other than this, a few other modules will now only be loaded at runtime when they are actually needed.

### Comparison

#### Before 🐌 🐢
```
$ time python -c 'import wetterdienst'

real	0m3.111s
user	0m3.962s
sys	0m0.773s
```

#### After 🥳 🚀
```
$ time python -c 'import wetterdienst'

real	0m0.633s
user	0m1.200s
sys	0m0.253s
```


