### PR TITLE
Modernize Docker environments, and fix erroneous `selftest.sh` not failing the Docker SuT procedure

### DIFF
--- a/.github/release/full/Dockerfile
+++ b/.github/release/full/Dockerfile
@@ -1,44 +1,28 @@
 # 1. Build GDAL-python
-FROM python:3.10-slim as build-step
+FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
-# Install GDAL, HDF5, and MariaDB client dependencies.
+# Install GDAL and HDF5 bindings for Python, and a few other dependencies.
 RUN apt-get update && \
-    apt-get --yes --no-install-recommends install build-essential pkg-config libgdal-dev libmariadb-dev libhdf5-dev && \
-    rm -rf /var/lib/apt/lists/*
+    apt-get --yes --no-install-recommends --no-install-suggests install \
+      ca-certificates python-is-python3 python3-gdal python3-h5py python3-pip python3-wheel && \
+    rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt
 
-# Make sure you have numpy installed before you attempt to install the GDAL Python bindings.
-# https://gis.stackexchange.com/a/274328
-RUN pip install --no-cache-dir --upgrade setuptools==57.0.0 pip
-RUN pip install --no-cache-dir numpy
-RUN pip install --no-cache-dir cartopy==0.21.0
-RUN pip install --no-cache-dir GDAL==$(gdal-config --version)
+# Use Python 3.11.
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 0
 
 # Install wradlib.
-RUN pip install --no-cache-dir wradlib --no-deps
-
-# Install database adapters
-RUN pip install --no-cache-dir mysqlclient
-
-
-# 2. Main
-FROM python:3.10-slim
-
-ENV DEBIAN_FRONTEND noninteractive
-ENV TERM linux
-
-# Copy build artefacts from first build step.
-COPY --from=build-step /usr/local/lib /usr/local/lib
+RUN python -m pip install --no-cache-dir --prefer-binary --no-deps wradlib
 
 # Install Wetterdienst.
 
-# Use "poetry build --format=wheel" to build wheel packages.
+# Use `poetry build --format=wheel` to build wheel packages into `dist` folder.
 COPY dist/wetterdienst-*.whl /tmp/
 
 # Install latest wheel package.
-RUN pip install --no-cache-dir $(ls -c /tmp/wetterdienst-*-py3-none-any.whl)[export,influxdb,cratedb,mysql,postgresql,radar,bufr,restapi,explorer]
+RUN python -m pip install --no-cache-dir --prefer-binary $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer]
 
 # Purge /tmp directory
 RUN rm /tmp/*

--- a/.github/release/selftest.sh
+++ b/.github/release/selftest.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Fail on error.
+set -e
+
 flavor=$1
 
 echo "Testing wetterdienst"

--- a/.github/release/selftest.sh
+++ b/.github/release/selftest.sh
@@ -9,9 +9,8 @@ set -e
 flavor=$1
 
 echo "Testing wetterdienst"
-foobar
-wetterdienst --version
-wetterdienst dwd about parameters
+wetterdienst version
+wetterdienst about coverage
 
 if [ "${flavor}" == "full" ]; then
   echo "Checking libraries"

--- a/.github/release/selftest.sh
+++ b/.github/release/selftest.sh
@@ -10,10 +10,11 @@ flavor=$1
 
 echo "Testing wetterdienst"
 wetterdienst version
+wetterdienst info
 wetterdienst about coverage
 
 if [ "${flavor}" == "full" ]; then
   echo "Checking libraries"
-  python -c 'import gdal; print("gdal:", gdal.VersionInfo())'
+  python -c 'from osgeo import gdal; print("gdal:", gdal.__version__)'
   python -c 'import wradlib; print("wradlib:", wradlib.__version__)'
 fi

--- a/.github/release/selftest.sh
+++ b/.github/release/selftest.sh
@@ -3,6 +3,7 @@
 flavor=$1
 
 echo "Testing wetterdienst"
+foobar
 wetterdienst --version
 wetterdienst dwd about parameters
 

--- a/.github/release/selftest.sh
+++ b/.github/release/selftest.sh
@@ -3,6 +3,9 @@
 # Fail on error.
 set -e
 
+# Display all commands.
+# set -x
+
 flavor=$1
 
 echo "Testing wetterdienst"
@@ -10,7 +13,7 @@ foobar
 wetterdienst --version
 wetterdienst dwd about parameters
 
-if [[ ${flavor} = "full" ]]; then
+if [ "${flavor}" == "full" ]; then
   echo "Checking libraries"
   python -c 'import gdal; print("gdal:", gdal.VersionInfo())'
   python -c 'import wradlib; print("wradlib:", wradlib.__version__)'

--- a/.github/release/standard/Dockerfile
+++ b/.github/release/standard/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim
+FROM python:3.11-slim-bullseye
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
@@ -7,7 +7,7 @@ ENV TERM linux
 COPY dist/wetterdienst-*.whl /tmp/
 
 # Install latest wheel package.
-RUN pip install --no-cache-dir $(ls -c /tmp/wetterdienst-*-py3-none-any.whl)[export,restapi]
+RUN pip install --no-cache-dir $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,restapi]
 
 # Purge /tmp directory
 RUN rm /tmp/*


### PR DESCRIPTION
### Problem
I recently discovered that the Docker builds are succeeding, even if `selftest.sh` fails. This PR exists to exercise the situation.
```
Step 7/7 : COPY .github/release/selftest.sh /usr/local/bin
 ---> c85a81956fa1
Successfully built c85a81956fa1
Successfully tagged release_sut:latest
Creating release_sut_run ... 
Creating release_sut_run ... done
/usr/local/bin/selftest.sh: line 6: foobar: command not found
Testing wetterdienst
Usage: wetterdienst [OPTIONS] COMMAND [ARGS]...
Try 'wetterdienst --help' for help.

Error: No such option: --version
Usage: wetterdienst [OPTIONS] COMMAND [ARGS]...
Try 'wetterdienst --help' for help.

Error: No such command 'dwd'.
```
-- https://github.com/earthobservations/wetterdienst/actions/runs/3976322659/jobs/6816730928#step:6:292

Despite this is clearly failing, the exit code is apparently not propagated correctly:

![image](https://user-images.githubusercontent.com/453543/213884732-93d1d131-1462-45c1-a32a-b5df9f4dd403.png)


### Details
https://github.com/earthobservations/wetterdienst/blob/3fe7991172053d714eea1e44ad6b1622ac9f2151/.github/release/selftest.sh#L1-L13

https://github.com/earthobservations/wetterdienst/blob/3fe7991172053d714eea1e44ad6b1622ac9f2151/.github/release/standard.test.yml#L1-L4


### References
> To set up your automated tests, create a `docker-compose.test.yml` file which defines a `sut` service that lists the tests to be run.
>
> -- https://docs.docker.com/docker-hub/builds/automated-testing/


### Outlook
Further patches to fix the problem may be added.
