### PR TITLE
CI: Fix/improve installation of `wradlib` and `h5py` packages

### DIFF
--- a/.github/release/full/Dockerfile
+++ b/.github/release/full/Dockerfile
@@ -19,7 +19,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 0
 COPY dist/wetterdienst-*.whl /tmp/
 
 # Install latest wheel package.
-RUN python -m pip install --no-cache-dir --prefer-binary $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer,radarplus]
+RUN python -m pip install --no-cache-dir --prefer-binary $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer,radar,radarplus]
 
 # Purge /tmp directory
 RUN rm /tmp/*

--- a/.github/release/full/Dockerfile
+++ b/.github/release/full/Dockerfile
@@ -13,16 +13,13 @@ RUN apt-get update && \
 # Use Python 3.11.
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 0
 
-# Install wradlib.
-RUN python -m pip install --no-cache-dir --prefer-binary --no-deps wradlib==1.18.0
-
 # Install Wetterdienst.
 
 # Use `poetry build --format=wheel` to build wheel packages into `dist` folder.
 COPY dist/wetterdienst-*.whl /tmp/
 
 # Install latest wheel package.
-RUN python -m pip install --no-cache-dir --prefer-binary $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer]
+RUN python -m pip install --no-cache-dir --prefer-binary $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer,radarplus]
 
 # Purge /tmp directory
 RUN rm /tmp/*

--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -13,13 +13,7 @@ set -e
 set -x
 
 if [ "${flavor}" = "testing" ]; then
-
-  poetry install --verbose --no-interaction --with=test,dev --extras=sql --extras=export --extras=restapi --extras=explorer --extras=interpolation --extras=ipython --extras=radarplus
-
-  # Wheels for `h5py` not available for cp311 yet.
-  poetry run python -c 'import sys; sys.exit(not sys.version_info < (3, 11))' \
-    && poetry run pip install --verbose --no-input --no-deps h5py \
-    || true
+  poetry install --verbose --no-interaction --with=test,dev --extras=sql --extras=export --extras=restapi --extras=explorer --extras=interpolation --extras=ipython --extras=radar --extras=radarplus
 
 elif [ "${flavor}" = "docs" ]; then
   poetry install --verbose --no-interaction --with=docs --extras=interpolation

--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -14,8 +14,7 @@ set -x
 
 if [ "${flavor}" = "testing" ]; then
 
-  poetry install --verbose --no-interaction --with=test,dev --extras=sql --extras=export --extras=restapi --extras=explorer --extras=interpolation --extras=ipython
-  poetry run pip install --verbose --no-input --no-deps wradlib==1.18.0
+  poetry install --verbose --no-interaction --with=test,dev --extras=sql --extras=export --extras=restapi --extras=explorer --extras=interpolation --extras=ipython --extras=radarplus
 
   # Wheels for `h5py` not available for cp311 yet.
   poetry run python -c 'import sys; sys.exit(not sys.version_info < (3, 11))' \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ dash-leaflet                    = { version = "^0.1.23", optional = true }  # Ex
 duckdb                          = { version = "^0.6.0", optional = true }  # Export feature.
 fastapi                         = { version = "^0.65", optional = true }  # HTTP REST API feature.
 geojson                         = { version = "^2.5.0", optional = true }  # Explorer UI feature.
-h5py                            = { version = "^3.1", optional = true, extras = ["radar"] }  # Radar feature.
+h5py                            = { version = "^3.1", optional = true }  # Radar feature.
 influxdb                        = { version = "^5.3", optional = true }  # Export feature.
 influxdb-client                 = { version = "^1.18", optional = true }  # Export feature.
 matplotlib                      = { version = "^3.3", optional = true }


### PR DESCRIPTION
With 8831ae1dd83e, we had to fix the installation of `wradlib`, see also GH-874 and GH-876. As outlined at GH-875, this patch aims to improve the situation more thoroughly.