### PR TITLE
CI: Improve installation of `wradlib` and `h5py`. Remove dependency on GDAL.

### DIFF
--- a/.github/release/full/Dockerfile
+++ b/.github/release/full/Dockerfile
@@ -13,8 +13,9 @@ RUN apt-get update && \
 # Use Python 3.11.
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 0
 
-# Install wradlib.
-RUN python -m pip install --no-cache-dir --prefer-binary --no-deps wradlib==1.18.0
+# Install wradlib, preventing installation of GDAL.
+RUN python -m pip install --prefer-binary xradar
+RUN python -m pip install --prefer-binary --no-deps wradlib==1.19.0
 
 # Install Wetterdienst.
 

--- a/.github/release/full/Dockerfile
+++ b/.github/release/full/Dockerfile
@@ -1,21 +1,19 @@
-# 1. Build GDAL-python
 FROM debian:bookworm-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
-# Install GDAL and HDF5 bindings for Python, and a few other dependencies.
+# Install HDF5 bindings for Python, and a few other dependencies.
 RUN apt-get update && \
     apt-get --yes --no-install-recommends --no-install-suggests install \
-      ca-certificates python-is-python3 python3-gdal python3-h5py python3-pip python3-wheel && \
+      ca-certificates python-is-python3 python3-h5py python3-pip python3-wheel && \
     rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt
 
 # Use Python 3.11.
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 0
 
-# Install wradlib, preventing installation of GDAL.
-RUN python -m pip install --prefer-binary xradar
-RUN python -m pip install --prefer-binary --no-deps wradlib==1.19.0
+# Install wradlib.
+RUN python -m pip install --prefer-binary wradlib==1.19.0
 
 # Install Wetterdienst.
 
@@ -23,7 +21,7 @@ RUN python -m pip install --prefer-binary --no-deps wradlib==1.19.0
 COPY dist/wetterdienst-*.whl /tmp/
 
 # Install latest wheel package.
-RUN python -m pip install --no-cache-dir --prefer-binary $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer]
+RUN python -m pip install --no-cache-dir --prefer-binary $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer,radar,radarplus]
 
 # Purge /tmp directory
 RUN rm /tmp/*

--- a/.github/release/selftest.sh
+++ b/.github/release/selftest.sh
@@ -15,6 +15,5 @@ wetterdienst about coverage
 
 if [ "${flavor}" == "full" ]; then
   echo "Checking libraries"
-  python -c 'from osgeo import gdal; print("gdal:", gdal.__version__)'
   python -c 'import wradlib; print("wradlib:", wradlib.__version__)'
 fi

--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -14,8 +14,6 @@ set -x
 
 if [ "${flavor}" = "testing" ]; then
 
-  poetry install --verbose --no-interaction --with=test,dev --extras=sql --extras=export --extras=restapi --extras=explorer --extras=interpolation --extras=ipython
-
   # Install wradlib 1.19 only on Python 3.9 or higher.
   if poetry run python -c 'import sys; sys.exit(not sys.version_info >= (3, 9))'; then
     poetry run pip install --verbose --no-input wradlib==1.19.0
@@ -25,10 +23,15 @@ if [ "${flavor}" = "testing" ]; then
     poetry run pip install --verbose --no-input --no-deps wradlib==1.18.0
   fi
 
-  # Wheels for `h5py` not available for cp311 yet.
-  poetry run python -c 'import sys; sys.exit(not sys.version_info < (3, 11))' \
-    && poetry run pip install --verbose --no-input --no-deps h5py \
-    || true
+  poetry install --verbose --no-interaction \
+    --with=test,dev \
+    --extras=explorer \
+    --extras=export \
+    --extras=interpolation \
+    --extras=ipython \
+    --extras=radar \
+    --extras=restapi \
+    --extras=sql
 
 elif [ "${flavor}" = "docs" ]; then
   poetry install --verbose --no-interaction --with=docs --extras=interpolation

--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -15,7 +15,10 @@ set -x
 if [ "${flavor}" = "testing" ]; then
 
   poetry install --verbose --no-interaction --with=test,dev --extras=sql --extras=export --extras=restapi --extras=explorer --extras=interpolation --extras=ipython
-  poetry run pip install --verbose --no-input --no-deps wradlib==1.18.0
+
+  # Install wradlib, preventing installation of GDAL.
+  poetry run pip install --verbose --no-input xradar
+  poetry run pip install --verbose --no-input --no-deps wradlib==1.19.0
 
   # Wheels for `h5py` not available for cp311 yet.
   poetry run python -c 'import sys; sys.exit(not sys.version_info < (3, 11))' \

--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -16,9 +16,14 @@ if [ "${flavor}" = "testing" ]; then
 
   poetry install --verbose --no-interaction --with=test,dev --extras=sql --extras=export --extras=restapi --extras=explorer --extras=interpolation --extras=ipython
 
+  # Install wradlib 1.19 only on Python 3.9 or higher.
+  if poetry run python -c 'import sys; sys.exit(not sys.version_info >= (3, 9))'; then
+    poetry run pip install --verbose --no-input wradlib==1.19.0
+
   # Install wradlib, preventing installation of GDAL.
-  poetry run pip install --verbose --no-input xradar
-  poetry run pip install --verbose --no-input --no-deps wradlib==1.19.0
+  else
+    poetry run pip install --verbose --no-input --no-deps wradlib==1.18.0
+  fi
 
   # Wheels for `h5py` not available for cp311 yet.
   poetry run python -c 'import sys; sys.exit(not sys.version_info < (3, 11))' \

--- a/README.rst
+++ b/README.rst
@@ -235,8 +235,8 @@ Docker images for each stable release will get pushed to GitHub Container Regist
 There are images in two variants, ``wetterdienst-standard`` and ``wetterdienst-full``.
 
 ``wetterdienst-standard`` will contain a minimum set of 3rd-party packages,
-while ``wetterdienst-full`` will try to serve a full environment by also
-including packages like GDAL and wradlib.
+while ``wetterdienst-full`` will try to serve a full environment, including
+*all* of the optional dependencies of Wetterdienst.
 
 Pull the Docker image:
 

--- a/docs/usage/docker.rst
+++ b/docs/usage/docker.rst
@@ -2,9 +2,10 @@
 Docker
 ######
 
-Wetterdienst comes in two Docker image flavors. A "standard" variant and a
-"full" variant. The "full" variant includes some additional dependencies
-out of the box, like GDAL.
+Wetterdienst comes in two Docker image flavors. A "standard" variant, including
+all dependency packages from the ``export,restapi`` extras, and a "full" variant,
+including all dependency packages from the ``export,influxdb,cratedb,postgresql,
+radar,bufr,restapi,explorer,radar,radarplus`` extras.
 
 
 *************

--- a/example/radar/radar_composite_rw.py
+++ b/example/radar/radar_composite_rw.py
@@ -5,6 +5,7 @@
 =====
 About
 =====
+
 Example for DWD RADOLAN Composite RW using wetterdienst and wradlib.
 
 See also:
@@ -12,15 +13,6 @@ See also:
 
 This program will request daily (RADOLAN SF) data for 2020-09-04T12:00:00
 and plot the outcome with matplotlib.
-
-
-=====
-Setup
-=====
-::
-
-    brew install gdal
-    pip install wradlib
 
 """  # Noqa:D205,D400
 import logging

--- a/example/radar/radar_radolan_cdc.py
+++ b/example/radar/radar_radolan_cdc.py
@@ -5,6 +5,7 @@
 =====
 About
 =====
+
 Example for DWD RADOLAN Composite RW/SF using wetterdienst and wradlib.
 Hourly and gliding 24h sum of radar- and station-based measurements (German).
 
@@ -15,18 +16,10 @@ This program will request daily (RADOLAN SF) data for 2020-09-04T12:00:00
 and plot the outcome with matplotlib.
 
 
-=====
-Setup
-=====
-::
-
-    brew install gdal
-    pip install wradlib
-
-
 =======
 Details
 =======
+
 RADOLAN: Radar Online Adjustment
 Radar based quantitative precipitation estimation
 

--- a/example/radar/radar_radolan_rw.py
+++ b/example/radar/radar_radolan_rw.py
@@ -5,6 +5,7 @@
 =====
 About
 =====
+
 Example for DWD RADOLAN Composite RW/SF using wetterdienst and wradlib.
 Hourly and gliding 24h sum of radar- and station-based measurements (German).
 
@@ -15,18 +16,10 @@ This program will request daily (RADOLAN SF) data for 2020-09-04T12:00:00
 and plot the outcome with matplotlib.
 
 
-=====
-Setup
-=====
-::
-
-    brew install gdal
-    pip install wradlib
-
-
 =======
 Details
 =======
+
 RADOLAN: Radar Online Adjustment
 Radar based quantitative precipitation estimation
 

--- a/example/radar/radar_scan_precip.py
+++ b/example/radar/radar_scan_precip.py
@@ -5,6 +5,7 @@
 =====
 About
 =====
+
 Example for DWD radar sites data in OPERA HDF5 (ODIM_H5) format using wetterdienst and wradlib. # noqa
 Derived from https://gist.github.com/kmuehlbauer/ac990569e6ad38a49412fc74a2035c37.
 
@@ -13,15 +14,6 @@ See also:
 
 This program will request the most recent complete SWEEP_PCP data
 for Essen and plot the outcome with matplotlib.
-
-
-=====
-Setup
-=====
-::
-
-    brew install gdal
-    pip install wradlib
 
 """  # Noqa:D205,D400
 import logging

--- a/example/radar/radar_scan_volume.py
+++ b/example/radar/radar_scan_volume.py
@@ -5,6 +5,7 @@
 =====
 About
 =====
+
 Example for DWD radar sites data in OPERA HDF5 (ODIM_H5) format using wetterdienst and wradlib. # noqa
 Derived from https://gist.github.com/kmuehlbauer/ac990569e6ad38a49412fc74a2035c37.
 
@@ -13,15 +14,6 @@ See also:
 
 This program will request the most recent complete SWEEP_VOL data
 for Essen and plot the outcome with matplotlib.
-
-
-=====
-Setup
-=====
-::
-
-    brew install gdal
-    pip install wradlib
 
 """  # Noqa:D205,D400
 import logging

--- a/example/radar/radar_site_dx.py
+++ b/example/radar/radar_site_dx.py
@@ -5,6 +5,7 @@
 =====
 About
 =====
+
 Example for DWD radar sites DX using wetterdienst and wradlib.
 
 The German Weather Service uses the DX file format to encode
@@ -16,15 +17,6 @@ See also:
 
 This program will request the latest RADAR DX data
 for Boostedt and plot the outcome with matplotlib.
-
-
-=====
-Setup
-=====
-::
-
-    brew install gdal
-    pip install wradlib
 
 """  # noqa:D205,D400,E501
 import logging

--- a/example/radar/radar_sweep_hdf5.py
+++ b/example/radar/radar_sweep_hdf5.py
@@ -5,6 +5,7 @@
 =====
 About
 =====
+
 Example for DWD radar sites OPERA HDF5 (ODIM_H5) format using wetterdienst and wradlib.
 
 See also:
@@ -12,15 +13,6 @@ See also:
 
 This program will request the latest RADAR SWEEP_PCP_VELOCITY_H data
 for Boostedt and plot the outcome with matplotlib.
-
-
-=====
-Setup
-=====
-::
-
-    brew install gdal
-    pip install wradlib
 
 """  # Noqa:D205,D400
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,7 +135,7 @@ dash-leaflet                    = { version = "^0.1.23", optional = true }  # Ex
 duckdb                          = { version = "^0.6.0", optional = true }  # Export feature.
 fastapi                         = { version = "^0.65", optional = true }  # HTTP REST API feature.
 geojson                         = { version = "^2.5.0", optional = true }  # Explorer UI feature.
-h5py                            = { version = "^3.1", optional = true, extras = ["radar"] }  # Radar feature.
+h5py                            = { version = "^3.1", optional = true }  # Radar feature.
 influxdb                        = { version = "^5.3", optional = true }  # Export feature.
 influxdb-client                 = { version = "^1.18", optional = true }  # Export feature.
 matplotlib                      = { version = "^3.3", optional = true }

--- a/tests/example/test_regular_examples.py
+++ b/tests/example/test_regular_examples.py
@@ -34,7 +34,7 @@ def test_regular_examples(example):
 @pytest.mark.cflake
 def test_radar_examples():
 
-    pytest.importorskip("osgeo.gdal")
+    pytest.importorskip("wradlib")
 
     from example.radar import (
         radar_composite_rw,


### PR DESCRIPTION
This is a followup to GH-878, improving the setup of wradlib and h5py, and finally resolving the GDAL gordian-knot for Python>=3.9.