### PR TITLE
Let dependabot search for Github Action updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
     schedule:
       interval: "monthly"
     versioning-strategy: lockfile-only
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Currently we only search for Python updates periodically.
This PR lets dependabot search for Github Action updates monthly.
This make it easier than manually searching for updates.