### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
       - name: 'Checkout Repository'
         uses: actions/checkout@v3
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v2
+        uses: actions/dependency-review-action@v3

--- a/.github/workflows/docker-publish-full.yml
+++ b/.github/workflows/docker-publish-full.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
       -
         name: Download wheel package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ runner.os }}-wheel-${{ github.sha }}
           path: dist

--- a/.github/workflows/docker-publish-full.yml
+++ b/.github/workflows/docker-publish-full.yml
@@ -47,7 +47,7 @@ jobs:
         run: poetry build --format=wheel
       -
         name: Upload wheel package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ runner.os }}-wheel-${{ github.sha }}
           path: dist/wetterdienst-*.whl

--- a/.github/workflows/docker-publish-full.yml
+++ b/.github/workflows/docker-publish-full.yml
@@ -126,7 +126,7 @@ jobs:
           password: ${{ github.token }}
       -
         name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: .github/release/full/Dockerfile

--- a/.github/workflows/docker-publish-standard.yml
+++ b/.github/workflows/docker-publish-standard.yml
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
       -
         name: Download wheel package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ runner.os }}-wheel-${{ github.sha }}
           path: dist

--- a/.github/workflows/docker-publish-standard.yml
+++ b/.github/workflows/docker-publish-standard.yml
@@ -126,7 +126,7 @@ jobs:
           password: ${{ github.token }}
       -
         name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: .github/release/standard/Dockerfile

--- a/.github/workflows/docker-publish-standard.yml
+++ b/.github/workflows/docker-publish-standard.yml
@@ -47,7 +47,7 @@ jobs:
         run: poetry build --format=wheel
       -
         name: Upload wheel package
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ runner.os }}-wheel-${{ github.sha }}
           path: dist/wetterdienst-*.whl


### PR DESCRIPTION
Updates all Github Actions to the latest version.
This is a combination of all dependabot PRs to avoid running the CI tests multiple times after merging.