### PR TITLE
Packaging: Improve Dockerfiles for OCI image building

### DIFF
--- a/.github/release/full/Dockerfile
+++ b/.github/release/full/Dockerfile
@@ -3,11 +3,16 @@ FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
-# Install HDF5 bindings for Python, and a few other dependencies.
-RUN apt-get update && \
-    apt-get --yes --no-install-recommends --no-install-suggests install \
-      ca-certificates python-is-python3 python3-h5py python3-pip python3-wheel python3-venv && \
-    rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt
+# Install build prerequisites.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
+    true \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests --yes \
+      git build-essential ca-certificates \
+      python-is-python3 python3-h5py python3-pip python3-wheel python3-venv
 
 # Use Python 3.11.
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.11 0
@@ -26,8 +31,17 @@ RUN python -m pip install --prefer-binary wradlib
 # Use `poetry build --format=wheel` to build wheel packages into `dist` folder.
 COPY dist/wetterdienst-*.whl /tmp/
 
-# Install latest wheel package.
-RUN python -m pip install --no-cache-dir --prefer-binary $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer,radar,radarplus]
+# Install package.
+# Pick latest wheel package from `/tmp` folder.
+RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
+    true \
+    && pip install --upgrade pip \
+    && pip install --prefer-binary versioningit wheel \
+    && WHEEL=$(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1) \
+    && pip install --use-pep517 --prefer-binary ${WHEEL}[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer,radar,radarplus]
+
+# Uninstall build prerequisites again.
+RUN apt-get --yes remove --purge git build-essential && apt-get --yes autoremove
 
 # Purge /tmp directory
 RUN rm /tmp/*

--- a/.github/release/standard/Dockerfile
+++ b/.github/release/standard/Dockerfile
@@ -3,13 +3,29 @@ FROM python:3.11-slim-bullseye
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
 
-RUN apt-get update && apt-get --yes --no-install-recommends install build-essential
+# Install build prerequisites.
+RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+RUN \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/cache/apt \
+    --mount=type=cache,id=apt,sharing=locked,target=/var/lib/apt \
+    true \
+    && apt-get update \
+    && apt-get install --no-install-recommends --no-install-suggests --yes git build-essential
 
 # Use "poetry build --format=wheel" to build wheel packages.
 COPY dist/wetterdienst-*.whl /tmp/
 
-# Install latest wheel package.
-RUN pip install --no-cache-dir $(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1)[export,restapi]
+# Install package.
+# Pick latest wheel package from `/tmp` folder.
+RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
+    true \
+    && pip install --upgrade pip \
+    && pip install --prefer-binary versioningit wheel \
+    && WHEEL=$(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1) \
+    && pip install --use-pep517 --prefer-binary ${WHEEL}[export,restapi]
+
+# Uninstall build prerequisites again.
+RUN apt-get --yes remove --purge git build-essential && apt-get --yes autoremove
 
 # Purge /tmp directory
 RUN rm /tmp/*

--- a/.github/workflows/docker-publish-full.yml
+++ b/.github/workflows/docker-publish-full.yml
@@ -55,6 +55,9 @@ jobs:
 
       - name: Run tests
         run: |
+          export DOCKER_BUILDKIT=1
+          export COMPOSE_DOCKER_CLI_BUILD=1
+          export BUILDKIT_PROGRESS=plain    
           if [[ -f .github/release/full.test.yml ]]; then
             docker-compose --file .github/release/full.test.yml build
             docker-compose --file .github/release/full.test.yml run sut

--- a/.github/workflows/docker-publish-standard.yml
+++ b/.github/workflows/docker-publish-standard.yml
@@ -56,6 +56,9 @@ jobs:
 
       - name: Run tests
         run: |
+          export DOCKER_BUILDKIT=1
+          export COMPOSE_DOCKER_CLI_BUILD=1
+          export BUILDKIT_PROGRESS=plain    
           if [[ -f .github/release/standard.test.yml ]]; then
             docker-compose --file .github/release/standard.test.yml build
             docker-compose --file .github/release/standard.test.yml run sut

--- a/docs/contribution/development.rst
+++ b/docs/contribution/development.rst
@@ -86,6 +86,53 @@ In order to run only specific tests, invoke::
     poe test -m "not (remote or slow)"
 
 
+****************
+Build OCI images
+****************
+
+Before building OCI images, you will need a recent wheel package. In order to
+build one from the current working tree, run::
+
+    pip install build
+    python -m build --wheel
+
+To build the OCI images suitable to run on Docker, Podman, Kubernetes, and friends,
+invoke::
+
+    export DOCKER_BUILDKIT=1
+    export COMPOSE_DOCKER_CLI_BUILD=1
+    export BUILDKIT_PROGRESS=plain
+
+    docker build \
+        --tag=local/wetterdienst-standard \
+        --file=.github/release/standard/Dockerfile \
+        .
+
+For the ``full`` image variant::
+
+    docker build \
+        --tag=local/wetterdienst-full \
+        --file=.github/release/full/Dockerfile \
+        .
+
+In order to build images for other platforms than ``linux/amd64``, use the
+``--platform`` option, For ARM 64-bit::
+
+    docker build \
+        --tag=local/wetterdienst-standard \
+        --file=.github/release/standard/Dockerfile \
+        --platform=linux/arm64 \
+        .
+
+For ARM 32-bit::
+
+    docker build \
+        --tag=local/wetterdienst-standard \
+        --file=.github/release/standard/Dockerfile \
+        --platform=linux/arm/v7 \
+        .
+
+
 ************
 Contributing
 ************


### PR DESCRIPTION
GH-904 will need a compiler toolchain to be installed, because the newly introduced dependency `backports-datetime-fromisoformat` requires it, as it does not ship as a wheel package.

So, while adding `build-essential` to the `standard/Dockerfile` variant, I took the chance to modernize the Dockerfiles a bit, and align them to the ones I am using at [mqttwarn](https://github.com/jpmens/mqttwarn).