### PR TITLE
Fix JOULE_PER_SQUARE_METER definition from kilojoule/m2 to joule/m2

### DIFF
--- a/wetterdienst/metadata/unit.py
+++ b/wetterdienst/metadata/unit.py
@@ -69,7 +69,7 @@ class OriginUnit(Enum):
     # Energy
     GLOBAL_IRRADIANCE = REGISTRY.global_irradiance  # should stay the same in SI
     JOULE_PER_SQUARE_CENTIMETER = REGISTRY.joule / (REGISTRY.centimeter**2)
-    JOULE_PER_SQUARE_METER = REGISTRY.kilojoule / (REGISTRY.meter**2)
+    JOULE_PER_SQUARE_METER = REGISTRY.joule / (REGISTRY.meter**2)
     KILOJOULE_PER_SQUARE_METER = REGISTRY.kilojoule / (REGISTRY.meter**2)
 
     # Volume


### PR DESCRIPTION
This was previously misdefined, which leads to wrongly scaled values at least for the DWD MOSMIX prognoses.