### PR TITLE
Fix Unit definition for RADIATION_GLOBAL

### DIFF
--- a/wetterdienst/metadata/unit.py
+++ b/wetterdienst/metadata/unit.py
@@ -16,7 +16,6 @@ REGISTRY.define("percent = 1e-2 frac = pct")
 REGISTRY.define("one_eighth = 0.125 frac = 1/8")
 REGISTRY.define("beaufort = 1 frac = bft")
 REGISTRY.define("significant_weather = 1frac = sign [0..95]")
-REGISTRY.define("global_irradiance = 1/80 frac = % [0..80]")
 REGISTRY.define("@alias degree = wind_direction = []")
 REGISTRY.define("siemens = 1 kg**-1 * m**−2 s**3 A**2 = S")
 REGISTRY.define("nephelometric_turbidity = 1 = NTU")  # turbidity unit, not actually convertable to any SI unit
@@ -67,7 +66,6 @@ class OriginUnit(Enum):
     WAVE_PERIOD = 1 / (100 * REGISTRY.second)
 
     # Energy
-    GLOBAL_IRRADIANCE = REGISTRY.global_irradiance  # should stay the same in SI
     JOULE_PER_SQUARE_CENTIMETER = REGISTRY.joule / (REGISTRY.centimeter**2)
     JOULE_PER_SQUARE_METER = REGISTRY.joule / (REGISTRY.meter**2)
     KILOJOULE_PER_SQUARE_METER = REGISTRY.kilojoule / (REGISTRY.meter**2)
@@ -119,7 +117,6 @@ class SIUnit(Enum):
     WAVE_PERIOD = 1 / (100 * REGISTRY.second)
 
     # Energy
-    GLOBAL_IRRADIANCE = REGISTRY.global_irradiance  # should stay the same in SI
     JOULE_PER_SQUARE_METER = REGISTRY.joule / (REGISTRY.meter**2)
 
     # Precipitation

--- a/wetterdienst/provider/dwd/mosmix/metadata/unit.py
+++ b/wetterdienst/provider/dwd/mosmix/metadata/unit.py
@@ -221,7 +221,7 @@ class DwdMosmixUnit(DatasetTreeCore):
             )
             RADIATION_GLOBAL = (
                 OriginUnit.KILOJOULE_PER_SQUARE_METER.value,
-                SIUnit.JOULE_PER_SQUARE_METER.value
+                SIUnit.JOULE_PER_SQUARE_METER.value,
             )
             RADIATION_SKY_LONG_WAVE_LAST_3H = (
                 OriginUnit.KILOJOULE_PER_SQUARE_METER.value,

--- a/wetterdienst/provider/dwd/mosmix/metadata/unit.py
+++ b/wetterdienst/provider/dwd/mosmix/metadata/unit.py
@@ -80,8 +80,8 @@ class DwdMosmixUnit(DatasetTreeCore):
                 SIUnit.DEGREE_KELVIN.value,
             )
             RADIATION_GLOBAL = (
-                OriginUnit.GLOBAL_IRRADIANCE.value,
-                SIUnit.GLOBAL_IRRADIANCE.value,
+                OriginUnit.KILOJOULE_PER_SQUARE_METER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value,
             )
             VISIBILITY_RANGE = OriginUnit.METER.value, SIUnit.METER.value
             SUNSHINE_DURATION = OriginUnit.SECOND.value, SIUnit.SECOND.value
@@ -220,8 +220,8 @@ class DwdMosmixUnit(DatasetTreeCore):
                 SIUnit.JOULE_PER_SQUARE_METER.value,
             )
             RADIATION_GLOBAL = (
-                OriginUnit.GLOBAL_IRRADIANCE.value,
-                SIUnit.GLOBAL_IRRADIANCE.value,
+                OriginUnit.KILOJOULE_PER_SQUARE_METER.value,
+                SIUnit.JOULE_PER_SQUARE_METER.value
             )
             RADIATION_SKY_LONG_WAVE_LAST_3H = (
                 OriginUnit.KILOJOULE_PER_SQUARE_METER.value,


### PR DESCRIPTION
Follow-up to #937

According to the DWD definition (https://opendata.dwd.de/weather/lib/MetElementDefinition.xml), the rad1h (RADIATION_GLOBAL) is expressed as kJ/m2, not as a percentage value. Or am I misunderstanding something here?