### PR TITLE
Upgrade Debian version to 12 bookworm

### DIFF
--- a/.github/release/standard/Dockerfile
+++ b/.github/release/standard/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bullseye
+FROM python:3.11-slim-bookworm
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux


### PR DESCRIPTION
Upgrades Docker image from Debian 11 bullseye to Debian 12 bookworm for the standard Dockerfile.
The full Dockerfile is already upgraded to Debian 12, see https://github.com/earthobservations/wetterdienst/blob/main/.github/release/full/Dockerfile#L1