### PR TITLE
Retroactively update change log about breaking change with Polars

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@ Development
 - Backend: Migrate from pandas to polars
 - Sources: Add DWD Road Weather data
 
+.. attention::
+
+    Switching to Polars may cause breaking changes for certain user-space code
+    heavily using pandas idioms, because Wetterdienst now returns a `Polars DataFrame`_.
+    If you absolutely must use a pandas DataFrame, you can cast the Polars DataFrame
+    to pandas by using the ``.to_pandas()`` method.
+
+.. _Polars DataFrame: https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/
+
 0.56.2 (11.05.2023)
 *******************
 

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,13 @@ This library is a work in progress!
 
 Breaking changes should be expected until a 1.0 release, so version pinning is recommended.
 
+.. note::
+
+    Wetterdienst 0.57.0 switched from pandas to Polars, which may cause breaking changes
+    for certain user-space code heavily using pandas idioms, because Wetterdienst now
+    returns a `Polars DataFrame`_. If you absolutely must use a pandas DataFrame, you can
+    cast the Polars DataFrame to pandas by using the ``.to_pandas()`` method.
+
 **What our customers say:**
 
 "Our house is on fire. I am here to say, our house is on fire. I saw it with my own eyes using **wetterdienst**
@@ -414,3 +421,6 @@ Important Links
 - Changelog: https://wetterdienst.readthedocs.io/en/latest/changelog.html
 - Examples (runnable scripts): https://github.com/earthobservations/wetterdienst/tree/main/example
 - Benchmarks: https://github.com/earthobservations/wetterdienst/tree/main/benchmarks
+
+
+.. _Polars DataFrame: https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/


### PR DESCRIPTION
Coming from https://github.com/earthobservations/wetterdienst/issues/963#issuecomment-1600860383, this patch aims to update the change log correspondingly, that some user-space code heavily using pandas idioms may need updates after the migration to Polars.
