### PR TITLE
CI: Do not build and publish OCI images on GHA PRs from non-members

### DIFF
--- a/.github/workflows/docker-publish-full.yml
+++ b/.github/workflows/docker-publish-full.yml
@@ -28,7 +28,6 @@ env:
 
 jobs:
   build_and_test:
-    if: ${{ ! startsWith(github.head_ref, '^dependabot/*') }} && ${{ ! github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Acquire sources
@@ -65,9 +64,10 @@ jobs:
           fi
 
   docker:
-    if: ${{ ! startsWith(github.head_ref, '^dependabot/*') }} && ${{ ! github.event.pull_request.head.repo.fork }}
     needs: build_and_test
     runs-on: ubuntu-latest
+    if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
+
     steps:
       - name: Acquire sources
         uses: actions/checkout@v3

--- a/.github/workflows/docker-publish-standard.yml
+++ b/.github/workflows/docker-publish-standard.yml
@@ -28,7 +28,6 @@ env:
 
 jobs:
   build_and_test:
-    if: ${{ ! startsWith(github.head_ref, '^dependabot/*') }} && ${{ ! github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     steps:
       - name: Acquire sources
@@ -65,9 +64,10 @@ jobs:
           fi
 
   docker:
-    if: ${{ ! startsWith(github.head_ref, '^dependabot/*') }} && ${{ ! github.event.pull_request.head.repo.fork }}
     needs: build_and_test
     runs-on: ubuntu-latest
+    if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
+
     steps:
       - name: Acquire sources
         uses: actions/checkout@v3


### PR DESCRIPTION
### About

The OCI image build machinery can't upload to GHCR when running on behalf of non-members.

_Thanks for outlining this idea on behalf of GH-950 already. I think this update actually makes it work as intended._

### References
- https://github.com/panodata/grafana-wtf/pull/71
- https://github.com/daq-tools/lorrystream/pull/19
