### PR TITLE
Fix documentation and unit conversion for Geosphere 10minute radiation data

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Development
 ***********
 
+- Fix documentation and unit conversion for Geosphere 10minute radiation data
+
 0.59.1 (18.07.2023)
 *******************
 

--- a/docs/data/coverage/geosphere/observation/daily.rst
+++ b/docs/data/coverage/geosphere/observation/daily.rst
@@ -148,7 +148,7 @@ radiation_global
    * - origin unit
      - :math:`J / cm^2`
    * - SI unit
-     - :math:`J / cm^2`
+     - :math:`J / m^2`
    * - constraints
      - :math:`\geq{0}`
 

--- a/docs/data/coverage/geosphere/observation/hourly.rst
+++ b/docs/data/coverage/geosphere/observation/hourly.rst
@@ -190,7 +190,7 @@ radiation_global
    * - origin unit
      - :math:`J / cm^2`
    * - SI unit
-     - :math:`J / cm^2`
+     - :math:`J / m^2`
    * - constraints
      - :math:`\geq{0}`
 
@@ -210,7 +210,7 @@ radiation_sky_short_wave_diffuse
    * - origin unit
      - :math:`J / cm^2`
    * - SI unit
-     - :math:`J / cm^2`
+     - :math:`J / m^2`
    * - constraints
      - :math:`\geq{0}`
 
@@ -230,7 +230,7 @@ radiation_sky_short_wave_direct
    * - origin unit
      - :math:`J / cm^2`
    * - SI unit
-     - :math:`J / cm^2`
+     - :math:`J / m^2`
    * - constraints
      - :math:`\geq{0}`
 

--- a/docs/data/coverage/geosphere/observation/minute_10.rst
+++ b/docs/data/coverage/geosphere/observation/minute_10.rst
@@ -148,9 +148,9 @@ radiation_global
    * - description
      -
    * - origin unit
-     - :math:`W / m^2`
-   * - SI unit
      - :math:`J / cm^2`
+   * - SI unit
+     - :math:`J / m^2`
    * - constraints
      - :math:`\geq{0}`
 
@@ -162,15 +162,15 @@ radiation_sky_short_wave_diffuse
    :stub-columns: 1
 
    * - original name
-     - GSX
+     - HSX
    * - description file
      - 
    * - description
      -
    * - origin unit
-     - :math:`W / m^2`
-   * - SI unit
      - :math:`J / cm^2`
+   * - SI unit
+     - :math:`J / m^2`
    * - constraints
      - :math:`\geq{0}`
 

--- a/docs/data/coverage/geosphere/observation/monthly.rst
+++ b/docs/data/coverage/geosphere/observation/monthly.rst
@@ -208,7 +208,7 @@ radiation_global
    * - origin unit
      - :math:`J / cm^2`
    * - SI unit
-     - :math:`J / cm^2`
+     - :math:`J / m^2`
    * - constraints
      - :math:`\geq{0}`
 

--- a/tests/provider/geosphere/observation/test_api.py
+++ b/tests/provider/geosphere/observation/test_api.py
@@ -18,3 +18,25 @@ def test_geopshere_observation_api():
     station_at = stations_at.filter_by_station_id("4821")
     df = station_at.values.all().df
     assert df.get_column("value").is_not_null().sum() == 25
+
+
+@pytest.mark.remote
+@pytest.mark.parametrize(
+    "resolution",
+    [
+        GeosphereObservationResolution.MINUTE_10,
+        GeosphereObservationResolution.HOURLY,
+        GeosphereObservationResolution.DAILY,
+    ],
+)
+def test_geopshere_observation_api_radiation(resolution):
+    """Test correct radiation conversion (W / m² -> J / cm²), factor should be 0.06"""
+    stations_at = GeosphereObservationRequest(
+        parameter=[Parameter.RADIATION_GLOBAL],
+        resolution=resolution,
+        start_date=datetime(2022, 6, 1),
+        end_date=datetime(2022, 6, 2, hour=23, minute=50),
+    )
+    station_at = stations_at.filter_by_station_id("4821")
+    df = station_at.values.all().df
+    assert df.get_column("value").sum() in (49710600, 49720000)

--- a/wetterdienst/provider/geosphere/observation/api.py
+++ b/wetterdienst/provider/geosphere/observation/api.py
@@ -680,7 +680,13 @@ class GeosphereObservationValues(TimeseriesValues):
         df = df.melt(
             id_vars=[Columns.DATE.value], variable_name=Columns.PARAMETER.value, value_name=Columns.VALUE.value
         )
-
+        if self.sr.resolution == Resolution.MINUTE_10:
+            df = df.with_columns(
+                pl.when(pl.col(Columns.PARAMETER.value).is_in(["GSX", "HSX"]))
+                .then(pl.col(Columns.VALUE.value) * 600)
+                .otherwise(pl.col(Columns.VALUE.value))
+                .alias(Columns.VALUE.value)
+            )
         return df.with_columns(
             pl.col(Columns.DATE.value).str.strptime(pl.Datetime, fmt="%Y-%m-%dT%H:%M+%Z").dt.replace_time_zone("UTC"),
             pl.col(Columns.PARAMETER.value).str.to_lowercase(),


### PR DESCRIPTION
Dear @mhuber89,

this patch should accommodate the needs to fix the documentation as well as unit conversion mentioned in #988 .

To ensure the right conversion factor I looked it up here: https://hextobinary.com/unit/heatflux/from/wpm2/to/jsm2

Please check the changes and comment below!