### PR TITLE
CI: Fix Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,14 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "monthly"
-    versioning-strategy: lockfile-only
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,8 @@
 name: Tests
 
 on:
+  pull_request: ~
   push:
-    branches: [ main ]
-  pull_request:
     branches: [ main ]
 
   # Allow job to be triggered manually.


### PR DESCRIPTION
## About

@kmuehlbauer reported dependency staleness at GH-1015. Thanks. It turned out that Dependabot only bumped versions in `poetry.lock`. That's not enough.

## Attention - DO NOT MERGE

**Please do not merge** before we updated the dependencies manually, en bloc. Otherwise, it will probably spawn hundreds of PRs ;].
