### PR TITLE
Dependencies: Bump leftover versions using version range constraints

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -895,6 +895,21 @@ files = [
 click = ">=8.0,<9.0"
 
 [[package]]
+name = "cmweather"
+version = "0.1.0"
+description = "A library of useful colormaps when visualizing weather and climate data, with numerous color vision deficiency friendly options"
+optional = true
+python-versions = ">=3.6"
+files = [
+    {file = "cmweather-0.1.0-py3-none-any.whl", hash = "sha256:3dd21141c868982d914126102464dfd33ab284dee8d29fbecf31c170ddbade3d"},
+    {file = "cmweather-0.1.0.tar.gz", hash = "sha256:7c2dc87d75732b4d890e6b903120445efe114b7be6d783236ecd7414403386a4"},
+]
+
+[package.dependencies]
+matplotlib = "*"
+numpy = "*"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -6874,16 +6889,17 @@ files = [
 
 [[package]]
 name = "xradar"
-version = "0.2.0"
+version = "0.4.0"
 description = "Xradar includes all the tools to get your weather radar into the xarray data model."
 optional = true
 python-versions = ">=3.9"
 files = [
-    {file = "xradar-0.2.0-py3-none-any.whl", hash = "sha256:f565364479f0838583e4378499208467c9151ece063454fa7bd13c7a40d55111"},
-    {file = "xradar-0.2.0.tar.gz", hash = "sha256:d5bf6bb3234b24ab4dae6dabf337df2d4f96090d65841006273d661d137ceadb"},
+    {file = "xradar-0.4.0-py3-none-any.whl", hash = "sha256:dcba75704311dae3c383cb5158731e618eb6bf307d16147ead00c2367a7b590c"},
+    {file = "xradar-0.4.0.tar.gz", hash = "sha256:c47f46accbabd8d09587c62f55cf6ee86496aba3905e35fe0d68f3f8bc681482"},
 ]
 
 [package.dependencies]
+cmweather = "*"
 dask = "*"
 h5netcdf = "*"
 h5py = "*"
@@ -7043,4 +7059,4 @@ streamlit = ["streamlit"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,!=3.9.7,<3.12"
-content-hash = "f883b64e409bc342784e54b276c234aaf749220e149273e8929148a1aa5f1686"
+content-hash = "4445c470a64ec78b4c5663534f90ceebfd4ef3527480eba6b6d89df711b53065"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,9 +125,9 @@ pypdf = ">=3.12.1,<3.17"
 python-dateutil = "<3"
 rapidfuzz = ">=3.1,<4"
 requests = ">=2.20,<3"
-scikit-learn = "^1.0.2"
+scikit-learn = ">=1.0.2,<1.4"
 stamina = ">=23,<24"
-tabulate = "^0.8"
+tabulate = ">=0.8,<0.9"
 timezonefinder = "<7"
 tqdm = ">=4,<5"
 tzdata = "^2023.3"
@@ -152,15 +152,15 @@ openpyxl                        = { version = ">=3,<4", optional = true }
 pdbufr                          = { version = ">=0.10.2,<0.12", optional = true, extras = ["eccodes"] }
 plotly                          = { version = ">=5.11,<6", optional = true }  # Explorer UI feature.
 psycopg2-binary                 = { version = ">=2.8,<3", optional = true }  # Export feature.
-scipy                           = { version = "^1.9", optional = true }  # Interpolation feature.
+scipy                           = { version = ">=1.9,<1.12", optional = true }  # Interpolation feature.
 shapely                         = { version = ">=2,<3", optional = true }  # Interpolation feature.
 sqlalchemy                      = { version = ">=2,<2.1", optional = true }  # Export feature.
 streamlit                       = { version = ">=1.27,<2", optional = true }  # Streamlit app
 utm                             = { version = ">=0.7,<1", optional = true }  # Interpolation feature.
 uvicorn                         = { version = ">=0.14,<1", optional = true }  # HTTP REST API feature.
-wradlib                         = { version = "^1.19", optional = true }  # Radar feature.
+wradlib                         = { version = ">=1.19,<2", optional = true }  # Radar feature.
 xarray                          = { version = "^2023.1", optional = true }
-xradar                          = { version = "^0.2.0", optional = true } # Radar feature.
+xradar                          = { version = ">=0.2,<0.5", optional = true } # Radar feature.
 zarr                            = { version = ">=2.13,<3", optional = true }  # Export feature.
 
 [tool.poetry.group.dev]
@@ -168,8 +168,8 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 black = { version = ">=23.1,<24", extras = ["jupyter"] }
-# TODO: currently there is a version constraint with jsonschema here
-#cff-from-621 = { version = "^0.0.1", python = ">= 3.10"}
+# TODO: Currently there is a version conflict with jsonschema here
+#cff-from-621 = { version = "==0.0.1", python = ">= 3.10"}
 poethepoet = ">=0.18.1,<0.24"
 ruff = "==0.0.291"
 
@@ -184,7 +184,7 @@ freezegun = ">=1.2,<2"
 ipykernel = ">=6.19.4,<7"
 jsonschema = { version = ">=4.17.3,<5", extras = ["format-nongpl"] }
 jupyter = ">=1,<2"
-lmfit = "^1.1.0"  # required for example observations_station_gaussian_model.py
+lmfit = ">=1.1.0,<1.3"  # required for example observations_station_gaussian_model.py
 percy-selenium = "<2"
 pybufrkit = ">=0.2,<0.3"
 pytest = ">=7.2,<8"
@@ -203,7 +203,7 @@ optional = true
 
 [tool.poetry.group.docs.dependencies]
 docformatter = ">=1.4,<1.8"
-furo = "^2023.8.19"
+furo = "^2023.9"
 ipython = ">=8.5,<9"
 matplotlib = ">=3.3,<3.9"
 sphinx = ">=7,<8"


### PR DESCRIPTION
## About

More version bumps, related to GH-1015, following up on GH-1017 and GH-1018.
