### PR TITLE
Dependencies: Remove Percy

### DIFF
--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -25,12 +25,6 @@ if [ "${flavor}" = "testing" ]; then
     --extras=restapi \
     --extras=sql
 
-  # FIXME: Remove this again.
-  # Fix dependency woes about percy: AttributeError: module 'percy' has no attribute 'Runner'.
-  # https://github.com/earthobservations/wetterdienst/pull/1017#issuecomment-1741240635
-  # pytest tests/ui/explorer/test_explorer.py -k test_app_layout
-  poetry run poe fix-percy
-
 elif [ "${flavor}" = "docs" ]; then
   poetry install --verbose --no-interaction --with=docs --extras=interpolation
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -4029,21 +4029,6 @@ files = [
 requests = ">=2.14.0"
 
 [[package]]
-name = "percy-selenium"
-version = "2.0.0"
-description = "Python client for visual testing with Percy"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "percy-selenium-2.0.0.tar.gz", hash = "sha256:369107b106f0404504e12cc713f0d17f04eea886034d4733b489d6d011b4db65"},
-    {file = "percy_selenium-2.0.0-py3-none-any.whl", hash = "sha256:ea4be0ac9feafe250b553422db66c88b218da55f922928a13856ed699dafedf2"},
-]
-
-[package.dependencies]
-requests = "==2.*"
-selenium = ">=3"
-
-[[package]]
 name = "pexpect"
 version = "4.8.0"
 description = "Pexpect allows easy control of interactive console applications."
@@ -7059,4 +7044,4 @@ streamlit = ["streamlit"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,!=3.9.7,<3.12"
-content-hash = "131308dcc2d3b86db7959e776d9ab97cf443cc6b9e0c70e4578e220ba591b4ed"
+content-hash = "399255673401d8ad1af383afe95534bdb05c218810b9f9448291b010e4ed29a9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ ipykernel = ">=6.19.4,<7"
 jsonschema = { version = ">=4.17.3,<5", extras = ["format-nongpl"] }
 jupyter = ">=1,<2"
 lmfit = ">=1.1.0,<1.3"  # required for example observations_station_gaussian_model.py
-percy-selenium = "<3"
 pybufrkit = ">=0.2,<0.3"
 pytest = ">=7.2,<8"
 pytest-cov = ">=4,<5"
@@ -321,7 +320,6 @@ update = "poetry update"
 citation = "python -m tools.citation"
 
 streamlit = "streamlit run ./wetterdienst/ui/streamlit/app.py"
-fix-percy = "python -m pip install percy>=2,<3 --force"
 
 [tool.pytest.ini_options]
 addopts = "-rsfEX -p pytester --strict-markers --verbosity=3 --webdriver=Firefox --headless"


### PR DESCRIPTION
Percy should actually be pulled in appropriately by `dash[testing]`, right? So, it should do no harm removing the direct dependency to `percy-selenium` here. CI may prove me wrong ;].