### PR TITLE
Tests: Re-run test cases on failures

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4828,6 +4828,21 @@ docs = ["coverage (>=5.0,<6.0)", "myst-nb (>=0.13.1,<0.14.0)", "pytest-cov", "py
 testing = ["beautifulsoup4 (==4.8.0)", "black (==19.3b0)", "coverage (>=5.0,<6.0)", "ipykernel", "pytest-cov", "pytest-regressions"]
 
 [[package]]
+name = "pytest-rerunfailures"
+version = "12.0"
+description = "pytest plugin to re-run tests to eliminate flaky failures"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-rerunfailures-12.0.tar.gz", hash = "sha256:784f462fa87fe9bdf781d0027d856b47a4bfe6c12af108f6bd887057a917b48e"},
+    {file = "pytest_rerunfailures-12.0-py3-none-any.whl", hash = "sha256:9a1afd04e21b8177faf08a9bbbf44de7a0fe3fc29f8ddbe83b9684bd5f8f92a9"},
+]
+
+[package.dependencies]
+packaging = ">=17.1"
+pytest = ">=6.2"
+
+[[package]]
 name = "pytest-xdist"
 version = "3.3.1"
 description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
@@ -7044,4 +7059,4 @@ streamlit = ["streamlit"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9,!=3.9.7,<3.12"
-content-hash = "dda12f434376a923de679670d9785a8fec57908743bc6abcf8285ada49afcd24"
+content-hash = "6b9d8129b6fb4aee4161245d2444ee522f2929d0279f91a9c7de665dcd3bdfad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,7 @@ pytest = ">=7.2,<8"
 pytest-cov = ">=4,<5"
 pytest-dictsdiff = ">=0.5,<0.6"
 pytest-notebook = ">=0.8,<0.9"
+pytest-rerunfailures = "<13"
 pytest-xdist = ">=3,<4"
 selenium = ">=4,<5"
 surrogate = "==0.1"
@@ -339,6 +340,10 @@ minversion = "2.0"
 testpaths = ["tests"]
 # Detect tests marked with xfail, which are actually succeeding.
 # xfail_strict = true
+
+# Retry flaky tests, thereby improving the consistency of the test suite results.
+reruns = 2
+reruns_delay = 5
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## About

There are lots of flukes when running the whole test suite, because, well, some data source is always intermittently down or is currently being populated at the time of being accessed, tripping one or another test case. See also GH-816 for a few samples we collected.

This patch intends to retry flaky tests, thereby improving the consistency of the test suite results, mostly for the scenarios outlined above. It obviously does not help if the data source is completely down, or unavailable/wrong/corrupt for a longer amount of time.
