### PR TITLE
Tests: Mark test case `test_api_values_missing_null` as `cflake`

### DIFF
--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -378,6 +378,7 @@ def test_dwd_summarize():
 
 
 @pytest.mark.remote
+@pytest.mark.cflake
 def test_api_values_missing_null():
     response = client.get(
         "/restapi/values",


### PR DESCRIPTION
May fix/improve https://github.com/earthobservations/wetterdienst/issues/816#issuecomment-1745473729, or not.

> Three failures of `test_api_values_missing_null` in two different PRs, GH-1038 and GH-1040, and when merging GH-1041 into the `main` branch, apparently only happening on Windows.
