### PR TITLE
CI: Run software tests on GHA/macOS/M1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
+          - os: "macos-14"
+            python-version: "3.12"
           - os: "macos-latest"
             python-version: "3.12"
           - os: "windows-latest"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,12 +22,17 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
         include:
+          # arm64 (M1)
           - os: "macos-14"
             python-version: "3.12"
+            architecture: "arm64"
+          # x86 (Intel)
           - os: "macos-latest"
             python-version: "3.12"
+            architecture: "x64"
           - os: "windows-latest"
             python-version: "3.12"
+            architecture: "x64"
 
     env:
       OS: ${{ matrix.os }}
@@ -42,23 +47,31 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v4
 
+      # Workaround until pipx is available on M1 machines
+      # - https://github.com/actions/runner-images/issues/9256
+      # We install poetry using brew instead of pipx
+      - name: Install Poetry (Mac only)
+        if: ${{ startsWith(matrix.os, 'macOS') }}
+        run: brew install poetry
+
       - name: Install Poetry
+        if: ${{ !startsWith(matrix.os, 'macOS') }}
         run: pipx install poetry
 
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
+          architecture: ${{ matrix.architecture }}
           cache: poetry
           cache-dependency-path: |
             pyproject.toml
             poetry.lock
 
       - name: Install eccodes (Mac only)
-        if: startsWith(matrix.os, 'macOS')
+        if: ${{ startsWith(matrix.os, 'macOS') }}
         run: |
-          brew install eccodes 
+          brew install eccodes
           export WD_ECCODES_DIR=$(brew --prefix eccodes)
 
       - name: Install project

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,14 +25,11 @@ jobs:
           # arm64 (M1)
           - os: "macos-14"
             python-version: "3.12"
-            architecture: "arm64"
           # x86 (Intel)
           - os: "macos-latest"
             python-version: "3.12"
-            architecture: "x64"
           - os: "windows-latest"
             python-version: "3.12"
-            architecture: "x64"
 
     env:
       OS: ${{ matrix.os }}
@@ -50,26 +47,38 @@ jobs:
       # Workaround until pipx is available on M1 machines
       # - https://github.com/actions/runner-images/issues/9256
       # We install poetry using brew instead of pipx
-      - name: Install Poetry (Mac only)
-        if: ${{ startsWith(matrix.os, 'macOS') }}
+      - name: Install Poetry (Mac M1 only)
+        if: ${{ startsWith(matrix.os, 'macos-14') }}
         run: brew install poetry
 
       - name: Install Poetry
-        if: ${{ !startsWith(matrix.os, 'macOS') }}
+        if: ${{ !startsWith(matrix.os, 'macos-14') }}
         run: pipx install poetry
 
       - name: Setup Python
+        if: ${{ !startsWith(matrix.os, 'macos-14') }}
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: ${{ matrix.architecture }}
+          architecture: x64
           cache: poetry
           cache-dependency-path: |
             pyproject.toml
             poetry.lock
 
+      - name: Setup Python (Mac M1 only)
+        if: ${{ startsWith(matrix.os, 'macos-14') }}
+        run: |
+          brew install pyenv
+          pyenv install ${{ matrix.python-version }}
+          pyenv global ${{ matrix.python-version }}
+
+          export PYENV_ROOT="$HOME/.pyenv"
+          [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+          eval "$(pyenv init -)"
+
       - name: Install eccodes (Mac only)
-        if: ${{ startsWith(matrix.os, 'macOS') }}
+        if: ${{ startsWith(matrix.os, 'macos-') }}
         run: |
           brew install eccodes
           export WD_ECCODES_DIR=$(brew --prefix eccodes)


### PR DESCRIPTION
## About

> January 30, 2024
>
> GitHub announced the launch of the new M1 macOS runner. It provides 3 vCPU, 7 GB RAM, and 14 GB of storage VM, and the latest Mac hardware Actions has to offer. The new runner operates exclusively on macOS 14 and to use it, simply update the runs-on key in your YAML workflow file to `macos-14`.

## References
- https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
- https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
- https://github.com/actions/runner-images/issues/7508
- https://github.com/actions/runner-images/issues/9254
- https://github.com/containerbase/base/issues/2084
