### PR TITLE
Define missing `eccodes` extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ tomlkit = ">=0.7,<1"
 bufr                = ["pybufrkit", "pdbufr"]
 cratedb             = ["pandas", "crate"]
 duckdb              = ["pandas", "duckdb"]
+eccodes             = ["eccodes"]
 explorer            = ["dash", "dash-bootstrap-components", "dash-leaflet", "geojson", "plotly"]
 export              = ["pandas", "openpyxl", "sqlalchemy", "xarray", "zarr"]
 influxdb            = ["influxdb", "influxdb-client", "influxdb3-python"]


### PR DESCRIPTION
The optional `pdbufr` dependency specifies that it needs an `eccodes` extra but this is not defined.  Presumaly the `eccodes` extra is just the `eccodes` package, as I have defined it here. However, it doesn't seem this happens automatically and it seems the fact that the `eccodes` extra was not defined somehow caused `eccodes` to become a required, rather than an optional, dependency.  With this fix, `pip check` passes in an environment with `wetterdienst` and without `eccodes`.  See:
https://github.com/conda-forge/wetterdienst-feedstock/pull/118