### PR TITLE
Reduce docker image size by using multi stage

### DIFF
--- a/.github/release/full/Dockerfile
+++ b/.github/release/full/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-bookworm AS build
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
@@ -30,13 +30,12 @@ RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
     && WHEEL=$(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1) \
     && pip install --use-pep517 --prefer-binary ${WHEEL}[export,influxdb,cratedb,postgresql,radar,bufr,restapi,explorer,radar,radarplus]
 
-# Uninstall build prerequisites again.
-RUN true \
-    && apt-get --yes remove --purge git build-essential python3-dev python3-pip python3-venv python3-wheel \
-    && apt-get --yes autoremove
+# Final stage
+FROM python:3.12-slim-bookworm
 
-# Purge /tmp directory
-RUN rm /tmp/*
+# Copy installed pip packages from build stage
+COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=build /usr/local/bin /usr/local/bin
 
 # Copy selftest.sh to the image
 COPY .github/release/selftest.sh /usr/local/bin

--- a/.github/release/standard/Dockerfile
+++ b/.github/release/standard/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bookworm
+FROM python:3.12-slim-bookworm AS build
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TERM linux
@@ -24,13 +24,12 @@ RUN --mount=type=cache,id=pip,target=/root/.cache/pip \
     && WHEEL=$(ls -r /tmp/wetterdienst-*-py3-none-any.whl | head -n 1) \
     && pip install --use-pep517 --prefer-binary ${WHEEL}[export,restapi,interpolation]
 
-# Uninstall build prerequisites again.
-RUN true \
-    && apt-get --yes remove --purge git build-essential python3-dev python3-pip python3-venv python3-wheel \
-    && apt-get --yes autoremove
+# Final stage
+FROM python:3.12-slim-bookworm
 
-# Purge /tmp directory
-RUN rm /tmp/*
+# Copy installed pip packages from build stage
+COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=build /usr/local/bin /usr/local/bin
 
 # Copy selftest.sh to the image
 COPY .github/release/selftest.sh /usr/local/bin

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Development
 - Update REST API index layout
 - Bump polars to 0.20.10
 - Docker: Bump to Python 3.12
+- Docker: Reduce image size
 
 0.74.0 (22.02.2024)
 *******************


### PR DESCRIPTION
We can reduce the image size by only taking the parts that we need for the final stage.

Tested on linux/amd64 platform:
* Standard: 447MB -> 299MB
* Full: 677Mb -> 385MB