### PR TITLE
docstring doesn't match method signature

### DIFF
--- a/wetterdienst/provider/dwd/observation/parser.py
+++ b/wetterdienst/provider/dwd/observation/parser.py
@@ -90,7 +90,7 @@ def parse_climate_observations_data(
         date field
         period: enumeration of period of data
     Returns:
-        pandas.DataFrame with requested data, for different station ids the data is
+        polars.LazyFrame with requested data, for different station ids the data is
         still put into one DataFrame
     """
     if resolution is Resolution.SUBDAILY and dataset is DwdObservationDataset.WIND_EXTREME:
@@ -125,7 +125,7 @@ def _parse_climate_observations_data(
         resolution: enumeration of time resolution used to correctly parse the
         date field
     Returns:
-        pandas.DataFrame with data from that station, acn be empty if no data is
+        polars.LazyFrame with data from that station, acn be empty if no data is
         provided or local file is not found or has no data in it
     """
     filename, file = filename_and_file


### PR DESCRIPTION
Make docstring match typehints.

I am working with the DWD at work and we've written our own parser (though much less sophisticated). 
Stumbling upon this project, it looks very promising (I wasn't even aware of Polars before!). :)

I read through some of the code to understand what the library is doing, and I noticed that the docstring didn't match the actual function typehints (Did you change from pandas -> polars at some point?)

There might be more documentation where this is the case.
If there is a misunderstanding on my end, please let me know.
Thanks for the work you've put into this! <3
