### PR TITLE
Fix `AsyncFileSystem` monkeypatching breaking 3rd-party file systems

### DIFF
--- a/wetterdienst/monkeypatch/fsspec_monkeypatch.py
+++ b/wetterdienst/monkeypatch/fsspec_monkeypatch.py
@@ -241,6 +241,7 @@ class AsyncFileSystem(asyn.AsyncFileSystem):
             warnings.warn("add_aliases has been removed.", FutureWarning, stacklevel=2)
         # This is set in _Cached
         self._fs_token_ = None
+        super().__init__(*args, **storage_options)
 
 
 def activate():


### PR DESCRIPTION
The monkeypatching done for `AsyncFileSystem` currently breaks 3rd party `AsyncFileSystem` because it doesn't use cooperative inheritance, so not `__init__`s in a classes MRO are called when subclassing `AsyncFileSystem`, breaking filesystems like [adlfs](https://github.com/fsspec/adlfs).

This PR fixes that by adding the missing `super().__init__` call.

