### PR TITLE
README fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -261,7 +261,7 @@ Library
     ...     ts_si_units=True  # convert values to SI units
     ... )
     >>> request = DwdObservationRequest(
-    ...    parameter=["climate_summary"],
+    ...    parameter="climate_summary",
     ...    resolution="daily",
     ...    start_date="1990-01-01",  # if not given timezone defaulted to UTC
     ...    end_date="2020-01-01",  # if not given timezone defaulted to UTC

--- a/README.rst
+++ b/README.rst
@@ -149,12 +149,11 @@ There are some extras available for ``wetterdienst``. Use them like:
 
 .. code-block:: bash
 
-    pip install wetterdienst[http,sql]
+    pip install wetterdienst[sql]
 
 - docs: Install the Sphinx documentation generator.
 - ipython: Install iPython stack.
 - export: Install openpyxl for Excel export and pyarrow for writing files in Feather- and Parquet-format.
-- http: Install HTTP API prerequisites.
 - sql: Install DuckDB for querying data using SQL.
 - duckdb: Install support for DuckDB.
 - influxdb: Install support for InfluxDB.


### PR DESCRIPTION
Remove mention of http extra from README: When going through the docs, I stumbled upon a little issue, that the http extra is not available anymore. So I think it makes sense to remove it from the README.rst, so others do not stumble upon the same issue again.

Fix code example: The given example does give a list of strings as parameters, although the code expects a string.