### PR TITLE
Revert "Remove unnecessary setup.py"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2021, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+
+# This is a shim to hopefully allow GitHub to detect the package.
+# The build is done with Poetry.
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup(name="wetterdienst")


### PR DESCRIPTION
## About
This reverts commit 8703eb9d9e76e012c5e2ebeafcca7248057fbe3e.

A surrogate `setup.py` is needed to enable the "Used by" section on GitHub. GitHub apparently still can't decode projects exclusively using `pyproject.toml` files in 2024.

## References
- GH-800
