### PR TITLE
Bump astral-sh/setup-uv from 4 to 5

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: CodeQL
 
 on:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,12 +26,9 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-
-      - name: Pin python version
-        run: uv python pin ${{ env.PYTHON }}
+          python-version: ${{ env.PYTHON }}
 
       - name: Install project
         run: uv sync
@@ -46,8 +43,10 @@ jobs:
 
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           env_vars: OS,PYTHON
           name: codecov-umbrella

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,12 +34,9 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-
-      - name: Pin python version
-        run: uv python pin ${{ env.PYTHON }}
+          python-version: ${{ env.PYTHON }}
 
       - name: Install project
         run: uv sync

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,12 +24,9 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-
-      - name: Pin python version
-        run: uv python pin ${{ env.PYTHON }}
+          python-version: ${{ env.PYTHON }}
 
       - name: Install project
         run: uv sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,9 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-
-      - name: Pin python version
-        run: uv python pin ${{ env.PYTHON }}
+          python-version: ${{ env.PYTHON }}
 
       - name: Install project
         run: uv sync

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,12 +44,9 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v5
         with:
-          enable-cache: true
-
-      - name: Pin python version
-        run: uv python pin ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON }}
 
       - name: Install project
         run: uv sync
@@ -60,7 +57,7 @@ jobs:
 #          brew install eccodes
 #          export WD_ECCODES_DIR=$(brew --prefix eccodes)
 
-      - name: Install project
+      - name: Install extras for testing
         run: .github/workflows/install.sh testing
 
       - name: Run tests


### PR DESCRIPTION
Drop the `uv python pin` block as well as `enable-cache` parameter which now defaults to true.