### PR TITLE
Use duckdb.sql and ask only for WHERE clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Settings: Switch to `pydantic_settings` for settings management
 - Improve wetterdienst api class
 - Dissolve wetterdienst notebook into examples
+- Use `duckdb.sql` and ask only for WHERE clause
 
 ## 0.98.0 - 2024-12-09
 

--- a/docs/usage/python-api.md
+++ b/docs/usage/python-api.md
@@ -530,7 +530,7 @@ The result data is provided through a virtual table called ``data``.
     )
     stations = request.filter_by_station_id(station_id=[1048])
     values = stations.values.all()
-    df = values.filter_by_sql("SELECT * FROM data WHERE parameter='temperature_air_mean_2m' AND value < -7.0;")
+    df = values.filter_by_sql("parameter='temperature_air_mean_2m' AND value < -7.0;")
     print(df.head())
 ```
 

--- a/docs/usage/restapi.md
+++ b/docs/usage/restapi.md
@@ -25,7 +25,7 @@ http localhost:7890/api/coverage
 http localhost:7890/api/stations provider==dwd network==observation parameters==daily/kl periods==recent all==true
 
 # Query list of stations with SQL.
-http localhost:7890/api/stations provider==dwd network==observation parameters==daily/kl periods==recent sql=="SELECT * FROM data WHERE lower(name) LIKE lower('%dresden%');"
+http localhost:7890/api/stations provider==dwd network==observation parameters==daily/kl periods==recent sql=="lower(name) LIKE lower('%dresden%');"
 
 # Acquire list of DWD DMO stations.
 http localhost:7890/api/stations provider==dwd network==dmo parameters==hourly/icon/temperature_air_mean_2m periods==recent all==true
@@ -44,7 +44,7 @@ http localhost:7890/api/values provider==dwd network==observation parameters==da
 http localhost:7890/api/values provider==dwd network==observation parameters==daily/kl periods==recent station==1048,4411 date==2020-08-01/2020-08-05
 
 # Observations with SQL.
-http localhost:7890/api/values provider==dwd network==observation parameters==daily/kl periods==recent station==1048,4411 shape=="wide" sql=="SELECT * FROM data WHERE temperature_air_max_2m < 2.0;"
+http localhost:7890/api/values provider==dwd network==observation parameters==daily/kl periods==recent station==1048,4411 shape=="wide" sql=="temperature_air_max_2m < 2.0;"
 
 # Acquire ICON data.
 http localhost:7890/api/values provider==dwd network==dmo parameters==hourly/icon/temperature_air_mean_2m station==01001 date==2024-05-27

--- a/examples/provider/dwd/observation/dwd_obs_stations_filter_by_examples.py
+++ b/examples/provider/dwd/observation/dwd_obs_stations_filter_by_examples.py
@@ -49,7 +49,7 @@ def stations_filter_by_examples():
     print(request.filter_by_bbox(*bbox).df)
 
     print("Filter by sql (starting with Dre)")
-    sql = "SELECT * FROM df WHERE name LIKE 'Dre%'"
+    sql = "name LIKE 'Dre%'"
     print(request.filter_by_sql(sql).df)
 
 

--- a/examples/provider/dwd/observation/dwd_obs_values_sql.py
+++ b/examples/provider/dwd/observation/dwd_obs_values_sql.py
@@ -41,7 +41,7 @@ def values_sql_example():
 
     print(stations.df)
 
-    sql = "SELECT * FROM data WHERE parameter='temperature_air_mean_2m' AND value < -7.0;"
+    sql = "parameter='temperature_air_mean_2m' AND value < -7.0;"
     log.info(f"Invoking SQL query '{sql}'")
 
     # Acquire observation values and filter with SQL.

--- a/tests/core/timeseries/test_io.py
+++ b/tests/core/timeseries/test_io.py
@@ -593,11 +593,11 @@ def test_filter_by_date_interval(df_values):
 def test_filter_by_sql(df_values):
     """Test filter by sql statement"""
     df = ExportMixin(df=df_values).filter_by_sql(
-        sql="SELECT * FROM data WHERE parameter='temperature_air_max_2m' AND value < 1.5",
+        sql="parameter='temperature_air_max_2m' AND value < 1.5",
     )
     assert not df.is_empty()
     df = ExportMixin(df=df_values).filter_by_sql(
-        sql="SELECT * FROM data WHERE parameter='temperature_air_max_2m' AND value > 4",
+        sql="parameter='temperature_air_max_2m' AND value > 4",
     )
     assert df.is_empty()
 

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -203,7 +203,7 @@ def test_dwd_stations_sql(client):
             "network": "observation",
             "parameters": "daily/kl",
             "periods": "recent",
-            "sql": "SELECT * FROM data WHERE lower(name) LIKE '%dresden%';",
+            "sql": "lower(name) LIKE '%dresden%';",
         },
     )
     assert response.status_code == 200
@@ -290,7 +290,7 @@ def test_dwd_values_sql_tabular(client):
             "parameters": "daily/kl",
             "periods": "historical",
             "date": "2020/2021",
-            "sql-values": "SELECT * FROM data WHERE temperature_air_max_2m < 2.0",
+            "sql-values": "temperature_air_max_2m < 2.0",
             "shape": "wide",
             "si-units": False,
         },
@@ -345,7 +345,7 @@ def test_dwd_values_sql_long(client):
             "station": "01048,4411",
             "parameters": "daily/kl",
             "date": "2019-12-01/2019-12-31",
-            "sql-values": "SELECT * FROM data WHERE parameter='temperature_air_max_2m' AND value < 1.5",
+            "sql-values": "parameter='temperature_air_max_2m' AND value < 1.5",
             "si-units": False,
         },
     )

--- a/wetterdienst/core/timeseries/request.py
+++ b/wetterdienst/core/timeseries/request.py
@@ -548,9 +548,9 @@ class TimeseriesRequest(Core):
 
     def filter_by_sql(self, sql: str) -> StationsResult:
         """
-
-        :param sql:
-        :return:
+        Method to filter stations by sql query
+        :param sql: SQL WHERE clause for filtering e.g. "name = 'Berlin'"
+        :return: df with stations filtered by sql
         """
         import duckdb
 
@@ -559,8 +559,8 @@ class TimeseriesRequest(Core):
             pl.col(Columns.START_DATE.value).dt.replace_time_zone(None),
             pl.col(Columns.END_DATE.value).dt.replace_time_zone(None),
         )
-        df = duckdb.query_df(df.to_pandas(), "data", sql).df()
-        df = pl.from_pandas(df)
+        sql = f"FROM df WHERE {sql}"
+        df = duckdb.sql(sql).pl()  # uses "df" from local scope
         df = df.with_columns(
             pl.col(Columns.START_DATE.value).dt.replace_time_zone(time_zone="UTC"),
             pl.col(Columns.END_DATE.value).dt.replace_time_zone(time_zone="UTC"),

--- a/wetterdienst/ui/cli.py
+++ b/wetterdienst/ui/cli.py
@@ -434,24 +434,24 @@ SQL filtering:
 
     # Find stations by state.
     wetterdienst stations --provider=dwd --network=observation --parameters=daily/kl --periods=recent \\
-        --sql="SELECT * FROM data WHERE state='Sachsen'"
+        --sql="state='Sachsen'"
 
     # Find stations by name (LIKE query).
     wetterdienst stations --provider=dwd --network=observation --parameters=daily/kl --periods=recent \\
-        --sql="SELECT * FROM data WHERE lower(name) LIKE lower('%dresden%')"
+        --sql="lower(name) LIKE lower('%dresden%')"
 
     # Find stations by name (regexp query).
     wetterdienst stations --provider=dwd --network=observation --parameters=daily/kl --periods=recent \\
-        --sql="SELECT * FROM data WHERE regexp_matches(lower(name), lower('.*dresden.*'))"
+        --sql="regexp_matches(lower(name), lower('.*dresden.*'))"
 
     # Filter values: Display daily climate observation readings where the maximum temperature is below two degrees celsius.
     wetterdienst values --provider=dwd --network=observation --parameters=daily/kl --periods=recent \\
-        --station=1048,4411 --sql-values="SELECT * FROM data WHERE wind_gust_max > 20.0;"
+        --station=1048,4411 --sql-values="wind_gust_max > 20.0;"
 
     # Filter measurements: Same as above, but use long format.
     wetterdienst values --provider=dwd --network=observation --parameters=daily/kl --periods=recent \\
         --station=1048,4411 --shape="long" \\
-        --sql-values="SELECT * FROM data WHERE parameter='wind_gust_max' AND value > 20.0"
+        --sql-values="parameter='wind_gust_max' AND value > 20.0"
 
 Inquire metadata:
 


### PR DESCRIPTION
This PR changes the SQL syntax we are using to `duckdb.sql` which queries the local scope data. This way we do not need the round trip with pandas. Also, we are now only asking for the WHERE clause e.g. `"parameter='precipitation_height'"`.