### PR TITLE
Use updated Polars API for row counting in grouped DataFrames

### DIFF
--- a/tests/core/timeseries/test_request.py
+++ b/tests/core/timeseries/test_request.py
@@ -351,7 +351,7 @@ def test_dwd_observation_multiple_datasets(default_settings: Settings) -> None:
     # station in climate_summary
     df_stats = (
         df_values.group_by(["resolution", "dataset", "station_id"], maintain_order=True)
-        .count()
+        .len(name="count")
         .sort(["resolution", "dataset", "station_id"])
     )
     assert df_stats.to_dicts() == [


### PR DESCRIPTION
## PR Summary
This small PR resolves the Polars deprecation warnings, which you can find in the [CI logs](https://github.com/earthobservations/wetterdienst/actions/runs/15287578226/job/43000924825):
```python
/Users/runner/work/wetterdienst/wetterdienst/tests/core/timeseries/test_request.py:354: DeprecationWarning: `GroupBy.count` is deprecated. It has been renamed to `len`.
```