### PR TITLE
DOC: Update link to radar examples in Usage/Python Examples/Data

### DIFF
--- a/docs/usage/python-examples.md
+++ b/docs/usage/python-examples.md
@@ -204,7 +204,7 @@ This is an example on how to acquire ``RADOLAN_CDC`` data using
 ``wetterdienst`` and process it using ``wradlib``.
 
 For more examples, please have a look at 
-[examples/radar/](https://github.com/earthobservations/wetterdienst/tree/main/examples/radar).
+[examples/provider/dwd/radar](https://github.com/earthobservations/wetterdienst/tree/main/examples/provider/dwd/radar).
 
 ```{code-cell}
 ---


### PR DESCRIPTION
This PR updates the link to the radar examples in the documentation at https://wetterdienst.readthedocs.io/en/latest/usage/python-examples.html#data.
No code changes are made.