### PR TITLE
Cast value in interpolate function to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Development
 
+### Fix
+- Cast value in interpolate function to float
+
+  @ninjeanne reported that wetterdienst lately quirks when running interpolation. This issue is related to one of the new polars versions > 1.33.1. A shorthand fix would be to cast the value coming from the scipy interpolate function to a float.
+
 ## 0.114.3 - 2025-11-07
 
 ### Fix

--- a/wetterdienst/core/interpolate.py
+++ b/wetterdienst/core/interpolate.py
@@ -333,4 +333,4 @@ def apply_interpolation(
         f_index = LinearNDInterpolator(points=(xs, ys), values=[float(v > 0) for v in list(vals.values())])
         value_index = f_index(utm_x, utm_y)
         value = value if value_index >= 0.5 else 0
-    return resolution, dataset, parameter, value, distance_mean, station_group_ids
+    return resolution, dataset, parameter, float(value), distance_mean, station_group_ids


### PR DESCRIPTION
@ninjeanne reported that wetterdienst lately quirks when running interpolation. This issue is related to one of the new polars versions > 1.33.1. A shorthand fix would be to cast the value coming from the scipy interpolate function to a float.