### PR TITLE
fix: update GHCN hourly parsing for upstream format changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Types of changes:
 - Station name filtering (`filter_by_name`, `--name`) was case-sensitive, causing
   lowercase queries like `"darmstadt"` to return no results. Fixed by adding
   `processor=fuzz_utils.default_process` to the rapidfuzz call.
+- NOAA GHCN hourly: adapted to upstream format changes — the station list CSV now
+  contains non-integer values in the `WMO_ID` column (e.g. `"open"`), and the
+  per-station PSV files renamed the station identifier column from `Station_ID` to
+  `STATION`.
 
 ### Changed
 

--- a/src/wetterdienst/provider/noaa/ghcn/api.py
+++ b/src/wetterdienst/provider/noaa/ghcn/api.py
@@ -59,12 +59,12 @@ class NoaaGhcnValues(TimeseriesValues):
         if isinstance(file.content, Exception):
             raise file.content
         df = pl.read_csv(file.content, separator="|", has_header=True, infer_schema_length=0)
-        # drop last line if it is header line
-        if df.get_column("Station_ID").last() == "Station_ID":
+        # drop last line if it is a repeated header line
+        if df.get_column("STATION").last() == "STATION":
             df = df[:-1, :]
         df = df.rename(
             {
-                "Station_ID": "station_id",
+                "STATION": "station_id",
                 "Station_name": "name",
                 "Year": "year",
                 "Month": "month",
@@ -224,6 +224,7 @@ class NoaaGhcnRequest(TimeseriesRequest):
         df = pl.read_csv(
             file.content,
             has_header=True,
+            infer_schema_length=0,
         )
         df = df.select(
             [


### PR DESCRIPTION
- Use infer_schema_length=0 when reading the station list CSV to handle non-integer values (e.g. 'open') in the WMO_ID column
- Update PSV column reference from 'Station_ID' to 'STATION' to match the renamed column in the upstream hourly data files