### PR TITLE
feat: return empty frame instead of error when no internet available

### DIFF
--- a/src/wetterdienst/exceptions.py
+++ b/src/wetterdienst/exceptions.py
@@ -37,3 +37,7 @@ class StationNotFoundError(Exception):
 
 class ApiNotFoundError(Exception):
     """Raised when an API is not found in the API list."""
+
+
+class NoInternetError(OSError):
+    """Raised when no internet connection is available."""

--- a/src/wetterdienst/provider/dwd/derived/api.py
+++ b/src/wetterdienst/provider/dwd/derived/api.py
@@ -62,7 +62,7 @@ def _get_data_from_file(
     :return: Parsed DataFrame
     """
     if isinstance(downloaded_file.content, Exception):
-        raise downloaded_file.content
+        return pl.DataFrame()
     df = pl.read_csv(
         downloaded_file.content,
         separator=";",
@@ -530,6 +530,8 @@ class DwdDerivedValues(TimeseriesValues):
                     )
                     continue
                 downloaded_file.raise_if_exception()
+                if isinstance(downloaded_file.content, Exception):
+                    continue
 
                 df = _get_data_from_file(
                     downloaded_file=downloaded_file,

--- a/src/wetterdienst/provider/dwd/derived/metaindex.py
+++ b/src/wetterdienst/provider/dwd/derived/metaindex.py
@@ -133,7 +133,7 @@ def _get_raw_station_data_from_plz_generator() -> pl.LazyFrame:
 def _read_meta_df(dataset: DatasetModel, file: File) -> pl.LazyFrame:
     """Read meta file into DataFrame."""
     if isinstance(file.content, Exception):
-        raise file.content
+        return pl.LazyFrame()
     if dataset in SOIL_DATASETS:
         df = pl.read_csv(
             file.content,

--- a/src/wetterdienst/provider/dwd/dmo/api.py
+++ b/src/wetterdienst/provider/dwd/dmo/api.py
@@ -369,7 +369,7 @@ class DwdDmoRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         text = StringIO(file.content.read().decode(encoding="latin-1"))
         lines = text.readlines()
         header = lines.pop(0)

--- a/src/wetterdienst/provider/dwd/mosmix/api.py
+++ b/src/wetterdienst/provider/dwd/mosmix/api.py
@@ -253,7 +253,7 @@ class DwdMosmixRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         text = StringIO(file.content.read().decode(encoding="latin-1"))
         lines = text.readlines()
         header = lines.pop(0)

--- a/src/wetterdienst/provider/dwd/observation/metaindex.py
+++ b/src/wetterdienst/provider/dwd/observation/metaindex.py
@@ -122,7 +122,7 @@ def _create_meta_index_for_climate_observations(
 def _read_meta_df(file: File) -> pl.LazyFrame:
     """Read meta file into DataFrame."""
     if isinstance(file.content, Exception):
-        raise file.content
+        return pl.LazyFrame()
     lines = file.content.readlines()[2:]
     first = lines[0].decode("latin-1")
     if first.startswith("SP"):

--- a/src/wetterdienst/provider/dwd/observation/parser.py
+++ b/src/wetterdienst/provider/dwd/observation/parser.py
@@ -74,6 +74,8 @@ def parse_climate_observations_data(
     """Parse the climate observations data from the DWD."""
     if dataset == DwdObservationMetadata.subdaily.wind_extreme:
         data = [_parse_climate_observations_data(file, dataset, period) for file in files]
+        if not data:
+            return pl.LazyFrame()
         try:
             df1, df2 = data
             df = df1.join(df2, on=["station_id", "date"], how="full", coalesce=True)

--- a/src/wetterdienst/provider/dwd/observation/parser.py
+++ b/src/wetterdienst/provider/dwd/observation/parser.py
@@ -84,6 +84,8 @@ def parse_climate_observations_data(
         data = []
         for file in files:
             data.append(_parse_climate_observations_data(file, dataset, period))
+        if not data:
+            return pl.LazyFrame()
         return pl.concat(data)
 
 

--- a/src/wetterdienst/provider/dwd/radar/api.py
+++ b/src/wetterdienst/provider/dwd/radar/api.py
@@ -456,7 +456,7 @@ class DwdRadarValues:  # noqa: PLW1641
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return
         # RadarParameter.FX_REFLECTIVITY
         if url.endswith(Extension.TAR_BZ2.value):
             tfs = TarFileSystem(file.content, compression="bz2")
@@ -530,7 +530,7 @@ class DwdRadarValues:  # noqa: PLW1641
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return
         for result in self._extract_radolan_data(file.content):
             if not result.timestamp:
                 # if result has no timestamp, take it from main url instead of files in archive

--- a/src/wetterdienst/provider/dwd/road/api.py
+++ b/src/wetterdienst/provider/dwd/road/api.py
@@ -278,9 +278,10 @@ class DwdRoadValues(TimeseriesValues):
         parameters: list[ParameterModel],
     ) -> pl.DataFrame:
         """Parse the road weather station data from a given file and returns a DataFrame."""
-        return pl.concat(
-            [self.__parse_dwd_road_weather_data(file, parameters) for file in files],
-        )
+        data = [self.__parse_dwd_road_weather_data(file, parameters) for file in files]
+        if not data:
+            return pl.DataFrame()
+        return pl.concat(data)
 
     @staticmethod
     def __parse_dwd_road_weather_data(
@@ -294,8 +295,6 @@ class DwdRoadValues(TimeseriesValues):
         first_batch = parameter_names[:10]
         second_batch = parameter_names[10:]
         with NamedTemporaryFile("w+b") as tf:
-            if file.is_no_internet_error:
-                return pl.DataFrame()
             if isinstance(file.content, Exception):
                 raise file.content
             tf.write(file.content.read())

--- a/src/wetterdienst/provider/dwd/road/api.py
+++ b/src/wetterdienst/provider/dwd/road/api.py
@@ -294,6 +294,8 @@ class DwdRoadValues(TimeseriesValues):
         first_batch = parameter_names[:10]
         second_batch = parameter_names[10:]
         with NamedTemporaryFile("w+b") as tf:
+            if file.is_no_internet_error:
+                return pl.DataFrame()
             if isinstance(file.content, Exception):
                 raise file.content
             tf.write(file.content.read())
@@ -416,7 +418,7 @@ class DwdRoadRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         df = pl.read_excel(source=file.content, sheet_name="Tabelle1", infer_schema_length=0)
         df = df.rename(mapping=self._column_mapping)
         df = df.select(pl.col(col) for col in self._column_mapping.values())

--- a/src/wetterdienst/provider/ea/hydrology/api.py
+++ b/src/wetterdienst/provider/ea/hydrology/api.py
@@ -139,7 +139,7 @@ class EAHydrologyValues(TimeseriesValues):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.DataFrame()
         df_measures = pl.read_json(
             file.content,
             schema={
@@ -194,7 +194,7 @@ class EAHydrologyValues(TimeseriesValues):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.DataFrame()
         df = pl.read_json(
             file.content,
             schema={
@@ -258,7 +258,7 @@ class EAHydrologyRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         df = pl.read_json(
             file.content,
             schema={

--- a/src/wetterdienst/provider/eaufrance/hubeau/api.py
+++ b/src/wetterdienst/provider/eaufrance/hubeau/api.py
@@ -140,7 +140,7 @@ class HubeauValues(TimeseriesValues):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return 1, "H"
         values_dict = json.load(file.content)["data"]
         try:
             second_date = values_dict[1]["date_obs"]
@@ -180,7 +180,7 @@ class HubeauValues(TimeseriesValues):
             )
             file.raise_if_exception()
             if isinstance(file.content, Exception):
-                raise file.content
+                return pl.DataFrame()
             df = pl.read_json(
                 file.content,
                 schema={
@@ -246,7 +246,7 @@ class HubeauRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         df_raw = pl.read_json(
             file.content,
             schema={

--- a/src/wetterdienst/provider/eccc/observation/api.py
+++ b/src/wetterdienst/provider/eccc/observation/api.py
@@ -170,7 +170,7 @@ class EcccObservationValues(TimeseriesValues):
             )
             file.raise_if_exception()
             if isinstance(file.content, Exception):
-                raise file.content
+                return pl.DataFrame()
             df = pl.read_json(
                 file.content,
                 schema=pl.Schema(
@@ -255,7 +255,7 @@ class EcccObservationRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         df_raw = pl.read_json(
             file.content,
             schema=pl.Schema(

--- a/src/wetterdienst/provider/eumetnet/opera/sites.py
+++ b/src/wetterdienst/provider/eumetnet/opera/sites.py
@@ -121,6 +121,8 @@ class OperaRadarSitesGenerator:
             cache_disable=default_settings.cache_disable,
             use_certifi=default_settings.use_certifi,
         )
+        if payload.is_no_internet_error:
+            return []
         if isinstance(payload.content, Exception):
             raise payload.content
         data = json.loads(payload.content.read())

--- a/src/wetterdienst/provider/geosphere/observation/api.py
+++ b/src/wetterdienst/provider/geosphere/observation/api.py
@@ -76,7 +76,7 @@ class GeosphereObservationValues(TimeseriesValues):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.DataFrame()
         df = pl.read_json(
             file.content,
             schema={
@@ -168,7 +168,7 @@ class GeosphereObservationRequest(TimeseriesRequest):
             )
             file.raise_if_exception()
             if isinstance(file.content, Exception):
-                raise file.content
+                return pl.LazyFrame()
             df = pl.read_csv(file.content)
             df = df.lazy()
             df = df.drop("Sonnenschein", "Globalstrahlung")

--- a/src/wetterdienst/provider/imgw/hydrology/api.py
+++ b/src/wetterdienst/provider/imgw/hydrology/api.py
@@ -399,7 +399,7 @@ class ImgwHydrologyRequest(TimeseriesRequest):
         )
         payload.raise_if_exception()
         if isinstance(payload.content, Exception):
-            raise payload.content
+            return pl.LazyFrame()
         # skip empty lines in the csv file
         lines = payload.content.read().decode("latin-1").replace("\r", "").split("\n")
         lines = [line for line in lines if line]

--- a/src/wetterdienst/provider/imgw/meteorology/api.py
+++ b/src/wetterdienst/provider/imgw/meteorology/api.py
@@ -740,7 +740,7 @@ class ImgwMeteorologyRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         df = pl.read_csv(file.content, encoding="latin-1", separator=";", skip_rows=1, infer_schema_length=0)
         df = df[:, 1:]
         df.columns = [

--- a/src/wetterdienst/provider/noaa/ghcn/api.py
+++ b/src/wetterdienst/provider/noaa/ghcn/api.py
@@ -202,6 +202,9 @@ class NoaaGhcnRequest(TimeseriesRequest):
             else:
                 msg = f"Resolution {dataset.resolution.value} is not supported."
                 raise ValueError(msg)
+        data = [d for d in data if d.columns]
+        if not data:
+            return pl.LazyFrame()
         df = pl.concat(data)
         return df.lazy()
 

--- a/src/wetterdienst/provider/noaa/ghcn/api.py
+++ b/src/wetterdienst/provider/noaa/ghcn/api.py
@@ -57,7 +57,7 @@ class NoaaGhcnValues(TimeseriesValues):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.DataFrame()
         df = pl.read_csv(file.content, separator="|", has_header=True, infer_schema_length=0)
         # drop last line if it is a repeated header line
         if df.get_column("STATION").last() == "STATION":
@@ -114,7 +114,7 @@ class NoaaGhcnValues(TimeseriesValues):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.DataFrame()
         df = pl.read_csv(
             source=file.content,
             separator=",",
@@ -220,7 +220,7 @@ class NoaaGhcnRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         df = pl.read_csv(
             file.content,
             has_header=True,
@@ -293,7 +293,7 @@ class NoaaGhcnRequest(TimeseriesRequest):
         )
         listings_file.raise_if_exception()
         if isinstance(listings_file.content, Exception):
-            raise listings_file.content
+            return pl.LazyFrame()
         lines = listings_file.content.read().decode("utf8").splitlines()
         df = pl.DataFrame(lines)
         column_specs = ((0, 10), (12, 19), (21, 29), (31, 36), (38, 39), (41, 70), (80, 84))
@@ -319,7 +319,7 @@ class NoaaGhcnRequest(TimeseriesRequest):
         )
         inventory_file.raise_if_exception()
         if isinstance(inventory_file.content, Exception):
-            raise inventory_file.content
+            return pl.LazyFrame()
         inventory_df = pl.read_csv(inventory_file.content, has_header=False, truncate_ragged_lines=True)
         column_specs = ((0, 10), (36, 39), (41, 44))
         inventory_df = read_fwf_from_df(inventory_df, column_specs)

--- a/src/wetterdienst/provider/nws/observation/api.py
+++ b/src/wetterdienst/provider/nws/observation/api.py
@@ -166,7 +166,7 @@ class NwsObservationValues(TimeseriesValues):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.DataFrame()
         df = pl.read_json(
             file.content,
             schema={
@@ -308,7 +308,7 @@ class NwsObservationRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         df = pl.read_csv(source=file.content, has_header=False, separator="\t", infer_schema_length=0).lazy()
         df = df.filter(pl.col("column_7").eq("US"))
         df = df.select(

--- a/src/wetterdienst/provider/wsv/pegel/api.py
+++ b/src/wetterdienst/provider/wsv/pegel/api.py
@@ -216,6 +216,8 @@ class WsvPegelValues(TimeseriesValues):
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
         )
+        if file.is_no_internet_error:
+            return pl.DataFrame()
         if isinstance(file.content, FileNotFoundError):
             return pl.DataFrame()
         if isinstance(file.content, Exception):
@@ -286,7 +288,7 @@ class WsvPegelRequest(TimeseriesRequest):
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
-            raise file.content
+            return pl.LazyFrame()
         df = pl.read_json(
             file.content,
             schema={

--- a/src/wetterdienst/util/network.py
+++ b/src/wetterdienst/util/network.py
@@ -65,9 +65,13 @@ class File:
     """The status code of the file download, if available."""
 
     def raise_if_exception(self) -> None:
-        """Raise an exception if the content is not a BytesIO object."""
+        """Raise an exception if the content is not a BytesIO object.
+
+        For NoInternetError, logs at debug level and returns silently instead of raising,
+        allowing callers to return empty frames rather than propagating the error.
+        """
         if isinstance(self.content, NoInternetError):
-            log.warning(f"No internet connection available for {self.url}.")
+            log.debug(f"No internet connection available for {self.url}, returning empty result.")
             return
         if isinstance(self.content, Exception):
             raise self.content

--- a/src/wetterdienst/util/network.py
+++ b/src/wetterdienst/util/network.py
@@ -15,10 +15,11 @@ from typing import TYPE_CHECKING, ClassVar, Literal
 from urllib.parse import urlparse
 
 import stamina
-from aiohttp import ClientResponse, ClientResponseError
+from aiohttp import ClientConnectorError, ClientResponse, ClientResponseError
 from fsspec.implementations.cached import WholeFileCacheFileSystem
 from fsspec.implementations.http import HTTPFileSystem as _HTTPFileSystem
 
+from wetterdienst.exceptions import NoInternetError
 from wetterdienst.metadata.cache import CacheExpiry
 
 if TYPE_CHECKING:
@@ -65,8 +66,16 @@ class File:
 
     def raise_if_exception(self) -> None:
         """Raise an exception if the content is not a BytesIO object."""
+        if isinstance(self.content, NoInternetError):
+            log.warning(f"No internet connection available for {self.url}.")
+            return
         if isinstance(self.content, Exception):
             raise self.content
+
+    @property
+    def is_no_internet_error(self) -> bool:
+        """Check if the content is a NoInternetError."""
+        return isinstance(self.content, NoInternetError)
 
     @property
     def nbytes(self) -> int:
@@ -415,6 +424,13 @@ def download_file(
             url=url,
             content=e,
             status=status,
+        )
+    except ClientConnectorError as e:
+        log.warning(f"No internet connection while downloading file {url}: {e}")
+        return File(
+            url=url,
+            content=NoInternetError(str(e)),
+            status=503,
         )
 
 

--- a/src/wetterdienst/util/pdf.py
+++ b/src/wetterdienst/util/pdf.py
@@ -23,6 +23,8 @@ def read_pdf(url: str) -> str:
         cache_disable=default_settings.cache_disable,
         use_certifi=default_settings.use_certifi,
     )
+    if file.is_no_internet_error:
+        return ""
     if isinstance(file.content, Exception):
         raise file.content
     pdf = pypdf.PdfReader(file.content)

--- a/tests/util/test_network.py
+++ b/tests/util/test_network.py
@@ -2,9 +2,16 @@
 # Distributed under the MIT License. See LICENSE for more info.
 """Tests for network utilities."""
 
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aiohttp import ClientConnectorError
+
+from wetterdienst.exceptions import NoInternetError
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.settings import Settings
-from wetterdienst.util.network import NetworkFilesystemManager
+from wetterdienst.util.network import File, NetworkFilesystemManager, download_file
 
 
 def test_create_fsspec_filesystem() -> None:
@@ -23,3 +30,51 @@ def test_create_fsspec_filesystem() -> None:
         cache_disable=default_settings.cache_disable,
     )
     assert id(fs1) == id(fs2)
+
+
+def test_file_raise_if_exception_no_internet_does_not_raise() -> None:
+    """File.raise_if_exception() must not raise for NoInternetError."""
+    f = File(url="http://example.com/file.txt", content=NoInternetError("no internet"), status=503)
+    f.raise_if_exception()  # should return silently
+
+
+def test_file_raise_if_exception_other_exception_raises() -> None:
+    """File.raise_if_exception() must still raise for non-NoInternetError exceptions."""
+    f = File(url="http://example.com/file.txt", content=FileNotFoundError("not found"), status=404)
+    with pytest.raises(FileNotFoundError):
+        f.raise_if_exception()
+
+
+def test_file_is_no_internet_error_true() -> None:
+    """File.is_no_internet_error returns True when content is NoInternetError."""
+    f = File(url="http://example.com/file.txt", content=NoInternetError("no internet"), status=503)
+    assert f.is_no_internet_error is True
+
+
+def test_file_is_no_internet_error_false() -> None:
+    """File.is_no_internet_error returns False when content is BytesIO."""
+    f = File(url="http://example.com/file.txt", content=BytesIO(b"data"), status=200)
+    assert f.is_no_internet_error is False
+
+
+def test_download_file_returns_no_internet_error_on_connector_error() -> None:
+    """download_file() stores NoInternetError in File when ClientConnectorError occurs."""
+    connector_error = ClientConnectorError(connection_key=MagicMock(), os_error=OSError("Network unreachable"))
+
+    mock_fs = MagicMock()
+    mock_fs.cat_file.side_effect = connector_error
+
+    default_settings = Settings(cache_disable=True)
+
+    with patch("wetterdienst.util.network.NetworkFilesystemManager.get", return_value=mock_fs):
+        result = download_file(
+            url="http://example.com/file.txt",
+            cache_dir=default_settings.cache_dir,
+            ttl=CacheExpiry.NO_CACHE,
+            client_kwargs=default_settings.fsspec_client_kwargs,
+            cache_disable=default_settings.cache_disable,
+        )
+
+    assert result.is_no_internet_error
+    assert result.status == 503
+    assert isinstance(result.content, NoInternetError)


### PR DESCRIPTION
Add NoInternetError exception and catch ClientConnectorError (TCP/DNS failures) in download_file, storing it in the File object. Update File.raise_if_exception() to log a warning and return silently for NoInternetError. Update all call sites across providers to return empty DataFrames/LazyFrames instead of re-raising when no internet is available.

Fixes #1624