### PR TITLE
fix: handle missing meta file gracefully in DWD observation request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Types of changes:
   contains non-integer values in the `WMO_ID` column (e.g. `"open"`), and the
   per-station PSV files renamed the station identifier column from `Station_ID` to
   `STATION`.
+- DWD observation requests no longer raise `MetaFileNotFoundError` when a period's
+  station description file is absent on the server (e.g. `10_minutes/precipitation/now`).
+  The missing period is skipped with a warning and remaining periods are still returned.
 - No internet connection no longer raises an error; instead, an empty result is
   returned. `ClientConnectorError` (TCP/DNS failures) is caught in `download_file`
   and stored as `NoInternetError` in the `File` object. All provider call sites

--- a/src/wetterdienst/provider/dwd/observation/api.py
+++ b/src/wetterdienst/provider/dwd/observation/api.py
@@ -17,6 +17,7 @@ import portion
 from fsspec.implementations.zip import ZipFileSystem
 from portion import Interval
 
+from wetterdienst.exceptions import MetaFileNotFoundError
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.resolution import Resolution
@@ -686,7 +687,11 @@ class DwdObservationRequest(TimeseriesRequest):
         for dataset in datasets:
             periods = set(dataset.periods) & cast("set[Period]", self.periods) if self.periods else dataset.periods
             for period in reversed(list(periods)):
-                df = create_meta_index_for_climate_observations(dataset, period, settings)
+                try:
+                    df = create_meta_index_for_climate_observations(dataset, period, settings)
+                except MetaFileNotFoundError:
+                    log.warning("No meta file found for %s/%s, skipping.", dataset.name, period.name)
+                    continue
                 file_index = create_file_index_for_climate_observations(dataset, period, settings)
                 df = df.join(
                     other=file_index.select(pl.col("station_id")),

--- a/tests/provider/dwd/observation/test_metaindex.py
+++ b/tests/provider/dwd/observation/test_metaindex.py
@@ -3,13 +3,16 @@
 """Tests for DWD observation meta index creation."""
 
 import datetime as dt
+from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
 
 from wetterdienst import Settings
+from wetterdienst.exceptions import MetaFileNotFoundError
 from wetterdienst.metadata.period import Period
+from wetterdienst.provider.dwd.observation.api import DwdObservationRequest
 from wetterdienst.provider.dwd.observation.metadata import DwdObservationMetadata
 from wetterdienst.provider.dwd.observation.metaindex import (
     _create_csv_line,
@@ -93,3 +96,16 @@ def test_create_csv_line() -> None:
         )
         == """01332,19660701,20240514,471,48.4832,12.7241,"Falkenberg,Kr.Rottal-Inn",Bayern"""
     )
+
+
+def test_missing_meta_file_skipped(default_settings: Settings) -> None:
+    """When a period's meta file is absent, the period is skipped and the request returns empty."""
+    with patch(
+        "wetterdienst.provider.dwd.observation.api.create_meta_index_for_climate_observations",
+        side_effect=MetaFileNotFoundError("No meta file found"),
+    ):
+        request = DwdObservationRequest(
+            parameters=DwdObservationMetadata.minute_10.precipitation,
+            settings=default_settings,
+        ).all()
+        assert request.df.is_empty()


### PR DESCRIPTION
When a period's meta file is absent on the DWD server (e.g. 10_minutes/precipitation/now/), catch MetaFileNotFoundError, log a warning, and skip that period instead of propagating the exception.