### PR TITLE
tests: remove xfail markers from passing tests

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -48,7 +48,6 @@ def test_examples_zarr() -> None:
     assert dwd_obs_climate_summary_zarr_dump.main() is None
 
 
-@pytest.mark.xfail
 @pytest.mark.cflake
 def test_examples_failing_describe_fields() -> None:
     """Test DWD observation describe fields for daily climate data."""
@@ -59,7 +58,6 @@ def test_examples_failing_describe_fields() -> None:
 
 @pytest.mark.skipif(IS_CI and IS_WINDOWS, reason="problem with storage on Windows in CI")
 @pytest.mark.skipif(IS_PYTHON_3_14 and not ENSURE_ECCODES_PDBUFR, reason="eccodes and pdbufr required")
-@pytest.mark.xfail
 def test_pdbufr_examples() -> None:
     """Test DWD observation PDBUFR examples."""
     from examples.provider.dwd.road import dwd_road_validation  # noqa: PLC0415

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -788,7 +788,6 @@ def test_dwd_observations_urban_values(default_settings: Settings) -> None:
     assert_frame_equal(given_df, expected_df)
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 @pytest.mark.parametrize(
     "dataset",
@@ -1585,7 +1584,6 @@ def test_dwd_observation_datasets_high_resolution(default_settings: Settings, da
     assert given_df.get_column("quality").is_not_null().mean() >= 0.99
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 @pytest.mark.parametrize(
     "dataset",

--- a/tests/provider/dwd/observation/test_api_metadata.py
+++ b/tests/provider/dwd/observation/test_api_metadata.py
@@ -47,7 +47,6 @@ def test_dwd_observation_metadata_discover_parameters() -> None:
     assert json.dumps(expected)[:-1] in json.dumps(metadata)
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_dwd_observation_metadata_describe_fields_kl_daily_english() -> None:
     """Test DWD observation describe fields for daily climate data."""
@@ -81,7 +80,6 @@ def test_dwd_observation_metadata_describe_fields_kl_daily_english() -> None:
     ]
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_dwd_observation_metadata_describe_fields_kl_daily_german() -> None:
     """Test metadata for daily climate data."""

--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -569,7 +569,6 @@ def test_radar_request_site_historic_pe_timerange(default_settings: Settings, fm
         assert re.match(bytes(header, encoding="ascii"), payload[:115])
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_historic_px250_bufr_yesterday(default_settings: Settings) -> None:
     """Example for testing radar/site PX250 for a specific date."""
@@ -795,7 +794,6 @@ def test_radar_request_site_historic_sweep_vol_v_hdf5_timerange(default_settings
     assert hdf["/what"].attrs.get("time").startswith(bytes(timestamp.strftime("%H%M"), encoding="ascii"))
 
 
-@pytest.mark.xfail(reason="radar locations empty")
 @pytest.mark.remote
 def test_radar_request_radvor_re_yesterday(default_settings: Settings, prefixed_radar_locations: list[str]) -> None:
     """Verify acquisition of radar/radvor/re data works when using a specific date.
@@ -892,7 +890,6 @@ def test_radar_request_radvor_re_timerange(
     assert re.match(pattern, requested_header[:200]), requested_header[:200]
 
 
-@pytest.mark.xfail(reason="radar locations empty")
 @pytest.mark.remote
 def test_radar_request_radvor_rq_yesterday(default_settings: Settings, radar_locations: list[str]) -> None:
     """Verify acquisition of radar/radvor/rq data works when using a specific date.
@@ -946,7 +943,6 @@ def test_radar_request_radvor_rq_yesterday(default_settings: Settings, radar_loc
     assert requested_attrs == attrs
 
 
-@pytest.mark.xfail(reason="radar locations empty")
 @pytest.mark.remote
 def test_radar_request_radvor_rq_timerange(
     default_settings: Settings,

--- a/tests/provider/dwd/radar/test_api_recent.py
+++ b/tests/provider/dwd/radar/test_api_recent.py
@@ -18,7 +18,6 @@ from wetterdienst.provider.dwd.radar.sites import DwdRadarSite
 h5py = pytest.importorskip("h5py", reason="h5py not installed")
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_radar_request_site_recent_sweep_pcp_v_hdf5(default_settings: Settings) -> None:
     """Example for testing radar sites SWEEP_PCP with timerange."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -418,7 +418,7 @@ def test_api_wsv_pegel(default_settings: Settings) -> None:
     assert not values.drop_nulls(subset="value").is_empty()
 
 
-@pytest.mark.xfail(reason="ClientResponseError 403: Forbidden")
+@pytest.mark.remote
 def test_api_ea_hydrology(default_settings: Settings) -> None:
     """Test ea hydrology API."""
     request = EAHydrologyRequest(parameters=[("daily", "data", "discharge_max")], settings=default_settings).all()

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -294,7 +294,6 @@ def test_stations_dwd_sql(client: TestClient) -> None:
     }
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 @pytest.mark.parametrize(
     "fmt",
@@ -358,7 +357,6 @@ def test_stations_dwd_obs_image_pdf(client: TestClient) -> None:
     assert response.headers["Content-Type"] == "application/pdf"
 
 
-@pytest.mark.xfail
 @pytest.mark.remote
 def test_stations_dwd_obs_image_png_custom_settings(client: TestClient) -> None:
     """Test custom settings."""


### PR DESCRIPTION
Remove xfail markers from tests that now pass:
- test_examples_failing_describe_fields
- test_pdbufr_examples
- test_api_ea_hydrology (403 Forbidden resolved)
- test_stations_dwd_obs_image (all image formats)
- test_stations_dwd_obs_image_png_custom_settings
- test_dwd_observation_metadata_describe_fields_kl_daily_english
- test_dwd_observation_metadata_describe_fields_kl_daily_german
- test_dwd_observations_urban_values_basic (all parametrizations)
- test_dwd_observation_datasets_low_resolution
- test_radar_request_site_recent_sweep_pcp_v_hdf5
- test_radar_request_site_historic_px250_bufr_yesterday
- test_radar_request_radvor_re_yesterday (radar locations empty resolved)
- test_radar_request_radvor_rq_yesterday (radar locations empty resolved)
- test_radar_request_radvor_rq_timerange (radar locations empty resolved)