### PR TITLE
fix: install libeccodes-dev on Ubuntu CI and fix pdbufr skipif condition

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,11 +59,13 @@ jobs:
       - name: Install project
         run: uv sync
 
+      - name: Install eccodes (Ubuntu only)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: sudo apt-get install -y libeccodes-dev
+
       - name: Install eccodes (Mac only)
         if: ${{ startsWith(matrix.os, 'macos-') }}
-        run: |
-          brew install eccodes
-          export WD_ECCODES_DIR=$(brew --prefix eccodes)
+        run: brew install eccodes
 
       - name: Install extras for testing
         run: .github/workflows/install.sh testing

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from tests.conftest import ENSURE_ECCODES_PDBUFR, IS_CI, IS_LINUX, IS_PYTHON_3_10, IS_PYTHON_3_14, IS_WINDOWS
+from tests.conftest import ENSURE_ECCODES_PDBUFR, IS_CI, IS_LINUX, IS_PYTHON_3_10, IS_WINDOWS
 
 
 @pytest.mark.xfail(IS_CI and IS_WINDOWS, reason="fails on Windows in CI")
@@ -57,7 +57,7 @@ def test_examples_failing_describe_fields() -> None:
 
 
 @pytest.mark.skipif(IS_CI and IS_WINDOWS, reason="problem with storage on Windows in CI")
-@pytest.mark.skipif(IS_PYTHON_3_14 and not ENSURE_ECCODES_PDBUFR, reason="eccodes and pdbufr required")
+@pytest.mark.skipif(not ENSURE_ECCODES_PDBUFR, reason="eccodes and pdbufr required")
 def test_pdbufr_examples() -> None:
     """Test DWD observation PDBUFR examples."""
     from examples.provider.dwd.road import dwd_road_validation  # noqa: PLC0415


### PR DESCRIPTION
- Add 'apt-get install libeccodes-dev' step for Ubuntu runners so the C ecCodes library is available when pdbufr runs
- Remove no-op 'export WD_ECCODES_DIR' from macOS step (env var does not persist between GitHub Actions steps)
- Fix skipif condition for test_pdbufr_examples from 'IS_PYTHON_3_14 and not ENSURE_ECCODES_PDBUFR' to 'not ENSURE_ECCODES_PDBUFR' so the test is skipped on any Python version when ecCodes/pdbufr is unavailable, not just 3.14
- Remove now-unused IS_PYTHON_3_14 import from test_examples.py