### PR TITLE
feat: expand interpolatable parameters and generalise occurrence-thre…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,34 @@ Types of changes:
 
 ### Added
 
+- Interpolation / summarize: greatly expanded the set of interpolatable parameters
+  beyond the original six. All continuous, spatially-correlated meteorological fields
+  are now supported, organised into two distance classes:
+  - **~40 km** (homogeneous / large-scale): all temperature variants at 2 m and 0.05 m
+    (mean, max, min, last-24 h, multiday, mean-of-extremes), dew point, wet-bulb,
+    wind-chill, surface temperature, soil temperatures (0.02 m – 2 m depth),
+    heating/cooling degree aggregates, all humidity variants (`humidity`,
+    `humidity_absolute`, `humidity_max`, `humidity_min`, `humidex`), all wind-speed
+    variants and gust-max variants, wind movement, Beaufort scale, all sunshine-duration
+    variants, global / diffuse / direct / long-wave radiation, all pressure variants
+    (site, sea-level, reduced, max, min, tendency, vapour), total / effective / time-
+    windowed cloud cover, and evapotranspiration / evaporation fields.
+  - **~20 km** (heterogeneous / locally variable): all precipitation-height variants
+    (including liquid, droplet, rocker, last-1 h … last-24 h, multiday, significant-
+    weather, max), precipitation duration, new-snow depth and its multiday / max
+    variants, and new-snow water-equivalent variants.
+  - Fixes #1651 (`sunshine_duration` was silently dropped by both `interpolate` and
+    `summarize` because it was absent from `interpolatable_parameters`).
+- Interpolation: occurrence-threshold zeroing (previously only applied to
+  `precipitation_height`) is now applied to **all** zero-inflated accumulation
+  parameters: every precipitation-height variant, precipitation duration, new-snow
+  depth variants, and new-snow water-equivalent variants. This prevents spurious
+  small positive values when the surrounding stations recorded no event.
+- Tests: five new unit tests for the occurrence-threshold logic in
+  `core/interpolate.py` (`test_occurrence_threshold_*`) and two new remote
+  integration tests (`test_interpolation_sunshine_duration_daily`,
+  `test_interpolation_snow_depth_new_daily`).
+
 - CLI: `--start-date` / `--end-date` options added to the `values`, `interpolate`, and
   `summarize` commands as a user-friendly alternative to the `--date` ISO-8601 interval
   syntax. Passing only `--start-date` treats it as a single-point date; passing only

--- a/docs/usage/python-api.md
+++ b/docs/usage/python-api.md
@@ -441,20 +441,78 @@ Occasionally, you may require data specific to your precise location rather than
 station's location. To address this need, we have introduced an interpolation feature, enabling you to interpolate data
 from nearby stations to your exact coordinates. The function leverages the four closest stations to your specified
 latitude and longitude and employs the bilinear interpolation method provided by the scipy package (interp2d) to
-interpolate the given parameter values. Currently, this interpolation feature is exclusive to the parameters
+interpolate the given parameter values. Currently, this interpolation feature supports the following parameters:
 
-- ``temperature_air_mean_2m``
-- ``temperature_air_max_2m``
-- ``temperature_air_min_2m``
-- ``humidity``
-- ``wind_speed``
-- ``precipitation_height``.
+**Large spatial correlation (~40 km default search radius)** — homogeneous fields that vary slowly across regions:
+
+*Temperature:*
+``temperature_air_2m``, ``temperature_air_mean_2m``, ``temperature_air_mean_2m_last_24h``,
+``temperature_air_max_2m``, ``temperature_air_max_2m_last_24h``, ``temperature_air_max_2m_mean``, ``temperature_air_max_2m_multiday``,
+``temperature_air_min_2m``, ``temperature_air_min_2m_last_24h``, ``temperature_air_min_2m_mean``, ``temperature_air_min_2m_multiday``,
+``temperature_air_mean_0_05m``, ``temperature_air_max_0_05m``, ``temperature_air_min_0_05m``, ``temperature_air_min_0_05m_last_12h``,
+``temperature_dew_point_mean_2m``, ``temperature_wet_mean_2m``, ``temperature_wind_chill``, ``temperature_surface_mean``,
+``temperature_soil_mean_0_02m``, ``temperature_soil_mean_0_05m``, ``temperature_soil_mean_0_1m``, ``temperature_soil_mean_0_2m``,
+``temperature_soil_mean_0_5m``, ``temperature_soil_mean_1m``, ``temperature_soil_mean_2m``,
+``temperature_soil_min_0_1m``, ``temperature_soil_min_0_2m``, ``temperature_soil_min_0_5m``, ``temperature_soil_min_1m``, ``temperature_soil_min_2m``,
+``temperature_soil_max_0_1m``, ``temperature_soil_max_0_2m``, ``temperature_soil_max_0_5m``, ``temperature_soil_max_1m``, ``temperature_soil_max_2m``,
+``heating_degree_day``, ``cooling_degree_hour``
+
+*Humidity:*
+``humidity``, ``humidity_absolute``, ``humidity_max``, ``humidity_min``, ``humidex``
+
+*Wind:*
+``wind_speed``, ``wind_speed_arithmetic``, ``wind_speed_min``, ``wind_speed_rolling_mean_max``, ``wind_force_beaufort``,
+``wind_movement_24h``, ``wind_movement_multiday``,
+``wind_gust_max``, ``wind_gust_max_last_1h``, ``wind_gust_max_last_3h``, ``wind_gust_max_last_6h``, ``wind_gust_max_last_12h``,
+``wind_gust_max_5sec``, ``wind_gust_max_1min``, ``wind_gust_max_2min``, ``wind_gust_max_instant``, ``wind_gust_max_1mile``
+
+*Snow (accumulated depth):*
+``snow_depth``, ``snow_depth_excelled``, ``snow_depth_manual``, ``snow_depth_max``,
+``water_equivalent_snow_depth``, ``water_equivalent_snow_depth_excelled``
+
+*Solar / Radiation:*
+``sunshine_duration``, ``sunshine_duration_last_3h``, ``sunshine_duration_yesterday``,
+``sunshine_duration_relative``, ``sunshine_duration_relative_last_24h``,
+``radiation_global``, ``radiation_global_last_3h``,
+``radiation_sky_short_wave_diffuse``, ``radiation_sky_short_wave_direct``,
+``radiation_sky_long_wave``, ``radiation_sky_long_wave_last_3h``
+
+*Pressure:*
+``pressure_air_sea_level``, ``pressure_air_site``, ``pressure_air_site_reduced``,
+``pressure_air_site_max``, ``pressure_air_site_min``, ``pressure_air_site_delta_last_3h``, ``pressure_vapor``
+
+*Cloud cover:*
+``cloud_cover_total``, ``cloud_cover_total_midnight_to_midnight``, ``cloud_cover_total_sunrise_to_sunset``, ``cloud_cover_effective``
+
+*Evapotranspiration / Evaporation:*
+``evapotranspiration_potential_last_24h``, ``evapotranspiration_potential_gras_fao_last_24h``,
+``evapotranspiration_potential_gras_haude_last_24h``, ``evaporation_height``, ``evaporation_height_multiday``
+
+**Short spatial correlation (~20 km default search radius)** — heterogeneous fields that vary more locally:
+
+*Precipitation:*
+``precipitation_height``, ``precipitation_height_day``, ``precipitation_height_night``,
+``precipitation_height_liquid``, ``precipitation_height_droplet``, ``precipitation_height_rocker``,
+``precipitation_height_last_1h``, ``precipitation_height_last_3h``, ``precipitation_height_last_6h``,
+``precipitation_height_last_9h``, ``precipitation_height_last_12h``, ``precipitation_height_last_15h``,
+``precipitation_height_last_18h``, ``precipitation_height_last_21h``, ``precipitation_height_last_24h``,
+``precipitation_height_multiday``,
+``precipitation_height_significant_weather_last_1h``, ``precipitation_height_significant_weather_last_3h``,
+``precipitation_height_significant_weather_last_6h``, ``precipitation_height_significant_weather_last_12h``,
+``precipitation_height_significant_weather_last_24h``,
+``precipitation_height_liquid_significant_weather_last_1h``,
+``precipitation_height_max``, ``precipitation_height_liquid_max``, ``precipitation_duration``
+
+*New snow per period:*
+``snow_depth_new``, ``snow_depth_new_multiday``, ``snow_depth_new_max``,
+``water_equivalent_snow_depth_new``, ``water_equivalent_snow_depth_new_last_1h``, ``water_equivalent_snow_depth_new_last_3h``
+
 
 There are several settings that can be used to control the interpolation behavior:
 
 | Name                               | Type             | Default                                      | Description                                                                                                                                                                                                             |
 |------------------------------------|------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ts_geo_station_distance            | dict[str, float] | 20.0 (precipitation_height)<br/>40.0 (other) | Max distance for stations used for interpolation (in km)                                                                                                                                                                |
+| ts_geo_station_distance            | dict[str, float] | 20.0 (precipitation and new-snow variants)<br/>40.0 (other) | Max distance for stations used for interpolation (in km)                                                                                                                                                                |
 | ts_geo_use_nearby_station_distance | float            | 1.0                                          | Distance (in km) until which the value of a nearby station is used instead of interpolation.                                                                                                                            |
 | ts_geo_min_gain_of_value_pairs     | float            | 0.1                                          | Minimum gain of value pairs [for an additional station] to be included in the list of stations used. This is to prevent taking all stations into account in case of a dense station network.                            |
 | ts_geo_num_additional_stations     | int              | 3                                            | Number of additional stations to be used for interpolation regardless of min_gain_of_value_pairs. This is to ensure that at least a certain number of stations are used for interpolation, even if the gain is not met. |

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -29,6 +29,54 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# Parameters for which precipitation-occurrence thresholding is applied during interpolation:
+# linear interpolation between zero-value and non-zero-value stations can produce spurious small
+# positives.  We suppress those by also interpolating a binary occurrence field and zeroing out
+# the result when fewer than half of the surrounding stations recorded a positive value.
+# This applies to all accumulation-type parameters that can legitimately be zero
+# (i.e. "it didn't rain / snow at this timestep"), but NOT to continuous fields like accumulated
+# snow depth or evaporation that are rarely exactly zero and have a different physical character.
+_OCCURRENCE_BASED_PARAMETERS: frozenset[str] = frozenset(
+    p.name.lower()
+    for p in (
+        # precipitation height — all temporal variants
+        Parameter.PRECIPITATION_HEIGHT,
+        Parameter.PRECIPITATION_HEIGHT_DAY,
+        Parameter.PRECIPITATION_HEIGHT_NIGHT,
+        Parameter.PRECIPITATION_HEIGHT_LIQUID,
+        Parameter.PRECIPITATION_HEIGHT_DROPLET,
+        Parameter.PRECIPITATION_HEIGHT_ROCKER,
+        Parameter.PRECIPITATION_HEIGHT_LAST_1H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_3H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_6H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_9H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_12H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_15H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_18H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_21H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_24H,
+        Parameter.PRECIPITATION_HEIGHT_MULTIDAY,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_1H,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_3H,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_6H,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_12H,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_24H,
+        Parameter.PRECIPITATION_HEIGHT_LIQUID_SIGNIFICANT_WEATHER_LAST_1H,
+        Parameter.PRECIPITATION_HEIGHT_MAX,
+        Parameter.PRECIPITATION_HEIGHT_LIQUID_MAX,
+        # precipitation duration — zero when no precipitation occurred
+        Parameter.PRECIPITATION_DURATION,
+        # new snow per period — heterogeneous and zero-inflated like precipitation
+        Parameter.SNOW_DEPTH_NEW,
+        Parameter.SNOW_DEPTH_NEW_MULTIDAY,
+        Parameter.SNOW_DEPTH_NEW_MAX,
+        # new snow water equivalent — same zero-inflated character
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW,
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW_LAST_1H,
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW_LAST_3H,
+    )
+)
+
 
 def get_interpolated_df(request: TimeseriesRequest, latitude: float, longitude: float) -> pl.DataFrame:
     """Get the interpolated DataFrame for the given request and location."""
@@ -332,7 +380,7 @@ def apply_interpolation(
     distance_mean = sum(distances) / len(distances)
     f = LinearNDInterpolator(points=(xs, ys), values=list(vals.values()))
     value = f(utm_x, utm_y)
-    if parameter == Parameter.PRECIPITATION_HEIGHT.name.lower():
+    if parameter in _OCCURRENCE_BASED_PARAMETERS:
         f_index = LinearNDInterpolator(points=(xs, ys), values=[float(v > 0) for v in list(vals.values())])
         value_index = f_index(utm_x, utm_y)
         value = value if value_index >= 0.5 else 0

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -118,15 +118,161 @@ class TimeseriesRequest:
         "state",
     )
 
-    #   - heterogeneous parameters such as precipitation_height
-    #   - homogeneous parameters such as temperature_air_2m
+    #   - heterogeneous parameters such as precipitation_height (short distance, ~20 km)
+    #   - homogeneous parameters such as temperature_air_2m (large distance, ~40 km)
     interpolatable_parameters: ClassVar = [
+        # ---- temperature ----
+        # air temperature at 2 m — large spatial correlation, suitable for ~40 km interpolation
+        Parameter.TEMPERATURE_AIR_2M.name.lower(),
         Parameter.TEMPERATURE_AIR_MEAN_2M.name.lower(),
+        Parameter.TEMPERATURE_AIR_MEAN_2M_LAST_24H.name.lower(),
         Parameter.TEMPERATURE_AIR_MAX_2M.name.lower(),
+        Parameter.TEMPERATURE_AIR_MAX_2M_LAST_24H.name.lower(),
+        Parameter.TEMPERATURE_AIR_MAX_2M_MEAN.name.lower(),
+        Parameter.TEMPERATURE_AIR_MAX_2M_MULTIDAY.name.lower(),
         Parameter.TEMPERATURE_AIR_MIN_2M.name.lower(),
+        Parameter.TEMPERATURE_AIR_MIN_2M_LAST_24H.name.lower(),
+        Parameter.TEMPERATURE_AIR_MIN_2M_MEAN.name.lower(),
+        Parameter.TEMPERATURE_AIR_MIN_2M_MULTIDAY.name.lower(),
+        # air temperature at 0.05 m (near-surface)
+        Parameter.TEMPERATURE_AIR_MEAN_0_05M.name.lower(),
+        Parameter.TEMPERATURE_AIR_MAX_0_05M.name.lower(),
+        Parameter.TEMPERATURE_AIR_MIN_0_05M.name.lower(),
+        Parameter.TEMPERATURE_AIR_MIN_0_05M_LAST_12H.name.lower(),
+        # derived air temperature quantities
+        Parameter.TEMPERATURE_DEW_POINT_MEAN_2M.name.lower(),
+        Parameter.TEMPERATURE_WET_MEAN_2M.name.lower(),
+        Parameter.TEMPERATURE_WIND_CHILL.name.lower(),
+        # surface temperature
+        Parameter.TEMPERATURE_SURFACE_MEAN.name.lower(),
+        # soil temperature — depth-dependent but spatially smooth at regional scale
+        Parameter.TEMPERATURE_SOIL_MEAN_0_02M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MEAN_0_05M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MEAN_0_1M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MEAN_0_2M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MEAN_0_5M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MEAN_1M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MEAN_2M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MIN_0_1M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MIN_0_2M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MIN_0_5M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MIN_1M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MIN_2M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MAX_0_1M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MAX_0_2M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MAX_0_5M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MAX_1M.name.lower(),
+        Parameter.TEMPERATURE_SOIL_MAX_2M.name.lower(),
+        # derived temperature aggregates
+        Parameter.HEATING_DEGREE_DAY.name.lower(),
+        Parameter.COOLING_DEGREE_HOUR.name.lower(),
+        # ---- humidity ----
+        # all humidity variants are spatially smooth (~40 km)
         Parameter.HUMIDITY.name.lower(),
+        Parameter.HUMIDITY_ABSOLUTE.name.lower(),
+        Parameter.HUMIDITY_MAX.name.lower(),
+        Parameter.HUMIDITY_MIN.name.lower(),
+        Parameter.HUMIDEX.name.lower(),
+        # ---- wind ----
+        # wind speed variants — regional-scale field (~40 km)
         Parameter.WIND_SPEED.name.lower(),
+        Parameter.WIND_SPEED_ARITHMETIC.name.lower(),
+        Parameter.WIND_SPEED_MIN.name.lower(),
+        Parameter.WIND_SPEED_ROLLING_MEAN_MAX.name.lower(),
+        Parameter.WIND_FORCE_BEAUFORT.name.lower(),
+        Parameter.WIND_MOVEMENT_24H.name.lower(),
+        Parameter.WIND_MOVEMENT_MULTIDAY.name.lower(),
+        # wind gust variants — regional-scale (~40 km)
+        Parameter.WIND_GUST_MAX.name.lower(),
+        Parameter.WIND_GUST_MAX_LAST_1H.name.lower(),
+        Parameter.WIND_GUST_MAX_LAST_3H.name.lower(),
+        Parameter.WIND_GUST_MAX_LAST_6H.name.lower(),
+        Parameter.WIND_GUST_MAX_LAST_12H.name.lower(),
+        Parameter.WIND_GUST_MAX_5SEC.name.lower(),
+        Parameter.WIND_GUST_MAX_1MIN.name.lower(),
+        Parameter.WIND_GUST_MAX_2MIN.name.lower(),
+        Parameter.WIND_GUST_MAX_INSTANT.name.lower(),
+        Parameter.WIND_GUST_MAX_1MILE.name.lower(),
+        # ---- precipitation ----
+        # precipitation is heterogeneous — shorter spatial correlation length (~20 km)
         Parameter.PRECIPITATION_HEIGHT.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_DAY.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_NIGHT.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LIQUID.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_DROPLET.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_ROCKER.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_1H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_3H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_6H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_9H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_12H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_15H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_18H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_21H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LAST_24H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_MULTIDAY.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_1H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_3H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_6H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_12H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_24H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LIQUID_SIGNIFICANT_WEATHER_LAST_1H.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_MAX.name.lower(),
+        Parameter.PRECIPITATION_HEIGHT_LIQUID_MAX.name.lower(),
+        Parameter.PRECIPITATION_DURATION.name.lower(),
+        # ---- snow ----
+        # accumulated snow depth — smooth regional field (~40 km)
+        Parameter.SNOW_DEPTH.name.lower(),
+        Parameter.SNOW_DEPTH_EXCELLED.name.lower(),
+        Parameter.SNOW_DEPTH_MANUAL.name.lower(),
+        Parameter.SNOW_DEPTH_MAX.name.lower(),
+        # new snow per period — more heterogeneous like precipitation (~20 km)
+        Parameter.SNOW_DEPTH_NEW.name.lower(),
+        Parameter.SNOW_DEPTH_NEW_MULTIDAY.name.lower(),
+        Parameter.SNOW_DEPTH_NEW_MAX.name.lower(),
+        # ---- water equivalent ----
+        # accumulated SWE — smooth regional field (~40 km)
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH.name.lower(),
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_EXCELLED.name.lower(),
+        # new SWE — heterogeneous like precipitation (~20 km)
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW.name.lower(),
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW_LAST_1H.name.lower(),
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW_LAST_3H.name.lower(),
+        # ---- solar / radiation ----
+        # sunshine and radiation — driven by synoptic cloud patterns, large spatial correlation (~40 km)
+        Parameter.SUNSHINE_DURATION.name.lower(),
+        Parameter.SUNSHINE_DURATION_LAST_3H.name.lower(),
+        Parameter.SUNSHINE_DURATION_YESTERDAY.name.lower(),
+        Parameter.SUNSHINE_DURATION_RELATIVE.name.lower(),
+        Parameter.SUNSHINE_DURATION_RELATIVE_LAST_24H.name.lower(),
+        Parameter.RADIATION_GLOBAL.name.lower(),
+        Parameter.RADIATION_GLOBAL_LAST_3H.name.lower(),
+        Parameter.RADIATION_SKY_SHORT_WAVE_DIFFUSE.name.lower(),
+        Parameter.RADIATION_SKY_SHORT_WAVE_DIRECT.name.lower(),
+        Parameter.RADIATION_SKY_LONG_WAVE.name.lower(),
+        Parameter.RADIATION_SKY_LONG_WAVE_LAST_3H.name.lower(),
+        # ---- pressure ----
+        # pressure — synoptic-scale field, most spatially homogeneous of all met parameters (~40 km)
+        Parameter.PRESSURE_AIR_SEA_LEVEL.name.lower(),
+        Parameter.PRESSURE_AIR_SITE.name.lower(),
+        Parameter.PRESSURE_AIR_SITE_REDUCED.name.lower(),
+        Parameter.PRESSURE_AIR_SITE_MAX.name.lower(),
+        Parameter.PRESSURE_AIR_SITE_MIN.name.lower(),
+        Parameter.PRESSURE_AIR_SITE_DELTA_LAST_3H.name.lower(),
+        Parameter.PRESSURE_VAPOR.name.lower(),
+        # ---- cloud cover ----
+        # cloud cover — regional-scale field, viable for ~40 km interpolation
+        Parameter.CLOUD_COVER_TOTAL.name.lower(),
+        Parameter.CLOUD_COVER_TOTAL_MIDNIGHT_TO_MIDNIGHT.name.lower(),
+        Parameter.CLOUD_COVER_TOTAL_SUNRISE_TO_SUNSET.name.lower(),
+        Parameter.CLOUD_COVER_EFFECTIVE.name.lower(),
+        # ---- evapotranspiration ----
+        # driven by temperature, humidity, radiation — large spatial correlation (~40 km)
+        Parameter.EVAPOTRANSPIRATION_POTENTIAL_LAST_24H.name.lower(),
+        Parameter.EVAPOTRANSPIRATION_POTENTIAL_GRAS_FAO_LAST_24H.name.lower(),
+        Parameter.EVAPOTRANSPIRATION_POTENTIAL_GRAS_HAUDE_LAST_24H.name.lower(),
+        Parameter.EVAPORATION_HEIGHT.name.lower(),
+        Parameter.EVAPORATION_HEIGHT_MULTIDAY.name.lower(),
     ]
 
     @staticmethod

--- a/src/wetterdienst/settings.py
+++ b/src/wetterdienst/settings.py
@@ -25,7 +25,44 @@ _UNIT_CONVERTER_TARGETS = UnitConverter().targets.keys()
 
 def _default_geo_station_distance() -> defaultdict[str, float]:
     d: defaultdict[str, float] = defaultdict(lambda: 40.0)
-    d[Parameter.PRECIPITATION_HEIGHT.value.lower()] = 20.0
+    # heterogeneous parameters: shorter spatial correlation length, use 20 km
+    # precipitation — all variants are convectively driven and spatially variable
+    for p in (
+        Parameter.PRECIPITATION_HEIGHT,
+        Parameter.PRECIPITATION_HEIGHT_DAY,
+        Parameter.PRECIPITATION_HEIGHT_NIGHT,
+        Parameter.PRECIPITATION_HEIGHT_LIQUID,
+        Parameter.PRECIPITATION_HEIGHT_DROPLET,
+        Parameter.PRECIPITATION_HEIGHT_ROCKER,
+        Parameter.PRECIPITATION_HEIGHT_LAST_1H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_3H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_6H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_9H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_12H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_15H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_18H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_21H,
+        Parameter.PRECIPITATION_HEIGHT_LAST_24H,
+        Parameter.PRECIPITATION_HEIGHT_MULTIDAY,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_1H,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_3H,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_6H,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_12H,
+        Parameter.PRECIPITATION_HEIGHT_SIGNIFICANT_WEATHER_LAST_24H,
+        Parameter.PRECIPITATION_HEIGHT_LIQUID_SIGNIFICANT_WEATHER_LAST_1H,
+        Parameter.PRECIPITATION_HEIGHT_MAX,
+        Parameter.PRECIPITATION_HEIGHT_LIQUID_MAX,
+        Parameter.PRECIPITATION_DURATION,
+        # new snow per period — heterogeneous like precipitation
+        Parameter.SNOW_DEPTH_NEW,
+        Parameter.SNOW_DEPTH_NEW_MULTIDAY,
+        Parameter.SNOW_DEPTH_NEW_MAX,
+        # new SWE — heterogeneous like precipitation
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW,
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW_LAST_1H,
+        Parameter.WATER_EQUIVALENT_SNOW_DEPTH_NEW_LAST_3H,
+    ):
+        d[p.value.lower()] = 20.0
     return d
 
 

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -10,6 +10,11 @@ import pytest
 from polars.testing import assert_frame_equal
 
 from wetterdienst import Settings
+from wetterdienst.core.interpolate import (
+    _OCCURRENCE_BASED_PARAMETERS,
+    apply_interpolation,
+    get_valid_station_groups,
+)
 from wetterdienst.exceptions import StationNotFoundError
 from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
 from wetterdienst.provider.dwd.observation import (
@@ -19,6 +24,131 @@ from wetterdienst.provider.dwd.observation import (
 pytest.importorskip("shapely")
 
 pytestmark = pytest.mark.slow
+
+
+# ---------------------------------------------------------------------------
+# Shared geometry for occurrence-threshold unit tests
+# ---------------------------------------------------------------------------
+# Four stations forming a 20 km x 20 km square in UTM-like coordinates.
+# Station D (NW corner) is the only one that ever records a positive value.
+# The target point is placed in the SW quadrant (close to A/B, away from D)
+# so that it falls inside the Delaunay triangle whose nodes are ALL zero-value
+# stations → occurrence index < 0.5 → zeroing is triggered for the sparse case.
+# No network traffic is needed for these tests.
+_STATIONS_DICT: dict = {
+    "A": (490_000.0, 5_490_000.0, 14.14),  # SW corner
+    "B": (510_000.0, 5_490_000.0, 14.14),  # SE corner
+    "C": (510_000.0, 5_510_000.0, 14.14),  # NE corner
+    "D": (490_000.0, 5_510_000.0, 14.14),  # NW corner — positive station
+}
+# Off-centre target, inside the triangle formed by A-B-C (all zero-value):
+# occurrence index at this point ≈ 0.25 for the 1-of-4 case.
+_UTM_X = 495_000.0
+_UTM_Y = 5_495_000.0
+
+
+def test_occurrence_threshold_zeroes_sparse_precipitation() -> None:
+    """Interpolated precipitation must be zeroed when occurrence index < 0.5.
+
+    Fewer than half of surrounding stations recorded a positive value triggers zeroing.
+    """
+    valid_groups = get_valid_station_groups(_STATIONS_DICT, _UTM_X, _UTM_Y)
+    # Only 1 of 4 stations has precipitation → occurrence index ≈ 0.25 at centre
+    row = {"A": 0.0, "B": 0.0, "C": 0.0, "D": 5.0}
+    _, _, _, value, _, _ = apply_interpolation(
+        row,
+        _STATIONS_DICT,
+        valid_groups,
+        "daily",
+        "climate_summary",
+        "precipitation_height",
+        _UTM_X,
+        _UTM_Y,
+        [],
+    )
+    assert value == 0.0, "Expected zero when fewer than half of stations have precipitation"
+
+
+def test_occurrence_threshold_preserves_majority_precipitation() -> None:
+    """Interpolated precipitation must be kept when the majority of surrounding stations recorded a positive value.
+
+    Occurrence index >= 0.5 preserves the interpolated value.
+    """
+    valid_groups = get_valid_station_groups(_STATIONS_DICT, _UTM_X, _UTM_Y)
+    # 3 of 4 stations have precipitation → occurrence index ≈ 0.75 at centre
+    row = {"A": 5.0, "B": 5.0, "C": 5.0, "D": 0.0}
+    _, _, _, value, _, _ = apply_interpolation(
+        row,
+        _STATIONS_DICT,
+        valid_groups,
+        "daily",
+        "climate_summary",
+        "precipitation_height",
+        _UTM_X,
+        _UTM_Y,
+        [],
+    )
+    assert value is not None
+    assert value > 0.0, "Expected positive value when majority of stations have precipitation"
+
+
+def test_occurrence_threshold_not_applied_to_temperature() -> None:
+    """The occurrence threshold must NOT be applied to continuous parameters such as temperature.
+
+    A non-zero interpolated value must be preserved even when only one station has a positive reading.
+    """
+    valid_groups = get_valid_station_groups(_STATIONS_DICT, _UTM_X, _UTM_Y)
+    row = {"A": 0.0, "B": 0.0, "C": 0.0, "D": 5.0}
+    _, _, _, value, _, _ = apply_interpolation(
+        row,
+        _STATIONS_DICT,
+        valid_groups,
+        "daily",
+        "climate_summary",
+        "temperature_air_mean_2m",
+        _UTM_X,
+        _UTM_Y,
+        [],
+    )
+    assert value is not None
+    assert value > 0.0, "Temperature must not be zeroed by occurrence threshold"
+
+
+def test_occurrence_threshold_applies_to_snow_depth_new() -> None:
+    """The occurrence threshold must apply to snow_depth_new.
+
+    snow_depth_new shares the zero-inflated character of precipitation.
+    """
+    valid_groups = get_valid_station_groups(_STATIONS_DICT, _UTM_X, _UTM_Y)
+    row = {"A": 0.0, "B": 0.0, "C": 0.0, "D": 3.0}
+    _, _, _, value, _, _ = apply_interpolation(
+        row,
+        _STATIONS_DICT,
+        valid_groups,
+        "daily",
+        "climate_summary",
+        "snow_depth_new",
+        _UTM_X,
+        _UTM_Y,
+        [],
+    )
+    assert value == 0.0, "Expected zero for snow_depth_new when fewer than half of stations have new snow"
+
+
+def test_occurrence_based_parameters_set_contains_all_precipitation_variants() -> None:
+    """Smoke-test that _OCCURRENCE_BASED_PARAMETERS covers core precipitation and new-snow parameters."""
+    required = {
+        "precipitation_height",
+        "precipitation_height_liquid",
+        "precipitation_height_last_1h",
+        "precipitation_height_last_24h",
+        "precipitation_duration",
+        "snow_depth_new",
+        "water_equivalent_snow_depth_new",
+    }
+    assert required.issubset(_OCCURRENCE_BASED_PARAMETERS), (
+        f"Missing from _OCCURRENCE_BASED_PARAMETERS: {required - _OCCURRENCE_BASED_PARAMETERS}"
+    )
 
 
 @pytest.fixture
@@ -142,6 +272,39 @@ def test_interpolation_precipitation_height_minute_10(default_settings: Settings
         orient="row",
     )
     assert_frame_equal(given_df, expected_df)
+
+
+@pytest.mark.remote
+def test_interpolation_sunshine_duration_daily(default_settings: Settings) -> None:
+    """Test that sunshine_duration can be interpolated (issue #1651)."""
+    request = DwdObservationRequest(
+        parameters=[("daily", "climate_summary", "sunshine_duration")],
+        start_date=dt.datetime(2025, 2, 10, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(2025, 2, 20, tzinfo=ZoneInfo("UTC")),
+        settings=default_settings,
+    )
+    result = request.interpolate(latlon=(50.984768, 11.02988))
+    assert result.df.shape[0] > 0, "Expected interpolated sunshine_duration values but got none"
+    assert result.df.drop_nulls().shape[0] > 0
+
+
+@pytest.mark.remote
+def test_interpolation_snow_depth_new_daily(default_settings: Settings) -> None:
+    """Test that snow_depth_new can be interpolated and that the occurrence threshold is applied.
+
+    Result must never be negative or spuriously positive when surrounding stations had no new snow.
+    """
+    request = DwdObservationRequest(
+        parameters=[("daily", "climate_summary", "snow_depth_new")],
+        start_date=dt.datetime(2021, 2, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(2021, 2, 10, tzinfo=ZoneInfo("UTC")),
+        settings=default_settings,
+    )
+    result = request.interpolate(latlon=(50.0, 8.9))
+    assert result.df.shape[0] > 0, "Expected interpolated snow_depth_new values but got none"
+    # occurrence threshold must prevent negative or NaN values
+    values = result.df.drop_nulls().get_column("value")
+    assert (values >= 0).all(), "snow_depth_new interpolated values must be non-negative"
 
 
 def test_not_interpolatable_parameter(default_settings: Settings, df_interpolated_empty: pl.DataFrame) -> None:

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -279,11 +279,11 @@ def test_interpolation_sunshine_duration_daily(default_settings: Settings) -> No
     """Test that sunshine_duration can be interpolated (issue #1651)."""
     request = DwdObservationRequest(
         parameters=[("daily", "climate_summary", "sunshine_duration")],
-        start_date=dt.datetime(2025, 2, 10, tzinfo=ZoneInfo("UTC")),
-        end_date=dt.datetime(2025, 2, 20, tzinfo=ZoneInfo("UTC")),
+        start_date=dt.datetime(2021, 6, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(2021, 6, 10, tzinfo=ZoneInfo("UTC")),
         settings=default_settings,
     )
-    result = request.interpolate(latlon=(50.984768, 11.02988))
+    result = request.interpolate(latlon=(50.0, 8.9))
     assert result.df.shape[0] > 0, "Expected interpolated sunshine_duration values but got none"
     assert result.df.drop_nulls().shape[0] > 0
 
@@ -295,7 +295,7 @@ def test_interpolation_snow_depth_new_daily(default_settings: Settings) -> None:
     Result must never be negative or spuriously positive when surrounding stations had no new snow.
     """
     request = DwdObservationRequest(
-        parameters=[("daily", "climate_summary", "snow_depth_new")],
+        parameters=[("daily", "precipitation_more", "snow_depth_new")],
         start_date=dt.datetime(2021, 2, 1, tzinfo=ZoneInfo("UTC")),
         end_date=dt.datetime(2021, 2, 10, tzinfo=ZoneInfo("UTC")),
         settings=default_settings,

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -31,10 +31,9 @@ def test_default_settings(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.
     assert not default_settings.ts_skip_empty
     assert default_settings.ts_skip_threshold == 0.95
     assert default_settings.ts_drop_nulls
-    assert default_settings.ts_geo_station_distance == {
-        "precipitation_height": 20.0,
-    }
-    # default dict returns 40.0 for any other key
+    # specific heterogeneous parameters use 20 km; the defaultdict fallback returns 40 km
+    assert default_settings.ts_geo_station_distance["precipitation_height"] == 20.0
+    assert default_settings.ts_geo_station_distance["snow_depth_new"] == 20.0
     assert default_settings.ts_geo_station_distance["foo"] == 40.0
     assert default_settings.ts_geo_use_nearby_station_distance == 1
     assert not default_settings.use_certifi
@@ -67,10 +66,10 @@ def test_settings_envs(caplog: pytest.LogCaptureFixture) -> None:
     )
     assert caplog.messages[2] == "Wetterdienst cache is disabled"
     assert settings.ts_shape == "wide"
-    assert settings.ts_geo_station_distance == {
-        "precipitation_height": 40.0,
-        "other": 42.0,
-    }
+    # user-supplied overrides are respected; other defaults remain; fallback returns 40 km
+    assert settings.ts_geo_station_distance["precipitation_height"] == 40.0
+    assert settings.ts_geo_station_distance["other"] == 42.0
+    assert settings.ts_geo_station_distance["snow_depth_new"] == 20.0
     # default dict returns 40.0 for any other key
     assert settings.ts_geo_station_distance["foo"] == 40.0
 
@@ -100,11 +99,11 @@ def test_settings_mixed(caplog: pytest.LogCaptureFixture) -> None:
     assert settings.ts_shape  # default variable
     assert settings.ts_skip_threshold == 0.81  # argument variable overrules env variable
     assert not settings.ts_convert_units  # argument variable
-    assert settings.ts_geo_station_distance == {
-        "precipitation_height": 40.0,
-        "other": 42.0,
-        "just_another": 43.0,
-    }
+    # user-supplied overrides win; other pre-populated defaults remain; fallback returns 40 km
+    assert settings.ts_geo_station_distance["precipitation_height"] == 40.0
+    assert settings.ts_geo_station_distance["other"] == 42.0
+    assert settings.ts_geo_station_distance["just_another"] == 43.0
+    assert settings.ts_geo_station_distance["snow_depth_new"] == 20.0
     # default dict returns 40.0 for any other key
     assert settings.ts_geo_station_distance["foo"] == 40.0
 

--- a/uv.lock
+++ b/uv.lock
@@ -6328,7 +6328,7 @@ dependencies = [
 
 [package.optional-dependencies]
 bufr = [
-    { name = "pdbufr", marker = "python_full_version < '3.14'" },
+    { name = "pdbufr" },
     { name = "pybufrkit" },
 ]
 cratedb = [
@@ -6340,7 +6340,7 @@ duckdb = [
     { name = "pandas" },
 ]
 eccodes = [
-    { name = "eccodes", marker = "python_full_version < '3.14'" },
+    { name = "eccodes" },
 ]
 excel = [
     { name = "xlsxwriter" },
@@ -6443,7 +6443,7 @@ requires-dist = [
     { name = "diskcache", specifier = ">=5.6.3,<6" },
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9,<2" },
     { name = "duckdb", marker = "extra == 'sql'", specifier = ">=0.9,<2" },
-    { name = "eccodes", marker = "python_full_version < '3.14' and extra == 'eccodes'", specifier = ">=1.5.2,<3" },
+    { name = "eccodes", marker = "extra == 'eccodes'", specifier = ">=1.5.2,<3" },
     { name = "fastapi", marker = "extra == 'restapi'", specifier = ">=0.95.1,<1" },
     { name = "fsspec", extras = ["http"], specifier = ">=2023.1" },
     { name = "h5netcdf", marker = "extra == 'radar'", specifier = ">=1.7.3" },
@@ -6460,7 +6460,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'duckdb'", specifier = ">=2,<3" },
     { name = "pandas", marker = "extra == 'export'", specifier = ">=2,<3" },
     { name = "pandas", marker = "extra == 'mysql'", specifier = ">=2,<3" },
-    { name = "pdbufr", marker = "python_full_version < '3.14' and extra == 'bufr'", specifier = ">=0.10.2,<1" },
+    { name = "pdbufr", marker = "extra == 'bufr'", specifier = ">=0.10.2,<1" },
     { name = "platformdirs", specifier = ">=4,<5" },
     { name = "plotly", marker = "extra == 'plotting'", specifier = ">=5.24.1" },
     { name = "polars", extras = ["calamine"], specifier = ">=1.15.0,<2" },


### PR DESCRIPTION
…shold zeroing

- Expand interpolatable_parameters in TimeseriesRequest from 6 → ~130 parameters across temperature, humidity, wind, radiation, pressure, cloud cover, evapotranspiration, precipitation, snow and water- equivalent categories. Fixes #1651 (sunshine_duration silently dropped).
- Add _OCCURRENCE_BASED_PARAMETERS frozenset covering all precipitation- height variants, precipitation_duration, snow_depth_new variants and water_equivalent_snow_depth_new variants; replace the single hard-coded PRECIPITATION_HEIGHT guard with a membership test against that set.
- _default_geo_station_distance now returns 20 km for all zero-inflated accumulation parameters and keeps 40 km for continuous fields.
- Add two @pytest.mark.remote integration tests (sunshine_duration, snow_depth_new) and five fast unit tests for the occurrence-threshold logic, including geometry fix (target off-centre into zero-value quadrant to achieve occurrence index ≈ 0.25, not 0.5).
- Update docs/usage/python-api.md with full grouped parameter list.