### PR TITLE
fix(network): respect Settings.use_certifi for fsspec HTTP clients (fixes #1669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- Propagate `Settings.use_certifi` through `NetworkFilesystemManager.get` and the
+  download helpers (`download_file`, `download_files`, `list_remote_files_fsspec`) so
+  that fsspec's HTTP clients use the certifi certificate bundle when requested. This
+  ensures provider code using these helpers respects the global `use_certifi` setting.
+  Fixes #1669.
+  Thanks to @KonstantinWaser for reporting the issue.
+
+
 ## [0.121.0] - 2026-05-09
 
 ### Added

--- a/src/wetterdienst/provider/dwd/mosmix/access.py
+++ b/src/wetterdienst/provider/dwd/mosmix/access.py
@@ -64,6 +64,7 @@ class KMLReader:
             cache_expiry=CacheExpiry.FIVE_MINUTES,
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
         )
 
     def download(self, url: str) -> BytesIO:

--- a/src/wetterdienst/provider/imgw/meteorology/api.py
+++ b/src/wetterdienst/provider/imgw/meteorology/api.py
@@ -566,6 +566,7 @@ class ImgwMeteorologyValues(TimeseriesValues):
             ttl=CacheExpiry.FIVE_MINUTES,
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
         )
         files = [file for file in files if isinstance(file.content, BytesIO)]
         data = []

--- a/src/wetterdienst/provider/noaa/ghcn/api.py
+++ b/src/wetterdienst/provider/noaa/ghcn/api.py
@@ -54,6 +54,7 @@ class NoaaGhcnValues(TimeseriesValues):
             ttl=CacheExpiry.FIVE_MINUTES,
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):
@@ -111,6 +112,7 @@ class NoaaGhcnValues(TimeseriesValues):
             ttl=CacheExpiry.FIVE_MINUTES,
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):

--- a/src/wetterdienst/provider/nws/observation/api.py
+++ b/src/wetterdienst/provider/nws/observation/api.py
@@ -163,6 +163,7 @@ class NwsObservationValues(TimeseriesValues):
             ttl=CacheExpiry.FIVE_MINUTES,
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
         )
         file.raise_if_exception()
         if isinstance(file.content, Exception):

--- a/src/wetterdienst/provider/wsv/pegel/api.py
+++ b/src/wetterdienst/provider/wsv/pegel/api.py
@@ -215,6 +215,7 @@ class WsvPegelValues(TimeseriesValues):
             ttl=CacheExpiry.NO_CACHE,
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
         )
         if file.is_no_internet_error:
             return pl.DataFrame()


### PR DESCRIPTION
Propagate Settings.use_certifi into NetworkFilesystemManager and the download helpers
(download_file, download_files, list_remote_files_fsspec) and update provider call-sites to
forward the setting. 

Thanks @KonstantinWaser.