### PR TITLE
feat(api): add available_issues endpoint and fix issue/lead_time forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ Types of changes:
 
 ## [Unreleased]
 
+### Added
+
+- `[DWD MOSMIX / DMO]` Add `available_issues(station_id, settings)` classmethod to
+  `DwdMosmixRequest` and `DwdDmoRequest` that lists the model-run datetimes currently
+  available on DWD's OpenData server for a given station (MOSMIX_L single-station KMZ
+  files and ICON single-station KMZ files respectively).
+- `[CLI]` Add `wetterdienst issues --provider <p> --network <n> --station <id>` command
+  that prints available issue datetimes as a JSON array.
+- `[REST API]` Add `GET /api/issues?provider=<p>&network=<n>&station=<id>` endpoint
+  returning `{"issues": ["<UTC ISO datetime>", ...]}`. Currently supported:
+  `provider=dwd, network=mosmix` and `provider=dwd, network=dmo`.
+
 ### Fixed
 
 - `[DWD MOSMIX / DMO]` Fix `issue` (and DMO `lead_time`) parameters being silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[DWD MOSMIX / DMO]` Fix `issue` (and DMO `lead_time`) parameters being silently
+  ignored when calling the REST API or `_get_stations_request` directly. The guard used
+  `isinstance(api, DwdMosmixRequest)` where `api` is the *class* itself (not an instance),
+  so the condition was always `False` and `DwdForecastDate.LATEST` was used regardless of
+  the caller's intent. Changed to `issubclass` and added a `None`-guard so that omitting
+  `issue` still falls through to the dataclass default (`DwdForecastDate.LATEST`).
+
 ## [0.123.0] - 2026-06-18
 
 ### Fixed

--- a/docs/usage/restapi.md
+++ b/docs/usage/restapi.md
@@ -60,6 +60,16 @@ http localhost:7890/api/stations provider==dwd network==observation parameters==
 http localhost:7890/api/stations provider==dwd network==dmo parameters==hourly/icon/temperature_air_mean_2m periods==recent all==true
 ```
 
+### Issues (available model-run datetimes)
+
+```bash
+# List available MOSMIX-L run datetimes for a station.
+http localhost:7890/api/issues provider==dwd network==mosmix station==10147
+
+# List available DMO ICON run datetimes for a station.
+http localhost:7890/api/issues provider==dwd network==dmo station==10147
+```
+
 ### Values
 
 ```bash

--- a/src/wetterdienst/provider/dwd/dmo/api.py
+++ b/src/wetterdienst/provider/dwd/dmo/api.py
@@ -274,6 +274,25 @@ class DwdDmoRequest(TimeseriesRequest):
             return adjusted_date.replace(hour=12)
         return adjusted_date
 
+    @classmethod
+    def available_issues(cls, station_id: str, settings: Settings) -> list[dt.datetime]:
+        """Return datetimes for which DMO ICON single-station files exist on DWD's server.
+
+        Run start times are deduplicated across lead times (078/168) and sorted in ascending UTC order.
+        """
+        url = urljoin("https://opendata.dwd.de", f"weather/local_forecasts/dmo/icon/single_stations/{station_id}/kmz/")
+        urls = list_remote_files_fsspec(url, settings, CacheExpiry.NO_CACHE)
+        df = pl.DataFrame({"url": urls}, orient="col")
+        df = df.with_columns(
+            pl.col("url").str.split("/").list.last().str.split("_").list.last().alias("date_str"),
+        )
+        df = df.with_columns(
+            pl.col("date_str").str.slice(offset=0, length=pl.col("date_str").str.len_chars() - 4),
+        )
+        now_utc = dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None)
+        df = add_date_from_filename(df, now_utc)
+        return df.get_column("date").dt.replace_time_zone("UTC").unique().sort().to_list()
+
     def __post_init__(self) -> None:
         """Post-initialize the DwdDmoRequest class."""
         super().__post_init__()

--- a/src/wetterdienst/provider/dwd/mosmix/api.py
+++ b/src/wetterdienst/provider/dwd/mosmix/api.py
@@ -222,6 +222,25 @@ class DwdMosmixRequest(TimeseriesRequest):
         "state",
     ]
 
+    @classmethod
+    def available_issues(cls, station_id: str, settings: Settings) -> list[dt.datetime]:
+        """Return datetimes for which MOSMIX L single-station files exist on DWD's server.
+
+        The list is sorted in ascending order and contains only unique UTC datetimes.
+        Only MOSMIX_L single-station files are considered; the LATEST symlink is excluded.
+        """
+        url = urljoin("https://opendata.dwd.de", DWD_MOSMIX_L_SINGLE_PATH.format(station_id=station_id))
+        urls = list_remote_files_fsspec(url, settings, CacheExpiry.NO_CACHE)
+        df = pl.DataFrame({"url": urls}, orient="col")
+        df = df.with_columns(
+            pl.col("url").str.split("/").list.last().str.split("_").list.get(2).alias("date"),
+        )
+        df = df.filter(pl.col("date").ne("LATEST"))
+        df = df.with_columns(
+            pl.concat_str([pl.col("date"), pl.lit("00")]).str.to_datetime("%Y%m%d%H%M").dt.replace_time_zone("UTC"),
+        )
+        return df.get_column("date").unique().sort().to_list()
+
     def __post_init__(self) -> None:
         """Post-initialization of the DwdMosmixRequest class."""
         super().__post_init__()

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -22,12 +22,14 @@ from wetterdienst.exceptions import ApiNotFoundError
 from wetterdienst.ui.core import (
     HistoryRequest,
     InterpolationRequest,
+    IssuesRequest,
     StationsRequest,
     SummaryRequest,
     ValuesRequest,
     _get_stripes_stations,
     _plot_stripes,
     get_interpolate,
+    get_issues,
     get_stations,
     get_summarize,
     get_values,
@@ -274,6 +276,10 @@ Data acquisition:
 
         # Export options
         [--target=<target>]
+
+Available model-run datetimes:
+
+    wetterdienst issues --provider=<provider> --network=<network> --station=<station>
 
 Data computation:
 
@@ -908,6 +914,33 @@ def stations(
     print(output)  # noqa: T201
 
     return
+
+
+@cli.command("issues", section=data_section)
+@provider_opt
+@network_opt
+@cloup.option("--station", type=click.STRING, required=True, help="Station ID to list available issue datetimes for.")
+@debug_opt
+def issues_cmd(provider: str, network: str, station: str, debug: bool) -> None:  # noqa: FBT001
+    """List available issue (model-run) datetimes for a station.
+
+    Currently supported: --provider dwd --network mosmix|dmo
+    """
+    set_logging_level(debug=debug)
+
+    api = get_api(provider=provider, network=network)
+    request = IssuesRequest.model_validate({"provider": provider, "network": network, "station": station})
+
+    try:
+        issue_list = get_issues(api=api, request=request, settings=Settings())
+    except NotImplementedError:
+        log.exception("Issues not available for the given request.")
+        sys.exit(1)
+    except Exception:
+        log.exception("Failed to get issues.")
+        sys.exit(1)
+
+    print(json.dumps({"issues": issue_list}, indent=2))  # noqa: T201
 
 
 # History command

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -556,11 +556,10 @@ def _get_stations_request(
     if any_multiple_period_dataset:
         kwargs["periods"] = getattr(request, "periods", None)
 
-    if isinstance(api, DwdMosmixRequest):
-        kwargs["issue"] = getattr(request, "issue", None)
-    elif isinstance(api, DwdDmoRequest):
-        kwargs["issue"] = getattr(request, "issue", None)
-        kwargs["lead_time"] = getattr(request, "lead_time", None)
+    if issubclass(api, (DwdMosmixRequest, DwdDmoRequest)) and (issue := getattr(request, "issue", None)) is not None:
+        kwargs["issue"] = issue
+    if issubclass(api, DwdDmoRequest) and (lead_time := getattr(request, "lead_time", None)) is not None:
+        kwargs["lead_time"] = lead_time
 
     return api(**kwargs, settings=settings)
 

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -516,6 +516,40 @@ class SummaryRequest(BaseModel):
     scale: Annotated[float, Field(gt=0)] | None = None
 
 
+class IssuesRequest(BaseModel):
+    """Request model for listing available issue datetimes."""
+
+    model_config = {"extra": "forbid"}
+
+    provider: str
+    network: str
+    station: str
+    debug: bool = False
+
+
+def get_issues(
+    api: type[TimeseriesRequest],
+    request: IssuesRequest,
+    settings: Settings,
+) -> list[str]:
+    """Return available issue datetimes as UTC ISO strings for provider/network/station.
+
+    Supported: DWD MOSMIX (MOSMIX_L single-station) and DWD DMO (ICON single-station).
+    """
+    from wetterdienst.provider.dwd.dmo import DwdDmoRequest  # noqa: PLC0415
+    from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest  # noqa: PLC0415
+
+    if issubclass(api, DwdMosmixRequest):
+        issues = DwdMosmixRequest.available_issues(request.station, settings)
+    elif issubclass(api, DwdDmoRequest):
+        issues = DwdDmoRequest.available_issues(request.station, settings)
+    else:
+        msg = f"Issue listing is only supported for DWD MOSMIX and DMO (got {api.__name__})"
+        raise NotImplementedError(msg)
+
+    return [issue.isoformat() for issue in issues]
+
+
 def _get_stations_request(
     api: type[TimeseriesRequest],
     request: StationsRequest | ValuesRequest | InterpolationRequest | SummaryRequest | HistoryRequest,

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -27,6 +27,7 @@ from wetterdienst.model.result import (
 from wetterdienst.ui.core import (
     HistoryRequest,
     InterpolationRequest,
+    IssuesRequest,
     StationsRequest,
     SummaryRequest,
     ValuesRequest,
@@ -34,6 +35,7 @@ from wetterdienst.ui.core import (
     _get_stripes_stations,
     _plot_stripes,
     get_interpolate,
+    get_issues,
     get_stations,
     get_summarize,
     get_values,
@@ -58,6 +60,8 @@ REQUEST_EXAMPLES = {
     "dwd_observation_daily_climate_stripes_stations": "api/stripes/stations?kind=temperature",
     "dwd_observation_daily_climate_stripes_values": "api/stripes/values?kind=temperature&station=1048",
     "dwd_observation_daily_climate_stripes_image": "api/stripes/image?kind=temperature&station=1048",
+    "dwd_mosmix_issues": "api/issues?provider=dwd&network=mosmix&station=10147",
+    "dwd_dmo_issues": "api/issues?provider=dwd&network=dmo&station=10147",
 }
 
 
@@ -325,6 +329,34 @@ def stations(
         media_type = "application/json"
 
     return Response(content=content, media_type=media_type)
+
+
+@app.get("/api/issues")
+def issues(
+    request: Annotated[IssuesRequest, Query()],
+) -> JSONResponse:
+    """Return available issue datetimes for a provider/network/station combination.
+
+    Currently supported: provider=dwd, network=mosmix|dmo.
+    """
+    set_logging_level(debug=request.debug)
+
+    try:
+        api = Wetterdienst(request.provider, request.network)
+    except ApiNotFoundError as e:
+        msg = f"{e} Use {app.url_path_for('coverage')} to discover available providers and networks."
+        log.exception(msg)
+        raise HTTPException(status_code=404, detail=msg) from e
+
+    try:
+        issue_list = get_issues(api=api, request=request, settings=Settings())
+    except NotImplementedError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        log.exception("Failed to get issues.")
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return JSONResponse(content={"issues": issue_list})
 
 
 # response models for the different formats are

--- a/tests/provider/dwd/dmo/test_api.py
+++ b/tests/provider/dwd/dmo/test_api.py
@@ -128,3 +128,13 @@ def test_add_date_from_filename_early_in_year(df_files_january: pl.DataFrame) ->
         dt.datetime(2020, 12, 31, 0, 0, 0, tzinfo=ZoneInfo("UTC")),
         dt.datetime(2020, 12, 31, 12, 0, 0, tzinfo=ZoneInfo("UTC")),
     ]
+
+
+@pytest.mark.remote
+def test_dwd_dmo_available_issues(default_settings: Settings) -> None:
+    """Verify available_issues returns a non-empty sorted list of UTC datetimes."""
+    issues = DwdDmoRequest.available_issues("10147", default_settings)
+    assert len(issues) > 0
+    assert all(isinstance(i, dt.datetime) for i in issues)
+    assert all(i.tzinfo is not None for i in issues)
+    assert issues == sorted(issues)

--- a/tests/provider/dwd/mosmix/test_api_stations.py
+++ b/tests/provider/dwd/mosmix/test_api_stations.py
@@ -9,6 +9,8 @@ and not in "Decimal Degrees".
 Source: https://www.dwd.de/EN/ourservices/met_application_mosmix/mosmix_stations.cfg?view=nasPublication&nn=495490
 """
 
+import datetime as dt
+
 import polars as pl
 import pytest
 from dirty_equals import IsInt, IsTuple
@@ -174,3 +176,13 @@ def test_dwd_mosmix_stations_filtered(default_settings: Settings, mosmix_station
         orient="row",
     )
     assert_frame_equal(given_df, expected_df)
+
+
+@pytest.mark.remote
+def test_dwd_mosmix_available_issues(default_settings: Settings) -> None:
+    """Verify available_issues returns a non-empty sorted list of UTC datetimes."""
+    issues = DwdMosmixRequest.available_issues("10147", default_settings)
+    assert len(issues) > 0
+    assert all(isinstance(i, dt.datetime) for i in issues)
+    assert all(i.tzinfo is not None for i in issues)
+    assert issues == sorted(issues)

--- a/tests/ui/cli/test_cli.py
+++ b/tests/ui/cli/test_cli.py
@@ -30,6 +30,7 @@ def test_cli_help() -> None:
         Data:
           about        Get information about the data.
           stations     Acquire stations.
+          issues       List available issue (model-run) datetimes for a station.
           history      Acquire station history.
           values       Acquire data.
           interpolate  Interpolate data.
@@ -132,3 +133,38 @@ def test_cli_radar_stations_dwd() -> None:
     response = json.loads(result.output)
     assert isinstance(response, list)
     assert len(response) == 20
+
+
+@pytest.mark.remote
+def test_issues_dwd_mosmix() -> None:
+    """Test issues command for DWD MOSMIX returns sorted UTC ISO datetimes."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issues", "--provider=dwd", "--network=mosmix", "--station=10147"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "issues" in data
+    issues = data["issues"]
+    assert len(issues) > 0
+    assert issues == sorted(issues)
+    assert all(issue.endswith("+00:00") for issue in issues)
+
+
+@pytest.mark.remote
+def test_issues_dwd_dmo() -> None:
+    """Test issues command for DWD DMO returns sorted UTC ISO datetimes."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issues", "--provider=dwd", "--network=dmo", "--station=10147"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "issues" in data
+    issues = data["issues"]
+    assert len(issues) > 0
+    assert issues == sorted(issues)
+    assert all(issue.endswith("+00:00") for issue in issues)
+
+
+def test_issues_unsupported_provider() -> None:
+    """Test issues command exits with error for unsupported providers."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issues", "--provider=dwd", "--network=observation", "--station=00011"])
+    assert result.exit_code == 1

--- a/tests/ui/cli/test_cli_values.py
+++ b/tests/ui/cli/test_cli_values.py
@@ -51,7 +51,7 @@ SETTINGS_VALUES = (
         [
             "--parameters=hourly/icon",
             "--lead_time=long",
-            f"--date={dt.datetime.strftime(dt.datetime.now(ZoneInfo('UTC')) + dt.timedelta(days=3), '%Y-%m-%d')}",
+            f"--date={dt.datetime.strftime(dt.datetime.now(ZoneInfo('UTC')) + dt.timedelta(days=5), '%Y-%m-%d')}",
         ],
         "10488",
         "DRESDEN",

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -962,6 +962,59 @@ def test_stations_missing_null(client: TestClient) -> None:
     }
 
 
+def test_get_stations_request_mosmix_issue_is_forwarded() -> None:
+    """_get_stations_request must pass the `issue` kwarg to DwdMosmixRequest.
+
+    Previously, isinstance(api, DwdMosmixRequest) was used where `api` is the
+    *class* itself (not an instance), so the condition was always False and
+    `issue` was silently dropped — DwdMosmixRequest always fell back to
+    DwdForecastDate.LATEST regardless of what the caller sent.
+    """
+    import datetime as dt  # noqa: PLC0415
+
+    from wetterdienst import Wetterdienst  # noqa: PLC0415
+    from wetterdienst.provider.dwd.mosmix.api import DwdForecastDate  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+    from wetterdienst.ui.core import ValuesRequest, _get_stations_request  # noqa: PLC0415
+
+    api = Wetterdienst("dwd", "mosmix")
+    settings = Settings()
+    request = ValuesRequest(
+        provider="dwd",
+        network="mosmix",
+        parameters=["hourly/large/ttt"],
+        station=["10147"],
+        issue="2026-06-27T09:00:00",
+    )
+    stations_request = _get_stations_request(api=api, request=request, date=None, settings=settings)
+
+    # issue must be resolved to the specific datetime, not LATEST
+    issue = getattr(stations_request, "issue")
+    assert issue is not DwdForecastDate.LATEST
+    assert isinstance(issue, dt.datetime)
+    assert issue == dt.datetime(2026, 6, 27, 9, 0, 0)
+
+
+def test_get_stations_request_mosmix_no_issue_defaults_to_latest() -> None:
+    """When no issue is supplied the request must default to DwdForecastDate.LATEST."""
+    from wetterdienst import Wetterdienst  # noqa: PLC0415
+    from wetterdienst.provider.dwd.mosmix.api import DwdForecastDate  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+    from wetterdienst.ui.core import ValuesRequest, _get_stations_request  # noqa: PLC0415
+
+    api = Wetterdienst("dwd", "mosmix")
+    settings = Settings()
+    request = ValuesRequest(
+        provider="dwd",
+        network="mosmix",
+        parameters=["hourly/large/ttt"],
+        station=["10147"],
+    )
+    stations_request = _get_stations_request(api=api, request=request, date=None, settings=settings)
+
+    assert getattr(stations_request, "issue") is DwdForecastDate.LATEST
+
+
 @pytest.mark.remote
 def test_values_dwd_mosmix(client: TestClient) -> None:
     """Test MOSMIX."""

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -989,10 +989,10 @@ def test_get_stations_request_mosmix_issue_is_forwarded() -> None:
     stations_request = _get_stations_request(api=api, request=request, date=None, settings=settings)
 
     # issue must be resolved to the specific datetime, not LATEST
-    issue = getattr(stations_request, "issue")
+    issue = stations_request.issue
     assert issue is not DwdForecastDate.LATEST
     assert isinstance(issue, dt.datetime)
-    assert issue == dt.datetime(2026, 6, 27, 9, 0, 0)
+    assert issue == dt.datetime(2026, 6, 27, 9, 0, 0)  # noqa: DTZ001
 
 
 def test_get_stations_request_mosmix_no_issue_defaults_to_latest() -> None:
@@ -1012,7 +1012,7 @@ def test_get_stations_request_mosmix_no_issue_defaults_to_latest() -> None:
     )
     stations_request = _get_stations_request(api=api, request=request, date=None, settings=settings)
 
-    assert getattr(stations_request, "issue") is DwdForecastDate.LATEST
+    assert stations_request.issue is DwdForecastDate.LATEST
 
 
 @pytest.mark.remote
@@ -1533,3 +1533,54 @@ def test_history_dwd_observation(client: TestClient) -> None:
         "station_id": "02564",
         "station_name": "Kiel-Holtenau",
     }
+
+
+@pytest.mark.remote
+def test_issues_dwd_mosmix(client: TestClient) -> None:
+    """Test /api/issues for DWD MOSMIX returns a non-empty sorted list of UTC ISO datetimes."""
+    response = client.get(
+        "/api/issues",
+        params={"provider": "dwd", "network": "mosmix", "station": "10147"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "issues" in data
+    issues = data["issues"]
+    assert len(issues) > 0
+    assert issues == sorted(issues)
+    assert all(issue.endswith("+00:00") for issue in issues)
+
+
+@pytest.mark.remote
+def test_issues_dwd_dmo(client: TestClient) -> None:
+    """Test /api/issues for DWD DMO returns a non-empty sorted list of UTC ISO datetimes."""
+    response = client.get(
+        "/api/issues",
+        params={"provider": "dwd", "network": "dmo", "station": "10147"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "issues" in data
+    issues = data["issues"]
+    assert len(issues) > 0
+    assert issues == sorted(issues)
+    assert all(issue.endswith("+00:00") for issue in issues)
+
+
+def test_issues_unsupported_provider(client: TestClient) -> None:
+    """Test /api/issues returns 400 for providers that don't support issue listing."""
+    response = client.get(
+        "/api/issues",
+        params={"provider": "dwd", "network": "observation", "station": "00011"},
+    )
+    assert response.status_code == 400
+    assert "supported" in response.json()["detail"].lower()
+
+
+def test_issues_unknown_provider(client: TestClient) -> None:
+    """Test /api/issues returns 404 for unknown provider/network combinations."""
+    response = client.get(
+        "/api/issues",
+        params={"provider": "unknown", "network": "unknown", "station": "00011"},
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Add `available_issues(station_id, settings)` classmethod to `DwdMosmixRequest` and `DwdDmoRequest` listing model-run datetimes available on DWD's OpenData server for a given station
- Add `wetterdienst issues --provider <p> --network <n> --station <id>` CLI command
- Add `GET /api/issues?provider=<p>&network=<n>&station=<id>` REST endpoint returning `{"issues": ["<UTC ISO datetime>", ...]}`; supported: `dwd/mosmix` and `dwd/dmo`
- Fix `issue` and `lead_time` parameters being silently ignored in the REST API — guard was using `isinstance` on the class itself instead of `issubclass`

## Test plan

- [ ] `wetterdienst issues --provider dwd --network mosmix --station 10382` returns a JSON array of ISO datetimes
- [ ] `GET /api/issues?provider=dwd&network=mosmix&station=10382` returns `{"issues": [...]}`
- [ ] `GET /api/values?provider=dwd&network=mosmix&...&issue=<specific>` now correctly uses the specified run instead of always defaulting to LATEST

🤖 Generated with [Claude Code](https://claude.com/claude-code)