### PR TITLE
feat(settings): load .env and support nested env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Types of changes:
 
 ## [Unreleased]
 
+### Added
+
+- `[Settings]` Load `.env` files automatically via `env_file=".env"` and support nested
+  env vars via `env_nested_delimiter="__"` (e.g. `WD_TS_UNIT_TARGETS__temperature=degree_fahrenheit`).
+
 ## [0.124.0] - 2026-06-30
 
 ### Added

--- a/src/wetterdienst/settings.py
+++ b/src/wetterdienst/settings.py
@@ -69,7 +69,12 @@ def _default_geo_station_distance() -> defaultdict[str, float]:
 class Settings(BaseSettings):
     """Settings for the wetterdienst package."""
 
-    model_config = SettingsConfigDict(env_ignore_empty=True, env_prefix="WD_")
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_ignore_empty=True,
+        env_prefix="WD_",
+        env_nested_delimiter="__",
+    )
 
     cache_disable: bool = Field(default=False)
     cache_dir: Path = Field(default_factory=lambda: Path(platformdirs.user_cache_dir(appname="wetterdienst")))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import re
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -106,6 +107,30 @@ def test_settings_mixed(caplog: pytest.LogCaptureFixture) -> None:
     assert settings.ts_geo_station_distance["snow_depth_new"] == 20.0
     # default dict returns 40.0 for any other key
     assert settings.ts_geo_station_distance["foo"] == 40.0
+
+
+def test_settings_env_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that Settings loads values from a .env file in the working directory."""
+    monkeypatch.delenv("WD_CACHE_DISABLE", raising=False)
+    (tmp_path / ".env").write_text("WD_CACHE_DISABLE=true\n")
+    monkeypatch.chdir(tmp_path)
+    settings = Settings()
+    assert settings.cache_disable
+
+
+def test_settings_env_file_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that Settings loads without error when no .env file exists."""
+    monkeypatch.delenv("WD_CACHE_DISABLE", raising=False)
+    monkeypatch.chdir(tmp_path)
+    settings = Settings()
+    assert not settings.cache_disable
+
+
+def test_settings_env_nested_delimiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that WD_ env vars with __ delimiter set individual keys in dict fields."""
+    monkeypatch.setenv("WD_TS_UNIT_TARGETS__temperature", "degree_fahrenheit")
+    settings = Settings()
+    assert settings.ts_unit_targets["temperature"] == "degree_fahrenheit"
 
 
 def test_use_certifi_setting() -> None:


### PR DESCRIPTION
## Summary

- Add `env_file=".env"` to `Settings.model_config` so a local `.env` file is picked up automatically
- Add `env_nested_delimiter="__"` to support nested model fields via environment variables (e.g. `WD_AUTH__METNO_FROST=<client_id>`)

This lays the groundwork for the upcoming MET Norway Frost provider which requires an API key set via `WD_AUTH__METNO_FROST`.

## Test plan

- [ ] `Settings()` loads without error when no `.env` file is present
- [ ] Create a `.env` with `WD_CACHE_DISABLE=true` — confirm `Settings().cache_disable` is `True`
- [ ] Create a `.env` with a nested key — confirm it is read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)