### PR TITLE
feat(api): credential-aware provider filtering (auth/configured/valid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ Types of changes:
 
 - `[Settings]` Load `.env` files automatically via `env_file=".env"` and support nested
   env vars via `env_nested_delimiter="__"` (e.g. `WD_TS_UNIT_TARGETS__temperature=degree_fahrenheit`).
+- `[Metadata]` Add `auth: bool = False` field to `MetadataModel` so providers requiring
+  an API key can declare it. Defaults to `False` for all existing providers.
+- `[API]` Add `is_configured() -> bool` and `is_valid() -> bool` classmethods to
+  `TimeseriesRequest`. `is_configured` checks whether credentials are present (cheap,
+  offline); `is_valid` probes the API to confirm they actually work (should be cached
+  by the implementation). Both default to `True` for providers that need no auth.
+- `[REST API]` `GET /api/coverage` (no parameters) now returns
+  `{provider: {network: {auth: bool, configured: bool, valid: bool}}}` instead of
+  `{provider: [network]}`, exposing per-network auth status to API consumers.
+- `[REST API]` Add `GET /api/auth?provider=&network=` endpoint that returns
+  `{provider, network, auth, configured, valid}` for a specific provider/network,
+  allowing clients to re-check credential validity without fetching all coverage.
+  `valid` is always `false` when `configured` is `false` (probe cannot run without credentials).
 
 ## [0.124.0] - 2026-06-30
 

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -16,6 +16,13 @@ Types of changes:
 
 ## [Unreleased]
 
+### Changed
+
+- `[Explorer]` Provider/network combinations that require authentication are now hidden
+  from the parameter selector unless credentials are both present (`configured`) and
+  verified (`valid`) by the backend. This prevents selecting a provider that cannot be
+  used without a working API key.
+
 ## [0.7.0] - 2026-07-02
 
 ### Added

--- a/frontend/app/components/ParameterSelection.vue
+++ b/frontend/app/components/ParameterSelection.vue
@@ -29,12 +29,25 @@ const isInitializing = ref(true)
 // fetch coverage data
 const { data: coverage } = await useFetch<CoverageResponse>('/api/coverage')
 
+// A provider/network is available when it needs no auth, or when auth credentials are present and valid.
+const isAvailable = (n: { auth: boolean, configured: boolean, valid: boolean }) => !n.auth || (n.configured && n.valid)
+
 // EXPECTING
-const providers = computed(() => coverage.value ? Object.keys(coverage.value).sort() : [])
-const networks = computed<string[]>(() => {
-  if (!provider.value || !coverage.value)
+const providers = computed(() => {
+  const cov = coverage.value
+  if (!cov)
     return []
-  return coverage.value[provider.value] ?? []
+  return Object.keys(cov)
+    .filter(p => Object.values(cov[p] ?? {}).some(isAvailable))
+    .sort()
+})
+const networks = computed<string[]>(() => {
+  const cov = coverage.value
+  if (!provider.value || !cov)
+    return []
+  return Object.entries(cov[provider.value] ?? {})
+    .filter(([, n]) => isAvailable(n))
+    .map(([name]) => name)
 })
 
 // provider-network coverage

--- a/frontend/shared/types/api.ts
+++ b/frontend/shared/types/api.ts
@@ -25,8 +25,24 @@ export interface CoverageParameter {
   unit_original?: string
 }
 
-/** Provider to networks mapping */
-export type CoverageResponse = Record<string, string[]>
+/** Per-network metadata in the coverage response */
+export interface CoverageNetworkInfo {
+  auth: boolean
+  configured: boolean
+  valid: boolean
+}
+
+/** Provider to networks mapping with per-network metadata */
+export type CoverageResponse = Record<string, Record<string, CoverageNetworkInfo>>
+
+/** Response from GET /api/auth */
+export interface AuthResponse {
+  provider: string
+  network: string
+  auth: boolean
+  configured: boolean
+  valid: boolean
+}
 
 /** Detailed coverage for a provider-network pair */
 export type ProviderNetworkCoverageResponse = Record<

--- a/frontend/tests/e2e/api.spec.ts
+++ b/frontend/tests/e2e/api.spec.ts
@@ -17,7 +17,15 @@ test.describe('API Coverage Endpoint', () => {
     const data = await response.json()
 
     expect(data).toHaveProperty('dwd')
-    expect(Array.isArray(data.dwd)).toBeTruthy()
+    expect(typeof data.dwd).toBe('object')
+    expect(Array.isArray(data.dwd)).toBeFalsy()
+    const networks = Object.keys(data.dwd)
+    expect(networks).toContain('observation')
+    for (const info of Object.values(data.dwd) as { auth: boolean, configured: boolean, valid: boolean }[]) {
+      expect(typeof info.auth).toBe('boolean')
+      expect(typeof info.configured).toBe('boolean')
+      expect(typeof info.valid).toBe('boolean')
+    }
   })
 
   test('should fetch provider-network coverage', async ({ request }) => {

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -98,8 +98,32 @@ class Wetterdienst:
 
     @classmethod
     def discover(cls) -> dict:
-        """Discover all available providers and networks."""
-        return {provider: list(networks.keys()) for provider, networks in cls.registry.items()}
+        """Discover all available providers and networks with their metadata."""
+        result = {}
+        for provider, networks in cls.registry.items():
+            result[provider] = {}
+            for network in networks:
+                try:
+                    api = cls(provider, network)
+                except ImportError:
+                    result[provider][network] = {"auth": False, "configured": True, "valid": True}
+                    continue
+                metadata = getattr(api, "metadata", None)
+                auth = metadata.auth if metadata is not None else False
+                is_configured = getattr(api, "is_configured", lambda: True)
+                is_valid = getattr(api, "is_valid", lambda: True)
+                configured = is_configured() if auth else True
+                if not auth:
+                    valid = True
+                elif not configured:
+                    valid = False
+                else:
+                    try:
+                        valid = is_valid()
+                    except Exception:  # noqa: BLE001
+                        valid = False
+                result[provider][network] = {"auth": auth, "configured": configured, "valid": valid}
+        return result
 
     @classmethod
     def get_provider_names(cls) -> list[str]:

--- a/src/wetterdienst/model/metadata.py
+++ b/src/wetterdienst/model/metadata.py
@@ -205,6 +205,7 @@ class MetadataModel(BaseModel):
     kind: Literal["observation", "forecast", "derived"]
     timezone: TimeZoneName
     timezone_data: TimeZoneName | Literal["dynamic"]
+    auth: bool = False
     resolutions: list[ResolutionModel]
 
     def __getitem__(self, item: str | int) -> ResolutionModel:

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -336,6 +336,23 @@ class TimeseriesRequest:
         return start_date, end_date
 
     @classmethod
+    def is_configured(cls) -> bool:
+        """Return True if this provider's required credentials are present (env var / settings).
+
+        This is a cheap, offline check. Override in subclasses that require authentication.
+        """
+        return True
+
+    @classmethod
+    def is_valid(cls) -> bool:
+        """Return True if the provider's credentials are valid (authenticated successfully).
+
+        This may perform a lightweight network probe and should cache the result.
+        Only called when is_configured() is True. Override in auth-requiring subclasses.
+        """
+        return True
+
+    @classmethod
     def discover(  # noqa: C901
         cls,
         resolutions: str | Resolution | ResolutionModel | Sequence[str | Resolution | ResolutionModel] | None = None,

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -222,6 +222,55 @@ def version() -> JSONResponse:
     return JSONResponse(content={"version": __version__})
 
 
+@app.get("/api/auth")
+def auth(
+    provider: str,
+    network: str,
+    *,
+    debug: bool = False,
+) -> JSONResponse:
+    """Check whether the credentials for an auth-required provider are present and valid.
+
+    Returns `{"provider": ..., "network": ..., "auth": bool, "configured": bool, "valid": bool}`.
+    For providers that do not require authentication, `auth` is false and `configured`/`valid` are true.
+    `configured` reflects whether credentials are present; `valid` whether a probe request succeeded.
+    `valid` is false whenever `configured` is false (a probe cannot be performed without credentials).
+    """
+    set_logging_level(debug=debug)
+
+    try:
+        api = Wetterdienst(str(provider), str(network))
+    except (ApiNotFoundError, ImportError) as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Choose provider and network from {app.url_path_for('coverage')}",
+        ) from e
+
+    metadata = getattr(api, "metadata", None)
+    requires_auth = metadata.auth if metadata is not None else False
+    is_configured = getattr(api, "is_configured", lambda: True)
+    is_valid = getattr(api, "is_valid", lambda: True)
+    configured = is_configured() if requires_auth else True
+    if not requires_auth:
+        valid = True
+    elif not configured:
+        valid = False
+    else:
+        try:
+            valid = is_valid()
+        except Exception:  # noqa: BLE001
+            valid = False
+    return JSONResponse(
+        content={
+            "provider": provider,
+            "network": network,
+            "auth": requires_auth,
+            "configured": configured,
+            "valid": valid,
+        }
+    )
+
+
 @app.get("/api/coverage")
 def coverage(
     provider: str | None = None,

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -67,8 +67,24 @@ def test_coverage(client: TestClient) -> None:
         "nws",
         "wsv",
     }
-    networks = data["dwd"]
-    assert networks == ["observation", "mosmix", "dmo", "road", "radar", "derived"]
+    dwd = data["dwd"]
+    assert list(dwd.keys()) == ["observation", "mosmix", "dmo", "road", "radar", "derived"]
+    for network_info in dwd.values():
+        assert network_info == {"auth": False, "configured": True, "valid": True}
+
+
+def test_auth_no_auth_required(client: TestClient) -> None:
+    """Providers without authentication always report configured=true and valid=true."""
+    response = client.get("/api/auth", params={"provider": "dwd", "network": "observation"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {"provider": "dwd", "network": "observation", "auth": False, "configured": True, "valid": True}
+
+
+def test_auth_unknown_provider(client: TestClient) -> None:
+    """Unknown provider/network returns 404."""
+    response = client.get("/api/auth", params={"provider": "nonexistent", "network": "fake"})
+    assert response.status_code == 404
 
 
 @pytest.mark.remote


### PR DESCRIPTION
## Summary

- Adds `auth: bool = False` to `MetadataModel` so providers requiring an API key can declare it
- Adds `is_configured()` (offline credential presence check) and `is_valid()` (live probe, should cache) classmethods to `TimeseriesRequest` — both default to `True` for providers that need no auth
- `GET /api/coverage` (no params) now returns `{provider: {network: {auth, configured, valid}}}` instead of `{provider: [network]}`
- New `GET /api/auth?provider=&network=` endpoint for standalone per-network credential checks
- Frontend hides provider/network combinations where `auth=true` and either `configured=false` or `valid=false`

## How providers plug in

A provider requiring auth sets `auth: True` in its `MetadataModel`, then overrides the two classmethods:

```python
@classmethod
def is_configured(cls) -> bool:
    return bool(Settings().my_provider_api_key)

@classmethod
def is_valid(cls) -> bool:
    # lightweight cached probe request
    ...
```

This branch delivers only the mechanics — the first consumer will be `metno/frost` in a follow-up PR.

## Test plan

- [ ] `GET /api/coverage` returns `{auth, configured, valid}` per network (all `false/true/true` for existing providers)
- [ ] `GET /api/auth?provider=dwd&network=observation` returns `{"auth": false, "configured": true, "valid": true}`
- [ ] Frontend Explorer shows all existing providers (no regressions)
- [ ] After merging `gutzbenj/frost` and setting `auth=True` + implementing both classmethods: Frost hidden without `WD_METNO_FROST_CLIENT_ID`, shown when key is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)