### PR TITLE
fix(frontend): add missing info icon to about sections

### DIFF
--- a/frontend/app/pages/history.vue
+++ b/frontend/app/pages/history.vue
@@ -228,6 +228,7 @@ function clear() {
     <UCollapsible v-model="showAbout">
       <UButton
         :label="t('history.aboutButton')"
+        icon="i-lucide-info"
         variant="subtle"
         color="neutral"
         trailing-icon="i-lucide-chevron-down"

--- a/frontend/app/pages/meteogram.vue
+++ b/frontend/app/pages/meteogram.vue
@@ -193,6 +193,7 @@ onMounted(async () => {
     <UCollapsible v-model="showAbout">
       <UButton
         :label="t('meteogram.aboutButton')"
+        icon="i-lucide-info"
         variant="subtle"
         color="neutral"
         trailing-icon="i-lucide-chevron-down"


### PR DESCRIPTION
## Summary
- Add missing `icon="i-lucide-info"` to the about button in `meteogram.vue` and `history.vue`, matching the pattern already used in `explorer.vue` and `stripes.vue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)