### PR TITLE
feat(frontend): sync page view state to URL

### DIFF
--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -16,6 +16,16 @@ Types of changes:
 
 ## [Unreleased]
 
+### Added
+
+- `[Meteogram]` Forecast model run (`issue`), horizon filter (`horizon`), visible panels
+  (`panels`), and compact mode (`compact`) are now synced to the URL. Sharing or
+  bookmarking the page restores the full view state.
+- `[Stripes]` `show_timeseries`, `show_trendline`, and `show_source` toggles are now
+  persisted in the URL, consistent with the other `show_*` parameters already synced.
+- `[Explorer]` Data-settings toggles (`shape`, `humanize`, `convertUnits`, `dropNulls`,
+  `skipEmpty`) are now persisted in the URL so the selected data view is shareable.
+
 ### Changed
 
 - `[Explorer]` Provider/network combinations that require authentication are now hidden

--- a/frontend/app/components/Meteogram.vue
+++ b/frontend/app/components/Meteogram.vue
@@ -64,7 +64,8 @@ watch(visiblePanels, (newVal) => {
 
 const seriesCache = computed(() => buildSeries(props.values ?? []))
 
-// On mount try to restore user preference and auto-enable compact on small screens
+// On mount try to restore user preference and auto-enable compact on small screens,
+// with URL params taking precedence over localStorage.
 onMounted(() => {
   try {
     if (typeof window !== 'undefined') {
@@ -77,6 +78,58 @@ onMounted(() => {
   }
   catch {
     // ignore
+  }
+
+  if (!props.widget) {
+    const q = useRoute().query
+    if (q.horizon) {
+      const h = Number(q.horizon.toString())
+      if (Number.isFinite(h) && h > 0)
+        horizonHours.value = h
+    }
+    if (q.panels) {
+      const names = q.panels.toString().split(',').filter(Boolean)
+      visiblePanels.value = {
+        temp: names.includes('temp'),
+        wind: names.includes('wind'),
+        precip: names.includes('precip'),
+        cloud: names.includes('cloud'),
+        pressure: names.includes('pressure'),
+      }
+    }
+    if (q.compact)
+      compact.value = q.compact.toString() === 'true'
+
+    const router = useRouter()
+    const route = useRoute()
+
+    watch(horizonHours, (h) => {
+      const q = { ...route.query } as Record<string, any>
+      if (h !== null)
+        q.horizon = String(h)
+      else
+        delete q.horizon
+      void router.replace({ query: q })
+    })
+
+    watch(visiblePanels, (panels) => {
+      const visible = (Object.keys(panels) as Array<keyof typeof panels>).filter(k => panels[k])
+      const q = { ...route.query } as Record<string, any>
+      if (visible.length < 5)
+        q.panels = visible.join(',')
+      else
+        delete q.panels
+      void router.replace({ query: q })
+    }, { deep: true })
+
+    watch(compact, (c) => {
+      const q = { ...route.query } as Record<string, any>
+      if (c)
+        q.compact = 'true'
+      else
+        delete q.compact
+      void router.replace({ query: q })
+    })
   }
 })
 

--- a/frontend/app/components/Meteogram.vue
+++ b/frontend/app/components/Meteogram.vue
@@ -124,10 +124,7 @@ onMounted(() => {
 
     watch(compact, (c) => {
       const q = { ...route.query } as Record<string, any>
-      if (c)
-        q.compact = 'true'
-      else
-        delete q.compact
+      q.compact = c ? 'true' : 'false'
       void router.replace({ query: q })
     })
   }

--- a/frontend/app/pages/explorer.vue
+++ b/frontend/app/pages/explorer.vue
@@ -112,6 +112,21 @@ function toQuery(paramSel: ParameterSelectionState, stationSel: StationSelection
   return q
 }
 
+function dataSettingsToQuery(settings: DataSettings): Record<string, string> {
+  const q: Record<string, string> = {}
+  if (!settings.humanize)
+    q.humanize = 'false'
+  if (!settings.convertUnits)
+    q.convertUnits = 'false'
+  if (settings.shape !== 'long')
+    q.shape = settings.shape
+  if (settings.skipEmpty)
+    q.skipEmpty = 'true'
+  if (!settings.dropNulls)
+    q.dropNulls = 'false'
+  return q
+}
+
 const showAbout = ref(false)
 const parameterSelectionState = ref<ParameterSelectionState>(fromQuery(route.query))
 const stationSelectionState = ref<StationSelectionState>({
@@ -127,14 +142,14 @@ const initialStationIds = ref<string[]>(stationIdsFromQuery(route.query))
 
 // Data settings
 const dataSettings = ref<DataSettings>({
-  humanize: true,
-  convertUnits: true,
+  humanize: route.query.humanize !== undefined ? route.query.humanize.toString() === 'true' : true,
+  convertUnits: route.query.convertUnits !== undefined ? route.query.convertUnits.toString() === 'true' : true,
   unitTargets: {},
-  shape: 'long',
-  skipEmpty: false,
+  shape: (route.query.shape?.toString() as 'long' | 'wide') || 'long',
+  skipEmpty: route.query.skipEmpty?.toString() === 'true',
   skipThreshold: 0.95,
   skipCriteria: 'min',
-  dropNulls: true,
+  dropNulls: route.query.dropNulls !== undefined ? route.query.dropNulls.toString() !== 'false' : true,
   useNearbyStationDistance: 1.0,
   useStationDistancePerParameter: {},
   minGainOfValuePairs: 0.10,
@@ -200,10 +215,10 @@ watch(
   },
 )
 
-// Update URL when parameter or station selection changes
+// Update URL when parameter, station selection, or data settings change
 watch(
-  [parameterSelectionState, () => stationSelectionState.value.selection.stations],
-  () => router.replace({ query: toQuery(parameterSelectionState.value, stationSelectionState.value) }),
+  [parameterSelectionState, () => stationSelectionState.value.selection.stations, dataSettings],
+  () => router.replace({ query: { ...toQuery(parameterSelectionState.value, stationSelectionState.value), ...dataSettingsToQuery(dataSettings.value) } }),
   { deep: true },
 )
 

--- a/frontend/app/pages/explorer.vue
+++ b/frontend/app/pages/explorer.vue
@@ -142,14 +142,14 @@ const initialStationIds = ref<string[]>(stationIdsFromQuery(route.query))
 
 // Data settings
 const dataSettings = ref<DataSettings>({
-  humanize: route.query.humanize !== undefined ? route.query.humanize.toString() === 'true' : true,
-  convertUnits: route.query.convertUnits !== undefined ? route.query.convertUnits.toString() === 'true' : true,
+  humanize: route.query.humanize != null ? route.query.humanize.toString() === 'true' : true,
+  convertUnits: route.query.convertUnits != null ? route.query.convertUnits.toString() === 'true' : true,
   unitTargets: {},
   shape: (['long', 'wide'].includes(route.query.shape?.toString() ?? '') ? route.query.shape!.toString() : 'long') as 'long' | 'wide',
   skipEmpty: route.query.skipEmpty?.toString() === 'true',
   skipThreshold: 0.95,
   skipCriteria: 'min',
-  dropNulls: route.query.dropNulls !== undefined ? route.query.dropNulls.toString() !== 'false' : true,
+  dropNulls: route.query.dropNulls != null ? route.query.dropNulls.toString() !== 'false' : true,
   useNearbyStationDistance: 1.0,
   useStationDistancePerParameter: {},
   minGainOfValuePairs: 0.10,

--- a/frontend/app/pages/explorer.vue
+++ b/frontend/app/pages/explorer.vue
@@ -145,7 +145,7 @@ const dataSettings = ref<DataSettings>({
   humanize: route.query.humanize !== undefined ? route.query.humanize.toString() === 'true' : true,
   convertUnits: route.query.convertUnits !== undefined ? route.query.convertUnits.toString() === 'true' : true,
   unitTargets: {},
-  shape: (route.query.shape?.toString() as 'long' | 'wide') || 'long',
+  shape: (['long', 'wide'].includes(route.query.shape?.toString() ?? '') ? route.query.shape!.toString() : 'long') as 'long' | 'wide',
   skipEmpty: route.query.skipEmpty?.toString() === 'true',
   skipThreshold: 0.95,
   skipCriteria: 'min',
@@ -217,7 +217,15 @@ watch(
 
 // Update URL when parameter, station selection, or data settings change
 watch(
-  [parameterSelectionState, () => stationSelectionState.value.selection.stations, dataSettings],
+  [
+    parameterSelectionState,
+    () => stationSelectionState.value.selection.stations,
+    () => dataSettings.value.humanize,
+    () => dataSettings.value.convertUnits,
+    () => dataSettings.value.shape,
+    () => dataSettings.value.skipEmpty,
+    () => dataSettings.value.dropNulls,
+  ],
   () => router.replace({ query: { ...toQuery(parameterSelectionState.value, stationSelectionState.value), ...dataSettingsToQuery(dataSettings.value) } }),
   { deep: true },
 )

--- a/frontend/app/pages/meteogram.vue
+++ b/frontend/app/pages/meteogram.vue
@@ -192,9 +192,9 @@ onMounted(async () => {
     })
     const station = (res.stations ?? [])[0]
     if (station) {
-      selectedStation.value = station
       if (issueFromUrl)
         selectedIssue.value = issueFromUrl
+      selectedStation.value = station
     }
   }
   catch {

--- a/frontend/app/pages/meteogram.vue
+++ b/frontend/app/pages/meteogram.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { Station } from '#shared/types/api'
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, nextTick } from 'vue'
 import Meteogram from '~/components/Meteogram.vue'
 import MeteogramStationSearch from '~/components/MeteogramStationSearch.vue'
 
@@ -28,6 +28,9 @@ const error = ref<string | null>(null)
 
 // '' = latest (auto), iso string = a specific run
 const selectedIssue = ref<string>('')
+
+// Prevents watch(selectedStation) from resetting selectedIssue when restoring from URL
+const isRestoringFromUrl = ref(false)
 
 // Real list of available runs fetched from the backend — populated when a station is selected.
 const availableIssues = ref<string[]>([])
@@ -141,11 +144,11 @@ watch(selectedIssue, () => {
 
 // Auto-fetch and sync URL whenever a station is chosen or cleared
 watch(selectedStation, (station) => {
-  selectedIssue.value = ''
+  if (!isRestoringFromUrl.value)
+    selectedIssue.value = ''
   if (station) {
     void loadAvailableIssues(station.station_id)
     void fetchMeteogram(station)
-    void router.replace({ query: { station: station.station_id } })
   }
   else {
     values.value = []
@@ -155,11 +158,29 @@ watch(selectedStation, (station) => {
   }
 })
 
-// Restore selected station from URL query param on page load
+// Sync station + issue to URL (fires once when both change together)
+watch([selectedStation, selectedIssue], ([station, issue]) => {
+  if (!station)
+    return
+  const q: Record<string, string> = { station: station.station_id }
+  if (issue)
+    q.issue = issue
+  // Preserve display params managed by the Meteogram component
+  for (const k of ['horizon', 'panels', 'compact'] as const) {
+    const v = route.query[k]
+    if (v)
+      q[k] = v.toString()
+  }
+  void router.replace({ query: q })
+})
+
+// Restore selected station and issue from URL query params on page load
 onMounted(async () => {
   const stationId = route.query.station as string | undefined
+  const issueFromUrl = route.query.issue?.toString()
   if (!stationId)
     return
+  isRestoringFromUrl.value = true
   try {
     const res = await $fetch<{ stations: Station[] }>('/api/stations', {
       query: {
@@ -170,11 +191,18 @@ onMounted(async () => {
       },
     })
     const station = (res.stations ?? [])[0]
-    if (station)
+    if (station) {
       selectedStation.value = station
+      if (issueFromUrl)
+        selectedIssue.value = issueFromUrl
+    }
   }
   catch {
     // ignore – station ID in URL may be invalid, just start fresh
+  }
+  finally {
+    await nextTick()
+    isRestoringFromUrl.value = false
   }
 })
 </script>

--- a/frontend/app/pages/stripes.vue
+++ b/frontend/app/pages/stripes.vue
@@ -428,6 +428,12 @@ if (route.query.show_years !== undefined && route.query.show_years !== null)
   showYears.value = route.query.show_years?.toString() === 'true'
 if (route.query.show_data_availability !== undefined && route.query.show_data_availability !== null)
   showDataAvailability.value = route.query.show_data_availability?.toString() === 'true'
+if (route.query.show_timeseries !== undefined && route.query.show_timeseries !== null)
+  showTimeseries.value = route.query.show_timeseries?.toString() === 'true'
+if (route.query.show_trendline !== undefined && route.query.show_trendline !== null)
+  showTrendline.value = route.query.show_trendline?.toString() === 'true'
+if (route.query.show_source !== undefined && route.query.show_source !== null)
+  showSource.value = route.query.show_source?.toString() === 'true'
 if (route.query.start_year)
   startYear.value = Number(route.query.start_year.toString())
 if (route.query.end_year)
@@ -514,6 +520,12 @@ function stripesToQuery(): Record<string, string> {
     q.show_years = String(showYears.value)
   if (showDataAvailability.value !== undefined)
     q.show_data_availability = String(showDataAvailability.value)
+  if (showTimeseries.value !== undefined)
+    q.show_timeseries = String(showTimeseries.value)
+  if (showTrendline.value !== undefined)
+    q.show_trendline = String(showTrendline.value)
+  if (showSource.value !== undefined)
+    q.show_source = String(showSource.value)
   if (startYear.value !== null && startYear.value !== undefined)
     q.start_year = String(startYear.value)
   if (endYear.value !== null && endYear.value !== undefined)
@@ -527,6 +539,9 @@ watch([
   () => showTitle.value,
   () => showYears.value,
   () => showDataAvailability.value,
+  () => showTimeseries.value,
+  () => showTrendline.value,
+  () => showSource.value,
   () => startYear.value,
   () => endYear.value,
 ], () => {


### PR DESCRIPTION
## Summary

- **Meteogram**: `issue` (model run), `horizon` (forecast horizon filter), `panels` (visible chart panels), and `compact` mode are now synced to the URL. URL takes precedence over localStorage for `compact`.
- **Stripes**: adds `show_timeseries`, `show_trendline`, `show_source` to URL — consistent with the existing `show_title`, `show_years`, `show_data_availability` params.
- **Explorer**: data-settings toggles (`shape`, `humanize`, `convertUnits`, `dropNulls`, `skipEmpty`) are now URL-persisted so a configured view can be bookmarked or shared.

## Test plan

- [ ] Meteogram: select a station, change horizon/panels/compact, copy URL, open in new tab — state restores correctly
- [ ] Meteogram: select a model run (issue), verify `?issue=` appears in URL; switching station clears it
- [ ] Stripes: toggle timeseries/trendline/source, verify URL updates; reload restores
- [ ] Explorer: change shape/humanize/convertUnits/dropNulls/skipEmpty, verify URL; reload restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)