### PR TITLE
fix(api): fix station listing for providers with date_required datasets (Frost no-stations bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[REST API]` Station listing no longer fails with `StartDateEndDateError` for providers
+  with `date_required` datasets (e.g. MET Norway Frost hourly, 10-minute, 6-hour). The
+  date requirement only applies to value fetching, not to listing available stations. Also
+  fixed a `TypeError` when constructing requests for providers that declare multi-period
+  datasets but do not accept a `periods` constructor argument.
+
 ## [0.125.0] - 2026-07-06
 
 ### Added

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -576,7 +576,7 @@ def _get_stations_request(
     parameters = parse_parameters(request.parameters, api.metadata)
 
     any_date_required = any(parameter.dataset.date_required for parameter in parameters)
-    if any_date_required and (not start_date or not end_date):
+    if any_date_required and (not start_date or not end_date) and not isinstance(request, StationsRequest):
         msg = "Start and end date required for single period datasets"
         raise StartDateEndDateError(msg)
 
@@ -587,7 +587,7 @@ def _get_stations_request(
         "start_date": start_date,
         "end_date": end_date,
     }
-    if any_multiple_period_dataset:
+    if any_multiple_period_dataset and "periods" in getattr(api, "__dataclass_fields__", {}):
         kwargs["periods"] = getattr(request, "periods", None)
 
     if issubclass(api, (DwdMosmixRequest, DwdDmoRequest)) and (issue := getattr(request, "issue", None)) is not None:

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -1032,6 +1032,45 @@ def test_get_stations_request_mosmix_no_issue_defaults_to_latest() -> None:
     assert stations_request.issue is DwdForecastDate.LATEST
 
 
+def test_get_stations_request_date_required_dataset_does_not_raise_for_stations_request() -> None:
+    """_get_stations_request must NOT raise StartDateEndDateError for StationsRequest.
+
+    MetNo Frost marks its hourly, 10-minute, and 6-hour datasets as date_required=True.
+    Previously the date-range check applied to StationsRequest too, so listing stations
+    without a date range raised StartDateEndDateError and the Explorer showed no stations.
+    """
+    from wetterdienst import Wetterdienst  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+    from wetterdienst.ui.core import StationsRequest, _get_stations_request  # noqa: PLC0415
+
+    api = Wetterdienst("metno", "frost")
+    settings = Settings(auth={"metno_frost": "fake-client-id"})
+    request = StationsRequest(provider="metno", network="frost", parameters=["hourly/data"])
+
+    # Must not raise StartDateEndDateError despite hourly/data having date_required=True
+    stations_request = _get_stations_request(api=api, request=request, date=None, settings=settings)
+    assert stations_request is not None
+
+
+def test_get_stations_request_no_periods_kwarg_for_providers_without_periods_field() -> None:
+    """_get_stations_request must not pass `periods` kwarg to providers that lack the field.
+
+    MetNoFrostRequest has multi-period datasets (historical + recent) but no `periods`
+    constructor argument. Previously this caused TypeError when building the request.
+    """
+    from wetterdienst import Wetterdienst  # noqa: PLC0415
+    from wetterdienst.provider.metno.frost.api import MetnoFrostRequest  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+    from wetterdienst.ui.core import StationsRequest, _get_stations_request  # noqa: PLC0415
+
+    api = Wetterdienst("metno", "frost")
+    settings = Settings(auth={"metno_frost": "fake-client-id"})
+    request = StationsRequest(provider="metno", network="frost", parameters=["hourly/data"])
+
+    stations_request = _get_stations_request(api=api, request=request, date=None, settings=settings)
+    assert isinstance(stations_request, MetnoFrostRequest)
+
+
 @pytest.mark.remote
 def test_values_dwd_mosmix(client: TestClient) -> None:
     """Test MOSMIX."""


### PR DESCRIPTION
## Summary

- Station listing via `/api/stations` raised `StartDateEndDateError` for providers where datasets set `date_required=True` (MET Norway Frost hourly, 10-minute, and 6-hour resolutions). The date range check is only needed for value fetching — station listing should always succeed regardless of dataset date requirements.
- A secondary `TypeError` was also fixed: the `periods` kwarg was unconditionally added to `kwargs` for any multi-period dataset, but providers like `MetnoFrostRequest` don't declare a `periods` constructor field. The kwarg is now only passed when the API class actually has that field.

These two bugs combined caused MetNo Frost to show zero stations in the Explorer even when credentials were correctly configured.

## Test plan

- [ ] Confirm `/api/stations?provider=metno&network=frost&parameters=hourly/data&all=true` returns stations (requires `WD_AUTH__METNO_FROST` set)
- [ ] Confirm same for `10_minutes/data` and `6_hour/data`
- [ ] Confirm `daily/data`, `monthly/data`, `annual/data` still work (were already working)
- [ ] Confirm DWD observation station listing still works (has `periods` field, multi-period datasets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)