### PR TITLE
fix(metno/frost): add 5-second timeout to credential probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[MET Norway Frost]` `GET /api/coverage` no longer hangs on a cold start (container
+  restart or first request after cache expiry). The Frost credential probe now uses a
+  5-second total timeout per attempt, capping worst-case delay at ~10 s instead of the
+  previous 10-minute maximum (2 × default 300 s aiohttp timeout).
+
 ## [0.126.0] - 2026-07-07
 
 ### Fixed

--- a/src/wetterdienst/provider/metno/frost/api.py
+++ b/src/wetterdienst/provider/metno/frost/api.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, cast
 from urllib.parse import parse_qs, urlparse
 
 import polars as pl
-from aiohttp import encode_basic_auth
+from aiohttp import ClientTimeout, encode_basic_auth
 
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, ParameterModel, build_metadata_model
@@ -648,6 +648,7 @@ def _probe_frost_credentials(settings: Settings) -> bool:
         return False
     client_kwargs = {**settings.fsspec_client_kwargs}
     client_kwargs.setdefault("headers", {})["Authorization"] = encode_basic_auth(*settings.auth.metno_frost)
+    client_kwargs.setdefault("timeout", ClientTimeout(total=5))
     file = download_file(
         url="https://frost.met.no/sources/v0.jsonld?ids=SN18700&fields=id",
         cache_dir=settings.cache_dir,


### PR DESCRIPTION
## Summary

`Wetterdienst.discover()` calls `is_valid()` for every auth-requiring provider on each `/api/coverage` request. For MetNo Frost, `is_valid()` calls `_probe_frost_credentials()` which does a `download_file()` HTTP request with **no timeout set**.

The default aiohttp timeout is 300 seconds. With stamina's 2-attempt retry, a slow or unreachable Frost API (common right after a container restart when the 1-hour disk cache is cold) could block `/api/coverage` for up to **10 minutes**, making parameter selection appear completely broken.

Fix: set `ClientTimeout(total=5)` on the probe request only. Worst case is now ~10 s. The full station fetch in `_all()` is unaffected.

## Test plan

- [ ] Verify `/api/coverage` returns quickly even when Frost credentials are set
- [ ] Verify parameter selection works immediately after container restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)