### PR TITLE
fix(frontend): restore parameters field and auto-select all on dataset change

### DIFF
--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -16,6 +16,16 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[Explorer]` Parameters selector was invisible due to Vue 3 boolean prop casting:
+  `showParameters?: boolean` was silently cast to `false` when not passed by the parent,
+  making the field hidden in the Explorer. Fixed with `withDefaults({ showParameters: true })`.
+- `[Explorer]` All parameters for the selected dataset are now auto-selected when a
+  dataset is chosen (initial load and on dataset change). URL-specified parameters are
+  preserved if still valid; otherwise all parameters are selected as the default.
+
+
 ## [0.8.0] - 2026-07-06
 
 ### Added

--- a/frontend/app/components/ParameterSelection.vue
+++ b/frontend/app/components/ParameterSelection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 // Accept initial values from parent via v-model
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   modelValue?: {
     provider?: string
     network?: string
@@ -9,7 +9,9 @@ const props = defineProps<{
     parameters?: string[]
   }
   showParameters?: boolean
-}>()
+}>(), {
+  showParameters: true,
+})
 
 const emit = defineEmits(['update:modelValue'])
 
@@ -99,7 +101,7 @@ const PRESELECTION = {
   network: 'observation',
   resolution: 'daily',
   dataset: 'climate_summary',
-  parameters: ['temperature_air_mean_2m'],
+  parameters: [],
 }
 
 // Initialize from query params and validate step by step
@@ -148,15 +150,16 @@ async function initializeFromProps() {
     return
   }
 
-  // Step 5: Validate parameters - keep only valid ones
-  // Need to wait for next tick so params computed updates after dataset is set
+  // Step 5: Use URL-specified parameters if valid; otherwise auto-select all
   await nextTick()
 
   if (initial.parameters?.length) {
     const validParams = initial.parameters.filter(p => params.value.includes(p))
-    parameters.value = validParams
+    parameters.value = validParams.length ? validParams : [...params.value]
   }
-  // Don't auto-select all parameters by default
+  else {
+    parameters.value = [...params.value]
+  }
 
   // Wait another tick to ensure watchers have processed before turning off initialization mode
   await nextTick()
@@ -198,11 +201,11 @@ watch(resolution, () => {
   parameters.value = []
 })
 
-watch(dataset, () => {
+watch(dataset, async () => {
   if (isInitializing.value)
     return
-  // Clear parameters when dataset changes
-  parameters.value = []
+  await nextTick()
+  parameters.value = [...params.value]
 })
 
 function selectAllParameters() {

--- a/frontend/app/components/StationSelection.vue
+++ b/frontend/app/components/StationSelection.vue
@@ -83,7 +83,6 @@ watch(allStations, (stations) => {
 
 watch(() => props.parameterSelection, (ps) => {
   if (!ps.parameters?.length) {
-    // No parameters selected, clear stations data
     stationsData.value = { stations: [] }
     selectedStations.value = []
     return


### PR DESCRIPTION
## Summary

Two fixes in `ParameterSelection.vue`:

1. **Parameters field was invisible** due to a Vue 3 boolean prop casting quirk: `showParameters?: boolean` is silently cast to `false` when not passed by the parent, making `v-if="props.showParameters !== false"` always false in the Explorer. Fixed with `withDefaults({ showParameters: true })`.
2. **All parameters for the selected dataset are now auto-selected** when a dataset is chosen (on initial load and on dataset change), instead of requiring the user to manually pick parameters. URL-specified parameters are preserved if still valid; otherwise all parameters are selected as the default.

This also fixes the underlying station-loading issue for MET Norway Frost and other providers without a hardcoded preselection: `StationSelection.vue`'s watcher only fetches stations once `parameterSelection.parameters.length > 0`. Previously, non-DWD providers had no parameters preselected and none were ever auto-selected, so that guard never passed and the station list stayed empty. Auto-selecting parameters on dataset change now satisfies that guard automatically — no change to the guard condition itself was needed.

## Test plan

- [ ] Select metno/frost + hourly + a dataset in Explorer → parameters auto-select and stations appear
- [ ] Verify DWD still works (preselected parameter/auto-select both lead to the same state)
- [ ] Verify changing dataset re-selects all parameters for the new dataset
- [ ] Verify URL-specified parameters are preserved when still valid for the dataset

🤖 Generated with [Claude Code](https://claude.com/claude-code)