### PR TITLE
ci(docker): add editable dev stage for backend hot-reload

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -4,20 +4,20 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile
+      target: dev
     image: wetterdienst-backend:dev
     container_name: wetterdienst-backend
     restart: unless-stopped
     environment:
       # Common development env overrides; can be overridden in .env
       - PYTHONUNBUFFERED=1
-    command: [ "wetterdienst", "restapi", "--listen", "0.0.0.0:3000" ]
     ports:
       - "3000:3000"
     develop:
       watch:
         - path: src/wetterdienst
           action: sync
-          target: /app
+          target: /app/src/wetterdienst
         - path: ./pyproject.toml
           action: rebuild
         - path: ./uv.lock

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,8 @@ RUN --mount=type=cache,id=uv,target=/root/.cache/uv \
     uv sync --frozen --active \
     --extra bufr --extra cratedb --extra duckdb --extra export --extra influxdb --extra interpolation --extra plotting --extra postgresql --extra radar --extra radarplus --extra restapi
 
-# Dev stage: editable install so uvicorn --reload picks up source changes
+# Dev stage: editable install so uvicorn --reload picks up source changes.
+# Installs the same extras and OS packages as the final stage for feature parity.
 FROM python:3.14-slim-trixie AS dev
 
 COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /bin/
@@ -32,6 +33,11 @@ ENV UV_NO_DEV=1
 ENV UV_LINK_MODE=copy
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 
+# Install chromium -> required for kaleido png export, and curl for health checks
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends chromium curl && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY uv.lock pyproject.toml ./
@@ -39,7 +45,8 @@ COPY src ./src
 COPY README.md LICENSE.md ./
 
 RUN --mount=type=cache,id=uv,target=/root/.cache/uv \
-    uv sync --frozen --active --extra restapi
+    uv sync --frozen --active \
+    --extra bufr --extra cratedb --extra duckdb --extra export --extra influxdb --extra interpolation --extra plotting --extra postgresql --extra radar --extra radarplus --extra restapi
 
 EXPOSE 3000
 CMD ["wetterdienst", "restapi", "--listen", "0.0.0.0:3000", "--reload"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,27 @@ RUN --mount=type=cache,id=uv,target=/root/.cache/uv \
     uv sync --frozen --active \
     --extra bufr --extra cratedb --extra duckdb --extra export --extra influxdb --extra interpolation --extra plotting --extra postgresql --extra radar --extra radarplus --extra restapi
 
+# Dev stage: editable install so uvicorn --reload picks up source changes
+FROM python:3.14-slim-trixie AS dev
+
+COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /bin/
+
+ENV UV_NO_DEV=1
+ENV UV_LINK_MODE=copy
+ENV UV_PROJECT_ENVIRONMENT=/usr/local
+
+WORKDIR /app
+
+COPY uv.lock pyproject.toml ./
+COPY src ./src
+COPY README.md LICENSE.md ./
+
+RUN --mount=type=cache,id=uv,target=/root/.cache/uv \
+    uv sync --frozen --active --extra restapi
+
+EXPOSE 3000
+CMD ["wetterdienst", "restapi", "--listen", "0.0.0.0:3000", "--reload"]
+
 # Final stage
 FROM python:3.14-slim-trixie
 


### PR DESCRIPTION
## Summary

- The final Docker stage installs wetterdienst non-editably (`UV_NO_EDITABLE=1`), so `docker compose watch` syncing source files never took effect — `uvicorn --reload` had nothing to reload since the installed package was a static copy.
- Added a `dev` build target: editable install, `--reload` moved into the Dockerfile `CMD`.
- Fixed the `compose.yml` watch sync target, which was syncing `src/wetterdienst` → `/app` (flattening the package into the container root) instead of `/app/src/wetterdienst`.

## Test plan

- [ ] `docker compose --profile backend build && docker compose --profile backend up`
- [ ] Edit a file under `src/wetterdienst`, confirm the running container picks up the change without a manual rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)