### PR TITLE
feat(api): report date_required in coverage response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ Types of changes:
 
 ## [Unreleased]
 
+### Added
+
+- `[REST API]` The `/api/coverage` endpoint now reports a `date_required` flag per
+  provider/network, true if any of its resolutions require a date range for value
+  queries (e.g. MET Norway Frost). Lets frontends surface this before submitting a
+  query rather than after the query fails.
+
 ## [0.126.0] - 2026-07-07
 
 ### Fixed

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -109,7 +109,12 @@ class Wetterdienst:
                 try:
                     api = cls(provider, network)
                 except ImportError:
-                    result[provider][network] = {"auth": False, "configured": True, "valid": True, "date_required": False}
+                    result[provider][network] = {
+                        "auth": False,
+                        "configured": True,
+                        "valid": True,
+                        "date_required": False,
+                    }
                     continue
                 metadata = getattr(api, "metadata", None)
                 auth = metadata.auth if metadata is not None else False
@@ -125,8 +130,17 @@ class Wetterdienst:
                         valid = is_valid()
                     except Exception:  # noqa: BLE001
                         valid = False
-                date_required = any(r.date_required for r in metadata) if metadata is not None else False
-                result[provider][network] = {"auth": auth, "configured": configured, "valid": valid, "date_required": date_required}
+                date_required = (
+                    any(dataset.date_required for resolution in metadata for dataset in resolution.datasets)
+                    if metadata is not None
+                    else False
+                )
+                result[provider][network] = {
+                    "auth": auth,
+                    "configured": configured,
+                    "valid": valid,
+                    "date_required": date_required,
+                }
         return result
 
     @classmethod

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -109,7 +109,7 @@ class Wetterdienst:
                 try:
                     api = cls(provider, network)
                 except ImportError:
-                    result[provider][network] = {"auth": False, "configured": True, "valid": True}
+                    result[provider][network] = {"auth": False, "configured": True, "valid": True, "date_required": False}
                     continue
                 metadata = getattr(api, "metadata", None)
                 auth = metadata.auth if metadata is not None else False
@@ -125,7 +125,8 @@ class Wetterdienst:
                         valid = is_valid()
                     except Exception:  # noqa: BLE001
                         valid = False
-                result[provider][network] = {"auth": auth, "configured": configured, "valid": valid}
+                date_required = any(r.date_required for r in metadata) if metadata is not None else False
+                result[provider][network] = {"auth": auth, "configured": configured, "valid": valid, "date_required": date_required}
         return result
 
     @classmethod

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -71,7 +71,10 @@ def test_coverage(client: TestClient) -> None:
     dwd = data["dwd"]
     assert list(dwd.keys()) == ["observation", "mosmix", "dmo", "road", "radar", "derived"]
     for network_info in dwd.values():
-        assert network_info == {"auth": False, "configured": True, "valid": True}
+        assert network_info["auth"] is False
+        assert network_info["configured"] is True
+        assert network_info["valid"] is True
+        assert "date_required" in network_info
 
 
 def test_auth_no_auth_required(client: TestClient) -> None:

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -74,7 +74,9 @@ def test_coverage(client: TestClient) -> None:
         assert network_info["auth"] is False
         assert network_info["configured"] is True
         assert network_info["valid"] is True
-        assert "date_required" in network_info
+    # `road` requires a date range for value queries, other DWD networks don't
+    assert dwd["observation"]["date_required"] is False
+    assert dwd["road"]["date_required"] is True
 
 
 def test_auth_no_auth_required(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

- `Wetterdienst.discover()` (and by extension `GET /api/coverage`) now reports a `date_required: bool` flag per provider/network — true if any of the network's resolutions declare `date_required` (e.g. MET Norway Frost's hourly/10-minute/6-hour resolutions).
- Lets a frontend prompt for a date range up front for providers that need one, instead of only discovering the requirement after a failed query.

## Test plan

- [x] `uv run pytest tests/ui/test_restapi.py -k test_coverage -vvv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)