### PR TITLE
feat(frontend): auto-fill required date range from station coverage

### DIFF
--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -25,6 +25,15 @@ Types of changes:
   dataset is chosen (initial load and on dataset change). URL-specified parameters are
   preserved if still valid; otherwise all parameters are selected as the default.
 
+### Added
+
+- `[Explorer]` The date range selector is now marked required for providers that need a
+  date range for value queries (e.g. MET Norway Frost), reflecting the backend's
+  `date_required` coverage flag instead of always showing "optional".
+- `[Explorer]` When a date range is required and stations are selected, the date range
+  auto-fills from the min start date / max end date across the selected stations
+  (stations still collecting data are treated as ending today).
+
 
 ## [0.8.0] - 2026-07-06
 

--- a/frontend/app/components/ParameterSelection.vue
+++ b/frontend/app/components/ParameterSelection.vue
@@ -7,6 +7,7 @@ const props = withDefaults(defineProps<{
     resolution?: string
     dataset?: string
     parameters?: string[]
+    dateRequired?: boolean
   }
   showParameters?: boolean
 }>(), {
@@ -86,6 +87,11 @@ const params = computed<string[]>(() => {
   return datasetParams
     .map((p: CoverageParameter) => p.name)
     .sort()
+})
+const dateRequired = computed<boolean>(() => {
+  if (!coverage.value || !provider.value || !network.value)
+    return false
+  return coverage.value[provider.value]?.[network.value]?.date_required === true
 })
 
 // Friendly, locale-aware labels for the select menus (value stays the raw backend id).
@@ -244,10 +250,11 @@ function emitUpdate() {
     resolution: resolution.value,
     dataset: dataset.value,
     parameters: parameters.value,
+    dateRequired: dateRequired.value,
   })
 }
 
-watch([provider, network, resolution, dataset, parameters], () => {
+watch([provider, network, resolution, dataset, parameters, dateRequired], () => {
   if (isInitializing.value)
     return
   emitUpdate()

--- a/frontend/app/pages/explorer.vue
+++ b/frontend/app/pages/explorer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import type { Station } from '#shared/types/api'
 import type { TableColumn } from '@nuxt/ui'
-import type { Station } from '~/shared/types/api'
 import type { DataSettings } from '~/types/data-settings.type'
 import type { ParameterSelectionState } from '~/types/parameter-selection-state.type'
 import type { StationMode, StationSelectionState } from '~/types/station-selection-state.type'

--- a/frontend/app/pages/explorer.vue
+++ b/frontend/app/pages/explorer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { TableColumn } from '@nuxt/ui'
+import type { Station } from '~/shared/types/api'
 import type { DataSettings } from '~/types/data-settings.type'
 import type { ParameterSelectionState } from '~/types/parameter-selection-state.type'
 import type { StationMode, StationSelectionState } from '~/types/station-selection-state.type'
@@ -255,8 +256,35 @@ const isHighResolution = computed(() => {
 const isInterpolationMode = computed(() => stationSelectionState.value.mode === 'interpolation')
 const isSummaryMode = computed(() => stationSelectionState.value.mode === 'summary')
 
-// Date range is required for interpolation, summary, or high resolution
-const dateRangeRequired = computed(() => isInterpolationMode.value || isSummaryMode.value || isHighResolution.value)
+// Date range is required for interpolation, summary, high resolution, or date_required providers
+const dateRangeRequired = computed(() =>
+  isInterpolationMode.value
+  || isSummaryMode.value
+  || isHighResolution.value
+  || parameterSelectionState.value.selection.dateRequired === true,
+)
+
+// When dates are required and stations are selected, auto-fill from min(start_date) / max(end_date).
+watch(
+  [
+    () => stationSelectionState.value.selection.stations,
+    dateRangeRequired,
+  ],
+  ([stations, required]) => {
+    if (!required || !(stations as Station[]).length)
+      return
+    const today = new Date().toISOString().slice(0, 10)
+    const toDate = (iso: string | undefined | null) => iso ? iso.slice(0, 10) : null
+    const starts = (stations as Station[]).map(s => toDate(s.start_date)).filter(Boolean) as string[]
+    // Active stations have no end_date — treat them as ending today
+    const ends = (stations as Station[]).map(s => toDate(s.end_date) ?? today)
+    if (starts.length)
+      stationSelectionState.value.dateRange.startDate = starts.reduce((a, b) => a < b ? a : b)
+    if (ends.length)
+      stationSelectionState.value.dateRange.endDate = ends.reduce((a, b) => a > b ? a : b)
+  },
+  { deep: true },
+)
 
 // Check if station/interpolation/summary selection is complete
 const hasLocationSelection = computed(() => {

--- a/frontend/app/types/parameter-selection-state.type.ts
+++ b/frontend/app/types/parameter-selection-state.type.ts
@@ -4,6 +4,7 @@ export interface ParameterSelection {
   resolution: Resolution | undefined
   dataset: string | undefined
   parameters: string[]
+  dateRequired?: boolean
 }
 
 export interface ParameterSelectionState {

--- a/frontend/shared/types/api.ts
+++ b/frontend/shared/types/api.ts
@@ -30,6 +30,7 @@ export interface CoverageNetworkInfo {
   auth: boolean
   configured: boolean
   valid: boolean
+  date_required: boolean
 }
 
 /** Provider to networks mapping with per-network metadata */


### PR DESCRIPTION
## Summary

Stacked on #1720 (needs the parameters-field/auto-select fix as a base) and depends on #1722 (backend `date_required` coverage flag) to be functional.

- `dateRangeRequired` in the Explorer now also considers `parameterSelectionState.selection.dateRequired`, sourced from the backend's per-network `date_required` coverage flag (e.g. true for MET Norway Frost). Previously only interpolation/summary/high-resolution modes marked the date range as required, so Frost always showed "optional" even though queries without a date range fail.
- Added a watcher that auto-fills the date range from `min(station.start_date)` / `max(station.end_date)` whenever required and stations are selected. Stations without an `end_date` (still actively collecting data) are treated as ending today.

## Test plan

- [ ] Select metno/frost in Explorer → date range selector shows as required
- [ ] Select a station → start/end dates auto-fill from station coverage
- [ ] Add/remove stations → date range recalculates
- [ ] Verify DWD/interpolation/summary date-required behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)