### PR TITLE
ci(docker): load local .env into backend container

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,9 @@ services:
     image: wetterdienst-backend:dev
     container_name: wetterdienst-backend
     restart: unless-stopped
+    env_file:
+      - path: .env
+        required: false
     environment:
       # Common development env overrides; can be overridden in .env
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

Stacked on #1721 (dev-stage hot-reload).

- Adds `env_file: [{ path: .env, required: false }]` to the backend service so a local, gitignored `.env` (provider credentials like MET Norway Frost client ID/secret, cache settings, etc.) is picked up automatically by `docker compose` instead of needing to be exported into the shell or hardcoded in `compose.yml`.
- `required: false` means the file is optional — compose works fine without one.

## Test plan

- [ ] Create a local `.env` with e.g. `WD_METNO_FROST_CLIENT_ID=...`, run `docker compose --profile backend up`, confirm the var is visible inside the container
- [ ] Confirm compose still starts fine with no `.env` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)