### PR TITLE
fix(imgw): repair broken meteorology/hydrology providers, prune file listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ Types of changes:
   request. Cuts the number of HTTP requests from ~33 (meteorology) / ~74 (hydrology) down
   to the 1-2 folders that actually matter for a given query.
 
+### Removed
+
+- `[IMGW]` Removed the hardcoded lat/lon override for hydrology station `150190410`,
+  a workaround for a corrupted upstream CSV line from ~2024-02. The station's data has
+  been clean upstream for a while, so the override had become a no-op; keeping it around
+  risked silently clobbering a legitimate future coordinate change for that station.
+
 ### Fixed
 
 - `[IMGW]` Station listing for both meteorology and hydrology no longer fails: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,13 @@ Types of changes:
 - `[IMGW]` Hydrology value downloads now honor `WD_USE_CERTIFI`/`use_certifi`, matching
   the station list fetch and the meteorology provider. Previously it was silently ignored
   for the actual data downloads.
+- `[IMGW]` Hydrology daily requests touching 2023 or later no longer crash with
+  `ValueError: month must be in 1..12`. IMGW switched from twelve monthly zips per year
+  to one consolidated yearly zip starting 2023, which broke the date-range parsing that
+  assumed a `codz_YYYY_MM.zip` filename. Also handles the two different (and, for 2024,
+  outright malformed) CSV export quirks IMGW has used for these consolidated files since,
+  for both daily and monthly hydrology data: semicolon-separated unquoted rows in 2023,
+  and in 2024 every row wrapped in a broken extra pair of quotes with doubled inner quotes.
 
 ## [0.126.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ Types of changes:
   request. Cuts the number of HTTP requests from ~33 (meteorology) / ~74 (hydrology) down
   to the 1-2 folders that actually matter for a given query.
 
+### Fixed
+
+- `[IMGW]` Station listing for both meteorology and hydrology no longer fails: the
+  upstream station CSVs gained an extra "founding year" column and switched from a
+  Windows codepage to UTF-8, which broke column parsing and produced mojibake names.
+  Also fixed a station-list column-index bug (hydrology latitude/longitude were reading
+  the wrong columns), a missing `return_dtype` on the lat/lon DMS-to-decimal conversion,
+  and station rows no longer carrying a `resolution`/`dataset` tag, which made
+  `.values.all()` fail outright.
+
 ## [0.126.0] - 2026-07-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Types of changes:
   the wrong columns), a missing `return_dtype` on the lat/lon DMS-to-decimal conversion,
   and station rows no longer carrying a `resolution`/`dataset` tag, which made
   `.values.all()` fail outright.
+- `[IMGW]` Hydrology value downloads now honor `WD_USE_CERTIFI`/`use_certifi`, matching
+  the station list fetch and the meteorology provider. Previously it was silently ignored
+  for the actual data downloads.
 
 ## [0.126.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ Types of changes:
   outright malformed) CSV export quirks IMGW has used for these consolidated files since,
   for both daily and monthly hydrology data: semicolon-separated unquoted rows in 2023,
   and in 2024 every row wrapped in a broken extra pair of quotes with doubled inner quotes.
+- `[IMGW]` Meteorology `synop` daily requests no longer crash with
+  `TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'`. Unlike
+  every other IMGW meteorology dataset, `synop` daily has always been archived one file
+  per station per period (e.g. `2024_100_s.zip` for the station whose id ends in `100`)
+  rather than one file per month across all stations, going back to at least the 1966-1970
+  archive — the URL selection logic never accounted for this, so `synop` daily was
+  non-functional for any date range.
 
 ## [0.126.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Types of changes:
   parameter, cutting the number of HTTP requests by up to 11x for multi-parameter queries.
   Falls back to the previous per-parameter behavior (including historical time-series
   discovery) if the batched request itself returns a 404.
+- `[IMGW]` File listing now prunes IMGW's per-period subfolders (named `YYYY` or
+  `YYYY_YYYY`, encoding the exact date range they cover) to only those overlapping the
+  requested date range, instead of recursively listing the entire directory tree on every
+  request. Cuts the number of HTTP requests from ~33 (meteorology) / ~74 (hydrology) down
+  to the 1-2 folders that actually matter for a given query.
 
 ## [0.126.0] - 2026-07-07
 

--- a/src/wetterdienst/provider/imgw/fileindex.py
+++ b/src/wetterdienst/provider/imgw/fileindex.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""File index helpers for IMGW providers.
+
+IMGW's file server groups the actual data files (zips) into per-period subdirectories, e.g.::
+
+    dobowe/klimat/2023/2023_01_k.zip
+    dobowe/klimat/1951_1955/1951_k.zip
+
+Subdirectory names are either a single year (``YYYY``) or a year range (``YYYY_YYYY``) and always cover
+exactly the date range of the files within. Since every IMGW dataset requires a date range to be given,
+this lets us list only the subdirectories that can possibly contain matching files instead of recursively
+walking the entire (fairly deep and wide) directory tree on every request.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
+
+import portion
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.util.network import list_remote_directory_fsspec
+
+if TYPE_CHECKING:
+    from wetterdienst.settings import Settings
+
+_FOLDER_PATTERN = re.compile(r"^(?P<start>\d{4})(?:_(?P<end>\d{4}))?$")
+# fallback interval for folder names that don't match the expected pattern, so we never silently drop data
+_ALWAYS_OVERLAPS = portion.closed(
+    dt.datetime.min.replace(tzinfo=ZoneInfo("UTC")),
+    dt.datetime.max.replace(tzinfo=ZoneInfo("UTC")),
+)
+
+
+def _folder_interval(folder_name: str) -> portion.Interval:
+    """Parse the date interval covered by an IMGW period folder name (``YYYY`` or ``YYYY_YYYY``)."""
+    match = _FOLDER_PATTERN.match(folder_name.rstrip("/").rsplit("/", 1)[-1])
+    if not match:
+        return _ALWAYS_OVERLAPS
+    year_start = int(match.group("start"))
+    year_end = int(match.group("end") or year_start)
+    return portion.closed(
+        dt.datetime(year_start, 1, 1, tzinfo=ZoneInfo("UTC")),
+        dt.datetime(year_end, 12, 31, tzinfo=ZoneInfo("UTC")),
+    )
+
+
+def list_files_for_interval(
+    url: str,
+    settings: Settings,
+    interval: portion.Interval | None,
+    cache_expiry: CacheExpiry = CacheExpiry.FILEINDEX,
+) -> list[str]:
+    """List all file urls below ``url``, only descending into period folders that overlap ``interval``.
+
+    If ``interval`` is None, all period folders are listed (equivalent to a full recursive listing).
+    """
+    entries = list_remote_directory_fsspec(url, settings, cache_expiry)
+    files = [entry["name"] for entry in entries if entry["type"] == "file"]
+    folders = [entry["name"] for entry in entries if entry["type"] == "directory"]
+    if interval is not None:
+        folders = [folder for folder in folders if _folder_interval(folder).overlaps(interval)]
+    for folder in folders:
+        folder_entries = list_remote_directory_fsspec(folder, settings, cache_expiry)
+        files.extend(entry["name"] for entry in folder_entries if entry["type"] == "file")
+    return files

--- a/src/wetterdienst/provider/imgw/hydrology/api.py
+++ b/src/wetterdienst/provider/imgw/hydrology/api.py
@@ -146,6 +146,54 @@ ImgwHydrologyMetadata = {
 ImgwHydrologyMetadata = build_metadata_model(ImgwHydrologyMetadata, "ImgwHydrologyMetadata")
 
 
+def _hydrology_daily_file_date_range(year: int, month: int | None) -> list[dt.datetime]:
+    """Compute the date range covered by a hydrology daily zip file from its filename year/month.
+
+    Daily files are either per-month (``codz_YYYY_MM.zip``, historical) or a single
+    consolidated file per year (``codz_YYYY.zip``, used from 2023 onwards). ``month`` is
+    None for the latter, in which case the whole hydrological year is covered.
+    """
+    if month is None:
+        d = dt.datetime(year, 1, 1, tzinfo=ZoneInfo("UTC"))
+        return [d - relativedelta(months=2), d + relativedelta(months=11) - relativedelta(days=1)]
+    # shift hydrological year/month to calendar year/month, mirroring __parse_file below
+    if month <= 2:
+        year -= 1
+    month = month - 2 if month + 10 > 12 else month + 10
+    return [
+        dt.datetime(year, month, 1, tzinfo=ZoneInfo("UTC")),
+        dt.datetime(year, month, 1, tzinfo=ZoneInfo("UTC")) + relativedelta(months=1) - relativedelta(days=1),
+    ]
+
+
+def _normalize_hydrology_csv(data: bytes) -> tuple[bytes, str]:
+    """Detect and normalize the CSV export quirks IMGW has used for hydrology zip files.
+
+    IMGW's per-row export format has changed multiple times:
+      - historically (through ~2022): comma-separated, individually quoted fields
+      - 2023: semicolon-separated, unquoted fields (sometimes with a UTF-8 BOM)
+      - 2024: comma-separated, but each row wrapped in one extra pair of quotes with
+        doubly-escaped inner quotes, e.g. ``"id,name,river,""2024"",""01"",...``
+
+    Returns the (possibly rewritten) bytes together with the separator to parse them with.
+    """
+    body = data.replace(b"\xef\xbb\xbf", b"")
+    first_line = body.split(b"\n", 1)[0].rstrip(b"\r")
+    if first_line.startswith(b'"') and b',""' in first_line:
+        unwrapped = []
+        for raw_line in body.split(b"\n"):
+            line = raw_line.rstrip(b"\r")
+            if not line:
+                continue
+            if line.startswith(b'"') and line.endswith(b'"'):
+                line = line[1:-1]
+            unwrapped.append(line.replace(b'""', b'"'))
+        return b"\r\n".join(unwrapped), ","
+    if b";" in first_line and b"," not in first_line:
+        return body, ";"
+    return body, ","
+
+
 class ImgwHydrologyValues(TimeseriesValues):
     """Values class for hydrological data from IMGW."""
 
@@ -260,10 +308,11 @@ class ImgwHydrologyValues(TimeseriesValues):
 
     def __parse_file(self, file: bytes, station_id: str, dataset: DatasetModel, schema: dict) -> pl.DataFrame:
         """Parse hydrological data from a single file."""
+        normalized, separator = _normalize_hydrology_csv(file)
         df = pl.read_csv(
-            file,
+            normalized,
             encoding="latin-1",
-            separator=",",
+            separator=separator,
             has_header=False,
             infer_schema_length=0,
             null_values=["9999", "99999.999", "99.9"],
@@ -329,29 +378,20 @@ class ImgwHydrologyValues(TimeseriesValues):
         df_files = df_files.filter(pl.col("file").str.ends_with(".zip") & ~pl.col("file").str.starts_with("zjaw"))
         if interval is not None:
             if dataset.resolution.value == Resolution.DAILY:
+                # daily files are either per-month ("codz_YYYY_MM.zip", historical) or a single
+                # consolidated file per year ("codz_YYYY.zip", used from 2023 onwards); month is
+                # null for the latter and _hydrology_daily_file_date_range() covers the whole year
                 df_files = df_files.with_columns(
                     pl.col("file").str.strip_chars_end(".zip").str.split("_").list.slice(1).alias("year_month"),
                 )
                 df_files = df_files.with_columns(
                     pl.col("year_month").list.first().cast(pl.Int64).alias("year"),
-                    pl.col("year_month").list.last().cast(pl.Int64).alias("month"),
-                )
-                df_files = df_files.with_columns(
-                    pl.when(pl.col("month") <= 2).then(pl.col("year") - 1).otherwise(pl.col("year")).alias("year"),
-                    pl.when(pl.col("month").add(10).gt(12))
-                    .then(pl.col("month").sub(2))
-                    .otherwise(pl.col("month"))
-                    .alias("month"),
+                    pl.col("year_month").list.get(1, null_on_oob=True).cast(pl.Int64).alias("month"),
                 )
                 df_files = df_files.with_columns(
                     pl.struct(["year", "month"])
                     .map_elements(
-                        lambda x: [
-                            dt.datetime(x["year"], x["month"], 1, tzinfo=ZoneInfo("UTC")),
-                            dt.datetime(x["year"], x["month"], 1, tzinfo=ZoneInfo("UTC"))
-                            + relativedelta(months=1)
-                            - relativedelta(days=1),
-                        ],
+                        lambda x: _hydrology_daily_file_date_range(x["year"], x["month"]),
                         return_dtype=pl.Array(pl.Datetime, shape=2),
                     )
                     .alias("date_range"),

--- a/src/wetterdienst/provider/imgw/hydrology/api.py
+++ b/src/wetterdienst/provider/imgw/hydrology/api.py
@@ -19,7 +19,7 @@ from fsspec.implementations.zip import ZipFileSystem
 
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.resolution import Resolution
-from wetterdienst.model.metadata import DatasetModel, build_metadata_model
+from wetterdienst.model.metadata import DatasetModel, ParameterModel, build_metadata_model
 from wetterdienst.model.request import TimeseriesRequest
 from wetterdienst.model.values import TimeseriesValues
 from wetterdienst.provider.imgw.fileindex import list_files_for_interval
@@ -370,8 +370,8 @@ class ImgwHydrologyValues(TimeseriesValues):
                 )
             df_files = df_files.select(
                 pl.col("url"),
-                pl.col("date_range").list.first().cast(pl.Datetime(time_zone="UTC")).alias("start_date"),
-                pl.col("date_range").list.last().cast(pl.Datetime(time_zone="UTC")).alias("end_date"),
+                pl.col("date_range").arr.first().cast(pl.Datetime(time_zone="UTC")).alias("start_date"),
+                pl.col("date_range").arr.last().cast(pl.Datetime(time_zone="UTC")).alias("end_date"),
             )
             df_files = df_files.with_columns(
                 pl.struct(["start_date", "end_date"])
@@ -412,19 +412,21 @@ class ImgwHydrologyRequest(TimeseriesRequest):
         if isinstance(payload.content, Exception):
             return pl.LazyFrame()
         # skip empty lines in the csv file
-        lines = payload.content.read().decode("latin-1").replace("\r", "").split("\n")
+        lines = payload.content.read().decode("utf-8").replace("\r", "").split("\n")
         lines = [line for line in lines if line]
         payload = StringIO("\n".join(lines))
         df = pl.read_csv(
             payload,
-            encoding="latin-1",
+            encoding="utf8",
             has_header=False,
             separator=";",
             skip_rows=1,
             infer_schema_length=0,
             truncate_ragged_lines=True,
         )
-        df = df[:, [1, 2, 4, 5]]
+        # columns (0-indexed): LP, Kod (station_id), Nazwa (name), Rzeka, Rok założenia, Szerokość (latitude),
+        # Długość (longitude), Rzędna zera wodowskazu, Kilometr biegu rzeki
+        df = df[:, [1, 2, 5, 6]]
         df.columns = [
             "station_id",
             "name",
@@ -444,8 +446,23 @@ class ImgwHydrologyRequest(TimeseriesRequest):
             .then(pl.lit("19 07 58").alias("longitude"))
             .otherwise(pl.col("longitude")),
         )
-        df = df.lazy()
-        return df.with_columns(
-            pl.col("latitude").map_batches(convert_dms_string_to_dd),
-            pl.col("longitude").map_batches(convert_dms_string_to_dd),
+        df = df.with_columns(
+            pl.col("latitude").map_batches(convert_dms_string_to_dd, return_dtype=pl.Float64),
+            pl.col("longitude").map_batches(convert_dms_string_to_dd, return_dtype=pl.Float64),
         )
+        # the station list is shared across all datasets, so tag each row once per requested resolution/dataset
+        resolutions_and_datasets = {
+            (parameter.dataset.resolution.name, parameter.dataset.name)
+            for parameter in self.parameters
+            if isinstance(parameter, ParameterModel)
+        }
+        data = [
+            df.with_columns(
+                pl.lit(resolution, pl.String).alias("resolution"),
+                pl.lit(dataset, pl.String).alias("dataset"),
+            )
+            for resolution, dataset in resolutions_and_datasets
+        ]
+        if not data:
+            return pl.LazyFrame()
+        return pl.concat(data).lazy()

--- a/src/wetterdienst/provider/imgw/hydrology/api.py
+++ b/src/wetterdienst/provider/imgw/hydrology/api.py
@@ -433,19 +433,6 @@ class ImgwHydrologyRequest(TimeseriesRequest):
             "latitude",
             "longitude",
         ]
-        # TODO: remove the following workaround once the data is fixed upstream
-        # since somewhere in 2024-02 one station of the station list is bugged
-        # 603;150190400;CZ�STOCHOWA 2;Kucelinka;50 48 22;19 09 15
-        # 604;150190410;CZ�STOCHOWA 3;Warta;50 48 50	19;07 58  <-- this is the bugged line
-        # 605;152140100;DOLSK;My�la;52 48 10;14 50 35
-        df = df.with_columns(
-            pl.when(pl.col("station_id") == "150190410")
-            .then(pl.lit("50 48 50").alias("latitude"))
-            .otherwise(pl.col("latitude")),
-            pl.when(pl.col("station_id") == "150190410")
-            .then(pl.lit("19 07 58").alias("longitude"))
-            .otherwise(pl.col("longitude")),
-        )
         df = df.with_columns(
             pl.col("latitude").map_batches(convert_dms_string_to_dd, return_dtype=pl.Float64),
             pl.col("longitude").map_batches(convert_dms_string_to_dd, return_dtype=pl.Float64),

--- a/src/wetterdienst/provider/imgw/hydrology/api.py
+++ b/src/wetterdienst/provider/imgw/hydrology/api.py
@@ -22,9 +22,10 @@ from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.model.metadata import DatasetModel, build_metadata_model
 from wetterdienst.model.request import TimeseriesRequest
 from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.imgw.fileindex import list_files_for_interval
 from wetterdienst.provider.imgw.metadata import _METADATA
 from wetterdienst.util.geo import convert_dms_string_to_dd
-from wetterdienst.util.network import File, download_file, download_files, list_remote_files_fsspec
+from wetterdienst.util.network import File, download_file, download_files
 
 if TYPE_CHECKING:
     from wetterdienst.settings import Settings
@@ -310,12 +311,22 @@ class ImgwHydrologyValues(TimeseriesValues):
     def _get_urls(self, dataset: DatasetModel) -> list[str]:
         """Get all urls for the given dataset."""
         url = self._endpoint.format(resolution=dataset.resolution.name_original, dataset=dataset.name_original)
-        files = list_remote_files_fsspec(url, self.sr.settings)
+        interval = None
+        folder_interval = None
+        if self.sr.start_date:
+            interval = portion.closed(self.sr.start_date, self.sr.end_date)
+            # widen by 2 months on each side when pruning folders: IMGW files use "hydrological years"
+            # (shifted by 2 months, see __parse_file below) internally, so e.g. a file living in the "2023"
+            # folder can contain data as early as 2022-11. The exact per-file filtering below is unaffected.
+            folder_interval = portion.closed(
+                self.sr.start_date - relativedelta(months=2),
+                self.sr.end_date + relativedelta(months=2),
+            )
+        files = list_files_for_interval(url, self.sr.settings, folder_interval)
         df_files = pl.DataFrame({"url": files})
         df_files = df_files.with_columns(pl.col("url").str.split("/").list.last().alias("file"))
         df_files = df_files.filter(pl.col("file").str.ends_with(".zip") & ~pl.col("file").str.starts_with("zjaw"))
-        if self.sr.start_date:
-            interval = portion.closed(self.sr.start_date, self.sr.end_date)
+        if interval is not None:
             if dataset.resolution.value == Resolution.DAILY:
                 df_files = df_files.with_columns(
                     pl.col("file").str.strip_chars_end(".zip").str.split("_").list.slice(1).alias("year_month"),

--- a/src/wetterdienst/provider/imgw/hydrology/api.py
+++ b/src/wetterdienst/provider/imgw/hydrology/api.py
@@ -195,6 +195,7 @@ class ImgwHydrologyValues(TimeseriesValues):
             ttl=CacheExpiry.FIVE_MINUTES,
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
         )
         files = [file for file in files if isinstance(file.content, BytesIO)]
         data = []

--- a/src/wetterdienst/provider/imgw/meteorology/api.py
+++ b/src/wetterdienst/provider/imgw/meteorology/api.py
@@ -21,9 +21,10 @@ from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.model.metadata import DatasetModel, build_metadata_model
 from wetterdienst.model.request import TimeseriesRequest
 from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.imgw.fileindex import list_files_for_interval
 from wetterdienst.provider.imgw.metadata import _METADATA
 from wetterdienst.util.geo import convert_dms_string_to_dd
-from wetterdienst.util.network import File, download_file, download_files, list_remote_files_fsspec
+from wetterdienst.util.network import File, download_file, download_files
 
 if TYPE_CHECKING:
     from wetterdienst.settings import Settings
@@ -646,12 +647,12 @@ class ImgwMeteorologyValues(TimeseriesValues):
     def _get_urls(self, dataset: DatasetModel) -> list[str]:
         """Get URLs for the given dataset."""
         url = self._endpoint.format(resolution=dataset.resolution.name_original, dataset=dataset.name_original)
-        files = list_remote_files_fsspec(url, self.sr.settings)
+        interval = portion.closed(self.sr.start_date, self.sr.end_date) if self.sr.start_date else None
+        files = list_files_for_interval(url, self.sr.settings, interval)
         df_files = pl.DataFrame({"url": files})
         df_files = df_files.with_columns(pl.col("url").str.split("/").list.last().alias("file"))
         df_files = df_files.filter(pl.col("file").str.ends_with(".zip"))
-        if self.sr.start_date:
-            interval = portion.closed(self.sr.start_date, self.sr.end_date)
+        if interval is not None:
             if dataset.resolution.value == Resolution.MONTHLY:
                 df_files = df_files.with_columns(
                     pl.when(pl.col("file").str.split("_").list.len() == 3)

--- a/src/wetterdienst/provider/imgw/meteorology/api.py
+++ b/src/wetterdienst/provider/imgw/meteorology/api.py
@@ -560,7 +560,7 @@ class ImgwMeteorologyValues(TimeseriesValues):
         from typing import cast  # noqa: PLC0415
 
         settings = cast("Settings", self.sr.stations.settings)
-        urls = self._get_urls(parameter_or_dataset)
+        urls = self._get_urls(parameter_or_dataset, station_id)
         files = download_files(
             urls=urls,
             cache_dir=settings.cache_dir,
@@ -644,7 +644,7 @@ class ImgwMeteorologyValues(TimeseriesValues):
         df = df.unpivot(index=["station_id", "date"], variable_name="parameter", value_name="value")
         return df.with_columns(pl.col("value").cast(pl.Float64))
 
-    def _get_urls(self, dataset: DatasetModel) -> list[str]:
+    def _get_urls(self, dataset: DatasetModel, station_id: str) -> list[str]:
         """Get URLs for the given dataset."""
         url = self._endpoint.format(resolution=dataset.resolution.name_original, dataset=dataset.name_original)
         interval = portion.closed(self.sr.start_date, self.sr.end_date) if self.sr.start_date else None
@@ -652,6 +652,14 @@ class ImgwMeteorologyValues(TimeseriesValues):
         df_files = pl.DataFrame({"url": files})
         df_files = df_files.with_columns(pl.col("url").str.split("/").list.last().alias("file"))
         df_files = df_files.filter(pl.col("file").str.ends_with(".zip"))
+        if dataset.resolution.value == Resolution.DAILY and dataset.name == "synop":
+            # unlike every other IMGW meteorology dataset, synop daily is archived per
+            # station rather than per month: one file per period (year, or decade for
+            # older data) *per station*, e.g. "2024_100_s.zip" for the station whose
+            # 9-digit id ends in "100", not "2024_08_k.zip" for August across all stations
+            station_code = station_id[-3:]
+            df_files = df_files.filter(pl.col("file").str.contains(rf"_{station_code}_"))
+            return df_files.get_column("url").to_list()
         if interval is not None:
             if dataset.resolution.value == Resolution.MONTHLY:
                 df_files = df_files.with_columns(

--- a/src/wetterdienst/provider/imgw/meteorology/api.py
+++ b/src/wetterdienst/provider/imgw/meteorology/api.py
@@ -18,7 +18,7 @@ from fsspec.implementations.zip import ZipFileSystem
 
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.resolution import Resolution
-from wetterdienst.model.metadata import DatasetModel, build_metadata_model
+from wetterdienst.model.metadata import DatasetModel, ParameterModel, build_metadata_model
 from wetterdienst.model.request import TimeseriesRequest
 from wetterdienst.model.values import TimeseriesValues
 from wetterdienst.provider.imgw.fileindex import list_files_for_interval
@@ -702,8 +702,8 @@ class ImgwMeteorologyValues(TimeseriesValues):
                 )
             df_files = df_files.select(
                 pl.col("url"),
-                pl.col("date_range").list.first().cast(pl.Datetime(time_zone="UTC")).alias("start_date"),
-                pl.col("date_range").list.last().cast(pl.Datetime(time_zone="UTC")).alias("end_date"),
+                pl.col("date_range").arr.first().cast(pl.Datetime(time_zone="UTC")).alias("start_date"),
+                pl.col("date_range").arr.last().cast(pl.Datetime(time_zone="UTC")).alias("end_date"),
             )
             df_files = df_files.with_columns(
                 pl.struct(["start_date", "end_date"])
@@ -743,8 +743,10 @@ class ImgwMeteorologyRequest(TimeseriesRequest):
         file.raise_if_exception()
         if isinstance(file.content, Exception):
             return pl.LazyFrame()
-        df = pl.read_csv(file.content, encoding="latin-1", separator=";", skip_rows=1, infer_schema_length=0)
+        df = pl.read_csv(file.content, encoding="utf8", separator=";", skip_rows=1, infer_schema_length=0)
         df = df[:, 1:]
+        # drop the "Rok założenia" (station founding year) column, which isn't part of our schema
+        df = df.drop(df.columns[3])
         df.columns = [
             "station_id",
             "name",
@@ -753,9 +755,24 @@ class ImgwMeteorologyRequest(TimeseriesRequest):
             "longitude",
             "height",
         ]
-        df = df.lazy()
-        return df.with_columns(
-            pl.col("latitude").map_batches(convert_dms_string_to_dd),
-            pl.col("longitude").map_batches(convert_dms_string_to_dd),
+        df = df.with_columns(
+            pl.col("latitude").map_batches(convert_dms_string_to_dd, return_dtype=pl.Float64),
+            pl.col("longitude").map_batches(convert_dms_string_to_dd, return_dtype=pl.Float64),
             pl.col("height").str.replace(" ", "").cast(pl.Float64, strict=False),
         )
+        # the station list is shared across all datasets, so tag each row once per requested resolution/dataset
+        resolutions_and_datasets = {
+            (parameter.dataset.resolution.name, parameter.dataset.name)
+            for parameter in self.parameters
+            if isinstance(parameter, ParameterModel)
+        }
+        data = [
+            df.with_columns(
+                pl.lit(resolution, pl.String).alias("resolution"),
+                pl.lit(dataset, pl.String).alias("dataset"),
+            )
+            for resolution, dataset in resolutions_and_datasets
+        ]
+        if not data:
+            return pl.LazyFrame()
+        return pl.concat(data).lazy()

--- a/src/wetterdienst/util/network.py
+++ b/src/wetterdienst/util/network.py
@@ -404,6 +404,36 @@ def list_remote_files_fsspec(
     return fs.find(url)
 
 
+@stamina.retry(on=Exception, attempts=3)
+def list_remote_directory_fsspec(
+    url: str, settings: Settings, cache_expiry: CacheExpiry = CacheExpiry.FILEINDEX
+) -> list[dict]:
+    """List the immediate contents (files and subdirectories) of a given path on the server, non-recursively.
+
+    Unlike ``list_remote_files_fsspec``, this does not descend into subdirectories, which is useful for
+    servers exposing a deeply nested directory tree where the folder names themselves carry enough
+    information (e.g. a date range) to decide which subdirectories are actually worth descending into.
+
+    Args:
+        url: The URL to list the contents of.
+        settings: The settings to use for the listing.
+        cache_expiry: The cache expiration time.
+
+    Returns:
+        A list of fsspec detail dicts (with "name" and "type" keys, among others) for each entry.
+
+    """
+    use_cache = not (settings.cache_disable or cache_expiry is CacheExpiry.NO_CACHE)
+    fs = HTTPFileSystem(
+        use_listings_cache=use_cache,
+        listings_expiry_time=not settings.cache_disable and cache_expiry.value,
+        listings_cache_location=settings.cache_dir,
+        client_kwargs=settings.fsspec_client_kwargs,
+        use_certifi=settings.use_certifi,
+    )
+    return fs.ls(url, detail=True)
+
+
 def download_file(
     url: str,
     cache_dir: Path,

--- a/tests/provider/imgw/hydrology/test_api.py
+++ b/tests/provider/imgw/hydrology/test_api.py
@@ -167,3 +167,68 @@ def test_imgw_hydrology_api_monthly() -> None:
         orient="row",
     )
     assert_frame_equal(values.df, df_expected_values)
+
+
+@pytest.mark.remote
+def test_imgw_hydrology_api_daily_consolidated_yearly_file() -> None:
+    """IMGW consolidated daily hydrology into one zip per year from 2023 onwards.
+
+    2023's zip uses a semicolon-separated, unquoted CSV export; 2024's zip wraps each
+    row in a broken extra pair of quotes. This exercises both, via the hydrological-year
+    shift that maps calendar 2023-11-01 into the "2024" file.
+    """
+    request = ImgwHydrologyRequest(
+        parameters=[("daily", "hydrology")],
+        start_date="2023-11-01",
+        end_date="2023-11-01",
+    ).filter_by_station_id("149180020")
+    values = request.values.all()
+    df_expected = pl.DataFrame(
+        [
+            {
+                "station_id": "149180020",
+                "resolution": "daily",
+                "dataset": "hydrology",
+                "parameter": "discharge",
+                "date": dt.datetime(2023, 11, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 25.4,
+                "quality": None,
+            },
+            {
+                "station_id": "149180020",
+                "resolution": "daily",
+                "dataset": "hydrology",
+                "parameter": "stage",
+                "date": dt.datetime(2023, 11, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 113.0,
+                "quality": None,
+            },
+        ],
+        schema={
+            "station_id": pl.String,
+            "resolution": pl.String,
+            "dataset": pl.String,
+            "parameter": pl.String,
+            "date": pl.Datetime(time_zone="UTC"),
+            "value": pl.Float64,
+            "quality": pl.Float64,
+        },
+        orient="row",
+    )
+    assert_frame_equal(values.df, df_expected)
+
+
+@pytest.mark.remote
+def test_imgw_hydrology_api_monthly_recent_export_formats() -> None:
+    """2023 and 2024 monthly hydrology exports each use a different CSV quirk (see api.py)."""
+    for start_date, expected_max, expected_mean, expected_min in [
+        ("2023-06-01", 50.6, 17.7, 9.76),
+        ("2024-06-01", 216.0, 36.7, 16.7),
+    ]:
+        request = ImgwHydrologyRequest(
+            parameters=[("monthly", "hydrology")],
+            start_date=start_date,
+        ).filter_by_station_id("149180020")
+        values = request.values.all()
+        discharge = values.df.filter(pl.col("parameter").str.starts_with("discharge")).sort("parameter")
+        assert discharge.get_column("value").to_list() == [expected_max, expected_mean, expected_min]

--- a/tests/provider/imgw/hydrology/test_api.py
+++ b/tests/provider/imgw/hydrology/test_api.py
@@ -12,23 +12,26 @@ from polars.testing import assert_frame_equal
 from wetterdienst.provider.imgw.hydrology.api import ImgwHydrologyRequest
 
 
-@pytest.fixture
-def df_expected_station() -> pl.DataFrame:
+def _expected_station(resolution: str) -> pl.DataFrame:
     """Provide expected DataFrame for station."""
     return pl.DataFrame(
         [
             {
+                "resolution": resolution,
+                "dataset": "hydrology",
                 "station_id": "150190130",
                 "start_date": None,
                 "end_date": None,
                 "latitude": 50.350278,
                 "longitude": 19.185556,
                 "height": None,
-                "name": "£AGISZA",
+                "name": "ŁAGISZA",
                 "state": None,
             },
         ],
         schema={
+            "resolution": pl.String,
+            "dataset": pl.String,
             "station_id": pl.String,
             "start_date": pl.Datetime(time_zone="UTC"),
             "end_date": pl.Datetime(time_zone="UTC"),
@@ -42,19 +45,20 @@ def df_expected_station() -> pl.DataFrame:
     )
 
 
-@pytest.mark.xfail
-def test_imgw_hydrology_api_daily(df_expected_station: pl.DataFrame) -> None:
+@pytest.mark.remote
+def test_imgw_hydrology_api_daily() -> None:
     """Test fetching of daily hydrology data."""
     request = ImgwHydrologyRequest(
         parameters=[("daily", "hydrology")],
         start_date="2010-08-01",
     ).filter_by_station_id("150190130")
-    assert_frame_equal(request.df, df_expected_station)
+    assert_frame_equal(request.df, _expected_station("daily"))
     values = request.values.all()
     df_expected = pl.DataFrame(
         [
             {
                 "station_id": "150190130",
+                "resolution": "daily",
                 "dataset": "hydrology",
                 "parameter": "discharge",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -63,23 +67,17 @@ def test_imgw_hydrology_api_daily(df_expected_station: pl.DataFrame) -> None:
             },
             {
                 "station_id": "150190130",
+                "resolution": "daily",
                 "dataset": "hydrology",
                 "parameter": "stage",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 1.64,
-                "quality": None,
-            },
-            {
-                "station_id": "150190130",
-                "dataset": "hydrology",
-                "parameter": "temperature_water",
-                "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": None,
+                "value": 164.0,
                 "quality": None,
             },
         ],
         schema={
             "station_id": pl.String,
+            "resolution": pl.String,
             "dataset": pl.String,
             "parameter": pl.String,
             "date": pl.Datetime(time_zone="UTC"),
@@ -91,19 +89,20 @@ def test_imgw_hydrology_api_daily(df_expected_station: pl.DataFrame) -> None:
     assert_frame_equal(values.df, df_expected)
 
 
-@pytest.mark.xfail
-def test_imgw_hydrology_api_monthly(df_expected_station: pl.DataFrame) -> None:
+@pytest.mark.remote
+def test_imgw_hydrology_api_monthly() -> None:
     """Test fetching of monthly hydrology data."""
     request = ImgwHydrologyRequest(
         parameters=[("monthly", "hydrology")],
         start_date="2010-06-01",
     ).filter_by_station_id("150190130")
-    assert_frame_equal(request.df, df_expected_station)
+    assert_frame_equal(request.df, _expected_station("monthly"))
     values = request.values.all()
     df_expected_values = pl.DataFrame(
         [
             {
                 "station_id": "150190130",
+                "resolution": "monthly",
                 "dataset": "hydrology",
                 "parameter": "discharge_max",
                 "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
@@ -112,6 +111,7 @@ def test_imgw_hydrology_api_monthly(df_expected_station: pl.DataFrame) -> None:
             },
             {
                 "station_id": "150190130",
+                "resolution": "monthly",
                 "dataset": "hydrology",
                 "parameter": "discharge_mean",
                 "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
@@ -120,6 +120,7 @@ def test_imgw_hydrology_api_monthly(df_expected_station: pl.DataFrame) -> None:
             },
             {
                 "station_id": "150190130",
+                "resolution": "monthly",
                 "dataset": "hydrology",
                 "parameter": "discharge_min",
                 "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
@@ -128,55 +129,35 @@ def test_imgw_hydrology_api_monthly(df_expected_station: pl.DataFrame) -> None:
             },
             {
                 "station_id": "150190130",
+                "resolution": "monthly",
                 "dataset": "hydrology",
                 "parameter": "stage_max",
                 "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 2.64,
+                "value": 264.0,
                 "quality": None,
             },
             {
                 "station_id": "150190130",
+                "resolution": "monthly",
                 "dataset": "hydrology",
                 "parameter": "stage_mean",
                 "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 1.99,
+                "value": 199.0,
                 "quality": None,
             },
             {
                 "station_id": "150190130",
+                "resolution": "monthly",
                 "dataset": "hydrology",
                 "parameter": "stage_min",
                 "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 1.49,
-                "quality": None,
-            },
-            {
-                "station_id": "150190130",
-                "dataset": "hydrology",
-                "parameter": "temperature_water_max",
-                "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
-                "value": None,
-                "quality": None,
-            },
-            {
-                "station_id": "150190130",
-                "dataset": "hydrology",
-                "parameter": "temperature_water_mean",
-                "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
-                "value": None,
-                "quality": None,
-            },
-            {
-                "station_id": "150190130",
-                "dataset": "hydrology",
-                "parameter": "temperature_water_min",
-                "date": dt.datetime(2010, 6, 1, tzinfo=ZoneInfo("UTC")),
-                "value": None,
+                "value": 149.0,
                 "quality": None,
             },
         ],
         schema={
             "station_id": pl.String,
+            "resolution": pl.String,
             "dataset": pl.String,
             "parameter": pl.String,
             "date": pl.Datetime(time_zone="UTC"),

--- a/tests/provider/imgw/meteorology/test_api.py
+++ b/tests/provider/imgw/meteorology/test_api.py
@@ -345,3 +345,114 @@ def test_imgw_meteorology_api_monthly() -> None:
         orient="row",
     )
     assert_frame_equal(values.df, df_expected_values)
+
+
+@pytest.mark.remote
+def test_imgw_meteorology_api_daily_synop() -> None:
+    """Test fetching of daily synop data.
+
+    Synop daily is archived per-station ("YYYY_<station-code>_s.zip"), not per-month like
+    the other meteorology daily datasets, and needs its own file-selection logic in _get_urls().
+    """
+    request = ImgwMeteorologyRequest(
+        parameters=[("daily", "synop")],
+        start_date="2024-01-01",
+        end_date="2024-01-01",
+    ).filter_by_station_id("354150100")
+    values = request.values.all()
+    df_expected_values = pl.DataFrame(
+        [
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "cloud_cover_total",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 0.0,
+                "quality": None,
+            },
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "humidity",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 0.905,
+                "quality": None,
+            },
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "precipitation_height_day",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 0.1,
+                "quality": None,
+            },
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "precipitation_height_night",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 4.8,
+                "quality": None,
+            },
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "pressure_air_sea_level",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 1004.2,
+                "quality": None,
+            },
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "pressure_air_site",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 1003.5,
+                "quality": None,
+            },
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "pressure_vapor",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 7.7,
+                "quality": None,
+            },
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "temperature_air_mean_2m",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 4.6,
+                "quality": None,
+            },
+            {
+                "station_id": "354150100",
+                "resolution": "daily",
+                "dataset": "synop",
+                "parameter": "wind_speed",
+                "date": dt.datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+                "value": 3.1,
+                "quality": None,
+            },
+        ],
+        schema={
+            "station_id": pl.String,
+            "resolution": pl.String,
+            "dataset": pl.String,
+            "parameter": pl.String,
+            "date": pl.Datetime(time_zone="UTC"),
+            "value": pl.Float64,
+            "quality": pl.Float64,
+        },
+        orient="row",
+    )
+    assert_frame_equal(values.df, df_expected_values)

--- a/tests/provider/imgw/meteorology/test_api.py
+++ b/tests/provider/imgw/meteorology/test_api.py
@@ -12,7 +12,7 @@ from polars.testing import assert_frame_equal
 from wetterdienst.provider.imgw.meteorology.api import ImgwMeteorologyRequest
 
 
-@pytest.mark.xfail
+@pytest.mark.remote
 def test_imgw_meteorology_api_daily() -> None:
     """Test fetching of meteorological data."""
     request = ImgwMeteorologyRequest(
@@ -22,6 +22,8 @@ def test_imgw_meteorology_api_daily() -> None:
     df_expected_station = pl.DataFrame(
         [
             {
+                "resolution": "daily",
+                "dataset": "climate",
                 "station_id": "253160090",
                 "start_date": None,
                 "end_date": None,
@@ -29,10 +31,12 @@ def test_imgw_meteorology_api_daily() -> None:
                 "longitude": 16.104444,
                 "height": 137.0,
                 "name": "WIERZCHOWO",
-                "state": "Drawa",
+                "state": "Drawa (1888)",
             },
         ],
         schema={
+            "resolution": pl.String,
+            "dataset": pl.String,
             "station_id": pl.String,
             "start_date": pl.Datetime(time_zone="UTC"),
             "end_date": pl.Datetime(time_zone="UTC"),
@@ -50,14 +54,16 @@ def test_imgw_meteorology_api_daily() -> None:
         [
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "cloud_cover_total",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 28.75,
+                "value": 0.2875,
                 "quality": None,
             },
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "humidity",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -66,6 +72,7 @@ def test_imgw_meteorology_api_daily() -> None:
             },
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "precipitation_height",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -74,6 +81,7 @@ def test_imgw_meteorology_api_daily() -> None:
             },
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "snow_depth",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -82,38 +90,43 @@ def test_imgw_meteorology_api_daily() -> None:
             },
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "temperature_air_max_2m",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 301.35,
+                "value": 28.2,
                 "quality": None,
             },
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "temperature_air_mean_0_05m",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 278.75,
+                "value": 5.6,
                 "quality": None,
             },
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "temperature_air_mean_2m",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 293.75,
+                "value": 20.6,
                 "quality": None,
             },
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "temperature_air_min_2m",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 282.35,
+                "value": 9.2,
                 "quality": None,
             },
             {
                 "station_id": "253160090",
+                "resolution": "daily",
                 "dataset": "climate",
                 "parameter": "wind_speed",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -123,6 +136,7 @@ def test_imgw_meteorology_api_daily() -> None:
         ],
         schema={
             "station_id": pl.String,
+            "resolution": pl.String,
             "dataset": pl.String,
             "parameter": pl.String,
             "date": pl.Datetime(time_zone="UTC"),
@@ -134,7 +148,7 @@ def test_imgw_meteorology_api_daily() -> None:
     assert_frame_equal(values.df, df_expected_values)
 
 
-@pytest.mark.xfail
+@pytest.mark.remote
 def test_imgw_meteorology_api_monthly() -> None:
     """Test fetching of meteorological data."""
     request = ImgwMeteorologyRequest(
@@ -144,17 +158,21 @@ def test_imgw_meteorology_api_monthly() -> None:
     df_expected_station = pl.DataFrame(
         [
             {
+                "resolution": "monthly",
+                "dataset": "synop",
                 "station_id": "349190600",
                 "start_date": None,
                 "end_date": None,
                 "latitude": 49.806666666666665,
                 "longitude": 19.002222222222223,
                 "height": 396.0,
-                "name": "BIELSKO-BIA£A",
-                "state": "Bia³a",
+                "name": "Bielsko-Biała",
+                "state": "Biała (2114)",
             },
         ],
         schema={
+            "resolution": pl.String,
+            "dataset": pl.String,
             "station_id": pl.String,
             "start_date": pl.Datetime(time_zone="UTC"),
             "end_date": pl.Datetime(time_zone="UTC"),
@@ -172,22 +190,25 @@ def test_imgw_meteorology_api_monthly() -> None:
         [
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "cloud_cover_total",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 60.0,
+                "value": 0.6,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "humidity",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 75.3,
+                "value": 0.753,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "precipitation_height",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -196,6 +217,7 @@ def test_imgw_meteorology_api_monthly() -> None:
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "precipitation_height_day",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -204,6 +226,7 @@ def test_imgw_meteorology_api_monthly() -> None:
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "precipitation_height_max",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -212,6 +235,7 @@ def test_imgw_meteorology_api_monthly() -> None:
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "precipitation_height_night",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -220,30 +244,34 @@ def test_imgw_meteorology_api_monthly() -> None:
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "pressure_air_sea_level",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 101380.0,
+                "value": 1013.8,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "pressure_air_site",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 96740.0,
+                "value": 967.4,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "pressure_vapor",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 1560.0,
+                "value": 15.6,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "snow_depth_max",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -252,54 +280,52 @@ def test_imgw_meteorology_api_monthly() -> None:
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "temperature_air_max_2m",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 302.65,
+                "value": 29.5,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "temperature_air_max_2m_mean",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 296.34999999999997,
+                "value": 23.2,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "temperature_air_mean_2m",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 291.34999999999997,
+                "value": 18.2,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "temperature_air_min_0_05m",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 280.84999999999997,
+                "value": 7.7,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "temperature_air_min_2m",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 281.65,
+                "value": 8.5,
                 "quality": None,
             },
             {
                 "station_id": "349190600",
-                "dataset": "synop",
-                "parameter": "temperature_air_min_2m_mean",
-                "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
-                "value": 287.15,
-                "quality": None,
-            },
-            {
-                "station_id": "349190600",
+                "resolution": "monthly",
                 "dataset": "synop",
                 "parameter": "wind_speed",
                 "date": dt.datetime(2010, 8, 1, tzinfo=ZoneInfo("UTC")),
@@ -309,6 +335,7 @@ def test_imgw_meteorology_api_monthly() -> None:
         ],
         schema={
             "station_id": pl.String,
+            "resolution": pl.String,
             "dataset": pl.String,
             "parameter": pl.String,
             "date": pl.Datetime(time_zone="UTC"),


### PR DESCRIPTION
## Summary

IMGW's file server structure and export formats have drifted significantly since the meteorology/hydrology providers were written, and the existing tests had been silently marked `xfail` for a while, masking several fully broken code paths. This PR:

- **Performance**: prunes IMGW's date-encoded folder listing (`YYYY`/`YYYY_YYYY`) instead of recursively walking the whole directory tree on every request (~33→1-2 requests for meteorology, ~74→1-2 for hydrology).
- **Fixes station listing** for both providers: upstream CSVs gained a "founding year" column and switched encoding to UTF-8 (previously read as latin-1, producing mojibake), a hydrology column-index bug, a missing `map_batches` `return_dtype`, a `.list`→`.arr` polars API break, and station rows missing their `resolution`/`dataset` tag (which made `.values.all()` fail outright).
- **Fixes hydrology value downloads** to honor `use_certifi`, matching the rest of the provider.
- **Fixes hydrology daily for 2023+**: IMGW consolidated 12 monthly zips/year into one yearly zip starting 2023, which crashed the date-range parser. Also handles two additional CSV export format quirks introduced along the way (semicolon-unquoted in 2023, a broken double-quote-wrapped format in 2024).
- **Fixes meteorology `synop` daily entirely**: unlike every other IMGW dataset, `synop` daily has always been archived one zip per *station* rather than per month (confirmed back to 1966-1970) — the URL selection logic never accounted for this, so `synop` daily has likely never returned data for any query.
- Removes a hardcoded lat/lon override for one hydrology station that was a no-op workaround for an upstream data bug fixed since ~2024.

Every fix was verified against live IMGW data (not just existing fixtures), with several new regression tests pinned to real values across the different format eras.

## Test plan

- [x] `uv run pytest tests/provider/imgw/ -q --runxfail` — all 7 tests pass
- [x] `uv run ty check src/wetterdienst/provider/imgw` — clean
- [x] `uv run ruff check`/`format --check` — clean
- [x] Manually cross-checked parsed values against raw upstream files for hydrology 2023/2024 and meteorology synop daily 2024/1968

🤖 Generated with [Claude Code](https://claude.com/claude-code)