### PR TITLE
fix(explorer): surface failed value fetch errors instead of swallowing them

### DIFF
--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -16,6 +16,14 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[Explorer]` Failed value requests (e.g. auth misconfiguration or upstream provider
+  errors) were silently swallowed: the data viewer never inspected the fetch `error`,
+  so any failure looked identical to "no query run yet", showing the generic
+  "select parameters and stations" hint with no indication anything went wrong.
+  The actual error message is now shown in the data viewer and as a toast.
+
 ## [0.9.0] - 2026-07-07
 
 ### Fixed

--- a/frontend/app/components/DataViewer.vue
+++ b/frontend/app/components/DataViewer.vue
@@ -166,7 +166,7 @@ const apiQuery = computed(() => {
   }
 })
 
-const { data: valuesData, pending: valuesPending, refresh: refreshValues } = useFetch<ValuesResponse>(
+const { data: valuesData, pending: valuesPending, error: valuesError, refresh: refreshValues } = useFetch<ValuesResponse>(
   apiEndpoint,
   {
     method: 'GET',
@@ -179,6 +179,25 @@ const { data: valuesData, pending: valuesPending, refresh: refreshValues } = use
 )
 
 const allValues = computed(() => valuesData.value?.values ?? [])
+
+const fetchErrorMessage = computed(() => {
+  const err = valuesError.value as { data?: { detail?: string }, message?: string } | undefined
+  if (!err)
+    return null
+  return err.data?.detail ?? err.message ?? String(err)
+})
+
+const toast = useToast()
+
+watch(valuesError, (err) => {
+  if (!err)
+    return
+  toast.add({
+    title: t('dataViewer.fetchErrorToastTitle'),
+    description: fetchErrorMessage.value ?? undefined,
+    color: 'error',
+  })
+})
 
 // Query transformed data
 const transformedData = ref<Value[]>([])
@@ -326,8 +345,6 @@ const paginatedValues = computed(() => {
 watch(pageSize, () => {
   currentPage.value = 1
 })
-
-const toast = useToast()
 
 function valuesToCsv(values: Value[]) {
   if (!values.length)
@@ -491,6 +508,7 @@ const canFetchData = computed(() => {
 function fetchData() {
   if (!canFetchData.value) {
     valuesData.value = { values: [] }
+    valuesError.value = undefined
     return
   }
   refreshValues()
@@ -500,6 +518,7 @@ function fetchData() {
 // Clear function to reset data
 function clearData() {
   valuesData.value = { values: [] }
+  valuesError.value = undefined
   currentPage.value = 1
 }
 
@@ -893,6 +912,7 @@ defineExpose({
   clearData,
   canFetchData,
   valuesPending,
+  fetchErrorMessage,
 })
 
 // Set facet chart ref
@@ -1011,7 +1031,11 @@ function setFacetChartRef(parameter: string, el: HTMLDivElement | null) {
           <UIcon name="i-lucide-loader-circle" class="w-8 h-8 animate-spin text-primary-500" />
         </div>
         <template v-else>
-          <div v-if="allValues.length === 0" class="flex items-center justify-center py-12 text-gray-500">
+          <div v-if="allValues.length === 0 && fetchErrorMessage" class="flex flex-col items-center justify-center gap-1 py-12 text-center text-red-600 dark:text-red-400">
+            <span class="font-medium">{{ t('dataViewer.fetchError') }}</span>
+            <span class="text-sm">{{ fetchErrorMessage }}</span>
+          </div>
+          <div v-else-if="allValues.length === 0" class="flex items-center justify-center py-12 text-gray-500">
             {{ t('dataViewer.emptyHint') }}
           </div>
           <UTable
@@ -1020,7 +1044,14 @@ function setFacetChartRef(parameter: string, el: HTMLDivElement | null) {
           />
           <div v-else class="py-4">
             <div
-              v-if="allValues.length === 0"
+              v-if="allValues.length === 0 && fetchErrorMessage"
+              class="flex flex-col items-center justify-center gap-1 py-12 text-center text-red-600 dark:text-red-400"
+            >
+              <span class="font-medium">{{ t('dataViewer.fetchError') }}</span>
+              <span class="text-sm">{{ fetchErrorMessage }}</span>
+            </div>
+            <div
+              v-else-if="allValues.length === 0"
               class="flex items-center justify-center py-12 text-gray-500"
             >
               {{ t('dataViewer.emptyHint') }}

--- a/frontend/i18n/locales/de.json
+++ b/frontend/i18n/locales/de.json
@@ -475,6 +475,8 @@
     "facetByParameter": "Nach Parameter aufteilen",
     "trendline": "Trendlinie",
     "emptyHint": "Wählen Sie Parameter und Stationen und klicken Sie auf „Anzeigen“, um Daten zu laden",
+    "fetchError": "Daten konnten nicht geladen werden",
+    "fetchErrorToastTitle": "Datenabfrage fehlgeschlagen",
     "dataTitle": "Daten",
     "noChartData": "Keine Daten für das Diagramm verfügbar",
     "rowsPerPage": "Zeilen pro Seite",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -475,6 +475,8 @@
     "facetByParameter": "Facet by parameter",
     "trendline": "Trendline",
     "emptyHint": "Select parameters and stations, then click Show to load data",
+    "fetchError": "Failed to load data",
+    "fetchErrorToastTitle": "Data request failed",
     "dataTitle": "Data",
     "noChartData": "No data available for chart",
     "rowsPerPage": "Rows per page",


### PR DESCRIPTION
## Summary
- `DataViewer.vue` never inspected the `error` returned by `useFetch` for `/api/values` (and interpolate/summarize) requests, so any failed fetch (auth misconfiguration, upstream provider error, network issue) was indistinguishable from "no query run yet" — it just showed the generic "select parameters and stations" hint with zero diagnostic info.
- The error message is now shown inline in the data viewer (styled distinctly from the normal empty-state hint) and surfaced as a toast, so failures are actually visible.
- Added `dataViewer.fetchError` / `dataViewer.fetchErrorToastTitle` i18n keys (en/de; other locales fall back to en per existing `fallbackLocale` config).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] Manually verified via `docker compose --profile app up` against a real MET Norway Frost request (valid and invalid credential scenarios)