### PR TITLE
fix(explorer): restrict provider/network to dwd/observation

### DIFF
--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -27,6 +27,10 @@ Types of changes:
   so any failure looked identical to "no query run yet", showing the generic
   "select parameters and stations" hint with no indication anything went wrong.
   The actual error message is now shown in the data viewer and as a toast.
+- `[Explorer]` Provider and network were freely selectable from all 10 supported
+  providers, even though Explorer is DWD-observation-only. The selects are now
+  disabled and locked to `dwd`/`observation`; History is unaffected and keeps full
+  provider/network choice.
 
 ### Changed
 

--- a/frontend/app/components/ParameterSelection.vue
+++ b/frontend/app/components/ParameterSelection.vue
@@ -10,6 +10,10 @@ const props = withDefaults(defineProps<{
     dateRequired?: boolean
   }
   showParameters?: boolean
+  /** When set, restricts the provider select to this single value (e.g. Explorer is DWD-observation-only). */
+  restrictProvider?: string
+  /** When set, restricts the network select to this single value. */
+  restrictNetwork?: string
 }>(), {
   showParameters: true,
 })
@@ -40,17 +44,23 @@ const providers = computed(() => {
   const cov = coverage.value
   if (!cov)
     return []
-  return Object.keys(cov)
+  const all = Object.keys(cov)
     .filter(p => Object.values(cov[p] ?? {}).some(isAvailable))
     .sort()
+  if (props.restrictProvider)
+    return all.includes(props.restrictProvider) ? [props.restrictProvider] : all
+  return all
 })
 const networks = computed<string[]>(() => {
   const cov = coverage.value
   if (!provider.value || !cov)
     return []
-  return Object.entries(cov[provider.value] ?? {})
+  const all = Object.entries(cov[provider.value] ?? {})
     .filter(([, n]) => isAvailable(n))
     .map(([name]) => name)
+  if (props.restrictNetwork)
+    return all.includes(props.restrictNetwork) ? [props.restrictNetwork] : all
+  return all
 })
 
 // provider-network coverage
@@ -112,7 +122,23 @@ const PRESELECTION = {
 
 // Initialize from query params and validate step by step
 async function initializeFromProps() {
-  const initial = props.modelValue?.provider ? props.modelValue : PRESELECTION
+  const initial = { ...(props.modelValue?.provider ? props.modelValue : PRESELECTION) }
+
+  // A restricted provider/network overrides anything URL-provided — there's
+  // only one valid value, so no point treating a mismatch as "invalid input".
+  if (props.restrictProvider && initial.provider !== props.restrictProvider) {
+    initial.provider = props.restrictProvider
+    initial.network = undefined
+    initial.resolution = undefined
+    initial.dataset = undefined
+    initial.parameters = []
+  }
+  if (props.restrictNetwork && initial.network !== props.restrictNetwork) {
+    initial.network = props.restrictNetwork
+    initial.resolution = undefined
+    initial.dataset = undefined
+    initial.parameters = []
+  }
 
   // Step 1: Validate provider
   if (initial.provider && providers.value.includes(initial.provider)) {
@@ -273,10 +299,10 @@ watch([provider, network, resolution, dataset, parameters, dateRequired], () => 
     </template>
     <UContainer class="flex flex-col gap-4">
       <UFormField :label="t('parameterSelection.providerLabel')">
-        <USelect v-model="provider" :items="providers" :placeholder="t('parameterSelection.selectProvider')" class="w-full" :class="{ 'needs-input': activeField === 'provider' }" />
+        <USelect v-model="provider" :items="providers" :placeholder="t('parameterSelection.selectProvider')" :disabled="!!restrictProvider" class="w-full" :class="{ 'needs-input': activeField === 'provider' }" />
       </UFormField>
       <UFormField :label="t('parameterSelection.networkLabel')">
-        <USelect v-model="network" :items="networks" :placeholder="t('parameterSelection.selectNetwork')" :disabled="!provider" class="w-full" :class="{ 'needs-input': activeField === 'network' }" />
+        <USelect v-model="network" :items="networks" :placeholder="t('parameterSelection.selectNetwork')" :disabled="!provider || !!restrictNetwork" class="w-full" :class="{ 'needs-input': activeField === 'network' }" />
       </UFormField>
       <UFormField :label="t('parameterSelection.resolutionLabel')">
         <USelect v-model="resolution" :items="resolutionItems" :placeholder="t('parameterSelection.selectResolution')" :disabled="!network || networkCoveragePending" class="w-full" :class="{ 'needs-input': activeField === 'resolution' }" />

--- a/frontend/app/pages/explorer.vue
+++ b/frontend/app/pages/explorer.vue
@@ -576,7 +576,7 @@ function handleUnitTargetChange(unitType: string, value: string) {
       </template>
     </UCollapsible>
 
-    <ParameterSelection v-model="parameterSelectionState.selection" />
+    <ParameterSelection v-model="parameterSelectionState.selection" restrict-provider="dwd" restrict-network="observation" />
 
     <!-- Mode Selection -->
     <UCard v-if="showModeSelection">

--- a/frontend/tests/e2e/integration.spec.ts
+++ b/frontend/tests/e2e/integration.spec.ts
@@ -38,6 +38,37 @@ test.describe('Explorer E2E Flow', () => {
     const bodyText = await page.locator('body').textContent()
     expect(bodyText).toBeTruthy()
   })
+
+  test('should restrict provider and network to dwd/observation', async ({ page }) => {
+    await page.goto('/explorer')
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(1000)
+
+    const providerSelect = page.getByLabel('Provider')
+    await expect(providerSelect).toBeDisabled()
+    await expect(providerSelect).toHaveText('dwd')
+
+    const networkSelect = page.getByLabel('Network')
+    await expect(networkSelect).toBeDisabled()
+    await expect(networkSelect).toHaveText('observation')
+
+    // Resolution/dataset stay freely selectable -- only provider/network are locked.
+    const resolutionSelect = page.getByLabel('Resolution')
+    await expect(resolutionSelect).toBeEnabled()
+  })
+
+  test('should leave provider/network freely selectable on History', async ({ page }) => {
+    await page.goto('/history')
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(1000)
+
+    const providerSelect = page.getByLabel('Provider')
+    await expect(providerSelect).toBeEnabled()
+
+    await providerSelect.click()
+    const optionCount = await page.getByRole('option').count()
+    expect(optionCount).toBeGreaterThan(1)
+  })
 })
 
 test.describe('API Integration Flow', () => {

--- a/frontend/tests/nuxt/components/ParameterSelection.test.ts
+++ b/frontend/tests/nuxt/components/ParameterSelection.test.ts
@@ -1,4 +1,4 @@
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { ParameterSelection } from '#components'
 
@@ -134,6 +134,56 @@ describe('parameterSelection Component', () => {
     const vm = wrapper.vm as any
     expect(vm.selectAllParameters).toBeDefined()
     expect(typeof vm.selectAllParameters).toBe('function')
+  })
+
+  it('restricts the provider select to restrictProvider', async () => {
+    registerEndpoint('/api/coverage', () => ({ dwd: { observation: {} }, noaa: { ghcn: {} } }))
+
+    const wrapper = await mountSuspended(ParameterSelection, {
+      props: {
+        modelValue: {},
+        restrictProvider: 'dwd',
+      },
+    })
+
+    const vm = wrapper.vm as any
+    expect(vm.providers).toEqual(['dwd'])
+  })
+
+  it('restricts the network select to restrictNetwork', async () => {
+    registerEndpoint('/api/coverage', () => ({ dwd: { observation: {}, mosmix: {} } }))
+
+    const wrapper = await mountSuspended(ParameterSelection, {
+      props: {
+        modelValue: { provider: 'dwd' },
+        restrictNetwork: 'observation',
+      },
+    })
+
+    const vm = wrapper.vm as any
+    expect(vm.networks).toEqual(['observation'])
+  })
+
+  it('overrides a mismatched initial provider/network with the restricted values', async () => {
+    registerEndpoint('/api/coverage', () => ({ dwd: { observation: {} }, noaa: { ghcn: {} } }))
+
+    const wrapper = await mountSuspended(ParameterSelection, {
+      props: {
+        modelValue: {
+          provider: 'noaa',
+          network: 'ghcn',
+          resolution: 'daily',
+          dataset: 'foo',
+          parameters: ['bar'],
+        },
+        restrictProvider: 'dwd',
+        restrictNetwork: 'observation',
+      },
+    })
+
+    const vm = wrapper.vm as any
+    expect(vm.provider).toBe('dwd')
+    expect(vm.network).toBe('observation')
   })
 
   it('supports clear parameters', async () => {


### PR DESCRIPTION
## Summary

Explorer's parameter selection let users pick any of the 10 supported providers/networks, even though Explorer is meant to be DWD-observation-only. Only Explorer should be restricted this way — History keeps full provider/network choice.

- Added `restrictProvider`/`restrictNetwork` props to `ParameterSelection.vue`: when set, the corresponding select is disabled and locked to the given value. A mismatched value from the URL query is overridden on init rather than left unresolved.
- Wired `restrict-provider="dwd" restrict-network="observation"` from `explorer.vue` only.

## Testing

- **Manual**: verified in a real browser against the live backend — Explorer's provider/network selects are disabled and show `dwd`/`observation`; History's remain fully interactive with all 10 providers.
- **Component test** (`ParameterSelection.test.ts`, 3 new cases): covers the restriction filtering both selects and overriding a mismatched initial value. Along the way, found the file's existing `globalThis.fetch` mock never actually intercepts Nuxt's `useFetch` (0 calls recorded) — none of the existing tests were exercising real fetched data. Used `registerEndpoint` (the correct `@nuxt/test-utils` mechanism) for the new tests instead of touching the existing (already-passing, if not fully meaningful) ones.
- **E2E test** (`integration.spec.ts`, 2 new cases): covers the Explorer restriction and confirms History is unaffected, against the real backend.

All green: typecheck, lint, 118 unit/component tests.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test:ci` (118 tests)
- [x] Manual browser verification against live backend (Explorer restricted, History unaffected)
- [x] New e2e assertions verified against Chromium locally (Firefox unavailable in this dev sandbox; CI installs it explicitly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)