### PR TITLE
fix(frontend): move provider/network restriction to History, speed up Explorer load

### DIFF
--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -31,6 +31,11 @@ Types of changes:
   providers, even though History is DWD-observation-only. The selects are now
   disabled and locked to `dwd`/`observation`; Explorer is unaffected and keeps full
   provider/network choice.
+- `[Explorer]` Opening Explorer with no existing selection auto-selected daily
+  climate-summary data and every one of its parameters, which made the page feel
+  like it hung for a couple of seconds before becoming interactive. Provider and
+  network are still pre-filled as a starting point, but resolution/dataset/
+  parameters are now left for the user to pick.
 
 ### Changed
 

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -27,9 +27,9 @@ Types of changes:
   so any failure looked identical to "no query run yet", showing the generic
   "select parameters and stations" hint with no indication anything went wrong.
   The actual error message is now shown in the data viewer and as a toast.
-- `[Explorer]` Provider and network were freely selectable from all 10 supported
-  providers, even though Explorer is DWD-observation-only. The selects are now
-  disabled and locked to `dwd`/`observation`; History is unaffected and keeps full
+- `[History]` Provider and network were freely selectable from all 10 supported
+  providers, even though History is DWD-observation-only. The selects are now
+  disabled and locked to `dwd`/`observation`; Explorer is unaffected and keeps full
   provider/network choice.
 
 ### Changed

--- a/frontend/app/components/ParameterSelection.vue
+++ b/frontend/app/components/ParameterSelection.vue
@@ -109,14 +109,16 @@ const resolutionItems = computed(() => resolutions.value.map(r => ({ label: reso
 const datasetItems = computed(() => datasets.value.map(d => ({ label: datasetLabel(d), value: d })))
 const paramItems = computed(() => params.value.map(p => ({ label: parameterLabel(p), value: p })))
 
-// Beginner-friendly starting point used when the Explorer is opened without any
-// existing selection (no URL query): DWD observation, daily climate summary,
-// mean 2 m air temperature. Gives newcomers a working example to tweak.
+// Beginner-friendly starting point used when the caller is opened without any
+// existing selection (no URL query): DWD observation. Resolution/dataset/parameters
+// are deliberately left unset here -- auto-selecting a full parameter set on load
+// (some datasets have a dozen-plus parameters) made the page feel like it hung
+// before becoming interactive, so the user picks those explicitly instead.
 const PRESELECTION = {
   provider: 'dwd',
   network: 'observation',
-  resolution: 'daily',
-  dataset: 'climate_summary',
+  resolution: undefined,
+  dataset: undefined,
   parameters: [],
 }
 

--- a/frontend/app/pages/explorer.vue
+++ b/frontend/app/pages/explorer.vue
@@ -576,7 +576,7 @@ function handleUnitTargetChange(unitType: string, value: string) {
       </template>
     </UCollapsible>
 
-    <ParameterSelection v-model="parameterSelectionState.selection" restrict-provider="dwd" restrict-network="observation" />
+    <ParameterSelection v-model="parameterSelectionState.selection" />
 
     <!-- Mode Selection -->
     <UCard v-if="showModeSelection">

--- a/frontend/app/pages/history.vue
+++ b/frontend/app/pages/history.vue
@@ -250,7 +250,7 @@ function clear() {
       </template>
     </UCollapsible>
 
-    <ParameterSelection v-model="paramSel" :show-parameters="false" />
+    <ParameterSelection v-model="paramSel" :show-parameters="false" restrict-provider="dwd" restrict-network="observation" />
 
     <UCard>
       <template #header>

--- a/frontend/tests/e2e/integration.spec.ts
+++ b/frontend/tests/e2e/integration.spec.ts
@@ -39,13 +39,19 @@ test.describe('Explorer E2E Flow', () => {
     expect(bodyText).toBeTruthy()
   })
 
-  test('should leave provider/network freely selectable on Explorer', async ({ page }) => {
+  test('should leave provider/network freely selectable and resolution/dataset unset on load', async ({ page }) => {
     await page.goto('/explorer')
     await page.waitForLoadState('networkidle')
     await page.waitForTimeout(1000)
 
     const providerSelect = page.getByLabel('Provider')
     await expect(providerSelect).toBeEnabled()
+    await expect(providerSelect).toHaveText('dwd')
+
+    // Resolution/dataset are no longer auto-preselected on load -- picking a full
+    // dataset's worth of parameters eagerly made the page feel like it hung.
+    const resolutionSelect = page.getByLabel('Resolution')
+    await expect(resolutionSelect).toHaveText('Select resolution')
 
     await providerSelect.click()
     const optionCount = await page.getByRole('option').count()

--- a/frontend/tests/e2e/integration.spec.ts
+++ b/frontend/tests/e2e/integration.spec.ts
@@ -39,8 +39,23 @@ test.describe('Explorer E2E Flow', () => {
     expect(bodyText).toBeTruthy()
   })
 
-  test('should restrict provider and network to dwd/observation', async ({ page }) => {
+  test('should leave provider/network freely selectable on Explorer', async ({ page }) => {
     await page.goto('/explorer')
+    await page.waitForLoadState('networkidle')
+    await page.waitForTimeout(1000)
+
+    const providerSelect = page.getByLabel('Provider')
+    await expect(providerSelect).toBeEnabled()
+
+    await providerSelect.click()
+    const optionCount = await page.getByRole('option').count()
+    expect(optionCount).toBeGreaterThan(1)
+  })
+})
+
+test.describe('History Provider/Network Restriction', () => {
+  test('should restrict provider and network to dwd/observation', async ({ page }) => {
+    await page.goto('/history')
     await page.waitForLoadState('networkidle')
     await page.waitForTimeout(1000)
 
@@ -52,22 +67,9 @@ test.describe('Explorer E2E Flow', () => {
     await expect(networkSelect).toBeDisabled()
     await expect(networkSelect).toHaveText('observation')
 
-    // Resolution/dataset stay freely selectable -- only provider/network are locked.
+    // Resolution stays freely selectable -- only provider/network are locked.
     const resolutionSelect = page.getByLabel('Resolution')
     await expect(resolutionSelect).toBeEnabled()
-  })
-
-  test('should leave provider/network freely selectable on History', async ({ page }) => {
-    await page.goto('/history')
-    await page.waitForLoadState('networkidle')
-    await page.waitForTimeout(1000)
-
-    const providerSelect = page.getByLabel('Provider')
-    await expect(providerSelect).toBeEnabled()
-
-    await providerSelect.click()
-    const optionCount = await page.getByRole('option').count()
-    expect(optionCount).toBeGreaterThan(1)
   })
 })
 


### PR DESCRIPTION
## Description

Follow-up to #1729, which restricted provider/network selection to dwd/observation but applied it to the wrong page. This PR:

- Moves the dwd/observation provider/network restriction from Explorer to History (that's where the original request was for). Explorer's `ParameterSelection` keeps full provider/network choice again; History now passes `restrictProvider`/`restrictNetwork`. The underlying component props/tests are unchanged, only which page uses them.
- Stops Explorer from auto-preselecting a full parameter set (resolution `daily` + dataset `climate_summary` + all 14 of its parameters) on load, which made the page feel like it hung for a couple of seconds before becoming interactive. Provider/network are still pre-filled, but resolution/dataset/parameters are left unset so the page renders immediately with an empty "Select resolution" step.

Both changes verified in a real browser against the live backend.

## Type of change

- [x] Bug fix

## Checklist

- [x] Tests added or updated
- [x] `uv run poe format` passed
- [ ] Remote/slow tests verified if network code was touched
- [x] Frontend changes tested locally (if applicable)