### PR TITLE
feat(meteofrance): add Météo-France provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Types of changes:
 ## [Unreleased]
 
 - Add Météo-France (France) synop network (subdaily, 3-hourly)
+- Add Météo-France (France) observation network (6-minute, hourly, daily, monthly)
 - Add MeteoSwiss (Switzerland) observation provider with 10-minute, hourly, daily, monthly and annual resolution
 
 ## [0.127.0] - 2026-07-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Types of changes:
 
 ## [Unreleased]
 
+- Add Météo-France (France) synop network (subdaily, 3-hourly)
 - Add MeteoSwiss (Switzerland) observation provider with 10-minute, hourly, daily, monthly and annual resolution
 
 ## [0.127.0] - 2026-07-07

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -53,6 +53,10 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
     - Hydrology
         - hydrological data of polish river stations
         - daily and monthly summaries
+- Météo-France (French National Meteorological Service / France)
+    - Synop
+        - SYNOP observations at the native 3-hourly reporting interval
+        - ~190 stations across metropolitan France and overseas territories, 1996 to present
 - MeteoSwiss (Federal Office of Meteorology and Climatology / Switzerland)
     - Observation
         - historical, recent and now data of the SwissMetNet automatic weather station network

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -57,6 +57,9 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
     - Synop
         - SYNOP observations at the native 3-hourly reporting interval
         - ~190 stations across metropolitan France and overseas territories, 1996 to present
+    - Observation
+        - 6-minute, hourly, daily and monthly climatological summaries ("Données climatologiques de base")
+        - a much larger network of several thousand stations, sharded by French department
 - MeteoSwiss (Federal Office of Meteorology and Climatology / Switzerland)
     - Observation
         - historical, recent and now data of the SwissMetNet automatic weather station network

--- a/docs/data/provider/index.md
+++ b/docs/data/provider/index.md
@@ -9,6 +9,7 @@ eaufrance/index.md
 eccc/index.md
 geosphere/index.md
 imgw/index.md
+meteofrance/index.md
 meteoswiss/index.md
 metno/index.md
 noaa/index.md

--- a/docs/data/provider/meteofrance/index.md
+++ b/docs/data/provider/meteofrance/index.md
@@ -1,0 +1,24 @@
+# Météo-France
+
+French National Meteorological Service
+
+## Overview
+
+Météo-France publishes two distinct open data products as part of its Open Government Data offering on
+[meteo.data.gouv.fr](https://meteo.data.gouv.fr/):
+
+- **synop**: SYNOP (surface synoptic observation) data of about 190 stations across metropolitan France and its
+  overseas territories, at their native 3-hourly reporting interval, from 1996 to present.
+- **observation**: "Données climatologiques de base", daily and monthly climatological summaries from a much
+  larger network of several thousand stations, sharded by French department.
+
+## License
+
+Météo-France data is published under the [Etalab Open License 2.0](https://www.etalab.gouv.fr/licence-ouverte-open-licence/).
+
+```{toctree}
+:hidden:
+
+synop/index.md
+observation/index.md
+```

--- a/docs/data/provider/meteofrance/observation/6_minutes.md
+++ b/docs/data/provider/meteofrance/observation/6_minutes.md
@@ -1,0 +1,27 @@
+# 6_minutes
+
+## metadata
+
+| property      | value |
+|---------------|-------|
+| name          | 6_minutes |
+| original name | 6 minutes |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | data |
+| original name | MIN |
+| grouped       | True |
+| periods       | historical, recent |
+
+#### parameters
+
+| name | original name | unit type | unit |
+|------|----------------|-----------|------|
+| precipitation_height | RR | precipitation | millimeter |

--- a/docs/data/provider/meteofrance/observation/daily.md
+++ b/docs/data/provider/meteofrance/observation/daily.md
@@ -1,0 +1,57 @@
+# daily
+
+## metadata
+
+| property      | value |
+|---------------|-------|
+| name          | daily |
+| original name | quot |
+
+## datasets
+
+### core
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | core |
+| original name | RR-T-Vent |
+| grouped       | True |
+| periods       | historical, recent |
+
+#### parameters
+
+| name | original name | unit type | unit |
+|------|----------------|-----------|------|
+| precipitation_height | RR | precipitation | millimeter |
+| temperature_air_min_2m | TN | temperature | degree_celsius |
+| temperature_air_max_2m | TX | temperature | degree_celsius |
+| temperature_air_mean_2m | TM | temperature | degree_celsius |
+| wind_speed | FFM | speed | meter_per_second |
+| wind_gust_max | FXI | speed | meter_per_second |
+| wind_direction_gust_max | DXI | angle | degree |
+
+### others
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | others |
+| original name | autres-parametres |
+| grouped       | True |
+| periods       | historical, recent |
+
+#### parameters
+
+| name | original name | unit type | unit |
+|------|----------------|-----------|------|
+| pressure_air_sea_level | PMERM | pressure | hectopascal |
+| pressure_vapor | TSVM | pressure | hectopascal |
+| sunshine_duration | INST | time | minute |
+| radiation_global | GLOT | energy_per_area | joule_per_square_centimeter |
+| humidity | UM | fraction | percent |
+| snow_depth | NEIGETOT06 | length_short | centimeter |
+| snow_depth_new | HNEIGEF | length_short | centimeter |
+

--- a/docs/data/provider/meteofrance/observation/hourly.md
+++ b/docs/data/provider/meteofrance/observation/hourly.md
@@ -1,0 +1,58 @@
+# hourly
+
+## metadata
+
+| property      | value |
+|---------------|-------|
+| name          | hourly |
+| original name | horaires |
+
+## datasets
+
+### core
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | core |
+| original name | core |
+| grouped       | True |
+| periods       | historical, recent |
+
+#### parameters
+
+| name | original name | unit type | unit |
+|------|----------------|-----------|------|
+| precipitation_height | RR1 | precipitation | millimeter |
+| temperature_air_min_2m | TN | temperature | degree_celsius |
+| temperature_air_max_2m | TX | temperature | degree_celsius |
+| temperature_air_mean_2m | T | temperature | degree_celsius |
+| wind_speed | FF | speed | meter_per_second |
+| wind_direction | DD | angle | degree |
+| wind_gust_max | FXY | speed | meter_per_second |
+| wind_direction_gust_max | DXY | angle | degree |
+
+### others
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | others |
+| original name | others |
+| grouped       | True |
+| periods       | historical, recent |
+
+#### parameters
+
+| name | original name | unit type | unit |
+|------|----------------|-----------|------|
+| temperature_dew_point_mean_2m | TD | temperature | degree_celsius |
+| humidity | U | fraction | percent |
+| pressure_air_sea_level | PMER | pressure | hectopascal |
+| pressure_air_site | PSTAT | pressure | hectopascal |
+| cloud_cover_total | N | fraction | one_eighth |
+| visibility_range | VV | length_medium | meter |
+| radiation_global | GLO | energy_per_area | joule_per_square_centimeter |
+| sunshine_duration | INS | time | minute |

--- a/docs/data/provider/meteofrance/observation/index.md
+++ b/docs/data/provider/meteofrance/observation/index.md
@@ -1,0 +1,25 @@
+# Observation
+
+## Overview
+
+"Données climatologiques de base", covering a much larger network of several thousand stations across
+metropolitan France and overseas territories, sharded by French department. Station identity, coordinates and
+start/end dates are sourced from Météo-France's canonical station metadata registry rather than the (much
+larger) per-department archives themselves; a small fraction of listed stations may not actually have
+downloadable daily/monthly records.
+
+- **daily**: split into a `core` dataset (precipitation, temperature, wind) and an `others` dataset (pressure,
+  radiation, humidity, snow) — roughly balanced in size, so neither gets the generic name
+- **monthly**: a single dataset, so it keeps the generic `data` name
+- **hourly**: also split into `core`/`others`, though this split only exists at the wetterdienst level — the
+  source publishes one unsplit file per department/period covering all ~100 parameters
+- **6_minutes**: a single dataset, covering only precipitation (the only parameter published at this resolution)
+
+```{toctree}
+:hidden:
+
+daily.md
+hourly.md
+6_minutes.md
+monthly.md
+```

--- a/docs/data/provider/meteofrance/observation/monthly.md
+++ b/docs/data/provider/meteofrance/observation/monthly.md
@@ -1,0 +1,39 @@
+# monthly
+
+## metadata
+
+| property      | value |
+|---------------|-------|
+| name          | monthly |
+| original name | mens |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | data |
+| original name | MENSQ |
+| grouped       | True |
+| periods       | historical, recent |
+
+#### parameters
+
+| name | original name | unit type | unit |
+|------|----------------|-----------|------|
+| precipitation_height | RR | precipitation | millimeter |
+| temperature_air_min_2m_mean | TN | temperature | degree_celsius |
+| temperature_air_max_2m_mean | TX | temperature | degree_celsius |
+| temperature_air_mean_2m | TMM | temperature | degree_celsius |
+| wind_speed | FFM | speed | meter_per_second |
+| wind_gust_max | FXIAB | speed | meter_per_second |
+| humidity | UMM | fraction | percent |
+| pressure_air_sea_level | PMERM | pressure | hectopascal |
+| pressure_vapor | TSVM | pressure | hectopascal |
+| sunshine_duration | INST | time | minute |
+| radiation_global | GLOT | energy_per_area | joule_per_square_centimeter |
+| snow_depth_new | HNEIGEFTOT | length_short | centimeter |
+

--- a/docs/data/provider/meteofrance/synop/index.md
+++ b/docs/data/provider/meteofrance/synop/index.md
@@ -1,0 +1,12 @@
+# SYNOP
+
+## Overview
+
+SYNOP observation data at the native 3-hourly reporting interval ("subdaily" resolution), covering the ~190 SYNOP
+stations from 1996 to present. Historical and current-year data are downloaded transparently as needed.
+
+```{toctree}
+:hidden:
+
+subdaily.md
+```

--- a/docs/data/provider/meteofrance/synop/subdaily.md
+++ b/docs/data/provider/meteofrance/synop/subdaily.md
@@ -1,0 +1,44 @@
+# subdaily
+
+## metadata
+
+| property      | value |
+|---------------|-------|
+| name          | subdaily |
+| original name | synop |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | data |
+| original name | synop |
+| grouped       | True |
+| periods       | historical |
+
+#### parameters
+
+| name | original name | unit type | unit |
+|------|----------------|-----------|------|
+| wind_direction | dd | angle | degree |
+| wind_speed | ff | speed | meter_per_second |
+| wind_gust_max | raf10 | speed | meter_per_second |
+| temperature_air_mean_2m | t | temperature | degree_kelvin |
+| temperature_dew_point_mean_2m | td | temperature | degree_kelvin |
+| temperature_air_min_2m_last_24h | tn24 | temperature | degree_kelvin |
+| temperature_air_max_2m_last_24h | tx24 | temperature | degree_kelvin |
+| humidity | u | fraction | percent |
+| visibility_range | vv | length_long | meter |
+| cloud_cover_total | n | fraction | percent |
+| pressure_air_site | pres | pressure | pascal |
+| pressure_air_sea_level | pmer | pressure | pascal |
+| precipitation_height_last_1h | rr1 | precipitation | millimeter |
+| precipitation_height_last_3h | rr3 | precipitation | millimeter |
+| precipitation_height_last_6h | rr6 | precipitation | millimeter |
+| precipitation_height_last_12h | rr12 | precipitation | millimeter |
+| precipitation_height_last_24h | rr24 | precipitation | millimeter |
+

--- a/docs/library/api.md
+++ b/docs/library/api.md
@@ -98,6 +98,13 @@ render_plugin = "myst"
 no_index = true
 ```
 
+### Observation
+
+```{autodoc2-object} wetterdienst.provider.meteofrance.observation.api.MeteoFranceObservationRequest
+render_plugin = "myst"
+no_index = true
+```
+
 ## MeteoSwiss
 
 ### Observation

--- a/docs/library/api.md
+++ b/docs/library/api.md
@@ -89,6 +89,15 @@ render_plugin = "myst"
 no_index = true
 ```
 
+## Météo-France
+
+### Synop
+
+```{autodoc2-object} wetterdienst.provider.meteofrance.synop.api.MeteoFranceSynopRequest
+render_plugin = "myst"
+no_index = true
+```
+
 ## MeteoSwiss
 
 ### Observation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ keywords = [
     "historical",
     # IMGW
     "institute-of-meteorology-and-water-management-poland",
+    # Météo-France
+    "meteo-france",
+    "synop",
     # MeteoSwiss
     "federal-office-of-meteorology-and-climatology-switzerland",
     "meteoswiss",

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -51,6 +51,7 @@ class Wetterdienst:
         },
         "meteofrance": {
             "synop": "wetterdienst.provider.meteofrance.synop.MeteoFranceSynopRequest",
+            "observation": "wetterdienst.provider.meteofrance.observation.MeteoFranceObservationRequest",
         },
         "meteoswiss": {
             "observation": "wetterdienst.provider.meteoswiss.observation.MeteoswissObservationRequest",

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -49,6 +49,9 @@ class Wetterdienst:
         "geosphere": {
             "observation": "wetterdienst.provider.geosphere.observation.GeosphereObservationRequest",
         },
+        "meteofrance": {
+            "synop": "wetterdienst.provider.meteofrance.synop.MeteoFranceSynopRequest",
+        },
         "meteoswiss": {
             "observation": "wetterdienst.provider.meteoswiss.observation.MeteoswissObservationRequest",
         },

--- a/src/wetterdienst/metadata/resolution.py
+++ b/src/wetterdienst/metadata/resolution.py
@@ -19,6 +19,7 @@ class Resolution(Enum):
 
     MINUTE_1 = "1_minute"  # used by DWD for file server
     MINUTE_5 = "5_minutes"
+    MINUTE_6 = "6_minutes"  # used by Météo-France
     MINUTE_10 = "10_minutes"  # used by DWD for file server
     MINUTE_15 = "15_minutes"  # used by DWD for file server
     HOURLY = "hourly"  # used by DWD for file server
@@ -37,6 +38,7 @@ class Resolution(Enum):
 DAILY_AT_MOST = [
     Resolution.MINUTE_1,
     Resolution.MINUTE_5,
+    Resolution.MINUTE_6,
     Resolution.MINUTE_10,
     Resolution.MINUTE_15,
     Resolution.HOURLY,
@@ -52,6 +54,7 @@ class Frequency(Enum):
     MINUTE_1 = "1m"
     MINUTE_2 = "2m"
     MINUTE_5 = "5m"
+    MINUTE_6 = "6m"
     MINUTE_10 = "10m"
     MINUTE_15 = "15m"
     MINUTE_60 = "60m"  # similar to hourly, needed for WSV frequency detection

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -709,7 +709,9 @@ class TimeseriesRequest:
             parameter.dataset.resolution.value for parameter in self.parameters if isinstance(parameter, ParameterModel)
         }
 
-        if resolutions.intersection({Resolution.MINUTE_1, Resolution.MINUTE_5, Resolution.MINUTE_10}):
+        if resolutions.intersection(
+            {Resolution.MINUTE_1, Resolution.MINUTE_5, Resolution.MINUTE_6, Resolution.MINUTE_10}
+        ):
             log.warning("Interpolation might be slow for high resolutions due to mass of data")
 
         lat, lon = latlon
@@ -761,7 +763,9 @@ class TimeseriesRequest:
             parameter.dataset.resolution.value for parameter in self.parameters if isinstance(parameter, ParameterModel)
         }
 
-        if resolutions.intersection({Resolution.MINUTE_1, Resolution.MINUTE_5, Resolution.MINUTE_10}):
+        if resolutions.intersection(
+            {Resolution.MINUTE_1, Resolution.MINUTE_5, Resolution.MINUTE_6, Resolution.MINUTE_10}
+        ):
             log.warning("Summary might be slow for high resolutions due to mass of data")
 
         lat, lon = latlon

--- a/src/wetterdienst/provider/meteofrance/__init__.py
+++ b/src/wetterdienst/provider/meteofrance/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/src/wetterdienst/provider/meteofrance/observation/__init__.py
+++ b/src/wetterdienst/provider/meteofrance/observation/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+from wetterdienst.provider.meteofrance.observation.api import (
+    MeteoFranceObservationMetadata,
+    MeteoFranceObservationRequest,
+)

--- a/src/wetterdienst/provider/meteofrance/observation/api.py
+++ b/src/wetterdienst/provider/meteofrance/observation/api.py
@@ -1,0 +1,897 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Météo-France observation data provider ("Données climatologiques de base")."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import IO, TYPE_CHECKING, cast
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.meteofrance.observation.metadata import MeteoFranceObservationMetadata
+from wetterdienst.util.network import download_file, download_files
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from wetterdienst.model.metadata import DatasetModel, ParameterModel
+    from wetterdienst.settings import Settings
+    from wetterdienst.util.network import File
+
+log = logging.getLogger(__name__)
+
+# "Données climatologiques de base" (daily / monthly), sharded per French department.
+# data.gouv.fr dataset ids. Used to discover the exact current resource URLs at request time
+# instead of hardcoding the period-bucket labels (e.g. "2025-2026"), which Météo-France shifts
+# forward over time as new data becomes available.
+_CLIMATE_DATASET_IDS = {
+    "daily": "6569b51ae64326786e4e8e1a",
+    "monthly": "6569b3d7d193b4daf2b43edc",
+    "hourly": "6569b4473bedf2e7abad3b72",
+    "6_minutes": "6569ad61106d1679c93cdf77",
+}
+_CLIMATE_RESOURCE_PREFIXES = {
+    "daily": "QUOT_departement_{department}_periode_",
+    "monthly": "MENS_departement_{department}_periode_",
+    "hourly": "HOR_departement_{department}_periode_",
+    "6_minutes": "MIN_departement_{department}_periode_",
+}
+# dataset name -> resource title suffix used to pick the right file group for a department;
+# only "daily" splits into multiple file groups at the source, hence the empty suffixes
+# elsewhere (hourly's "core"/"others" split only exists at the wetterdienst level, both read
+# from the same unsplit source file)
+_CLIMATE_RESOURCE_SUFFIXES = {
+    "daily": {"core": "_RR-T-Vent", "others": "_autres-parametres"},
+    "monthly": {"data": ""},
+    "hourly": {"core": "", "others": ""},
+    "6_minutes": {"data": ""},
+}
+_CLIMATE_DATE_COLUMNS = {"daily": "AAAAMMJJ", "monthly": "AAAAMM", "hourly": "AAAAMMJJHH", "6_minutes": "AAAAMMJJHHMN"}
+_CLIMATE_DATE_FORMATS = {"daily": "%Y%m%d", "monthly": "%Y%m", "hourly": "%Y%m%d%H", "6_minutes": "%Y%m%d%H%M"}
+
+_QUOT_RR_T_VENT_SCHEMA = {
+    "NUM_POSTE": pl.String,
+    "NOM_USUEL": pl.String,
+    "LAT": pl.String,
+    "LON": pl.String,
+    "ALTI": pl.String,
+    "AAAAMMJJ": pl.String,
+    "RR": pl.String,
+    "QRR": pl.String,
+    "TN": pl.String,
+    "QTN": pl.String,
+    "HTN": pl.String,
+    "QHTN": pl.String,
+    "TX": pl.String,
+    "QTX": pl.String,
+    "HTX": pl.String,
+    "QHTX": pl.String,
+    "TM": pl.String,
+    "QTM": pl.String,
+    "TNTXM": pl.String,
+    "QTNTXM": pl.String,
+    "TAMPLI": pl.String,
+    "QTAMPLI": pl.String,
+    "TNSOL": pl.String,
+    "QTNSOL": pl.String,
+    "TN50": pl.String,
+    "QTN50": pl.String,
+    "DG": pl.String,
+    "QDG": pl.String,
+    "FFM": pl.String,
+    "QFFM": pl.String,
+    "FF2M": pl.String,
+    "QFF2M": pl.String,
+    "FXY": pl.String,
+    "QFXY": pl.String,
+    "DXY": pl.String,
+    "QDXY": pl.String,
+    "HXY": pl.String,
+    "QHXY": pl.String,
+    "FXI": pl.String,
+    "QFXI": pl.String,
+    "DXI": pl.String,
+    "QDXI": pl.String,
+    "HXI": pl.String,
+    "QHXI": pl.String,
+    "FXI2": pl.String,
+    "QFXI2": pl.String,
+    "DXI2": pl.String,
+    "QDXI2": pl.String,
+    "HXI2": pl.String,
+    "QHXI2": pl.String,
+    "FXI3S": pl.String,
+    "QFXI3S": pl.String,
+    "DXI3S": pl.String,
+    "QDXI3S": pl.String,
+    "HXI3S": pl.String,
+    "QHXI3S": pl.String,
+    "DRR": pl.String,
+    "QDRR": pl.String,
+    "STATUS_FXI3S": pl.String,
+    "STATUS_DXI3S": pl.String,
+}
+
+_QUOT_AUTRES_SCHEMA = {
+    "NUM_POSTE": pl.String,
+    "NOM_USUEL": pl.String,
+    "LAT": pl.String,
+    "LON": pl.String,
+    "ALTI": pl.String,
+    "AAAAMMJJ": pl.String,
+    "DHUMEC": pl.String,
+    "QDHUMEC": pl.String,
+    "PMERM": pl.String,
+    "QPMERM": pl.String,
+    "PMERMIN": pl.String,
+    "QPMERMIN": pl.String,
+    "INST": pl.String,
+    "QINST": pl.String,
+    "GLOT": pl.String,
+    "QGLOT": pl.String,
+    "DIFT": pl.String,
+    "QDIFT": pl.String,
+    "DIRT": pl.String,
+    "QDIRT": pl.String,
+    "INFRART": pl.String,
+    "QINFRART": pl.String,
+    "UV": pl.String,
+    "QUV": pl.String,
+    "UV_INDICEX": pl.String,
+    "QUV_INDICEX": pl.String,
+    "SIGMA": pl.String,
+    "QSIGMA": pl.String,
+    "UN": pl.String,
+    "QUN": pl.String,
+    "HUN": pl.String,
+    "QHUN": pl.String,
+    "UX": pl.String,
+    "QUX": pl.String,
+    "HUX": pl.String,
+    "QHUX": pl.String,
+    "UM": pl.String,
+    "QUM": pl.String,
+    "DHUMI40": pl.String,
+    "QDHUMI40": pl.String,
+    "DHUMI80": pl.String,
+    "QDHUMI80": pl.String,
+    "TSVM": pl.String,
+    "QTSVM": pl.String,
+    "ETPMON": pl.String,
+    "QETPMON": pl.String,
+    "ETPGRILLE": pl.String,
+    "QETPGRILLE": pl.String,
+    "ECOULEMENTM": pl.String,
+    "QECOULEMENTM": pl.String,
+    "HNEIGEF": pl.String,
+    "QHNEIGEF": pl.String,
+    "NEIGETOTX": pl.String,
+    "QNEIGETOTX": pl.String,
+    "NEIGETOT06": pl.String,
+    "QNEIGETOT06": pl.String,
+    "NEIG": pl.String,
+    "QNEIG": pl.String,
+    "BROU": pl.String,
+    "QBROU": pl.String,
+    "ORAG": pl.String,
+    "QORAG": pl.String,
+    "GRESIL": pl.String,
+    "QGRESIL": pl.String,
+    "GRELE": pl.String,
+    "QGRELE": pl.String,
+    "ROSEE": pl.String,
+    "QROSEE": pl.String,
+    "VERGLAS": pl.String,
+    "QVERGLAS": pl.String,
+    "SOLNEIGE": pl.String,
+    "QSOLNEIGE": pl.String,
+    "GELEE": pl.String,
+    "QGELEE": pl.String,
+    "FUMEE": pl.String,
+    "QFUMEE": pl.String,
+    "BRUME": pl.String,
+    "QBRUME": pl.String,
+    "ECLAIR": pl.String,
+    "QECLAIR": pl.String,
+    "NB300": pl.String,
+    "QNB300": pl.String,
+    "BA300": pl.String,
+    "QBA300": pl.String,
+    "TMERMIN": pl.String,
+    "QTMERMIN": pl.String,
+    "TMERMAX": pl.String,
+    "QTMERMAX": pl.String,
+}
+
+_MENSQ_SCHEMA = {
+    "NUM_POSTE": pl.String,
+    "NOM_USUEL": pl.String,
+    "LAT": pl.String,
+    "LON": pl.String,
+    "ALTI": pl.String,
+    "AAAAMM": pl.String,
+    "RR": pl.String,
+    "QRR": pl.String,
+    "NBRR": pl.String,
+    "RR_ME": pl.String,
+    "RRAB": pl.String,
+    "QRRAB": pl.String,
+    "RRABDAT": pl.String,
+    "NBJRR1": pl.String,
+    "NBJRR5": pl.String,
+    "NBJRR10": pl.String,
+    "NBJRR30": pl.String,
+    "NBJRR50": pl.String,
+    "NBJRR100": pl.String,
+    "PMERM": pl.String,
+    "QPMERM": pl.String,
+    "NBPMERM": pl.String,
+    "PMERMINAB": pl.String,
+    "QPMERMINAB": pl.String,
+    "PMERMINABDAT": pl.String,
+    "TX": pl.String,
+    "QTX": pl.String,
+    "NBTX": pl.String,
+    "TX_ME": pl.String,
+    "TXAB": pl.String,
+    "QTXAB": pl.String,
+    "TXDAT": pl.String,
+    "TXMIN": pl.String,
+    "QTXMIN": pl.String,
+    "TXMINDAT": pl.String,
+    "NBJTX0": pl.String,
+    "NBJTX25": pl.String,
+    "NBJTX30": pl.String,
+    "NBJTX35": pl.String,
+    "NBJTXI20": pl.String,
+    "NBJTXI27": pl.String,
+    "NBJTXS32": pl.String,
+    "TN": pl.String,
+    "QTN": pl.String,
+    "NBTN": pl.String,
+    "TN_ME": pl.String,
+    "TNAB": pl.String,
+    "QTNAB": pl.String,
+    "TNDAT": pl.String,
+    "TNMAX": pl.String,
+    "QTNMAX": pl.String,
+    "TNMAXDAT": pl.String,
+    "NBJTN5": pl.String,
+    "NBJTN10": pl.String,
+    "NBJTNI10": pl.String,
+    "NBJTNI15": pl.String,
+    "NBJTNI20": pl.String,
+    "NBJTNS20": pl.String,
+    "NBJTNS25": pl.String,
+    "NBJGELEE": pl.String,
+    "TAMPLIM": pl.String,
+    "QTAMPLIM": pl.String,
+    "TAMPLIAB": pl.String,
+    "QTAMPLIAB": pl.String,
+    "TAMPLIABDAT": pl.String,
+    "NBTAMPLI": pl.String,
+    "TM": pl.String,
+    "QTM": pl.String,
+    "NBTM": pl.String,
+    "TMM": pl.String,
+    "QTMM": pl.String,
+    "NBTMM": pl.String,
+    "NBJTMS24": pl.String,
+    "TMMIN": pl.String,
+    "QTMMIN": pl.String,
+    "TMMINDAT": pl.String,
+    "TMMAX": pl.String,
+    "QTMMAX": pl.String,
+    "TMMAXDAT": pl.String,
+    "UNAB": pl.String,
+    "QUNAB": pl.String,
+    "UNABDAT": pl.String,
+    "NBUN": pl.String,
+    "UXAB": pl.String,
+    "QUXAB": pl.String,
+    "UXABDAT": pl.String,
+    "NBUX": pl.String,
+    "UMM": pl.String,
+    "QUMM": pl.String,
+    "NBUM": pl.String,
+    "TSVM": pl.String,
+    "QTSVM": pl.String,
+    "NBTSVM": pl.String,
+    "ETP": pl.String,
+    "QETP": pl.String,
+    "FXIAB": pl.String,
+    "QFXIAB": pl.String,
+    "DXIAB": pl.String,
+    "QDXIAB": pl.String,
+    "FXIDAT": pl.String,
+    "NBJFF10": pl.String,
+    "NBJFF16": pl.String,
+    "NBJFF28": pl.String,
+    "NBFXI": pl.String,
+    "FXI3SAB": pl.String,
+    "QFXI3SAB": pl.String,
+    "DXI3SAB": pl.String,
+    "QDXI3SAB": pl.String,
+    "FXI3SDAT": pl.String,
+    "NBJFXI3S10": pl.String,
+    "NBJFXI3S16": pl.String,
+    "NBJFXI3S28": pl.String,
+    "NBFXI3S": pl.String,
+    "FXYAB": pl.String,
+    "QFXYAB": pl.String,
+    "DXYAB": pl.String,
+    "QDXYAB": pl.String,
+    "FXYABDAT": pl.String,
+    "NBJFXY8": pl.String,
+    "NBJFXY10": pl.String,
+    "NBJFXY15": pl.String,
+    "NBFXY": pl.String,
+    "FFM": pl.String,
+    "QFFM": pl.String,
+    "NBFFM": pl.String,
+    "INST": pl.String,
+    "QINST": pl.String,
+    "NBINST": pl.String,
+    "NBSIGMA0": pl.String,
+    "NBSIGMA20": pl.String,
+    "NBSIGMA80": pl.String,
+    "GLOT": pl.String,
+    "QGLOT": pl.String,
+    "NBGLOT": pl.String,
+    "DIFT": pl.String,
+    "QDIFT": pl.String,
+    "NBDIFT": pl.String,
+    "DIRT": pl.String,
+    "QDIRT": pl.String,
+    "NBDIRT": pl.String,
+    "HNEIGEFTOT": pl.String,
+    "QHNEIGEFTOT": pl.String,
+    "HNEIGEFAB": pl.String,
+    "QHNEIGEFAB": pl.String,
+    "HNEIGEFDAT": pl.String,
+    "NBHNEIGEF": pl.String,
+    "NBJNEIG": pl.String,
+    "NBJHNEIGEF1": pl.String,
+    "NBJHNEIGEF5": pl.String,
+    "NBJHNEIGEF10": pl.String,
+    "NBJSOLNG": pl.String,
+    "NEIGETOTM": pl.String,
+    "QNEIGETOTM": pl.String,
+    "NEIGETOTAB": pl.String,
+    "QNEIGETOTAB": pl.String,
+    "NEIGETOTABDAT": pl.String,
+    "NBJNEIGETOT1": pl.String,
+    "NBJNEIGETOT10": pl.String,
+    "NBJNEIGETOT30": pl.String,
+    "NBJGREL": pl.String,
+    "NBJORAG": pl.String,
+    "NBJBROU": pl.String,
+}
+
+_HOR_SCHEMA = {
+    "NUM_POSTE": pl.String,
+    "NOM_USUEL": pl.String,
+    "LAT": pl.String,
+    "LON": pl.String,
+    "ALTI": pl.String,
+    "AAAAMMJJHH": pl.String,
+    "RR1": pl.String,
+    "QRR1": pl.String,
+    "DRR1": pl.String,
+    "QDRR1": pl.String,
+    "FF": pl.String,
+    "QFF": pl.String,
+    "DD": pl.String,
+    "QDD": pl.String,
+    "FXY": pl.String,
+    "QFXY": pl.String,
+    "DXY": pl.String,
+    "QDXY": pl.String,
+    "HXY": pl.String,
+    "QHXY": pl.String,
+    "FXI": pl.String,
+    "QFXI": pl.String,
+    "DXI": pl.String,
+    "QDXI": pl.String,
+    "HXI": pl.String,
+    "QHXI": pl.String,
+    "FF2": pl.String,
+    "QFF2": pl.String,
+    "DD2": pl.String,
+    "QDD2": pl.String,
+    "FXI2": pl.String,
+    "QFXI2": pl.String,
+    "DXI2": pl.String,
+    "QDXI2": pl.String,
+    "HXI2": pl.String,
+    "QHXI2": pl.String,
+    "FXI3S": pl.String,
+    "QFXI3S": pl.String,
+    "DXI3S": pl.String,
+    "QDXI3S": pl.String,
+    "HFXI3S": pl.String,
+    "QHFXI3S": pl.String,
+    "T": pl.String,
+    "QT": pl.String,
+    "TD": pl.String,
+    "QTD": pl.String,
+    "TN": pl.String,
+    "QTN": pl.String,
+    "HTN": pl.String,
+    "QHTN": pl.String,
+    "TX": pl.String,
+    "QTX": pl.String,
+    "HTX": pl.String,
+    "QHTX": pl.String,
+    "DG": pl.String,
+    "QDG": pl.String,
+    "T10": pl.String,
+    "QT10": pl.String,
+    "T20": pl.String,
+    "QT20": pl.String,
+    "T50": pl.String,
+    "QT50": pl.String,
+    "T100": pl.String,
+    "QT100": pl.String,
+    "TNSOL": pl.String,
+    "QTNSOL": pl.String,
+    "TN50": pl.String,
+    "QTN50": pl.String,
+    "TCHAUSSEE": pl.String,
+    "QTCHAUSSEE": pl.String,
+    "DHUMEC": pl.String,
+    "QDHUMEC": pl.String,
+    "U": pl.String,
+    "QU": pl.String,
+    "UN": pl.String,
+    "QUN": pl.String,
+    "HUN": pl.String,
+    "QHUN": pl.String,
+    "UX": pl.String,
+    "QUX": pl.String,
+    "HUX": pl.String,
+    "QHUX": pl.String,
+    "DHUMI40": pl.String,
+    "QDHUMI40": pl.String,
+    "DHUMI80": pl.String,
+    "QDHUMI80": pl.String,
+    "TSV": pl.String,
+    "QTSV": pl.String,
+    "PMER": pl.String,
+    "QPMER": pl.String,
+    "PSTAT": pl.String,
+    "QPSTAT": pl.String,
+    "PMERMIN": pl.String,
+    "QPMERMIN": pl.String,
+    "GEOP": pl.String,
+    "QGEOP": pl.String,
+    "N": pl.String,
+    "QN": pl.String,
+    "NBAS": pl.String,
+    "QNBAS": pl.String,
+    "CL": pl.String,
+    "QCL": pl.String,
+    "CM": pl.String,
+    "QCM": pl.String,
+    "CH": pl.String,
+    "QCH": pl.String,
+    "N1": pl.String,
+    "QN1": pl.String,
+    "C1": pl.String,
+    "QC1": pl.String,
+    "B1": pl.String,
+    "QB1": pl.String,
+    "N2": pl.String,
+    "QN2": pl.String,
+    "C2": pl.String,
+    "QC2": pl.String,
+    "B2": pl.String,
+    "QB2": pl.String,
+    "N3": pl.String,
+    "QN3": pl.String,
+    "C3": pl.String,
+    "QC3": pl.String,
+    "B3": pl.String,
+    "QB3": pl.String,
+    "N4": pl.String,
+    "QN4": pl.String,
+    "C4": pl.String,
+    "QC4": pl.String,
+    "B4": pl.String,
+    "QB4": pl.String,
+    "VV": pl.String,
+    "QVV": pl.String,
+    "DVV200": pl.String,
+    "QDVV200": pl.String,
+    "WW": pl.String,
+    "QWW": pl.String,
+    "W1": pl.String,
+    "QW1": pl.String,
+    "W2": pl.String,
+    "QW2": pl.String,
+    "SOL": pl.String,
+    "QSOL": pl.String,
+    "SOLNG": pl.String,
+    "QSOLNG": pl.String,
+    "TMER": pl.String,
+    "QTMER": pl.String,
+    "VVMER": pl.String,
+    "QVVMER": pl.String,
+    "ETATMER": pl.String,
+    "QETATMER": pl.String,
+    "DIRHOULE": pl.String,
+    "QDIRHOULE": pl.String,
+    "HVAGUE": pl.String,
+    "QHVAGUE": pl.String,
+    "PVAGUE": pl.String,
+    "QPVAGUE": pl.String,
+    "HNEIGEF": pl.String,
+    "QHNEIGEF": pl.String,
+    "NEIGETOT": pl.String,
+    "QNEIGETOT": pl.String,
+    "TSNEIGE": pl.String,
+    "QTSNEIGE": pl.String,
+    "TUBENEIGE": pl.String,
+    "QTUBENEIGE": pl.String,
+    "HNEIGEFI3": pl.String,
+    "QHNEIGEFI3": pl.String,
+    "HNEIGEFI1": pl.String,
+    "QHNEIGEFI1": pl.String,
+    "ESNEIGE": pl.String,
+    "QESNEIGE": pl.String,
+    "CHARGENEIGE": pl.String,
+    "QCHARGENEIGE": pl.String,
+    "GLO": pl.String,
+    "QGLO": pl.String,
+    "GLO2": pl.String,
+    "QGLO2": pl.String,
+    "DIR": pl.String,
+    "QDIR": pl.String,
+    "DIR2": pl.String,
+    "QDIR2": pl.String,
+    "DIF": pl.String,
+    "QDIF": pl.String,
+    "DIF2": pl.String,
+    "QDIF2": pl.String,
+    "UV": pl.String,
+    "QUV": pl.String,
+    "UV2": pl.String,
+    "QUV2": pl.String,
+    "UV_INDICE": pl.String,
+    "QUV_INDICE": pl.String,
+    "INFRAR": pl.String,
+    "QINFRAR": pl.String,
+    "INFRAR2": pl.String,
+    "QINFRAR2": pl.String,
+    "INS": pl.String,
+    "QINS": pl.String,
+    "INS2": pl.String,
+    "QINS2": pl.String,
+    "TLAGON": pl.String,
+    "QTLAGON": pl.String,
+    "TVEGETAUX": pl.String,
+    "QTVEGETAUX": pl.String,
+    "ECOULEMENT": pl.String,
+    "QECOULEMENT": pl.String,
+    "STATUS_FXI3S": pl.String,
+    "STATUS_DXI3S": pl.String,
+}
+
+_MIN_SCHEMA = {
+    "NUM_POSTE": pl.String,
+    "NOM_USUEL": pl.String,
+    "LAT": pl.String,
+    "LON": pl.String,
+    "ALTI": pl.String,
+    "AAAAMMJJHHMN": pl.String,
+    "RR": pl.String,
+    "QRR": pl.String,
+}
+
+_CLIMATE_SCHEMAS = {
+    ("daily", "core"): _QUOT_RR_T_VENT_SCHEMA,
+    ("daily", "others"): _QUOT_AUTRES_SCHEMA,
+    ("monthly", "data"): _MENSQ_SCHEMA,
+    ("hourly", "core"): _HOR_SCHEMA,
+    ("hourly", "others"): _HOR_SCHEMA,
+    ("6_minutes", "data"): _MIN_SCHEMA,
+}
+
+
+def _department_from_station_id(station_id: str) -> str:
+    """Get the French department code from an 8-digit NUM_POSTE station id."""
+    return station_id[:3] if station_id[:2] in ("97", "98") else station_id[:2]
+
+
+def _parse_climate_date(date_column: pl.Expr, resolution_name: str) -> pl.Expr:
+    """Parse a resolution's raw date column into a UTC datetime.
+
+    polars' strptime requires a minute whenever an hour is present in the format string, but
+    "hourly"'s AAAAMMJJHH has no minute component, so it's padded in before parsing.
+    """
+    date_format = _CLIMATE_DATE_FORMATS[resolution_name]
+    if resolution_name == "hourly":
+        date_column = date_column + "00"
+        date_format += "%M"
+    return date_column.str.to_datetime(date_format, strict=False).dt.replace_time_zone("UTC")
+
+
+def _get_climate_resources(resolution_name: str, settings: Settings) -> list[dict]:
+    """Fetch (and cache) the resource listing published for a climatological dataset.
+
+    Resource URLs are discovered at request time via the data.gouv.fr dataset API instead of
+    being hardcoded, since Météo-France periodically shifts the period-bucket labels (e.g.
+    "2025-2026" becomes "2025-2027") as new data becomes available.
+    """
+    dataset_id = _CLIMATE_DATASET_IDS[resolution_name]
+    url = f"https://www.data.gouv.fr/api/1/datasets/{dataset_id}/"
+    file = download_file(
+        url=url,
+        cache_dir=settings.cache_dir,
+        ttl=CacheExpiry.METAINDEX,
+        client_kwargs=settings.fsspec_client_kwargs,
+        cache_disable=settings.cache_disable,
+        use_certifi=settings.use_certifi,
+    )
+    file.raise_if_exception()
+    if isinstance(file.content, Exception):
+        return []
+    return json.loads(file.content.read()).get("resources", [])
+
+
+def _match_department_resources(resources: list[dict], prefix: str, suffix: str) -> list[dict]:
+    """Filter resources by department (prefix) and file group (suffix)."""
+    pattern = re.compile(rf"^{re.escape(prefix)}.*{re.escape(suffix)}$")
+    return [resource for resource in resources if pattern.match(resource["title"])]
+
+
+def _resource_year_range(resource: dict) -> tuple[int, int]:
+    """Get the year range embedded in a resource title, e.g. (1950, 2024) for "...1950-2024".
+
+    A "avant-YYYY" ("before YYYY") title only embeds its end year, with an effectively unbounded
+    start.
+    """
+    years = [int(year) for year in re.findall(r"\d{4}", resource["title"])]
+    if not years:
+        return 1, 9999
+    if "avant" in resource["title"]:
+        return 1, years[0]
+    return min(years), max(years)
+
+
+def _resource_max_year(resource: dict) -> int:
+    """Get the most recent year embedded in a resource title, e.g. 2026 for "...2025-2026"."""
+    return _resource_year_range(resource)[1]
+
+
+def _resource_cache_ttl(resource: dict) -> CacheExpiry:
+    """Cache period buckets that may still receive updates for a shorter time."""
+    current_year = datetime.now(tz=ZoneInfo("UTC")).year
+    return CacheExpiry.FIVE_MINUTES if _resource_max_year(resource) >= current_year - 1 else CacheExpiry.INFINITE
+
+
+def _resource_overlaps_request(resource: dict, start_date: datetime | None, end_date: datetime | None) -> bool:
+    """Check whether a period-bucket resource can contain any data within the requested range.
+
+    Météo-France's climatological archives shard each department into a handful of multi-decade
+    period buckets (e.g. one alone can decompress to 100+ MB); skipping buckets that clearly fall
+    outside the requested date range avoids downloading/parsing them at all.
+    """
+    if start_date is None or end_date is None:
+        return True
+    min_year, max_year = _resource_year_range(resource)
+    return max_year >= start_date.year and min_year <= end_date.year
+
+
+def _download_climate_resources(resources: list[dict], settings: Settings) -> dict[str, File]:
+    """Download resources concurrently (grouped by cache ttl), keyed by url.
+
+    A handful of downloads commonly fail transiently when many requests go out at once (e.g.
+    server-side rate limiting) even after download_file's own retries, so failed ones get one
+    more, less concurrent attempt rather than silently dropping their data from the result.
+    """
+    files_by_url: dict[str, File] = {}
+    resources_by_ttl: dict[CacheExpiry, list[dict]] = {}
+    for resource in resources:
+        resources_by_ttl.setdefault(_resource_cache_ttl(resource), []).append(resource)
+    for ttl, ttl_resources in resources_by_ttl.items():
+        urls = [resource["url"] for resource in ttl_resources]
+        files = download_files(
+            urls=urls,
+            cache_dir=settings.cache_dir,
+            ttl=ttl,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        files_by_url.update(zip(urls, files, strict=True))
+        # retrying is only worthwhile for likely-transient failures; a missing connection or a
+        # genuinely nonexistent resource (404) will just fail again immediately
+        failed_urls = [
+            url
+            for url, file in files_by_url.items()
+            if url in urls
+            and isinstance(file.content, Exception)
+            and not file.is_no_internet_error
+            and file.status != 404
+        ]
+        if failed_urls:
+            log.info(f"Retrying {len(failed_urls)} file(s) that failed to download.")
+            for url in failed_urls:
+                files_by_url[url] = download_file(
+                    url=url,
+                    cache_dir=settings.cache_dir,
+                    ttl=ttl,
+                    client_kwargs=settings.fsspec_client_kwargs,
+                    cache_disable=settings.cache_disable,
+                    use_certifi=settings.use_certifi,
+                )
+    return files_by_url
+
+
+# Météo-France's canonical station metadata registry (~14.7k stations, ~2MB single CSV), built
+# from their internal API. Used for station identity/coordinates/start_date/end_date instead of
+# scanning every department's climatological archive (up to ~300 files, tens of GB decompressed
+# in total) just to derive the same information -- this registry already publishes exact per
+# station start_date/end_date directly. It covers a broader set of stations than actually have
+# downloadable daily/monthly records in the archives scanned by _collect_station_parameter_or_dataset
+# below (e.g. very recently opened stations, or station types outside that archive's curation);
+# querying one of those returns an empty result, same as any other station without data for a
+# requested parameter.
+# data.gouv.fr's stable "latest resource" redirect for this dataset's single CSV resource,
+# rather than the dated static.data.gouv.fr path it currently points to (which changes whenever
+# Météo-France republishes the file, like the period-bucket labels in the climate archives above)
+_STATIONS_REGISTRY_URL = "https://www.data.gouv.fr/api/1/datasets/r/5ec141e4-3650-4365-82b1-db459efe690c"
+_STATIONS_REGISTRY_SCHEMA = {
+    "id": pl.String,
+    "name": pl.String,
+    "long_name": pl.String,
+    "named_place": pl.String,
+    "station_type": pl.String,
+    "basin": pl.String,
+    "lon": pl.String,
+    "lat": pl.String,
+    "alt": pl.String,
+    "start_date": pl.String,
+    "end_date": pl.String,
+    "is_open": pl.String,
+    "is_public": pl.String,
+    "department_id": pl.String,
+    "is_daily": pl.String,
+    "is_hourly": pl.String,
+    "is_minutely": pl.String,
+}
+
+
+class MeteoFranceObservationValues(TimeseriesValues):
+    """Values class for Météo-France observation data."""
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        dataset = cast("DatasetModel", parameter_or_dataset)
+        resolution_name = dataset.resolution.name
+        settings = cast("Settings", self.sr.stations.settings)
+        department = _department_from_station_id(station_id)
+        resources = _get_climate_resources(resolution_name, settings)
+        prefix = _CLIMATE_RESOURCE_PREFIXES[resolution_name].format(department=department)
+        suffix = _CLIMATE_RESOURCE_SUFFIXES[resolution_name][dataset.name]
+        matches = _match_department_resources(resources, prefix, suffix)
+        # a department's period buckets can each decompress to 100+ MB; skip any that clearly
+        # fall outside the requested date range instead of downloading/parsing them regardless
+        matches = [
+            resource
+            for resource in matches
+            if _resource_overlaps_request(resource, self.sr.start_date, self.sr.end_date)
+        ]
+        if not matches:
+            return pl.DataFrame()
+        schema = _CLIMATE_SCHEMAS[resolution_name, dataset.name]
+        date_column = _CLIMATE_DATE_COLUMNS[resolution_name]
+        parameter_columns = [parameter.name_original for parameter in dataset]
+        read_columns = ["NUM_POSTE", date_column, *parameter_columns]
+        files_by_url = _download_climate_resources(matches, settings)
+        dfs = []
+        for resource in matches:
+            file = files_by_url[resource["url"]]
+            if isinstance(file.content, Exception):
+                if not file.is_no_internet_error:
+                    # _download_climate_resources already retried this once; a failure surviving
+                    # that is unexpected, so log it instead of silently treating this bucket as
+                    # having no data, but keep processing the remaining buckets
+                    log.warning(f"Failed to download {file.url}: {file.content}")
+                continue
+            with gzip.GzipFile(fileobj=file.content) as gz:
+                df = pl.read_csv(cast("IO[bytes]", gz), separator=";", schema=schema, columns=read_columns)
+            df = df.filter(pl.col("NUM_POSTE").eq(station_id))
+            if not df.is_empty():
+                dfs.append(df)
+        if not dfs:
+            return pl.DataFrame()
+        df = pl.concat(dfs, how="diagonal")
+        df = df.unpivot(
+            on=parameter_columns,
+            index=[date_column],
+            variable_name="parameter",
+            value_name="value",
+        )
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            # kept as published (e.g. "RR", "TN"), matching the case of name_original in the
+            # metadata below; the base class matches requested parameters against this column
+            # using an exact, case-sensitive comparison against parameter.name_original
+            pl.col("parameter"),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            _parse_climate_date(pl.col(date_column), resolution_name).alias("date"),
+            pl.col("value").cast(pl.Float64, strict=False),
+            pl.lit(None, pl.Float64).alias("quality"),
+        )
+
+
+@dataclass
+class MeteoFranceObservationRequest(TimeseriesRequest):
+    """Request class for Météo-France observation data."""
+
+    metadata = MeteoFranceObservationMetadata
+    _values = MeteoFranceObservationValues
+
+    def _all(self) -> pl.LazyFrame:
+        # self.parameters is parsed at runtime to a list[ParameterModel], but the static type of
+        # the attribute is a union of input forms; cast here so the typechecker understands we
+        # iterate ParameterModel instances.
+        parameters = cast("Iterable[ParameterModel]", self.parameters)
+        stations_df = self._climate_stations(cast("Settings", self.settings))
+        if stations_df.is_empty():
+            return pl.LazyFrame()
+        # groupby() only groups consecutive items, but parameters preserves the user-supplied
+        # order, so datasets interleaved across parameters (e.g. [core, others, core]) would
+        # otherwise produce duplicate groups for the same dataset and duplicate station rows
+        datasets = {(p.dataset.resolution.name, p.dataset.name): p.dataset for p in parameters}
+        data = [
+            stations_df.lazy().with_columns(
+                pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+                pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            )
+            for dataset in datasets.values()
+        ]
+        return pl.concat(data)
+
+    @staticmethod
+    def _climate_stations(settings: Settings) -> pl.DataFrame:
+        """Build the station list from Météo-France's canonical station metadata registry."""
+        file = download_file(
+            url=_STATIONS_REGISTRY_URL,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.METAINDEX,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        file.raise_if_exception()
+        if isinstance(file.content, Exception):
+            return pl.DataFrame()
+        df = pl.read_csv(file.content, schema=_STATIONS_REGISTRY_SCHEMA)
+        return df.select(
+            pl.col("id").alias("station_id"),
+            pl.col("name"),
+            pl.col("lat").cast(pl.Float64, strict=False).alias("latitude"),
+            pl.col("lon").cast(pl.Float64, strict=False).alias("longitude"),
+            pl.col("alt").cast(pl.Float64, strict=False).alias("height"),
+            pl.col("start_date").str.to_datetime("%Y-%m-%d", strict=False).dt.replace_time_zone("UTC"),
+            # nullable: still-open stations (the vast majority) have no end_date, matching how
+            # the frontend already treats a missing end_date as "still reporting"
+            pl.col("end_date").str.to_datetime("%Y-%m-%d", strict=False).dt.replace_time_zone("UTC"),
+        )

--- a/src/wetterdienst/provider/meteofrance/observation/metadata.py
+++ b/src/wetterdienst/provider/meteofrance/observation/metadata.py
@@ -1,0 +1,363 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Météo-France observation metadata."""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, build_metadata_model
+
+MeteoFranceObservationMetadata = {
+    "name_short": "Météo-France",
+    "name_english": "Météo-France",
+    "name_local": "Météo-France",
+    "country": "France",
+    "copyright": "© Météo-France, Etalab Open License 2.0",
+    "url": "https://meteo.data.gouv.fr/",
+    "kind": "observation",
+    "timezone": "Europe/Paris",
+    "timezone_data": "UTC",
+    "resolutions": [
+        {
+            # "Données climatologiques de base - quotidiennes": per-department daily archives,
+            # covering the full climatological station network (much larger than the ~190 SYNOP
+            # stations in the sibling "synop" network), split into two file groups per department
+            "name": "daily",
+            "name_original": "quot",
+            "periods": ["historical", "recent"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": "core",
+                    "name_original": "RR-T-Vent",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "RR",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "temperature_air_min_2m",
+                            "name_original": "TN",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_max_2m",
+                            "name_original": "TX",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "TM",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "wind_speed",
+                            "name_original": "FFM",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_gust_max",
+                            "name_original": "FXI",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_direction_gust_max",
+                            "name_original": "DXI",
+                            "unit_type": "angle",
+                            "unit": "degree",
+                        },
+                    ],
+                },
+                {
+                    "name": "others",
+                    "name_original": "autres-parametres",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "pressure_air_sea_level",
+                            "name_original": "PMERM",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "pressure_vapor",
+                            "name_original": "TSVM",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "sunshine_duration",
+                            "name_original": "INST",
+                            "unit_type": "time",
+                            "unit": "minute",
+                        },
+                        {
+                            "name": "radiation_global",
+                            "name_original": "GLOT",
+                            "unit_type": "energy_per_area",
+                            "unit": "joule_per_square_centimeter",
+                        },
+                        {
+                            "name": "humidity",
+                            "name_original": "UM",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "snow_depth",
+                            "name_original": "NEIGETOT06",
+                            "unit_type": "length_short",
+                            "unit": "centimeter",
+                        },
+                        {
+                            "name": "snow_depth_new",
+                            "name_original": "HNEIGEF",
+                            "unit_type": "length_short",
+                            "unit": "centimeter",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            # "Données climatologiques de base -  6 minutes": per-department archives of a single
+            # parameter (precipitation) at its native 6-minute reporting interval, since 2005
+            "name": "6_minutes",
+            "name_original": "6 minutes",
+            "periods": ["historical", "recent"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": DATASET_NAME_DEFAULT,
+                    "name_original": "MIN",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "RR",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            # "Données climatologiques de base - horaires": per-department hourly archives, one
+            # (unsplit) file group per department covering all ~100 published parameters
+            "name": "hourly",
+            "name_original": "horaires",
+            "periods": ["historical", "recent"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": "core",
+                    "name_original": "core",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "RR1",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "temperature_air_min_2m",
+                            "name_original": "TN",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_max_2m",
+                            "name_original": "TX",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "T",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "wind_speed",
+                            "name_original": "FF",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_direction",
+                            "name_original": "DD",
+                            "unit_type": "angle",
+                            "unit": "degree",
+                        },
+                        {
+                            "name": "wind_gust_max",
+                            "name_original": "FXY",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_direction_gust_max",
+                            "name_original": "DXY",
+                            "unit_type": "angle",
+                            "unit": "degree",
+                        },
+                    ],
+                },
+                {
+                    "name": "others",
+                    "name_original": "others",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "temperature_dew_point_mean_2m",
+                            "name_original": "TD",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "humidity",
+                            "name_original": "U",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "pressure_air_sea_level",
+                            "name_original": "PMER",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "pressure_air_site",
+                            "name_original": "PSTAT",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "cloud_cover_total",
+                            "name_original": "N",
+                            "unit_type": "fraction",
+                            "unit": "one_eighth",
+                        },
+                        {
+                            "name": "visibility_range",
+                            "name_original": "VV",
+                            "unit_type": "length_medium",
+                            "unit": "meter",
+                        },
+                        {
+                            "name": "radiation_global",
+                            "name_original": "GLO",
+                            "unit_type": "energy_per_area",
+                            "unit": "joule_per_square_centimeter",
+                        },
+                        {
+                            "name": "sunshine_duration",
+                            "name_original": "INS",
+                            "unit_type": "time",
+                            "unit": "minute",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            # "Données climatologiques de base - mensuelles": per-department monthly archives,
+            # aggregated from the daily data, in a single file group per department
+            "name": "monthly",
+            "name_original": "mens",
+            "periods": ["historical", "recent"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": DATASET_NAME_DEFAULT,
+                    "name_original": "MENSQ",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "RR",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "temperature_air_min_2m_mean",
+                            "name_original": "TN",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_max_2m_mean",
+                            "name_original": "TX",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "TMM",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "wind_speed",
+                            "name_original": "FFM",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_gust_max",
+                            "name_original": "FXIAB",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "humidity",
+                            "name_original": "UMM",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "pressure_air_sea_level",
+                            "name_original": "PMERM",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "pressure_vapor",
+                            "name_original": "TSVM",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "sunshine_duration",
+                            "name_original": "INST",
+                            "unit_type": "time",
+                            "unit": "minute",
+                        },
+                        {
+                            "name": "radiation_global",
+                            "name_original": "GLOT",
+                            "unit_type": "energy_per_area",
+                            "unit": "joule_per_square_centimeter",
+                        },
+                        {
+                            "name": "snow_depth_new",
+                            "name_original": "HNEIGEFTOT",
+                            "unit_type": "length_short",
+                            "unit": "centimeter",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+MeteoFranceObservationMetadata = build_metadata_model(MeteoFranceObservationMetadata, "MeteoFranceObservationMetadata")

--- a/src/wetterdienst/provider/meteofrance/synop/__init__.py
+++ b/src/wetterdienst/provider/meteofrance/synop/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+from wetterdienst.provider.meteofrance.synop.api import (
+    MeteoFranceSynopMetadata,
+    MeteoFranceSynopRequest,
+)

--- a/src/wetterdienst/provider/meteofrance/synop/api.py
+++ b/src/wetterdienst/provider/meteofrance/synop/api.py
@@ -1,0 +1,243 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Météo-France SYNOP data provider."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import IO, TYPE_CHECKING, cast
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.meteofrance.synop.metadata import MeteoFranceSynopMetadata
+from wetterdienst.util.network import download_file
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from wetterdienst.model.metadata import DatasetModel, ParameterModel
+    from wetterdienst.settings import Settings
+
+log = logging.getLogger(__name__)
+
+# "Archive Synop OMM" dataset on data.gouv.fr: one gzipped csv per year, covering all ~190
+# SYNOP stations at their native 3-hourly reporting interval
+_SYNOP_ENDPOINT = "https://meteofrance.s3.sbg.io.cloud.ovh.net/data/synchro_ftp/OBS/SYNOP/synop_{year}.csv.gz"
+_SYNOP_STATIONS_ENDPOINT = "https://meteofrance.s3.sbg.io.cloud.ovh.net/data/synchro_ftp/OBS/SYNOP/postes_synop.geojson"
+# earliest year for which a yearly archive is published
+_SYNOP_ARCHIVE_START_YEAR = 1996
+
+# explicit schema of the exact columns published by the source, read as strings throughout since
+# many columns are entirely empty for a given station or year, which would otherwise lead to
+# inconsistent dtype inference (e.g. an all-null column inferred as Boolean in one year and
+# Float64 in another) and break the concat below. Column order matches the source CSV, as
+# required by polars' `schema` argument.
+_SYNOP_CSV_SCHEMA = {
+    "lat": pl.String,
+    "lon": pl.String,
+    "geo_id_wmo": pl.String,
+    "geo_id_wigos": pl.String,
+    "name": pl.String,
+    "reference_time": pl.String,
+    "insert_time": pl.String,
+    "validity_time": pl.String,
+    "pmer": pl.String,
+    "tend": pl.String,
+    "cod_tend": pl.String,
+    "dd": pl.String,
+    "ff": pl.String,
+    "t": pl.String,
+    "td": pl.String,
+    "u": pl.String,
+    "vv": pl.String,
+    "ww": pl.String,
+    "w1": pl.String,
+    "w2": pl.String,
+    "n": pl.String,
+    "nbas": pl.String,
+    "hbas": pl.String,
+    "cl": pl.String,
+    "cm": pl.String,
+    "ch": pl.String,
+    "pres": pl.String,
+    "niv_bar": pl.String,
+    "geop": pl.String,
+    "tend24": pl.String,
+    "tn12": pl.String,
+    "tn24": pl.String,
+    "tx12": pl.String,
+    "tx24": pl.String,
+    "tminsol": pl.String,
+    "sw": pl.String,
+    "tw": pl.String,
+    "raf10": pl.String,
+    "rafper": pl.String,
+    "per": pl.String,
+    "etat_sol": pl.String,
+    "ht_neige": pl.String,
+    "ssfrai": pl.String,
+    "perssfrai": pl.String,
+    "rr1": pl.String,
+    "rr3": pl.String,
+    "rr6": pl.String,
+    "rr12": pl.String,
+    "rr24": pl.String,
+    "phenspe1": pl.String,
+    "phenspe2": pl.String,
+    "phenspe3": pl.String,
+    "phenspe4": pl.String,
+    "nnuage1": pl.String,
+    "ctype1": pl.String,
+    "hnuage1": pl.String,
+    "nnuage2": pl.String,
+    "ctype2": pl.String,
+    "hnuage2": pl.String,
+    "nnuage3": pl.String,
+    "ctype3": pl.String,
+    "hnuage3": pl.String,
+    "nnuage4": pl.String,
+    "ctype4": pl.String,
+    "hnuage4": pl.String,
+}
+
+
+class MeteoFranceSynopValues(TimeseriesValues):
+    """Values class for Météo-France SYNOP data."""
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        dataset = cast("DatasetModel", parameter_or_dataset)
+        current_year = datetime.now(tz=ZoneInfo("UTC")).year
+        start_date = self.sr.start_date or datetime(_SYNOP_ARCHIVE_START_YEAR, 1, 1, tzinfo=ZoneInfo("UTC"))
+        end_date = self.sr.end_date or datetime.now(tz=ZoneInfo("UTC"))
+        settings = cast("Settings", self.sr.stations.settings)
+        parameter_columns = [parameter.name_original for parameter in dataset]
+        read_columns = ["geo_id_wmo", "validity_time", *parameter_columns]
+        dfs = []
+        # clamp to the years actually covered by the archive: station opening dates (used as a
+        # fallback start_date by e.g. the frontend) can predate 1996, and requesting a year
+        # outside [1996, current_year] would 404
+        first_year = max(start_date.year, _SYNOP_ARCHIVE_START_YEAR)
+        last_year = min(end_date.year, current_year)
+        for year in range(first_year, last_year + 1):
+            file = download_file(
+                url=_SYNOP_ENDPOINT.format(year=year),
+                cache_dir=settings.cache_dir,
+                ttl=CacheExpiry.FIVE_MINUTES if year == current_year else CacheExpiry.INFINITE,
+                client_kwargs=settings.fsspec_client_kwargs,
+                cache_disable=settings.cache_disable,
+                use_certifi=settings.use_certifi,
+            )
+            if isinstance(file.content, Exception):
+                if not file.is_no_internet_error:
+                    # the year range above is already clamped to the archive's known coverage,
+                    # so a failure here (unlike a missing-year 404) is unexpected; log it instead
+                    # of silently treating this year as having no data, but keep processing the
+                    # remaining years rather than aborting the whole multi-year request
+                    log.warning(f"Failed to download {file.url}: {file.content}")
+                continue
+            with gzip.GzipFile(fileobj=file.content) as gz:
+                df = pl.read_csv(cast("IO[bytes]", gz), separator=";", schema=_SYNOP_CSV_SCHEMA, columns=read_columns)
+            df = df.filter(pl.col("geo_id_wmo").eq(station_id))
+            if not df.is_empty():
+                dfs.append(df)
+        if not dfs:
+            return pl.DataFrame()
+        df = pl.concat(dfs, how="diagonal")
+        df = df.unpivot(
+            on=parameter_columns,
+            index=["validity_time"],
+            variable_name="parameter",
+            value_name="value",
+        )
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            pl.col("parameter").str.to_lowercase(),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            pl.col("validity_time")
+            .str.to_datetime("%Y-%m-%dT%H:%M:%SZ", strict=False)
+            .dt.replace_time_zone("UTC")
+            .alias("date"),
+            pl.col("value").cast(pl.Float64, strict=False),
+            pl.lit(None, pl.Float64).alias("quality"),
+        )
+
+
+@dataclass
+class MeteoFranceSynopRequest(TimeseriesRequest):
+    """Request class for Météo-France SYNOP data."""
+
+    metadata = MeteoFranceSynopMetadata
+    _values = MeteoFranceSynopValues
+
+    def _all(self) -> pl.LazyFrame:
+        settings = cast("Settings", self.settings)
+        file = download_file(
+            url=_SYNOP_STATIONS_ENDPOINT,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.METAINDEX,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        file.raise_if_exception()
+        if isinstance(file.content, Exception):
+            return pl.LazyFrame()
+        collection = json.loads(file.content.read())
+        rows = []
+        for feature in collection.get("features", []):
+            properties = feature["properties"]
+            longitude, latitude = feature["geometry"]["coordinates"]
+            rows.append(
+                {
+                    "station_id": properties["Id"],
+                    "name": properties["Nom"],
+                    "height": properties["Altitude"],
+                    "start_date": properties["Date_ouverture"],
+                    "latitude": latitude,
+                    "longitude": longitude,
+                },
+            )
+        df = pl.DataFrame(
+            rows,
+            schema={
+                "station_id": pl.String,
+                "name": pl.String,
+                "height": pl.Float64,
+                "start_date": pl.String,
+                "latitude": pl.Float64,
+                "longitude": pl.Float64,
+            },
+        )
+        df = df.lazy()
+        df = df.with_columns(
+            pl.col("start_date").str.to_datetime("%Y-%m-%d", strict=False).dt.replace_time_zone("UTC"),
+        )
+        # self.parameters is parsed at runtime to a list[ParameterModel], but the static type of
+        # the attribute is a union of input forms; cast here so the typechecker understands we
+        # iterate ParameterModel instances.
+        parameters = cast("Iterable[ParameterModel]", self.parameters)
+        # groupby() only groups consecutive items, but parameters preserves the user-supplied
+        # order, so datasets interleaved across parameters would otherwise produce duplicate
+        # groups for the same dataset and duplicate station rows
+        datasets = {(p.dataset.resolution.name, p.dataset.name): p.dataset for p in parameters}
+        data = [
+            df.with_columns(
+                pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+                pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            )
+            for dataset in datasets.values()
+        ]
+        return pl.concat(data)

--- a/src/wetterdienst/provider/meteofrance/synop/metadata.py
+++ b/src/wetterdienst/provider/meteofrance/synop/metadata.py
@@ -1,0 +1,141 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Météo-France SYNOP metadata."""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, build_metadata_model
+
+MeteoFranceSynopMetadata = {
+    "name_short": "Météo-France",
+    "name_english": "Météo-France",
+    "name_local": "Météo-France",
+    "country": "France",
+    "copyright": "© Météo-France, Etalab Open License 2.0",
+    "url": "https://meteo.data.gouv.fr/",
+    "kind": "observation",
+    "timezone": "Europe/Paris",
+    "timezone_data": "UTC",
+    "resolutions": [
+        {
+            "name": "subdaily",
+            "name_original": "synop",
+            "periods": ["historical"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": DATASET_NAME_DEFAULT,
+                    "name_original": "synop",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "wind_direction",
+                            "name_original": "dd",
+                            "unit_type": "angle",
+                            "unit": "degree",
+                        },
+                        {
+                            "name": "wind_speed",
+                            "name_original": "ff",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_gust_max",
+                            "name_original": "raf10",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "t",
+                            "unit_type": "temperature",
+                            "unit": "degree_kelvin",
+                        },
+                        {
+                            "name": "temperature_dew_point_mean_2m",
+                            "name_original": "td",
+                            "unit_type": "temperature",
+                            "unit": "degree_kelvin",
+                        },
+                        {
+                            "name": "temperature_air_min_2m_last_24h",
+                            "name_original": "tn24",
+                            "unit_type": "temperature",
+                            "unit": "degree_kelvin",
+                        },
+                        {
+                            "name": "temperature_air_max_2m_last_24h",
+                            "name_original": "tx24",
+                            "unit_type": "temperature",
+                            "unit": "degree_kelvin",
+                        },
+                        {
+                            "name": "humidity",
+                            "name_original": "u",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "visibility_range",
+                            "name_original": "vv",
+                            "unit_type": "length_long",
+                            "unit": "meter",
+                        },
+                        {
+                            "name": "cloud_cover_total",
+                            "name_original": "n",
+                            # source already publishes the WMO okta code as a percentage
+                            # class (0, 10, 25, 40, 50, 60, 75, 90, 100), not raw eighths
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "pressure_air_site",
+                            "name_original": "pres",
+                            "unit_type": "pressure",
+                            "unit": "pascal",
+                        },
+                        {
+                            "name": "pressure_air_sea_level",
+                            "name_original": "pmer",
+                            "unit_type": "pressure",
+                            "unit": "pascal",
+                        },
+                        {
+                            "name": "precipitation_height_last_1h",
+                            "name_original": "rr1",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "precipitation_height_last_3h",
+                            "name_original": "rr3",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "precipitation_height_last_6h",
+                            "name_original": "rr6",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "precipitation_height_last_12h",
+                            "name_original": "rr12",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "precipitation_height_last_24h",
+                            "name_original": "rr24",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+MeteoFranceSynopMetadata = build_metadata_model(MeteoFranceSynopMetadata, "MeteoFranceSynopMetadata")

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -54,7 +54,7 @@ provider_opt = cloup.option_group(
         help=(
             "Data provider/organisation. Must be combined with --network. "
             "Valid provider/network combinations can be listed with: wetterdienst about coverage. "
-            "Examples: dwd, eccc, noaa, wsv, ea, eaufrance, nws, geosphere, meteoswiss"
+            "Examples: dwd, eccc, noaa, wsv, ea, eaufrance, nws, geosphere, meteofrance, meteoswiss"
         ),
     ),
 )
@@ -312,7 +312,7 @@ This section explains all command line options in detail.
 Selection options:
 
     --provider                  The data provider / organisation.
-                                Examples: dwd, eccc, noaa, wsv, ea, eaufrance, nws, geosphere, meteoswiss
+                                Examples: dwd, eccc, noaa, wsv, ea, eaufrance, nws, geosphere, meteofrance, meteoswiss
 
     --network                   The network of the data provider
                                 Examples: observation, mosmix, radar, ghcn, pegel, hydrology

--- a/tests/provider/meteofrance/observation/test_api.py
+++ b/tests/provider/meteofrance/observation/test_api.py
@@ -1,0 +1,141 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for Météo-France observation API ("Données climatologiques de base")."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from wetterdienst.provider.meteofrance.observation import MeteoFranceObservationRequest
+
+
+@pytest.mark.remote
+def test_meteofrance_observation_api_interleaved_datasets_no_duplicate_stations() -> None:
+    """Test that requesting datasets in interleaved order doesn't duplicate station rows.
+
+    itertools.groupby() only groups consecutive items; since parameter order is preserved from
+    user input, interleaving datasets (here: core, others, core) used to produce a separate group
+    -- and a duplicated station row -- for the second "core" occurrence.
+    """
+    request = MeteoFranceObservationRequest(
+        parameters=[
+            ("daily", "core", "precipitation_height"),
+            ("daily", "others", "humidity"),
+            ("daily", "core", "wind_speed"),
+        ],
+    ).filter_by_station_id("31069001")
+    df = request.df
+    assert len(df) == 2
+    assert sorted(df.get_column("dataset").to_list()) == ["core", "others"]
+
+
+@pytest.mark.remote
+def test_meteofrance_observation_api_daily_stations() -> None:
+    """Test that the daily resolution's much larger climatological station network resolves.
+
+    Station discovery for daily/monthly is built from Météo-France's canonical station metadata
+    registry rather than scanning every French department's climatological archive.
+    """
+    request = MeteoFranceObservationRequest(
+        parameters=[("daily", "core", "temperature_air_mean_2m")],
+    ).filter_by_station_id("31069001")
+    df = request.df
+    assert not df.is_empty()
+    assert df.get_column("name").to_list() == ["TOULOUSE-BLAGNAC"]
+    # regression check: start_date must be populated, since the frontend seeds its date-range
+    # picker from it; end_date is legitimately null here since the station is still open (the
+    # frontend already falls back to "today" for a null end_date)
+    assert df.get_column("start_date").is_not_null().all()
+
+
+@pytest.mark.remote
+@pytest.mark.parametrize(
+    ("dataset", "parameter"),
+    [
+        ("core", "temperature_air_mean_2m"),
+        ("core", "wind_gust_max"),
+        ("core", "wind_direction_gust_max"),
+        ("others", "radiation_global"),
+        ("others", "humidity"),
+    ],
+)
+def test_meteofrance_observation_api_daily(dataset: str, parameter: str) -> None:
+    """Test daily climatological values ("Données climatologiques de base - quotidiennes").
+
+    Also guards against the parameter-name case mismatch bug: the source columns are uppercase
+    (e.g. "RR", "TN"), and the base class matches requested parameters against name_original
+    using an exact, case-sensitive comparison.
+    """
+    request = MeteoFranceObservationRequest(
+        parameters=[("daily", dataset, parameter)],
+        start_date=datetime(2023, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=datetime(2023, 1, 31, tzinfo=ZoneInfo("UTC")),
+    ).filter_by_station_id("31069001")
+    df = next(request.values.query()).df
+    assert df.get_column("value").is_not_null().sum() > 0
+
+
+@pytest.mark.remote
+@pytest.mark.parametrize(
+    "parameter",
+    [
+        "precipitation_height",
+        "temperature_air_max_2m_mean",
+        "wind_gust_max",
+        "sunshine_duration",
+    ],
+)
+def test_meteofrance_observation_api_monthly(parameter: str) -> None:
+    """Test monthly climatological values ("Données climatologiques de base - mensuelles")."""
+    request = MeteoFranceObservationRequest(
+        parameters=[("monthly", "data", parameter)],
+        start_date=datetime(2023, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=datetime(2023, 6, 1, tzinfo=ZoneInfo("UTC")),
+    ).filter_by_station_id("31069001")
+    df = next(request.values.query()).df
+    assert df.get_column("value").is_not_null().sum() > 0
+
+
+@pytest.mark.remote
+@pytest.mark.parametrize(
+    ("dataset", "parameter"),
+    [
+        ("core", "temperature_air_mean_2m"),
+        ("core", "precipitation_height"),
+        ("core", "wind_direction_gust_max"),
+        ("others", "cloud_cover_total"),
+        ("others", "visibility_range"),
+    ],
+)
+def test_meteofrance_observation_api_hourly(dataset: str, parameter: str) -> None:
+    """Test hourly climatological values ("Données climatologiques de base - horaires").
+
+    Also guards against the AAAAMMJJHH date format regression: polars' strptime requires a
+    minute whenever an hour is present in the format string, but this date column has none.
+    """
+    request = MeteoFranceObservationRequest(
+        parameters=[("hourly", dataset, parameter)],
+        start_date=datetime(2025, 6, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=datetime(2025, 6, 7, tzinfo=ZoneInfo("UTC")),
+    ).filter_by_station_id("31069001")
+    df = next(request.values.query()).df
+    assert df.get_column("value").is_not_null().sum() > 0
+
+
+@pytest.mark.remote
+def test_meteofrance_observation_api_6_minutes() -> None:
+    """Test 6-minute climatological values ("Données climatologiques de base -  6 minutes").
+
+    Only precipitation is published at this resolution.
+    """
+    request = MeteoFranceObservationRequest(
+        parameters=[("6_minutes", "data", "precipitation_height")],
+        start_date=datetime(2025, 6, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=datetime(2025, 6, 2, tzinfo=ZoneInfo("UTC")),
+    ).filter_by_station_id("31069001")
+    df = next(request.values.query()).df
+    assert not df.is_empty()
+    # 6-minute intervals within a day: exercise that the date column parses to real, distinct
+    # timestamps rather than e.g. all collapsing to midnight
+    assert df.get_column("date").n_unique() > 1

--- a/tests/provider/meteofrance/synop/test_api.py
+++ b/tests/provider/meteofrance/synop/test_api.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for Météo-France SYNOP API."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from wetterdienst.provider.meteofrance.synop import MeteoFranceSynopRequest
+
+
+@pytest.mark.remote
+def test_meteofrance_synop_api_stations() -> None:
+    """Test that station metadata can be retrieved and is complete."""
+    request = MeteoFranceSynopRequest(
+        parameters=[("subdaily", "data", "temperature_air_mean_2m")],
+    ).filter_by_station_id("07005")
+    df = request.df
+    assert not df.is_empty()
+    assert df.get_column("name").to_list() == ["ABBEVILLE"]
+
+
+@pytest.mark.remote
+def test_meteofrance_synop_api_values() -> None:
+    """Test subdaily (3-hourly synop) values, including unit conversion from source Kelvin."""
+    request = MeteoFranceSynopRequest(
+        parameters=[("subdaily", "data", "temperature_air_mean_2m")],
+        start_date=datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=datetime(2024, 1, 2, tzinfo=ZoneInfo("UTC")),
+    ).filter_by_station_id("07005")
+    df = next(request.values.query()).df
+    values = df.get_column("value")
+    assert values.is_not_null().sum() > 0
+    # temperature is converted from Kelvin to Celsius, so should be within a plausible range
+    assert values.drop_nulls().is_between(-50, 50).all()
+
+
+@pytest.mark.remote
+@pytest.mark.parametrize(
+    "parameter",
+    [
+        "wind_speed",
+        "wind_direction",
+        "humidity",
+        "pressure_air_sea_level",
+        "precipitation_height_last_3h",
+        "cloud_cover_total",
+    ],
+)
+def test_meteofrance_synop_api_parameters(parameter: str) -> None:
+    """Test that core parameters can be requested and yield data for a well-covered station."""
+    request = MeteoFranceSynopRequest(
+        parameters=[("subdaily", "data", parameter)],
+        start_date=datetime(2024, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=datetime(2024, 1, 3, tzinfo=ZoneInfo("UTC")),
+    ).filter_by_station_id("07690")
+    df = next(request.values.query()).df
+    assert df.get_column("value").is_not_null().sum() > 0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@
 """Tests for the API."""
 
 import zoneinfo
+from datetime import datetime
 
 import polars as pl
 import pytest
@@ -22,6 +23,7 @@ from wetterdienst.provider.eccc.observation import EcccObservationMetadata, Eccc
 from wetterdienst.provider.geosphere.observation import GeosphereObservationMetadata, GeosphereObservationRequest
 from wetterdienst.provider.imgw.hydrology import ImgwHydrologyMetadata, ImgwHydrologyRequest
 from wetterdienst.provider.imgw.meteorology import ImgwMeteorologyMetadata, ImgwMeteorologyRequest
+from wetterdienst.provider.meteofrance.synop import MeteoFranceSynopMetadata, MeteoFranceSynopRequest
 from wetterdienst.provider.meteoswiss.observation import MeteoswissObservationMetadata, MeteoswissObservationRequest
 from wetterdienst.provider.metno.frost.api import MetnoFrostMetadata, MetnoFrostRequest
 from wetterdienst.provider.noaa.ghcn import NoaaGhcnMetadata, NoaaGhcnRequest
@@ -102,6 +104,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
         HubeauMetadata,
         ImgwHydrologyMetadata,
         ImgwMeteorologyMetadata,
+        MeteoFranceSynopMetadata,
         MeteoswissObservationMetadata,
         MetnoFrostMetadata,
         NoaaGhcnMetadata,
@@ -130,6 +133,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
         HubeauMetadata,
         ImgwHydrologyMetadata,
         ImgwMeteorologyMetadata,
+        MeteoFranceSynopMetadata,
         MeteoswissObservationMetadata,
         MetnoFrostMetadata,
         NoaaGhcnMetadata,
@@ -514,6 +518,29 @@ def test_api_geosphere_observation(default_settings: Settings) -> None:
     ).filter_by_station_id("5882")
     assert not request.df.is_empty()
     assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
+    first_date = request.df.get_column("start_date").gather(0).to_list()[0]
+    if first_date:
+        assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")
+    values = next(request.values.query()).df
+    first_date = values.get_column("date").gather(0).to_list()[0]
+    assert first_date.tzinfo
+    assert set(values.columns).issuperset(DF_VALUES_MINIMUM_COLUMNS)
+    assert not values.drop_nulls(subset="value").is_empty()
+
+
+def test_api_meteofrance_synop(default_settings: Settings) -> None:
+    """Test Météo-France SYNOP API."""
+    # bounded to a few days: without a date range, values would default to downloading and
+    # parsing every yearly archive since 1996, which is unnecessarily slow for a smoke test
+    request = MeteoFranceSynopRequest(
+        parameters=[("subdaily", "data", "temperature_air_mean_2m")],
+        start_date=datetime(2024, 1, 1, tzinfo=zoneinfo.ZoneInfo("UTC")),
+        end_date=datetime(2024, 1, 3, tzinfo=zoneinfo.ZoneInfo("UTC")),
+        settings=default_settings,
+    ).filter_by_station_id("07005")
+    assert not request.df.is_empty()
+    assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
+    assert _is_complete_stations_df(request.df, exclude_columns={"end_date", "state"})
     first_date = request.df.get_column("start_date").gather(0).to_list()[0]
     if first_date:
         assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,6 +23,7 @@ from wetterdienst.provider.eccc.observation import EcccObservationMetadata, Eccc
 from wetterdienst.provider.geosphere.observation import GeosphereObservationMetadata, GeosphereObservationRequest
 from wetterdienst.provider.imgw.hydrology import ImgwHydrologyMetadata, ImgwHydrologyRequest
 from wetterdienst.provider.imgw.meteorology import ImgwMeteorologyMetadata, ImgwMeteorologyRequest
+from wetterdienst.provider.meteofrance.observation import MeteoFranceObservationMetadata, MeteoFranceObservationRequest
 from wetterdienst.provider.meteofrance.synop import MeteoFranceSynopMetadata, MeteoFranceSynopRequest
 from wetterdienst.provider.meteoswiss.observation import MeteoswissObservationMetadata, MeteoswissObservationRequest
 from wetterdienst.provider.metno.frost.api import MetnoFrostMetadata, MetnoFrostRequest
@@ -104,6 +105,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
         HubeauMetadata,
         ImgwHydrologyMetadata,
         ImgwMeteorologyMetadata,
+        MeteoFranceObservationMetadata,
         MeteoFranceSynopMetadata,
         MeteoswissObservationMetadata,
         MetnoFrostMetadata,
@@ -133,6 +135,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
         HubeauMetadata,
         ImgwHydrologyMetadata,
         ImgwMeteorologyMetadata,
+        MeteoFranceObservationMetadata,
         MeteoFranceSynopMetadata,
         MeteoswissObservationMetadata,
         MetnoFrostMetadata,
@@ -544,6 +547,31 @@ def test_api_meteofrance_synop(default_settings: Settings) -> None:
     first_date = request.df.get_column("start_date").gather(0).to_list()[0]
     if first_date:
         assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")
+    values = next(request.values.query()).df
+    first_date = values.get_column("date").gather(0).to_list()[0]
+    assert first_date.tzinfo
+    assert set(values.columns).issuperset(DF_VALUES_MINIMUM_COLUMNS)
+    assert not values.drop_nulls(subset="value").is_empty()
+
+
+def test_api_meteofrance_observation(default_settings: Settings) -> None:
+    """Test Météo-France observation API ("Données climatologiques de base")."""
+    # bounded to a few months: without a date range, values would download every period-bucket
+    # archive for the station's department (up to multi-decade, 100+ MB decompressed each)
+    request = MeteoFranceObservationRequest(
+        parameters=[("monthly", "data", "precipitation_height")],
+        start_date=datetime(2023, 1, 1, tzinfo=zoneinfo.ZoneInfo("UTC")),
+        end_date=datetime(2023, 6, 1, tzinfo=zoneinfo.ZoneInfo("UTC")),
+        settings=default_settings,
+    ).filter_by_station_id("31069001")
+    assert not request.df.is_empty()
+    assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
+    # end_date is legitimately null here: station "31069001" (Toulouse-Blagnac) is still open, and
+    # the canonical Météo-France station registry (unlike the per-department archive scan this
+    # used to derive dates from) reports null end_date for still-open stations
+    assert _is_complete_stations_df(request.df, exclude_columns={"state", "end_date"})
+    first_date = request.df.get_column("start_date").gather(0).to_list()[0]
+    assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")
     values = next(request.values.query()).df
     first_date = values.get_column("date").gather(0).to_list()[0]
     assert first_date.tzinfo

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -63,6 +63,7 @@ def test_coverage(client: TestClient) -> None:
         "eccc",
         "geosphere",
         "imgw",
+        "meteofrance",
         "meteoswiss",
         "metno",
         "noaa",


### PR DESCRIPTION
## Summary
- Adds Météo-France (France) as a new provider with two networks:
  - **synop**: SYNOP surface observations at 3-hourly resolution (~190 stations, 1996–present)
  - **observation**: "Données climatologiques de base" at 6-minute, hourly, daily and monthly resolution (several thousand stations, sharded by French department; daily/hourly split into `core`/`others` datasets for their roughly balanced parameter groups, 6-minute covers precipitation only)
- Station identity, coordinates and start/end dates for `observation` are sourced from Météo-France's canonical station metadata registry (a single ~2MB CSV) rather than scanning the much larger per-department archives (previously up to ~300 files, tens of GB decompressed) just to derive the same information.
- Values fetches skip period-bucket archive files that fall outside the requested date range and only parse the CSV columns actually needed, instead of reading full ~60-200 column files.
- Adds a new shared `Resolution.MINUTE_6` enum member, since no existing resolution matched Météo-France's native 6-minute interval.

## Test plan
- [x] `uv run pytest tests/provider/meteofrance -q` — 24 passed
- [x] `uv run pytest tests/test_api.py -k meteofrance -q` — 8 passed
- [x] `uv run poe format` / `uv run poe lint` — clean
- [x] `uv run poe typecheck` — no meteofrance-specific issues
- [x] Verified end-to-end via the REST API + frontend explorer (station list load, map selection, values fetch) against a memory-constrained Docker deployment
- [x] Manually verified hourly/6-minute values against the raw source CSVs (dates, units, plausible magnitudes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)