### PR TITLE
ci(knmi): pass WD_AUTH__KNMI to tests and coverage workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,8 @@ env:
   OS: "ubuntu-latest"
   PYTHON: "3.14"
   WD_AUTH__METNO_FROST: ${{ secrets.WD_AUTH__METNO_FROST }}
+  WD_AUTH__AEMET: ${{ secrets.WD_AUTH__AEMET }}
+  WD_AUTH__KNMI: ${{ secrets.WD_AUTH__KNMI }}
 
 permissions: {}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
       PYTHON: ${{ matrix.python-version }}
       WD_AUTH__METNO_FROST: ${{ secrets.WD_AUTH__METNO_FROST }}
       WD_AUTH__AEMET: ${{ secrets.WD_AUTH__AEMET }}
+      WD_AUTH__KNMI: ${{ secrets.WD_AUTH__KNMI }}
 
     defaults:
       run:


### PR DESCRIPTION
Wire the `WD_AUTH__KNMI` repository secret (just added) into the `tests.yml` and `coverage.yml` workflow `env`, so the KNMI provider's credential-gated remote tests run in CI instead of skipping.

Also adds `WD_AUTH__AEMET` to `coverage.yml` for parity with `tests.yml` (it was only wired in `tests.yml` before).

Follow-up to #1739.

🤖 Generated with [Claude Code](https://claude.com/claude-code)