### PR TITLE
perf(values): reduce value result memory via Enum metadata columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Types of changes:
 - Add Météo-France (France) synop network (subdaily, 3-hourly)
 - Add Météo-France (France) observation network (6-minute, hourly, daily, monthly)
 - Add MeteoSwiss (Switzerland) observation provider with 10-minute, hourly, daily, monthly and annual resolution
+- Reduce memory footprint of value results by storing the `station_id`, `resolution`, `dataset` and
+  `parameter` columns as polars `Enum` instead of `String` (roughly halves the size of tidy frames);
+  note that the dtype of these columns is now `Enum` rather than `String`
 
 ## [0.127.0] - 2026-07-07
 

--- a/src/wetterdienst/model/values.py
+++ b/src/wetterdienst/model/values.py
@@ -244,6 +244,29 @@ class TimeseriesValues(ABC):
         )
         return df.select(pl.col(col) if col in df.columns else pl.lit(None).alias(col) for col in columns)
 
+    def _get_meta_enum_dtypes(self) -> dict[str, pl.Enum]:
+        """Build ``Enum`` dtypes for the low-cardinality metadata columns.
+
+        The categories are derived from the request itself, so they are identical across
+        every per-station frame. That lets the frames be concatenated in :meth:`all` without
+        an ``Enum`` mismatch, while making these highly repetitive columns integer-backed
+        instead of ``String`` - roughly halving the memory footprint of the tidy value frame.
+        """
+        parameters = self.sr.parameters
+        station_ids = self.sr.station_id.unique().sort().to_list()
+        resolutions = sorted({parameter.dataset.resolution.name for parameter in parameters})
+        datasets = sorted({parameter.dataset.name.lower() for parameter in parameters})
+        if self.sr.settings.ts_humanize:
+            parameter_names = sorted({parameter.name for parameter in parameters})
+        else:
+            parameter_names = sorted({parameter.name_original for parameter in parameters})
+        return {
+            "station_id": pl.Enum(station_ids),
+            "resolution": pl.Enum(resolutions),
+            "dataset": pl.Enum(datasets),
+            "parameter": pl.Enum(parameter_names),
+        }
+
     def query(self) -> Iterator[ValuesResult]:
         """Query data for all stations and parameters and return a DataFrame for each station."""
         # reset station stations_counter
@@ -253,6 +276,8 @@ class TimeseriesValues(ABC):
         hpm: dict[str, str] = {}
         if self.sr.settings.ts_humanize:
             hpm = self._create_humanized_parameters_mapping()
+        # global Enum dtypes shared across all per-station frames to save memory (see all)
+        enum_dtypes = self._get_meta_enum_dtypes()
         for (station_id,), df_station_meta in self.sr.df.group_by(["station_id"], maintain_order=True):
             if self.stations_counter == self.sr.rank:
                 break
@@ -285,6 +310,10 @@ class TimeseriesValues(ABC):
                 df = self._widen_df(df=df)
             sort_columns = ["dataset", "parameter", "date"] if self.sr.settings.ts_tidy else ["dataset", "date"]
             df = df.sort(sort_columns)
+            # cast after sorting so row order stays lexical, not Enum-category order
+            df = df.with_columns(
+                pl.col(column).cast(dtype) for column, dtype in enum_dtypes.items() if column in df.columns
+            )
             self.stations_counter += 1
             self.stations_collected.append(station_id)
             yield ValuesResult(stations=self.sr, values=self, df=df)


### PR DESCRIPTION
## Summary

Reduces the memory footprint of value results by storing the low-cardinality metadata columns (`station_id`, `resolution`, `dataset`, `parameter`) as polars `Enum` instead of `String`. In tidy frames these columns repeat every row and account for roughly half the footprint; integer-backed `Enum` codes replace the repeated strings.

Verified on DWD `daily/kl`, 5 stations: **54.0 → 22.7 MiB (~58% smaller)**, data byte-identical after a `String`↔`Enum` round-trip.

## Design notes

- **Enum categories are derived from the request**, so the dtype is identical across every per-station frame — the diagonal `concat` in `all()` stays valid (mismatched `Enum` category sets would otherwise raise `SchemaError`).
- **Cast happens at the end of `query()`**, after sorting, so row order stays lexical rather than following `Enum` category order, and the pipeline keeps running in `String` throughout (avoiding the friction of casting early).

## Behavior change

The dtype of these columns in returned frames changes from `String` to `Enum`. Downstream code doing strict dtype checks may notice. Documented in the changelog.

> Note: an earlier revision also downcast the value columns to `Float32` for a further ~12% saving, but that was dropped — it produced ugly non-round values in `to_dict`/`to_json`/REST output (`10.600000381469727`) and genuinely lost the 4th decimal for magnitude ≳1000 values (e.g. air pressure), which no amount of output-side rounding recovers.

## Testing

- `tests/test_io.py tests/model tests/core` (non-remote): **188 passed**
- CI on the branch (workflow_dispatch): Tests, Lint, Unused all green
- Verified data integrity via `String`↔`Enum` round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)