### PR TITLE
feat(fmi): add FMI (Finland) observation provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Types of changes:
 
 ## [Unreleased]
 
+- Add FMI (Finland) observation provider with hourly and daily resolution
+  (no authentication required)
+
 ## [0.128.0] - 2026-07-22
 
 - Add KNMI (Netherlands) observation provider with 10-minute, hourly and daily resolution

--- a/docs/data/provider/fmi/index.md
+++ b/docs/data/provider/fmi/index.md
@@ -1,0 +1,9 @@
+# FMI
+
+Finnish Meteorological Institute (Ilmatieteen laitos)
+
+```{toctree}
+:hidden:
+
+observation/index.md
+```

--- a/docs/data/provider/fmi/observation/daily.md
+++ b/docs/data/provider/fmi/observation/daily.md
@@ -1,0 +1,22 @@
+# daily
+
+## metadata
+
+| property      | value |
+|---------------|-------|
+| name          | daily |
+| original name | daily |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                    | original name | unit type     | unit |
+|-------------------------|---------------|---------------|------|
+| temperature_air_mean_2m | tday          | temperature   | °C   |
+| temperature_air_max_2m  | tmax          | temperature   | °C   |
+| temperature_air_min_2m  | tmin          | temperature   | °C   |
+| precipitation_height    | rrday         | precipitation | mm   |
+| snow_depth              | snow          | length_short  | cm   |

--- a/docs/data/provider/fmi/observation/hourly.md
+++ b/docs/data/provider/fmi/observation/hourly.md
@@ -1,0 +1,27 @@
+# hourly
+
+## metadata
+
+| property      | value  |
+|---------------|--------|
+| name          | hourly |
+| original name | hourly |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                          | original name | unit type     | unit |
+|-------------------------------|---------------|---------------|------|
+| temperature_air_mean_2m       | t2m           | temperature   | °C   |
+| temperature_dew_point_mean_2m | td            | temperature   | °C   |
+| humidity                      | rh            | fraction      | %    |
+| wind_speed                    | ws_10min      | speed         | m/s  |
+| wind_gust_max                 | wg_10min      | speed         | m/s  |
+| wind_direction                | wd_10min      | angle         | °    |
+| precipitation_height          | r_1h          | precipitation | mm   |
+| snow_depth                    | snow_aws      | length_short  | cm   |
+| pressure_air_sea_level        | p_sea         | pressure      | hPa  |
+| visibility_range              | vis           | length_medium | m    |

--- a/docs/data/provider/fmi/observation/index.md
+++ b/docs/data/provider/fmi/observation/index.md
@@ -1,0 +1,34 @@
+# Observation
+
+## Overview
+
+FMI's Open Data platform provides access to hourly and daily observation values from the
+Finnish Meteorological Institute's station network across Finland. No API key or
+registration is required — the WFS service is fully public.
+
+Observations are retrieved per station and date range through FMI's WFS stored queries
+(`fmi::observations::weather::simple` for hourly, `fmi::observations::weather::daily::simple`
+for daily). FMI caps a single sub-daily request at 168 hours (7 days), so longer hourly
+ranges are transparently fetched in consecutive windows and stitched back together.
+
+Station metadata comes from the `fmi::ef::stations` catalogue. It does not expose station
+elevation, so `height` is always null. A station's `end_date` is null while it is still
+active.
+
+Not every station measures every parameter — a station/parameter combination that FMI
+doesn't have simply contributes no rows, the same as a station reporting no data for a
+requested date range.
+
+## License
+
+Data is © Finnish Meteorological Institute, licensed under
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). See
+[FMI Open Data](https://en.ilmatieteenlaitos.fi/open-data) for further information and
+usage conditions.
+
+```{toctree}
+:hidden:
+
+hourly.md
+daily.md
+```

--- a/docs/data/provider/index.md
+++ b/docs/data/provider/index.md
@@ -9,6 +9,7 @@ dwd/index.md
 ea/index.md
 eaufrance/index.md
 eccc/index.md
+fmi/index.md
 geosphere/index.md
 imgw/index.md
 knmi/index.md

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -33,6 +33,9 @@ class Wetterdienst:
         "eccc": {
             "observation": "wetterdienst.provider.eccc.observation.EcccObservationRequest",
         },
+        "fmi": {
+            "observation": "wetterdienst.provider.fmi.observation.FmiObservationRequest",
+        },
         "imgw": {
             "hydrology": "wetterdienst.provider.imgw.hydrology.ImgwHydrologyRequest",
             "meteorology": "wetterdienst.provider.imgw.meteorology.ImgwMeteorologyRequest",

--- a/src/wetterdienst/provider/fmi/__init__.py
+++ b/src/wetterdienst/provider/fmi/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/src/wetterdienst/provider/fmi/observation/__init__.py
+++ b/src/wetterdienst/provider/fmi/observation/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+from wetterdienst.provider.fmi.observation.api import FmiObservationRequest
+from wetterdienst.provider.fmi.observation.metadata import FmiObservationMetadata
+
+__all__ = ["FmiObservationMetadata", "FmiObservationRequest"]

--- a/src/wetterdienst/provider/fmi/observation/api.py
+++ b/src/wetterdienst/provider/fmi/observation/api.py
@@ -1,0 +1,267 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""FMI (Finnish Meteorological Institute) observation provider.
+
+FMI publishes open weather-observation data through a key-less WFS service. Station metadata
+comes from the ``fmi::ef::stations`` stored query (INSPIRE EF catalogue); observations come
+from the ``fmi::observations::weather::simple`` (sub-daily) and
+``fmi::observations::weather::daily::simple`` (daily) stored queries, filtered by ``fmisid``,
+``parameters`` and a ``starttime``/``endtime`` window.
+
+See https://en.ilmatieteenlaitos.fi/open-data-manual and
+https://en.ilmatieteenlaitos.fi/observation-stations.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar, cast
+from urllib.parse import urlencode
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.metadata.resolution import Resolution
+from wetterdienst.model.metadata import DatasetModel, ParameterModel
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.fmi.observation.metadata import FmiObservationMetadata
+from wetterdienst.provider.fmi.observation.parser import (
+    extract_exception_text,
+    parse_fmi_observations,
+    parse_fmi_stations,
+)
+from wetterdienst.util.network import download_file
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from wetterdienst.settings import Settings
+
+log = logging.getLogger(__name__)
+
+_BASE_URL = "https://opendata.fmi.fi/wfs"
+_UTC = ZoneInfo("UTC")
+
+# The station catalogue does not vary by parameter, so a single stored query covers every
+# resolution/dataset (mirroring DMI).
+_STATIONS_QUERY = "fmi::ef::stations"
+
+_EMPTY_VALUES_SCHEMA = {
+    "resolution": pl.String,
+    "dataset": pl.String,
+    "parameter": pl.String,
+    "station_id": pl.String,
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "value": pl.Float64,
+    "quality": pl.Float64,
+}
+
+# FMI caps a single observation request's time span (sub-daily queries reject spans over 168
+# hours outright); daily queries are not capped in practice but are chunked too for safety on
+# multi-decade ranges. Consecutive windows share their boundary timestamp and the result is
+# de-duplicated, so no observation is lost regardless of FMI's endtime inclusivity.
+_RESOLUTION_CONFIG: dict[Resolution, dict[str, object]] = {
+    Resolution.HOURLY: {
+        "stored_query_id": "fmi::observations::weather::simple",
+        "timestep": "60",
+        "window": dt.timedelta(hours=168),
+    },
+    Resolution.DAILY: {
+        "stored_query_id": "fmi::observations::weather::daily::simple",
+        "timestep": None,
+        "window": dt.timedelta(days=365),
+    },
+}
+
+
+def _time_windows(
+    start: dt.datetime,
+    end: dt.datetime,
+    window: dt.timedelta,
+) -> Iterator[tuple[dt.datetime, dt.datetime]]:
+    """Split ``[start, end]`` into ``(start, end)`` windows no longer than ``window``.
+
+    Consecutive windows share their boundary timestamp -- the next window restarts at the
+    previous window's ``stop`` rather than one step past it -- so an observation lying exactly on
+    a boundary is fetched whether FMI treats ``endtime`` as inclusive or exclusive. The caller
+    de-duplicates the shared boundary row.
+    """
+    cursor = start
+    while cursor <= end:
+        stop = min(cursor + window, end)
+        yield cursor, stop
+        if stop >= end:
+            break
+        cursor = stop
+
+
+class FmiObservationValues(TimeseriesValues):
+    """Values class for FMI observation data."""
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        if isinstance(parameter_or_dataset, DatasetModel):
+            dataset = parameter_or_dataset
+        elif isinstance(parameter_or_dataset, ParameterModel):
+            dataset = parameter_or_dataset.dataset
+        else:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        settings = cast("Settings", self.sr.stations.settings)
+        start_date = self.sr.start_date
+        end_date = self.sr.end_date
+        if not start_date or not end_date:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        resolution = dataset.resolution.value
+        config = _RESOLUTION_CONFIG[resolution]
+        # FMI returns every requested parameter in one response, so ask for the whole dataset at
+        # once; the raw `parameter` column then holds each parameter's name_original.
+        parameter_codes = ",".join(parameter.name_original for parameter in dataset.parameters)
+
+        frames = []
+        for window_start, window_end in _time_windows(
+            start_date.astimezone(_UTC),
+            end_date.astimezone(_UTC),
+            cast("dt.timedelta", config["window"]),
+        ):
+            df = self._collect_window(
+                station_id=station_id,
+                parameter_codes=parameter_codes,
+                stored_query_id=cast("str", config["stored_query_id"]),
+                timestep=cast("str | None", config["timestep"]),
+                start=window_start,
+                end=window_end,
+                settings=settings,
+            )
+            if not df.is_empty():
+                frames.append(df)
+        if not frames:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        df = pl.concat(frames)
+        # consecutive windows share their boundary timestamp (see _time_windows), so drop the
+        # duplicate boundary row -- keep="first" retains the earlier window's copy.
+        df = df.unique(subset=["parameter", "date"], keep="first", maintain_order=True)
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            pl.col("parameter"),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            pl.col("date"),
+            pl.col("value").cast(pl.Float64, strict=False),
+            pl.lit(None, dtype=pl.Float64).alias("quality"),
+        )
+
+    def _collect_window(
+        self,
+        station_id: str,
+        parameter_codes: str,
+        stored_query_id: str,
+        timestep: str | None,
+        start: dt.datetime,
+        end: dt.datetime,
+        settings: Settings,
+    ) -> pl.DataFrame:
+        query = {
+            "service": "WFS",
+            "version": "2.0.0",
+            "request": "getFeature",
+            "storedquery_id": stored_query_id,
+            "fmisid": station_id,
+            "parameters": parameter_codes,
+            "starttime": start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "endtime": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        }
+        if timestep is not None:
+            query["timestep"] = timestep
+        url = f"{_BASE_URL}?{urlencode(query)}"
+        file = download_file(
+            url=url,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.FIVE_MINUTES,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            # a station reporting no data for a window yields an empty (200) response, so any
+            # exception here is a real transport/HTTP failure; NoInternetError is already logged
+            # at debug upstream.
+            if not file.is_no_internet_error:
+                log.warning(f"Failed to fetch FMI data for station {station_id}: {file.content}")
+            return pl.DataFrame(
+                schema={
+                    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+                    "parameter": pl.String,
+                    "value": pl.Float64,
+                }
+            )
+        content = file.content.read()
+        df = parse_fmi_observations(content)
+        # an empty result is normally a station reporting no data; distinguish a genuine server
+        # error (returned as an ExceptionReport with HTTP 200) so it is not silently swallowed.
+        if df.is_empty() and b"ExceptionReport" in content:
+            log.warning(f"FMI returned an exception for station {station_id}: {extract_exception_text(content)}")
+        return df
+
+
+@dataclass
+class FmiObservationRequest(TimeseriesRequest):
+    """Request class for FMI (Finnish Meteorological Institute) observation data."""
+
+    metadata = FmiObservationMetadata
+    _values = FmiObservationValues
+
+    _endpoint: ClassVar[str] = f"{_BASE_URL}?" + urlencode(
+        {
+            "service": "WFS",
+            "version": "2.0.0",
+            "request": "getFeature",
+            "storedquery_id": _STATIONS_QUERY,
+        },
+    )
+
+    def _all(self) -> pl.LazyFrame:
+        settings = cast("Settings", self.settings)
+        file = download_file(
+            url=self._endpoint,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.METAINDEX,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            log.warning(f"Failed to fetch FMI station catalogue: {file.content}")
+            return pl.LazyFrame()
+        stations = parse_fmi_stations(file.content.read())
+        if stations.is_empty():
+            return pl.LazyFrame()
+
+        # the catalogue is provider-wide; replicate it across each requested (resolution,
+        # dataset) so stations not reporting a requested parameter simply return no values.
+        resolutions_and_datasets = {
+            (parameter.dataset.resolution.name, parameter.dataset.name)
+            for parameter in self.parameters
+            if isinstance(parameter, ParameterModel)
+        }
+        if not resolutions_and_datasets:
+            return pl.LazyFrame()
+        data = [
+            stations.with_columns(
+                pl.lit(resolution, pl.String).alias("resolution"),
+                pl.lit(dataset, pl.String).alias("dataset"),
+            )
+            for resolution, dataset in resolutions_and_datasets
+        ]
+        # TimeseriesRequest.all() selects _base_columns and fills any the catalogue omits (e.g.
+        # height) with null, so no explicit padding is needed here.
+        return pl.concat(data).lazy()

--- a/src/wetterdienst/provider/fmi/observation/metadata.py
+++ b/src/wetterdienst/provider/fmi/observation/metadata.py
@@ -1,0 +1,153 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""FMI (Finland) observation metadata.
+
+The Finnish Meteorological Institute publishes open weather-observation data through a
+key-less WFS service (https://opendata.fmi.fi/wfs). Observations are retrieved per station
+and date range via the ``fmi::observations::weather::simple`` (sub-daily) and
+``fmi::observations::weather::daily::simple`` (daily) stored queries, both of which return
+every requested parameter in one response -- so each resolution is modelled as a single
+grouped default dataset (mirroring DMI).
+
+``name_original`` holds the raw FMI parameter code used directly in the ``parameters=`` query
+argument, e.g. ``t2m``, ``ws_10min``, ``rrday``.
+"""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, build_metadata_model
+
+FmiObservationMetadata = {
+    "name_short": "FMI",
+    "name_english": "Finnish Meteorological Institute",
+    "name_local": "Ilmatieteen laitos",
+    "country": "Finland",
+    "copyright": "© Finnish Meteorological Institute",
+    "url": "https://en.ilmatieteenlaitos.fi/open-data",
+    "kind": "observation",
+    "timezone": "Europe/Helsinki",
+    "timezone_data": "UTC",
+    "resolutions": [
+        {
+            "name": "hourly",
+            "name_original": "hourly",
+            "periods": ["historical"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": DATASET_NAME_DEFAULT,
+                    "name_original": DATASET_NAME_DEFAULT,
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "t2m",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_dew_point_mean_2m",
+                            "name_original": "td",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "humidity",
+                            "name_original": "rh",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "wind_speed",
+                            "name_original": "ws_10min",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_gust_max",
+                            "name_original": "wg_10min",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_direction",
+                            "name_original": "wd_10min",
+                            "unit_type": "angle",
+                            "unit": "degree",
+                        },
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "r_1h",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "snow_depth",
+                            "name_original": "snow_aws",
+                            "unit_type": "length_short",
+                            "unit": "centimeter",
+                        },
+                        {
+                            "name": "pressure_air_sea_level",
+                            "name_original": "p_sea",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "visibility_range",
+                            "name_original": "vis",
+                            "unit_type": "length_medium",
+                            "unit": "meter",
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "daily",
+            "name_original": "daily",
+            "periods": ["historical"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": DATASET_NAME_DEFAULT,
+                    "name_original": DATASET_NAME_DEFAULT,
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "tday",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_max_2m",
+                            "name_original": "tmax",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_min_2m",
+                            "name_original": "tmin",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "rrday",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "snow_depth",
+                            "name_original": "snow",
+                            "unit_type": "length_short",
+                            "unit": "centimeter",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+FmiObservationMetadata = build_metadata_model(FmiObservationMetadata, "FmiObservationMetadata")

--- a/src/wetterdienst/provider/fmi/observation/parser.py
+++ b/src/wetterdienst/provider/fmi/observation/parser.py
@@ -1,0 +1,196 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Parsers for FMI's WFS XML responses (station catalogue and simple observations)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+from lxml.etree import XMLParser, fromstring
+
+if TYPE_CHECKING:
+    from lxml.etree import _Element
+
+_EMPTY_STATIONS_SCHEMA = {
+    "station_id": pl.String,
+    "name": pl.String,
+    "state": pl.String,
+    "latitude": pl.Float64,
+    "longitude": pl.Float64,
+    "start_date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "end_date": pl.Datetime(time_unit="us", time_zone="UTC"),
+}
+
+_EMPTY_OBSERVATIONS_SCHEMA = {
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "parameter": pl.String,
+    "value": pl.Float64,
+}
+
+# FMI encodes "no precipitation" / "no snow cover" as the sentinel -1 (rather than 0) for these
+# parameter codes; normalise it to 0.0 so aggregations are not corrupted by negative amounts
+# (mirroring the KNMI trace-precipitation handling).
+_NO_VALUE_SENTINEL_PARAMETERS = ("r_1h", "rrday", "snow_aws", "snow")
+
+# Disable entity resolution and network access -- FMI is first-party, but there is no reason to
+# fetch external entities/DTDs and it guards against XXE (matching the DWD mosmix KML reader).
+_XML_PARSER = XMLParser(resolve_entities=False, no_network=True)
+
+
+def _local_name(tag: object) -> str:
+    """Return an element's local name, stripping lxml's ``{namespace}`` prefix.
+
+    lxml yields non-element nodes (comments, processing instructions) with a callable ``tag``
+    during iteration; those are reported as an empty local name so callers skip them.
+    """
+    if not isinstance(tag, str):
+        return ""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _parse_operational_period(facility: _Element) -> tuple[str | None, str | None]:
+    """Return the ``(begin, end)`` of a facility's operational-activity period.
+
+    Only the first begin/endPosition pair is honoured so a stray later time period cannot
+    overwrite it. An ``endPosition`` carrying an ``indeterminatePosition`` attribute (``"now"``)
+    marks a still-active station and leaves ``end`` null.
+    """
+    start = end = None
+    start_seen = end_seen = False
+    for el in facility.iter():
+        tag = _local_name(el.tag)
+        if tag == "beginPosition" and not start_seen:
+            start_seen = True
+            start = (el.text or "").strip() or None
+        elif tag == "endPosition" and not end_seen:
+            end_seen = True
+            if el.get("indeterminatePosition") is None:
+                end = (el.text or "").strip() or None
+    return start, end
+
+
+def _parse_facility(facility: _Element) -> dict[str, str | None] | None:
+    """Extract one station row from a single ``EnvironmentalMonitoringFacility`` element.
+
+    Returns ``None`` for a facility without a resolvable fmisid.
+    """
+    station_id = name = region = latitude = longitude = None
+    for el in facility.iter():
+        tag = _local_name(el.tag)
+        code_space = el.get("codeSpace", "")
+        text = (el.text or "").strip()
+        if tag == "identifier" and code_space.endswith("/fmisid"):
+            station_id = text or None
+        elif tag == "name" and code_space.endswith("/locationcode/name") and name is None:
+            name = text or None
+        elif tag == "name" and code_space.endswith("/location/region") and region is None:
+            region = text or None
+        elif tag == "pos" and latitude is None:
+            parts = text.split()
+            if len(parts) >= 2:
+                latitude, longitude = parts[0], parts[1]
+    if not station_id:
+        return None
+    start, end = _parse_operational_period(facility)
+    return {
+        "station_id": station_id,
+        "name": name,
+        "state": region,
+        "latitude": latitude,
+        "longitude": longitude,
+        "start_date": start,
+        "end_date": end,
+    }
+
+
+def parse_fmi_stations(content: bytes) -> pl.DataFrame:
+    """Parse FMI's ``fmi::ef::stations`` INSPIRE EF catalogue into a station DataFrame.
+
+    Each ``EnvironmentalMonitoringFacility`` carries its FMI station id (fmisid) as a
+    ``gml:identifier`` in the ``.../stationcode/fmisid`` code space, human-readable name and
+    region as ``gml:name`` entries in the ``.../locationcode/name`` and ``.../location/region``
+    code spaces, its position as a ``gml:pos`` (``lat lon``), and its operational period as a
+    ``gml:beginPosition``/``gml:endPosition`` pair. Elevation is not exposed by this catalogue,
+    so ``height`` is left for the request layer to fill with null.
+    """
+    root = fromstring(content, parser=_XML_PARSER)
+    rows = [
+        row
+        for facility in root.iter()
+        if _local_name(facility.tag) == "EnvironmentalMonitoringFacility"
+        and (row := _parse_facility(facility)) is not None
+    ]
+    if not rows:
+        return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
+    return pl.DataFrame(rows, infer_schema_length=None).select(
+        pl.col("station_id").cast(pl.String),
+        pl.col("name").cast(pl.String),
+        pl.col("state").cast(pl.String),
+        pl.col("latitude").cast(pl.Float64, strict=False),
+        pl.col("longitude").cast(pl.Float64, strict=False),
+        # cast to String first: when every station is still active (or the field is absent) the
+        # column is inferred as Null dtype, which str.to_datetime rejects.
+        pl.col("start_date")
+        .cast(pl.String)
+        .str.to_datetime("%Y-%m-%dT%H:%M:%SZ", time_unit="us")
+        .dt.replace_time_zone("UTC"),
+        pl.col("end_date")
+        .cast(pl.String)
+        .str.to_datetime("%Y-%m-%dT%H:%M:%SZ", time_unit="us")
+        .dt.replace_time_zone("UTC"),
+    )
+
+
+def extract_exception_text(content: bytes) -> str | None:
+    """Return the text of an OWS ``ExceptionReport`` in ``content``, else ``None``.
+
+    FMI returns an ``ows:ExceptionReport`` (with HTTP 200) for server-side errors such as an
+    invalid stored query or rate limiting; those otherwise parse as an empty observation frame
+    and would be indistinguishable from a station legitimately reporting no data.
+    """
+    root = fromstring(content, parser=_XML_PARSER)
+    if _local_name(root.tag) != "ExceptionReport":
+        return None
+    texts = [text for el in root.iter() if _local_name(el.tag) == "ExceptionText" and (text := (el.text or "").strip())]
+    return "; ".join(texts) or "unknown FMI exception"
+
+
+def parse_fmi_observations(content: bytes) -> pl.DataFrame:
+    """Parse an FMI ``...::simple`` WFS response into a (date, parameter, value) DataFrame.
+
+    The simple stored queries return a flat list of ``BsWfsElement`` features, each holding a
+    single ``Time`` / ``ParameterName`` / ``ParameterValue`` triple. Missing readings are
+    emitted as ``NaN`` and normalised to null here.
+    """
+    root = fromstring(content, parser=_XML_PARSER)
+    times: list[str] = []
+    names: list[str] = []
+    values: list[str | None] = []
+    for el in root.iter():
+        if _local_name(el.tag) != "BsWfsElement":
+            continue
+        time = name = value = None
+        for child in el:
+            tag = _local_name(child.tag)
+            if tag == "Time":
+                time = child.text
+            elif tag == "ParameterName":
+                name = child.text
+            elif tag == "ParameterValue":
+                value = child.text
+        if time and name:
+            times.append(time)
+            names.append(name)
+            values.append(value)
+    if not times:
+        return pl.DataFrame(schema=_EMPTY_OBSERVATIONS_SCHEMA)
+    value = pl.col("value").cast(pl.Float64, strict=False).fill_nan(None)
+    return pl.DataFrame({"date": times, "parameter": names, "value": values}).select(
+        pl.col("date").str.to_datetime("%Y-%m-%dT%H:%M:%SZ", time_unit="us").dt.replace_time_zone("UTC"),
+        pl.col("parameter").cast(pl.String),
+        pl.when(pl.col("parameter").is_in(_NO_VALUE_SENTINEL_PARAMETERS) & (value == -1.0))
+        .then(pl.lit(0.0, dtype=pl.Float64))
+        .otherwise(value)
+        .alias("value"),
+    )

--- a/tests/provider/fmi/__init__.py
+++ b/tests/provider/fmi/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/fmi/observation/__init__.py
+++ b/tests/provider/fmi/observation/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/fmi/observation/test_api.py
+++ b/tests/provider/fmi/observation/test_api.py
@@ -1,0 +1,199 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for FMI observation provider."""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from wetterdienst.provider.fmi.observation import FmiObservationRequest
+from wetterdienst.provider.fmi.observation.parser import (
+    extract_exception_text,
+    parse_fmi_observations,
+    parse_fmi_stations,
+)
+
+HELSINKI_KAISANIEMI = "100971"
+UTC = ZoneInfo("UTC")
+
+# FMI's open-data WFS is a live third-party service; xfail rather than a hard failure keeps a
+# transient blip from blocking CI/merges, matching the AEMET/SMHI precedent.
+xfail_if_fmi_unavailable = pytest.mark.xfail(strict=False, reason="FMI server intermittently unavailable")
+
+
+def test_parse_fmi_observations_trace_sentinel() -> None:
+    """FMI's -1 'no precipitation/no snow' sentinel is normalised to 0.0, other values untouched."""
+    content = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <wfs:FeatureCollection
+        xmlns:wfs="http://www.opengis.net/wfs/2.0"
+        xmlns:BsWfs="http://xml.fmi.fi/schema/wfs/2.0">
+      <wfs:member>
+        <BsWfs:BsWfsElement>
+          <BsWfs:Time>2024-01-01T00:00:00Z</BsWfs:Time>
+          <BsWfs:ParameterName>rrday</BsWfs:ParameterName>
+          <BsWfs:ParameterValue>-1.0</BsWfs:ParameterValue>
+        </BsWfs:BsWfsElement>
+      </wfs:member>
+      <wfs:member>
+        <BsWfs:BsWfsElement>
+          <BsWfs:Time>2024-01-01T00:00:00Z</BsWfs:Time>
+          <BsWfs:ParameterName>snow</BsWfs:ParameterName>
+          <BsWfs:ParameterValue>-1.0</BsWfs:ParameterValue>
+        </BsWfs:BsWfsElement>
+      </wfs:member>
+      <wfs:member>
+        <BsWfs:BsWfsElement>
+          <BsWfs:Time>2024-01-01T00:00:00Z</BsWfs:Time>
+          <BsWfs:ParameterName>tday</BsWfs:ParameterName>
+          <BsWfs:ParameterValue>-1.0</BsWfs:ParameterValue>
+        </BsWfs:BsWfsElement>
+      </wfs:member>
+      <wfs:member>
+        <BsWfs:BsWfsElement>
+          <BsWfs:Time>2024-01-01T00:00:00Z</BsWfs:Time>
+          <BsWfs:ParameterName>rrday</BsWfs:ParameterName>
+          <BsWfs:ParameterValue>NaN</BsWfs:ParameterValue>
+        </BsWfs:BsWfsElement>
+      </wfs:member>
+    </wfs:FeatureCollection>"""
+    df = parse_fmi_observations(content)
+    values = {(row["parameter"], row["value"]) for row in df.select("parameter", "value").to_dicts()}
+    # -1 sentinel -> 0.0 for precipitation and snow depth
+    assert ("rrday", 0.0) in values
+    assert ("snow", 0.0) in values
+    # -1 is a real reading for temperature and must be preserved
+    assert ("tday", -1.0) in values
+    # NaN stays null and is never coerced to 0.0
+    assert ("rrday", None) in values
+
+
+def test_extract_exception_text() -> None:
+    """An OWS ExceptionReport is detected and its text extracted; a normal response returns None."""
+    exception = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <ExceptionReport xmlns="http://www.opengis.net/ows/1.1" version="2.0.0">
+      <Exception exceptionCode="InvalidParameterValue" locator="fmisid">
+        <ExceptionText>No locations found for the query.</ExceptionText>
+      </Exception>
+    </ExceptionReport>"""
+    assert extract_exception_text(exception) == "No locations found for the query."
+    empty = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <wfs:FeatureCollection xmlns:wfs="http://www.opengis.net/wfs/2.0" numberReturned="0"/>"""
+    assert extract_exception_text(empty) is None
+
+
+def test_parse_fmi_stations_active_station_end_date_null() -> None:
+    """A trailing concrete endPosition does not override an active station's null end_date."""
+    content = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <wfs:FeatureCollection
+        xmlns:wfs="http://www.opengis.net/wfs/2.0"
+        xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:ef="http://inspire.ec.europa.eu/schemas/ef/4.0">
+      <wfs:member>
+        <ef:EnvironmentalMonitoringFacility>
+          <gml:identifier codeSpace="http://xml.fmi.fi/namespace/stationcode/fmisid">100971</gml:identifier>
+          <gml:name codeSpace="http://xml.fmi.fi/namespace/locationcode/name">Helsinki Kaisaniemi</gml:name>
+          <gml:name codeSpace="http://xml.fmi.fi/namespace/location/region">Helsinki</gml:name>
+          <gml:pos>60.17523 24.94459</gml:pos>
+          <ef:operationalActivityPeriod>
+            <gml:TimePeriod>
+              <gml:beginPosition>1844-01-01T00:00:00Z</gml:beginPosition>
+              <gml:endPosition indeterminatePosition="now"/>
+            </gml:TimePeriod>
+          </ef:operationalActivityPeriod>
+          <gml:TimePeriod>
+            <gml:beginPosition>2000-01-01T00:00:00Z</gml:beginPosition>
+            <gml:endPosition>2020-01-01T00:00:00Z</gml:endPosition>
+          </gml:TimePeriod>
+        </ef:EnvironmentalMonitoringFacility>
+      </wfs:member>
+    </wfs:FeatureCollection>"""
+    df = parse_fmi_stations(content)
+    assert df.height == 1
+    row = df.to_dicts()[0]
+    assert row["station_id"] == "100971"
+    assert row["start_date"] == dt.datetime(1844, 1, 1, tzinfo=UTC)
+    # active station: the indeterminate operational endPosition wins over the later concrete one
+    assert row["end_date"] is None
+
+
+@pytest.mark.remote
+@xfail_if_fmi_unavailable
+def test_fmi_observation_stations() -> None:
+    """Station metadata for Helsinki Kaisaniemi matches the FMI station catalogue."""
+    request = FmiObservationRequest(
+        parameters=[("hourly", "data", "temperature_air_mean_2m")],
+    ).filter_by_station_id(HELSINKI_KAISANIEMI)
+    df = request.df
+    assert df.select(pl.exclude("latitude", "longitude", "start_date", "end_date", "height")).to_dicts() == [
+        {
+            "resolution": "hourly",
+            "dataset": "data",
+            "station_id": HELSINKI_KAISANIEMI,
+            "name": "Helsinki Kaisaniemi",
+            "state": "Helsinki",
+        },
+    ]
+    # assert coordinates with a tolerance -- FMI may adjust these slightly over time
+    assert df["latitude"].item() == pytest.approx(60.17523)
+    assert df["longitude"].item() == pytest.approx(24.94459)
+
+
+@pytest.mark.remote
+@xfail_if_fmi_unavailable
+def test_fmi_observation_values_hourly() -> None:
+    """Hourly values at Helsinki Kaisaniemi for 2024-01-01 00:00 match the FMI reference values."""
+    df = (
+        FmiObservationRequest(
+            parameters=[("hourly", "data")],
+            start_date=dt.datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=dt.datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        .filter_by_station_id(HELSINKI_KAISANIEMI)
+        .values.all()
+        .df
+    )
+    assert df["station_id"].unique().to_list() == [HELSINKI_KAISANIEMI]
+    assert df["resolution"].unique().to_list() == ["hourly"]
+
+    def value_at(parameter: str, hour: int) -> float:
+        date = dt.datetime(2024, 1, 1, hour, tzinfo=UTC)
+        return df.filter(pl.col("parameter").eq(parameter), pl.col("date").eq(date)).get_column("value").item()
+
+    assert value_at("temperature_air_mean_2m", 0) == pytest.approx(-14.6)
+    assert value_at("temperature_dew_point_mean_2m", 0) == pytest.approx(-16.6)
+    assert value_at("wind_speed", 0) == pytest.approx(2.7)
+    assert value_at("wind_gust_max", 0) == pytest.approx(5.0)
+    assert value_at("wind_direction", 0) == pytest.approx(36.0)
+    assert value_at("precipitation_height", 0) == pytest.approx(0.0)
+    # humidity is reported by FMI as percent, wetterdienst stores it as fraction
+    assert value_at("humidity", 0) == pytest.approx(0.84)
+    assert value_at("pressure_air_sea_level", 0) == pytest.approx(1020.1)
+    assert value_at("visibility_range", 0) == pytest.approx(10730.0)
+
+
+@pytest.mark.remote
+@xfail_if_fmi_unavailable
+def test_fmi_observation_values_daily() -> None:
+    """Daily values at Helsinki Kaisaniemi for 2024-01-01 match the FMI reference values."""
+    df = (
+        FmiObservationRequest(
+            parameters=[("daily", "data")],
+            start_date=dt.datetime(2024, 1, 1, tzinfo=UTC),
+            end_date=dt.datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        .filter_by_station_id(HELSINKI_KAISANIEMI)
+        .values.all()
+        .df
+    )
+    assert df["station_id"].unique().to_list() == [HELSINKI_KAISANIEMI]
+    assert df["resolution"].unique().to_list() == ["daily"]
+    assert df["date"].unique().to_list() == [dt.datetime(2024, 1, 1, tzinfo=UTC)]
+
+    def value_of(parameter: str) -> float:
+        return df.filter(pl.col("parameter").eq(parameter)).get_column("value").item()
+
+    assert value_of("temperature_air_mean_2m") == pytest.approx(-15.8)
+    assert value_of("temperature_air_max_2m") == pytest.approx(-13.7)
+    assert value_of("temperature_air_min_2m") == pytest.approx(-17.4)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,6 +22,7 @@ from wetterdienst.provider.dwd.road import DwdRoadMetadata, DwdRoadRequest
 from wetterdienst.provider.ea.hydrology import EAHydrologyMetadata, EAHydrologyRequest
 from wetterdienst.provider.eaufrance.hubeau import HubeauMetadata, HubeauRequest
 from wetterdienst.provider.eccc.observation import EcccObservationMetadata, EcccObservationRequest
+from wetterdienst.provider.fmi.observation import FmiObservationMetadata, FmiObservationRequest
 from wetterdienst.provider.geosphere.observation import GeosphereObservationMetadata, GeosphereObservationRequest
 from wetterdienst.provider.imgw.hydrology import ImgwHydrologyMetadata, ImgwHydrologyRequest
 from wetterdienst.provider.imgw.meteorology import ImgwMeteorologyMetadata, ImgwMeteorologyRequest
@@ -107,6 +108,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
         DwdRoadMetadata,
         EAHydrologyMetadata,
         EcccObservationMetadata,
+        FmiObservationMetadata,
         GeosphereObservationMetadata,
         HubeauMetadata,
         ImgwHydrologyMetadata,
@@ -141,6 +143,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
         DwdRoadMetadata,
         EAHydrologyMetadata,
         EcccObservationMetadata,
+        FmiObservationMetadata,
         GeosphereObservationMetadata,
         HubeauMetadata,
         ImgwHydrologyMetadata,
@@ -674,6 +677,30 @@ def test_api_smhi_observation(default_settings: Settings) -> None:
     assert not request.df.is_empty()
     assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
     assert _is_complete_stations_df(request.df, exclude_columns={"end_date", "state"})
+    first_date = request.df.get_column("start_date").gather(0).to_list()[0]
+    if first_date:
+        assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")
+    values = next(request.values.query()).df
+    first_date = values.get_column("date").gather(0).to_list()[0]
+    assert first_date.tzinfo
+    assert set(values.columns).issuperset(DF_VALUES_MINIMUM_COLUMNS)
+    assert not values.drop_nulls(subset="value").is_empty()
+
+
+@pytest.mark.xfail(strict=False, reason="FMI server intermittently unavailable")
+@pytest.mark.remote
+def test_api_fmi_observation(default_settings: Settings) -> None:
+    """Test FMI observation API."""
+    request = FmiObservationRequest(
+        parameters=[("daily", "data", "temperature_air_mean_2m")],
+        start_date="2024-01-01",
+        end_date="2024-01-02",
+        settings=default_settings,
+    ).filter_by_station_id("100971")  # Helsinki Kaisaniemi
+    assert not request.df.is_empty()
+    assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
+    # FMI's station catalogue exposes neither elevation nor an end_date for active stations.
+    assert _is_complete_stations_df(request.df, exclude_columns={"end_date", "height"})
     first_date = request.df.get_column("start_date").gather(0).to_list()[0]
     if first_date:
         assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -63,6 +63,7 @@ def test_coverage(client: TestClient) -> None:
         "ea",
         "eaufrance",
         "eccc",
+        "fmi",
         "geosphere",
         "imgw",
         "knmi",


### PR DESCRIPTION
## Summary

Adds a new key-less **FMI (Finnish Meteorological Institute)** observation provider, following the SMHI/DMI/KNMI provider pattern.

- **Stations**: parsed from the `fmi::ef::stations` INSPIRE EF catalogue (443 stations). Elevation is not exposed by the catalogue, so `height` stays null; active stations have a null `end_date`.
- **Values**: fetched from the `fmi::observations::weather::simple` (hourly) and `fmi::observations::weather::daily::simple` (daily) WFS stored queries. Each resolution is modelled as a single grouped dataset (all parameters returned in one response).
- **Windowing**: FMI rejects sub-daily requests spanning more than 168 hours, so requests are transparently chunked. Consecutive windows share their boundary timestamp and the result is de-duplicated, so no reading is dropped whether FMI treats `endtime` as inclusive or exclusive.
- **Sentinel handling**: FMI's `-1` "no precipitation / no snow cover" code (`r_1h`, `rrday`, `snow_aws`, `snow`) is normalised to `0.0`, mirroring the existing KNMI trace-precipitation handling.
- **Error surfacing**: an OWS `ExceptionReport` (returned with HTTP 200) is logged as a warning rather than silently treated as an empty result.
- **Parsing**: uses `lxml` with entity resolution and network access disabled (XXE-safe), matching the DWD mosmix reader.

### Parameters

- **Hourly**: air/dew-point temperature, humidity, wind speed/gust/direction, precipitation, snow depth, sea-level pressure, visibility.
- **Daily**: mean/max/min air temperature, precipitation, snow depth.

## Test plan

- `tests/provider/fmi/observation/test_api.py`:
  - deterministic unit tests for the `-1` sentinel normalisation, `ExceptionReport` extraction, and active-station `end_date` handling
  - remote tests (`@pytest.mark.remote`, xfail-if-unavailable) validating station metadata and hourly/daily reference values for Helsinki Kaisaniemi
- Added FMI to the metadata/API parametrisations in `tests/test_api.py` and a remote smoke test.
- `uv run poe format`, `uv run poe typecheck`, and `test_docs.py::test_data_coverage` all pass; docs added under `docs/data/provider/fmi/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)