### PR TITLE
fix(noaa/ghcn): parse GHCN-hourly timestamps from the ISO date column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Types of changes:
   (no authentication required)
 - Reduce DWD MOSMIX/DMO KML parsing memory by streaming the zipped KML instead of
   decompressing it fully in memory (~6.5x lower peak RSS on MOSMIX-S)
+- Parse NOAA GHCN-hourly (GHCNh) timestamps from the provided ISO date column instead of
+  reconstructing them from separate year/month/day/hour/minute fields
 
 ## [0.128.0] - 2026-07-22
 

--- a/src/wetterdienst/provider/noaa/ghcn/api.py
+++ b/src/wetterdienst/provider/noaa/ghcn/api.py
@@ -66,18 +66,13 @@ class NoaaGhcnValues(TimeseriesValues):
         df = df.rename(
             {
                 "STATION": "station_id",
-                "Station_name": "name",
-                "Year": "year",
-                "Month": "month",
-                "Day": "day",
-                "Hour": "hour",
-                "Minute": "minute",
+                "DATE": "date",
             },
         )
         parameters = [parameter.name_original for parameter in dataset]
         df = df.select(
             "station_id",
-            pl.concat_str(["year", "month", "day", "hour", "minute"]).alias("date"),
+            "date",
             *parameters,
         )
         df = df.unpivot(
@@ -90,7 +85,9 @@ class NoaaGhcnValues(TimeseriesValues):
             pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
             pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
             pl.col("parameter").str.to_lowercase(),
-            pl.col("date").str.to_datetime("%Y%m%d%H%M", time_zone="UTC"),
+            # GHCNh provides a ready-made ISO-8601 timestamp column; parse it directly rather than
+            # reconstructing from the separate year/month/day/hour/minute fields
+            pl.col("date").str.to_datetime("%Y-%m-%dT%H:%M:%S", time_zone="UTC"),
             pl.col("value").replace("-None", None).cast(pl.Float64),
             pl.lit(value=None, dtype=pl.Float64).alias("quality"),
         )

--- a/tests/provider/noaa/ghcn/test_api_data.py
+++ b/tests/provider/noaa/ghcn/test_api_data.py
@@ -62,3 +62,42 @@ def test_api_amsterdam(start_date: dt.datetime, end_date: dt.datetime, default_s
         given_df.filter(pl.col("date").eq(dt.datetime(2021, 1, 1, 23, tzinfo=ZoneInfo("UTC")))),
         expected_df,
     )
+
+
+@pytest.mark.slow
+def test_api_hourly_neustrelitz(default_settings: Settings) -> None:
+    """Hourly (GHCNh) values parse with correct timestamps from the ISO date column."""
+    request = NoaaGhcnRequest(
+        parameters=[NoaaGhcnMetadata.hourly.data.temperature_air_mean_2m],
+        start_date=dt.datetime(1977, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(1977, 2, 1, tzinfo=ZoneInfo("UTC")),
+        settings=default_settings,
+    ).filter_by_station_id("GMA00092791")  # Neustrelitz, Germany -- non-US, immutable historical data
+    given_df = request.values.all().df
+    expected_df = pl.DataFrame(
+        [
+            {
+                "station_id": "GMA00092791",
+                "resolution": "hourly",
+                "dataset": "data",
+                "parameter": "temperature_air_mean_2m",
+                "date": dt.datetime(1977, 1, 10, 2, tzinfo=ZoneInfo("UTC")),
+                "value": 1.0,
+                "quality": None,
+            },
+        ],
+        schema={
+            "station_id": pl.Enum(["GMA00092791"]),
+            "resolution": pl.Enum(["hourly"]),
+            "dataset": pl.Enum(["data"]),
+            "parameter": pl.Enum(["temperature_air_mean_2m"]),
+            "date": pl.Datetime(time_zone="UTC"),
+            "value": pl.Float64,
+            "quality": pl.Float64,
+        },
+        orient="row",
+    )
+    assert_frame_equal(
+        given_df.filter(pl.col("date").eq(dt.datetime(1977, 1, 10, 2, tzinfo=ZoneInfo("UTC")))),
+        expected_df,
+    )


### PR DESCRIPTION
## Summary

Small robustness fix + regression test for the NOAA GHCN-hourly (GHCNh) reader, prompted by investigating #871.

The hourly reader built each timestamp by concatenating the separate `Year`/`Month`/`Day`/`Hour`/`Minute` columns and parsing `%Y%m%d%H%M`. That silently relies on every field being zero-padded — any unpadded row would produce a wrong (or unparseable) timestamp. GHCNh already ships a ready-made ISO-8601 `DATE` column (`1952-01-01T00:00:00`), so this parses that directly with `%Y-%m-%dT%H:%M:%S` instead.

Output is byte-identical for current data (verified end-to-end); the change just removes the zero-padding assumption.

## Test coverage

The hourly path previously had **no test coverage** (only daily was tested). Added `test_api_hourly_neustrelitz`, which uses a **non-US** station (Neustrelitz, Germany — immutable 1977 historical data) and asserts an exact `(date, value)` row, so it guards both the timestamp parsing and global (non-US) coverage.

## Context — #871 (Add ISD)

While here I verified issue #871 is effectively resolved: ISD data is already available via GHCNh (`noaa`/`ghcn`, hourly resolution). The two follow-up concerns from that thread are no longer valid:
- **"only covers US stations"** — the GHCNh station list is now global (38,871 stations, US ~17%; France, Russia, Canada, Australia, China, Germany, …). Verified non-US data downloads and parses.
- **"date parsing issue"** — addressed by this PR (and already produced correct output beforehand for the zero-padded data).

## Test plan

- `poe format`, `poe typecheck` clean
- `tests/provider/noaa/ghcn/test_api_data.py` — all 5 pass (4 daily + new hourly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)