### PR TITLE
feat(chmi): add CHMI (Czechia) observation provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Types of changes:
 
 ## [Unreleased]
 
+- Add CHMI (Czechia) observation provider with 10-minute, hourly, daily, monthly and annual
+  resolution (no authentication required)
+
 - Add FMI (Finland) observation provider with hourly and daily resolution
   (no authentication required)
 - Reduce DWD MOSMIX/DMO KML parsing memory by streaming the zipped KML instead of

--- a/docs/data/provider/chmi/index.md
+++ b/docs/data/provider/chmi/index.md
@@ -1,0 +1,9 @@
+# CHMI
+
+Czech Hydrometeorological Institute (Český hydrometeorologický ústav)
+
+```{toctree}
+:hidden:
+
+observation/index.md
+```

--- a/docs/data/provider/chmi/observation/10_minutes.md
+++ b/docs/data/provider/chmi/observation/10_minutes.md
@@ -1,0 +1,21 @@
+# 10_minutes
+
+## metadata
+
+| property      | value      |
+|---------------|------------|
+| name          | 10_minutes |
+| original name | 10_minutes |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                    | original name | unit type   | unit |
+|-------------------------|---------------|-------------|------|
+| temperature_air_mean_2m | T             | temperature | °C   |
+| humidity                | H             | fraction    | %    |
+| pressure_air_site       | P             | pressure    | hPa  |
+| wind_speed              | F             | speed       | m/s  |

--- a/docs/data/provider/chmi/observation/annual.md
+++ b/docs/data/provider/chmi/observation/annual.md
@@ -1,0 +1,21 @@
+# annual
+
+## metadata
+
+| property      | value   |
+|---------------|---------|
+| name          | annual |
+| original name | annual |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                    | original name | unit type     | unit |
+|-------------------------|---------------|---------------|------|
+| temperature_air_mean_2m | T             | temperature   | °C   |
+| temperature_air_max_2m  | TMA           | temperature   | °C   |
+| temperature_air_min_2m  | TMI           | temperature   | °C   |
+| precipitation_height    | SRA           | precipitation | mm   |

--- a/docs/data/provider/chmi/observation/daily.md
+++ b/docs/data/provider/chmi/observation/daily.md
@@ -1,0 +1,27 @@
+# daily
+
+## metadata
+
+| property      | value |
+|---------------|-------|
+| name          | daily |
+| original name | daily |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                    | original name | unit type     | unit |
+|-------------------------|---------------|---------------|------|
+| temperature_air_mean_2m | T             | temperature   | °C   |
+| temperature_air_max_2m  | TMA           | temperature   | °C   |
+| temperature_air_min_2m  | TMI           | temperature   | °C   |
+| humidity                | H             | fraction      | %    |
+| precipitation_height    | SRA           | precipitation | mm   |
+| pressure_air_site       | P             | pressure      | hPa  |
+| wind_speed              | F             | speed         | m/s  |
+| wind_gust_max           | Fmax          | speed         | m/s  |
+| snow_depth              | SCE           | length_short  | cm   |
+| sunshine_duration       | SSV           | time          | h    |

--- a/docs/data/provider/chmi/observation/hourly.md
+++ b/docs/data/provider/chmi/observation/hourly.md
@@ -1,0 +1,20 @@
+# hourly
+
+## metadata
+
+| property      | value  |
+|---------------|--------|
+| name          | hourly |
+| original name | hourly |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                          | original name | unit type     | unit |
+|-------------------------------|---------------|---------------|------|
+| temperature_dew_point_mean_2m | Td            | temperature   | °C   |
+| precipitation_height          | SRA1H         | precipitation | mm   |
+| pressure_air_site             | P             | pressure      | hPa  |

--- a/docs/data/provider/chmi/observation/index.md
+++ b/docs/data/provider/chmi/observation/index.md
@@ -1,0 +1,43 @@
+# Observation
+
+## Overview
+
+CHMI's open-data portal provides access to historical climate observations from the
+Czech Hydrometeorological Institute's station network across Czechia at 10-minute, hourly,
+daily, monthly and annual resolution. No API key or registration is required — the portal is
+fully public.
+
+Station metadata comes from `metadata/meta1.csv`. A station whose sensor was relocated appears
+under several operational periods; these are collapsed to a single station using the most recent
+position for the coordinates and the full extent for the operational dates. The catalogue does
+not expose a region, so `state` is always null, and a station's `end_date` is null while it is
+still active.
+
+Observations are addressed per station and element. The `daily`, `monthly` and `annual`
+resolutions store one flat CSV per station/element (e.g. `dly-<WSI>-T.csv`); the `10_minutes`
+and `hourly` resolutions store one CSV per station/element/month under a year sub-directory, so
+they require a date range. The 10-minute and hourly files only reach back to 2018.
+
+The `daily` files may hold several time functions — the daily mean (`AVG`) alongside fixed-term
+readings — so the appropriate one is selected per parameter and timestamps are normalised to the
+calendar day. The `monthly`/`annual` files additionally carry an aggregation function, so the
+climatological mean of daily means/maxima/minima is used for temperature and the total for
+precipitation.
+
+Not every station measures every parameter — a station/parameter combination that CHMI doesn't
+have simply contributes no rows.
+
+## License
+
+Data is © Czech Hydrometeorological Institute (CHMI). See
+[CHMI open data](https://opendata.chmi.cz/) for further information and usage conditions.
+
+```{toctree}
+:hidden:
+
+10_minutes.md
+hourly.md
+daily.md
+monthly.md
+annual.md
+```

--- a/docs/data/provider/chmi/observation/monthly.md
+++ b/docs/data/provider/chmi/observation/monthly.md
@@ -1,0 +1,21 @@
+# monthly
+
+## metadata
+
+| property      | value   |
+|---------------|---------|
+| name          | monthly |
+| original name | monthly |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                    | original name | unit type     | unit |
+|-------------------------|---------------|---------------|------|
+| temperature_air_mean_2m | T             | temperature   | °C   |
+| temperature_air_max_2m  | TMA           | temperature   | °C   |
+| temperature_air_min_2m  | TMI           | temperature   | °C   |
+| precipitation_height    | SRA           | precipitation | mm   |

--- a/docs/data/provider/index.md
+++ b/docs/data/provider/index.md
@@ -4,6 +4,7 @@
 :hidden:
 
 aemet/index.md
+chmi/index.md
 dmi/index.md
 dwd/index.md
 ea/index.md

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -19,6 +19,9 @@ class Wetterdienst:
         "aemet": {
             "observation": "wetterdienst.provider.aemet.observation.AemetObservationRequest",
         },
+        "chmi": {
+            "observation": "wetterdienst.provider.chmi.observation.ChmiObservationRequest",
+        },
         "dmi": {
             "observation": "wetterdienst.provider.dmi.observation.DmiObservationRequest",
         },

--- a/src/wetterdienst/provider/chmi/__init__.py
+++ b/src/wetterdienst/provider/chmi/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""CHMI (Czech Hydrometeorological Institute) provider."""

--- a/src/wetterdienst/provider/chmi/observation/__init__.py
+++ b/src/wetterdienst/provider/chmi/observation/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""CHMI (Czech Hydrometeorological Institute) observation provider."""
+
+from wetterdienst.provider.chmi.observation.api import ChmiObservationRequest
+from wetterdienst.provider.chmi.observation.metadata import ChmiObservationMetadata
+
+__all__ = ["ChmiObservationMetadata", "ChmiObservationRequest"]

--- a/src/wetterdienst/provider/chmi/observation/api.py
+++ b/src/wetterdienst/provider/chmi/observation/api.py
@@ -1,0 +1,284 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""CHMI (Czech Hydrometeorological Institute) observation provider.
+
+CHMI publishes historical climate observations as key-less CSV files through its open-data
+portal. Station metadata comes from ``metadata/meta1.csv``. Observations are addressed per
+``(station, element)``: ``daily``/``monthly``/``annual`` as one flat CSV each, ``10_minutes`` and
+``hourly`` as one CSV per ``(station, element, month)`` under a year sub-directory.
+
+See https://opendata.chmi.cz/meteorology/climate/historical_csv/ and the accompanying
+``Klimatologicka_data_popis.pdf``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar, cast
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.metadata.resolution import Resolution
+from wetterdienst.model.metadata import DatasetModel, ParameterModel
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.chmi.observation.metadata import ChmiObservationMetadata
+from wetterdienst.provider.chmi.observation.parser import (
+    parse_chmi_stations,
+    parse_chmi_values_aggregate,
+    parse_chmi_values_daily,
+    parse_chmi_values_subdaily,
+)
+from wetterdienst.util.network import download_file
+
+if TYPE_CHECKING:
+    import datetime as dt
+    from collections.abc import Iterator
+
+    from wetterdienst.settings import Settings
+
+log = logging.getLogger(__name__)
+
+_UTC = ZoneInfo("UTC")
+_BASE_URL = "https://opendata.chmi.cz/meteorology/climate/historical_csv"
+
+_EMPTY_VALUES_SCHEMA = {
+    "resolution": pl.String,
+    "dataset": pl.String,
+    "parameter": pl.String,
+    "station_id": pl.String,
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "value": pl.Float64,
+    "quality": pl.Float64,
+}
+
+# monthly/annual elements as (category, TIMEFUNCTION, MDFUNCTION): the daily value that is
+# aggregated, and how it is aggregated over the period -- the climatological mean of daily means /
+# daily maxima / daily minima, and the total for precipitation.
+_AGGREGATE_ELEMENTS = {
+    "T": ("temperature", "AVG", "AVG"),
+    "TMA": ("temperature", "20:00", "AVG"),
+    "TMI": ("temperature", "20:00", "AVG"),
+    "SRA": ("precipitation", "06:00", "SUM"),
+}
+
+# Per resolution: the URL path segment, the per-file prefix, the file layout and, for each
+# element, its category sub-directory plus the value-selection term(s). The element tuple is
+# ``(category,)``-like: ``(category, None)`` for sub-daily (a single reading per timestamp),
+# ``(category, TIMEFUNC)`` for daily, ``(category, TIMEFUNCTION, MDFUNCTION)`` for monthly/annual.
+#   layout "daily"     -> one flat CSV, select by TIMEFUNC, day-truncated timestamp
+#   layout "aggregate" -> one flat CSV, select by TIMEFUNCTION+MDFUNCTION, date from YEAR(+MONTH)
+#   layout "subdaily"  -> one CSV per (element, month) under <path>/<category>/<year>/
+_RESOLUTION_CONFIG: dict[Resolution, dict] = {
+    Resolution.MINUTE_10: {
+        "path": "10min",
+        "prefix": "10m",
+        "layout": "subdaily",
+        "elements": {
+            "T": ("temperature", None),
+            "H": ("humidity", None),
+            "P": ("air_pressure", None),
+            "F": ("wind", None),
+        },
+    },
+    Resolution.HOURLY: {
+        "path": "1hour",
+        "prefix": "1h",
+        "layout": "subdaily",
+        "elements": {"Td": ("synop", None), "SRA1H": ("precipitation", None), "P": ("synop", None)},
+    },
+    Resolution.DAILY: {
+        "path": "daily",
+        "prefix": "dly",
+        "layout": "daily",
+        "elements": {
+            "T": ("temperature", "AVG"),
+            "TMA": ("temperature", "20:00"),
+            "TMI": ("temperature", "20:00"),
+            "H": ("humidity", "AVG"),
+            "SRA": ("precipitation", "06:00"),
+            "P": ("air_pressure", "AVG"),
+            "F": ("wind", "AVG"),
+            "Fmax": ("wind", "00:00"),
+            "SCE": ("snow", "06:00"),
+            "SSV": ("sunshine", "00:00"),
+        },
+    },
+    Resolution.MONTHLY: {
+        "path": "monthly",
+        "prefix": "mly",
+        "layout": "aggregate",
+        "has_month": True,
+        "elements": _AGGREGATE_ELEMENTS,
+    },
+    Resolution.ANNUAL: {
+        "path": "yearly",
+        "prefix": "yrs",
+        "layout": "aggregate",
+        "has_month": False,
+        "elements": _AGGREGATE_ELEMENTS,
+    },
+}
+
+
+def _months(start: dt.datetime, end: dt.datetime) -> Iterator[tuple[int, int]]:
+    """Yield ``(year, month)`` for every month in ``[start, end]`` inclusive."""
+    year, month = start.year, start.month
+    while (year, month) <= (end.year, end.month):
+        yield year, month
+        month += 1
+        if month > 12:
+            year, month = year + 1, 1
+
+
+class ChmiObservationValues(TimeseriesValues):
+    """Values class for CHMI observation data."""
+
+    def _download(self, url: str, settings: Settings, station_id: str) -> bytes | None:
+        file = download_file(
+            url=url,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.TWELVE_HOURS,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            # a station that does not measure an element (or has no data for a month) has no file
+            if not file.is_no_internet_error:
+                log.debug(f"No CHMI file {url} for station {station_id}: {file.content}")
+            return None
+        return file.content.read()
+
+    def _collect_element(
+        self,
+        station_id: str,
+        element: str,
+        element_config: tuple,
+        config: dict,
+        settings: Settings,
+    ) -> list[pl.DataFrame]:
+        layout = config["layout"]
+        category = element_config[0]
+        if layout == "subdaily":
+            frames = []
+            # the month files are named by UTC calendar month; normalise so a tz-aware, non-UTC
+            # request date near a month boundary still selects the correct file
+            start = cast("dt.datetime", self.sr.start_date).astimezone(_UTC)
+            end = cast("dt.datetime", self.sr.end_date).astimezone(_UTC)
+            for year, month in _months(start, end):
+                url = (
+                    f"{_BASE_URL}/data/{config['path']}/{category}/{year}/"
+                    f"{config['prefix']}-{station_id}-{element}-{year}{month:02d}.csv"
+                )
+                content = self._download(url, settings, station_id)
+                if content is not None:
+                    df = parse_chmi_values_subdaily(content, element=element)
+                    if not df.is_empty():
+                        frames.append(df)
+            return frames
+        url = f"{_BASE_URL}/data/{config['path']}/{category}/{config['prefix']}-{station_id}-{element}.csv"
+        content = self._download(url, settings, station_id)
+        if content is None:
+            return []
+        if layout == "daily":
+            df = parse_chmi_values_daily(content, element=element, timefunc=element_config[1])
+        else:
+            df = parse_chmi_values_aggregate(
+                content,
+                element=element,
+                timefunc=element_config[1],
+                mdfunc=element_config[2],
+                has_month=config["has_month"],
+            )
+        return [df] if not df.is_empty() else []
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        if isinstance(parameter_or_dataset, DatasetModel):
+            dataset = parameter_or_dataset
+            parameters = list(parameter_or_dataset.parameters)
+        elif isinstance(parameter_or_dataset, ParameterModel):
+            dataset = parameter_or_dataset.dataset
+            parameters = [parameter_or_dataset]
+        else:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        settings = cast("Settings", self.sr.stations.settings)
+        config = _RESOLUTION_CONFIG[dataset.resolution.value]
+        # the sub-daily files are partitioned by month, so a date range is required to address them
+        if config["layout"] == "subdaily" and (not self.sr.start_date or not self.sr.end_date):
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        frames: list[pl.DataFrame] = []
+        for parameter in parameters:
+            element_config = config["elements"].get(parameter.name_original)
+            if element_config is None:
+                continue
+            frames.extend(self._collect_element(station_id, parameter.name_original, element_config, config, settings))
+        if not frames:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        df = pl.concat(frames)
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            pl.col("parameter"),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            pl.col("date"),
+            pl.col("value"),
+            pl.lit(None, dtype=pl.Float64).alias("quality"),
+        )
+
+
+@dataclass
+class ChmiObservationRequest(TimeseriesRequest):
+    """Request class for CHMI (Czech Hydrometeorological Institute) observation data."""
+
+    metadata = ChmiObservationMetadata
+    _values = ChmiObservationValues
+
+    _endpoint: ClassVar[str] = f"{_BASE_URL}/metadata/meta1.csv"
+
+    def _all(self) -> pl.LazyFrame:
+        settings = cast("Settings", self.settings)
+        file = download_file(
+            url=self._endpoint,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.METAINDEX,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            log.warning(f"Failed to fetch CHMI station catalogue: {file.content}")
+            return pl.LazyFrame()
+        stations = parse_chmi_stations(file.content.read())
+        if stations.is_empty():
+            return pl.LazyFrame()
+
+        # the catalogue is provider-wide; replicate it across each requested (resolution, dataset)
+        # so stations not reporting a requested parameter simply return no values.
+        resolutions_and_datasets = {
+            (parameter.dataset.resolution.name, parameter.dataset.name)
+            for parameter in self.parameters
+            if isinstance(parameter, ParameterModel)
+        }
+        if not resolutions_and_datasets:
+            return pl.LazyFrame()
+        data = [
+            stations.with_columns(
+                pl.lit(resolution, pl.String).alias("resolution"),
+                pl.lit(dataset, pl.String).alias("dataset"),
+            )
+            for resolution, dataset in resolutions_and_datasets
+        ]
+        # TimeseriesRequest.all() selects _base_columns and fills any the catalogue omits (state)
+        # with null, so no explicit padding is needed here.
+        return pl.concat(data).lazy()

--- a/src/wetterdienst/provider/chmi/observation/metadata.py
+++ b/src/wetterdienst/provider/chmi/observation/metadata.py
@@ -1,0 +1,94 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""CHMI (Czechia) observation metadata.
+
+The Czech Hydrometeorological Institute publishes historical climate observations as key-less
+CSV files through its open-data portal (https://opendata.chmi.cz/). Station metadata comes from
+``metadata/meta1.csv``; observations are addressed per ``(station, element)``.
+
+Five resolutions are exposed. The ``daily``, ``monthly`` and ``annual`` resolutions store one flat
+CSV per ``(station, element)``; ``10_minutes`` and ``hourly`` are partitioned into one CSV per
+``(station, element, month)`` under a year sub-directory (so they require a date range). Every
+parameter maps to one CHMI element code (its ``name_original``); the element's storage
+sub-directory, the value-selection rule and the file layout are resolved in ``api.py``.
+"""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, build_metadata_model
+
+_TEMPERATURE = {"unit_type": "temperature", "unit": "degree_celsius"}
+_PRECIPITATION = {"unit_type": "precipitation", "unit": "millimeter"}
+_PRESSURE = {"unit_type": "pressure", "unit": "hectopascal"}
+_HUMIDITY = {"unit_type": "fraction", "unit": "percent"}
+_WIND_SPEED = {"unit_type": "speed", "unit": "meter_per_second"}
+
+# daily/monthly/annual share the same climatological element codes and value-selection scheme;
+# only the file layout and date granularity differ (handled in api.py).
+_CLIMATE_PARAMETERS = [
+    {"name": "temperature_air_mean_2m", "name_original": "T", **_TEMPERATURE},
+    {"name": "temperature_air_max_2m", "name_original": "TMA", **_TEMPERATURE},
+    {"name": "temperature_air_min_2m", "name_original": "TMI", **_TEMPERATURE},
+    {"name": "precipitation_height", "name_original": "SRA", **_PRECIPITATION},
+]
+
+_DAILY_PARAMETERS = [
+    *_CLIMATE_PARAMETERS,
+    {"name": "humidity", "name_original": "H", **_HUMIDITY},
+    {"name": "pressure_air_site", "name_original": "P", **_PRESSURE},
+    {"name": "wind_speed", "name_original": "F", **_WIND_SPEED},
+    {"name": "wind_gust_max", "name_original": "Fmax", **_WIND_SPEED},
+    {"name": "snow_depth", "name_original": "SCE", "unit_type": "length_short", "unit": "centimeter"},
+    {"name": "sunshine_duration", "name_original": "SSV", "unit_type": "time", "unit": "hour"},
+]
+
+_MINUTE_10_PARAMETERS = [
+    {"name": "temperature_air_mean_2m", "name_original": "T", **_TEMPERATURE},
+    {"name": "humidity", "name_original": "H", **_HUMIDITY},
+    {"name": "pressure_air_site", "name_original": "P", **_PRESSURE},
+    {"name": "wind_speed", "name_original": "F", **_WIND_SPEED},
+]
+
+_HOURLY_PARAMETERS = [
+    {"name": "temperature_dew_point_mean_2m", "name_original": "Td", **_TEMPERATURE},
+    {"name": "precipitation_height", "name_original": "SRA1H", **_PRECIPITATION},
+    {"name": "pressure_air_site", "name_original": "P", **_PRESSURE},
+]
+
+
+def _resolution(name: str, parameters: list[dict], *, date_required: bool) -> dict:
+    return {
+        "name": name,
+        "name_original": name,
+        "periods": ["historical"],
+        "date_required": date_required,
+        "datasets": [
+            {
+                "name": DATASET_NAME_DEFAULT,
+                "name_original": DATASET_NAME_DEFAULT,
+                "grouped": True,
+                "parameters": parameters,
+            },
+        ],
+    }
+
+
+ChmiObservationMetadata = {
+    "name_short": "CHMI",
+    "name_english": "Czech Hydrometeorological Institute",
+    "name_local": "Český hydrometeorologický ústav",
+    "country": "Czechia",
+    "copyright": "© Czech Hydrometeorological Institute (CHMI)",
+    "url": "https://opendata.chmi.cz/",
+    "kind": "observation",
+    "timezone": "Europe/Prague",
+    "timezone_data": "UTC",
+    "resolutions": [
+        _resolution("10_minutes", _MINUTE_10_PARAMETERS, date_required=True),
+        _resolution("hourly", _HOURLY_PARAMETERS, date_required=True),
+        _resolution("daily", _DAILY_PARAMETERS, date_required=False),
+        _resolution("monthly", _CLIMATE_PARAMETERS, date_required=False),
+        _resolution("annual", _CLIMATE_PARAMETERS, date_required=False),
+    ],
+}
+ChmiObservationMetadata = build_metadata_model(ChmiObservationMetadata, "ChmiObservationMetadata")

--- a/src/wetterdienst/provider/chmi/observation/parser.py
+++ b/src/wetterdienst/provider/chmi/observation/parser.py
@@ -1,0 +1,134 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Parsers for CHMI's open-data CSV files (station catalogue and per-element observations).
+
+Observation files come in three shapes: the ``daily`` files carry a ``TIMEFUNC``/``DT`` pair, the
+sub-daily (``10_minutes``/``hourly``) files a bare ``DT``, and the ``monthly``/``annual`` files a
+``YEAR``(+``MONTH``)/``TIMEFUNCTION`` aggregate layout. Each parser normalises to a common
+``(date, parameter, value)`` frame.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+# CHMI encodes timestamps without seconds, e.g. ``1863-10-01T00:00Z``.
+_DATE_FORMAT = "%Y-%m-%dT%H:%MZ"
+
+_EMPTY_STATIONS_SCHEMA = {
+    "station_id": pl.String,
+    "name": pl.String,
+    "latitude": pl.Float64,
+    "longitude": pl.Float64,
+    "height": pl.Float64,
+    "start_date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "end_date": pl.Datetime(time_unit="us", time_zone="UTC"),
+}
+
+_EMPTY_VALUES_SCHEMA = {
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "parameter": pl.String,
+    "value": pl.Float64,
+}
+
+
+def parse_chmi_stations(content: bytes) -> pl.DataFrame:
+    """Parse CHMI's ``metadata/meta1.csv`` station catalogue into one row per station.
+
+    The catalogue carries one row per operational period (``WSI``, ``BEGIN_DATE``/``END_DATE``,
+    ``FULL_NAME``, ``GEOGR1``/``GEOGR2`` = longitude/latitude, ``ELEVATION``), so a station with a
+    relocated sensor appears multiple times. Collapse to a single row using the most recent
+    position for the coordinates/name and the full operational extent for the dates. An
+    ``END_DATE`` in year 3999 marks a still-active station and leaves ``end_date`` null.
+    """
+    df = pl.read_csv(content, has_header=True, infer_schema_length=0)
+    if df.is_empty():
+        return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
+    df = df.with_columns(
+        pl.col("BEGIN_DATE").str.to_datetime(_DATE_FORMAT, time_unit="us").dt.replace_time_zone("UTC"),
+        pl.col("END_DATE").str.to_datetime(_DATE_FORMAT, time_unit="us").dt.replace_time_zone("UTC"),
+    )
+    df = df.group_by("WSI").agg(
+        pl.col("FULL_NAME").sort_by("END_DATE").last().alias("name"),
+        pl.col("GEOGR2").sort_by("END_DATE").last().alias("latitude"),
+        pl.col("GEOGR1").sort_by("END_DATE").last().alias("longitude"),
+        pl.col("ELEVATION").sort_by("END_DATE").last().alias("height"),
+        pl.col("BEGIN_DATE").min().alias("start_date"),
+        pl.col("END_DATE").max().alias("end_date"),
+    )
+    return df.select(
+        pl.col("WSI").cast(pl.String).alias("station_id"),
+        pl.col("name").cast(pl.String),
+        pl.col("latitude").cast(pl.Float64, strict=False),
+        pl.col("longitude").cast(pl.Float64, strict=False),
+        pl.col("height").cast(pl.Float64, strict=False),
+        pl.col("start_date"),
+        pl.when(pl.col("end_date").dt.year() >= 3999).then(None).otherwise(pl.col("end_date")).alias("end_date"),
+    )
+
+
+def _values(date: pl.Expr, element: str, df: pl.DataFrame) -> pl.DataFrame:
+    return df.select(
+        date.alias("date"),
+        pl.lit(element, dtype=pl.String).alias("parameter"),
+        pl.col("VALUE").cast(pl.Float64, strict=False).alias("value"),
+    )
+
+
+def parse_chmi_values_daily(content: bytes, element: str, timefunc: str) -> pl.DataFrame:
+    """Parse a daily per-element CSV, keeping only the ``TIMEFUNC`` for the requested parameter.
+
+    A single file (e.g. ``dly-<WSI>-T.csv``) may hold several ``TIMEFUNC`` variants (the daily
+    mean ``AVG`` alongside fixed-term readings), so keep only the relevant one. Timestamps are
+    normalised to the calendar day so every daily parameter aligns on ``YYYY-MM-DD``.
+    """
+    df = pl.read_csv(content, has_header=True, infer_schema_length=0)
+    if df.is_empty():
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    df = df.filter(pl.col("TIMEFUNC") == timefunc)
+    if df.is_empty():
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    date = pl.col("DT").str.to_datetime(_DATE_FORMAT, time_unit="us").dt.replace_time_zone("UTC").dt.truncate("1d")
+    return _values(date, element, df)
+
+
+def parse_chmi_values_subdaily(content: bytes, element: str) -> pl.DataFrame:
+    """Parse a sub-daily (10-minute/hourly) per-element CSV.
+
+    Sub-daily files hold a single reading per ``DT`` (no ``TIMEFUNC``), so the native timestamp is
+    kept as-is.
+    """
+    df = pl.read_csv(content, has_header=True, infer_schema_length=0)
+    if df.is_empty():
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    date = pl.col("DT").str.to_datetime(_DATE_FORMAT, time_unit="us").dt.replace_time_zone("UTC")
+    return _values(date, element, df)
+
+
+def parse_chmi_values_aggregate(
+    content: bytes,
+    element: str,
+    timefunc: str,
+    mdfunc: str,
+    *,
+    has_month: bool,
+) -> pl.DataFrame:
+    """Parse a monthly/annual per-element CSV.
+
+    Aggregate files store the period as ``YEAR`` (plus ``MONTH`` for monthly) and two aggregation
+    keys: ``TIMEFUNCTION`` mirrors the daily ``TIMEFUNC`` (which daily value was aggregated) and
+    ``MDFUNCTION`` is how the daily values were combined over the period (``AVG`` mean, ``SUM`` total,
+    ``MAX``/``MIN`` extremes, ``GE(..)``/``L(..)`` day counts). Both must be pinned to select a
+    single series. The date is set to the period start.
+    """
+    df = pl.read_csv(content, has_header=True, infer_schema_length=0)
+    if df.is_empty():
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    df = df.filter(pl.col("TIMEFUNCTION") == timefunc, pl.col("MDFUNCTION") == mdfunc)
+    if df.is_empty():
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    month = pl.col("MONTH").cast(pl.Int32) if has_month else pl.lit(1, dtype=pl.Int32)
+    date = (
+        pl.date(pl.col("YEAR").cast(pl.Int32), month, 1).cast(pl.Datetime(time_unit="us")).dt.replace_time_zone("UTC")
+    )
+    return _values(date, element, df)

--- a/tests/provider/chmi/__init__.py
+++ b/tests/provider/chmi/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for CHMI provider."""

--- a/tests/provider/chmi/observation/__init__.py
+++ b/tests/provider/chmi/observation/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for CHMI observation provider."""

--- a/tests/provider/chmi/observation/test_api.py
+++ b/tests/provider/chmi/observation/test_api.py
@@ -1,0 +1,218 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for CHMI observation provider."""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from wetterdienst.provider.chmi.observation import ChmiObservationRequest
+from wetterdienst.provider.chmi.observation.parser import (
+    parse_chmi_stations,
+    parse_chmi_values_aggregate,
+    parse_chmi_values_daily,
+    parse_chmi_values_subdaily,
+)
+
+CHEB = "0-20000-0-11406"
+UTC = ZoneInfo("UTC")
+
+
+def test_parse_chmi_stations_collapses_periods() -> None:
+    """A relocated station collapses to one row: latest position, full extent, active end_date null."""
+    content = (
+        b"WSI,GH_ID,BEGIN_DATE,END_DATE,FULL_NAME,GEOGR1,GEOGR2,ELEVATION,\n"
+        b"0-X,GA,1961-01-01T00:00Z,2000-12-31T23:59Z,Cheb,12.30,50.00,458,\n"
+        b"0-X,GA,2001-01-01T00:00Z,3999-12-31T23:59Z,Cheb,12.391389,50.068333,483,\n"
+    )
+    df = parse_chmi_stations(content)
+    assert df.to_dicts() == [
+        {
+            "station_id": "0-X",
+            "name": "Cheb",
+            "latitude": 50.068333,  # GEOGR2 of the most recent (active) period
+            "longitude": 12.391389,  # GEOGR1 of the most recent period
+            "height": 483.0,
+            "start_date": dt.datetime(1961, 1, 1, tzinfo=UTC),  # earliest BEGIN_DATE
+            "end_date": None,  # END_DATE year 3999 -> active -> null
+        },
+    ]
+
+
+def test_parse_chmi_values_daily_selects_timefunc_and_truncates() -> None:
+    """Daily parsing keeps only the requested TIMEFUNC and normalises the timestamp to the day."""
+    content = (
+        b"STATION,ELEMENT,TIMEFUNC,DT,VALUE,FLAG,QUALITY,\n"
+        b"0-X,T,AVG,2020-01-01T00:00Z,-3.0,,0.0,\n"
+        b"0-X,T,20:00,2020-01-01T20:00Z,-1.0,,0.0,\n"  # different TIMEFUNC -> excluded
+        b"0-X,T,AVG,2020-01-02T00:00Z,-2.0,,0.0,\n"
+    )
+    df = parse_chmi_values_daily(content, element="T", timefunc="AVG")
+    assert df.to_dicts() == [
+        {"date": dt.datetime(2020, 1, 1, tzinfo=UTC), "parameter": "T", "value": -3.0},
+        {"date": dt.datetime(2020, 1, 2, tzinfo=UTC), "parameter": "T", "value": -2.0},
+    ]
+    # a 20:00-term reading is truncated back to the calendar day (not kept at 20:00)
+    df_max = parse_chmi_values_daily(content, element="T", timefunc="20:00")
+    assert df_max.to_dicts() == [{"date": dt.datetime(2020, 1, 1, tzinfo=UTC), "parameter": "T", "value": -1.0}]
+
+
+def test_parse_chmi_values_subdaily_keeps_native_timestamp() -> None:
+    """Sub-daily parsing keeps the native timestamp (no TIMEFUNC, no truncation)."""
+    content = (
+        b"STATION,ELEMENT,DT,VALUE,FLAG,QUALITY,\n"
+        b"0-X,T,2020-01-01T00:00Z,-2.8,,0.0,\n"
+        b"0-X,T,2020-01-01T00:10Z,-2.7,,0.0,\n"
+    )
+    df = parse_chmi_values_subdaily(content, element="T")
+    assert df.to_dicts() == [
+        {"date": dt.datetime(2020, 1, 1, 0, 0, tzinfo=UTC), "parameter": "T", "value": -2.8},
+        {"date": dt.datetime(2020, 1, 1, 0, 10, tzinfo=UTC), "parameter": "T", "value": -2.7},
+    ]
+
+
+def test_parse_chmi_values_aggregate_pins_both_functions() -> None:
+    """Monthly/annual parsing must pin TIMEFUNCTION *and* MDFUNCTION to select a single series."""
+    monthly = (
+        b"STATION,ELEMENT,YEAR,MONTH,TIMEFUNCTION,MDFUNCTION,VALUE,FLAG_REPEAT,FLAG_INTERRUPTED,\n"
+        b"0-X,T,2020,1,AVG,AVG,1.1,,,\n"
+        b"0-X,T,2020,1,AVG,MAX,8.0,,,\n"  # same TIMEFUNCTION, different MDFUNCTION -> excluded
+        b"0-X,T,2020,1,AVG,MIN,-9.0,,,\n"
+    )
+    df = parse_chmi_values_aggregate(monthly, element="T", timefunc="AVG", mdfunc="AVG", has_month=True)
+    assert df.to_dicts() == [{"date": dt.datetime(2020, 1, 1, tzinfo=UTC), "parameter": "T", "value": 1.1}]
+
+    # precipitation must select the SUM (monthly total), not another MDFUNCTION
+    precip = (
+        b"STATION,ELEMENT,YEAR,MONTH,TIMEFUNCTION,MDFUNCTION,VALUE,FLAG_REPEAT,FLAG_INTERRUPTED,\n"
+        b"0-X,SRA,2020,1,06:00,SUM,21.3,,,\n"
+        b"0-X,SRA,2020,1,06:00,MAX,7.0,,,\n"
+    )
+    df_precip = parse_chmi_values_aggregate(precip, element="SRA", timefunc="06:00", mdfunc="SUM", has_month=True)
+    assert df_precip.to_dicts() == [{"date": dt.datetime(2020, 1, 1, tzinfo=UTC), "parameter": "SRA", "value": 21.3}]
+
+
+def test_parse_chmi_values_aggregate_annual_has_no_month() -> None:
+    """Annual files carry no MONTH column; the date is the year start."""
+    annual = (
+        b"STATION,ELEMENT,YEAR,TIMEFUNCTION,MDFUNCTION,VALUE,FLAG_REPEAT,FLAG_INTERRUPTED,\n0-X,T,2018,AVG,AVG,9.7,,,\n"
+    )
+    df = parse_chmi_values_aggregate(annual, element="T", timefunc="AVG", mdfunc="AVG", has_month=False)
+    assert df.to_dicts() == [{"date": dt.datetime(2018, 1, 1, tzinfo=UTC), "parameter": "T", "value": 9.7}]
+
+
+# CHMI's open-data portal is a live third-party service; xfail rather than a hard failure keeps a
+# transient blip from blocking CI/merges, matching the AEMET/FMI precedent.
+xfail_if_chmi_unavailable = pytest.mark.xfail(strict=False, reason="CHMI server intermittently unavailable")
+
+
+def _values(resolution: str, start: dt.datetime, end: dt.datetime) -> pl.DataFrame:
+    return (
+        ChmiObservationRequest(
+            parameters=[(resolution, "data")],
+            start_date=start,
+            end_date=end,
+        )
+        .filter_by_station_id(CHEB)
+        .values.all()
+        .df
+    )
+
+
+def _value_of(df: pl.DataFrame, parameter: str, date: dt.datetime) -> float:
+    return df.filter(pl.col("parameter").eq(parameter), pl.col("date").eq(date)).get_column("value").item()
+
+
+@pytest.mark.remote
+@xfail_if_chmi_unavailable
+def test_chmi_observation_stations() -> None:
+    """Station metadata for Cheb matches the CHMI catalogue."""
+    request = ChmiObservationRequest(
+        parameters=[("daily", "data", "temperature_air_mean_2m")],
+    ).filter_by_station_id(CHEB)
+    df = request.df
+    assert df.select(pl.exclude("latitude", "longitude", "start_date", "end_date", "height")).to_dicts() == [
+        {
+            "resolution": "daily",
+            "dataset": "data",
+            "station_id": CHEB,
+            "name": "Cheb",
+            "state": None,
+        },
+    ]
+    assert df["latitude"].item() == pytest.approx(50.068333)
+    assert df["longitude"].item() == pytest.approx(12.391389)
+    assert df["height"].item() == pytest.approx(483.0)
+    assert df["start_date"].item() == dt.datetime(1863, 10, 1, tzinfo=UTC)
+    assert df["end_date"].item() is None
+
+
+@pytest.mark.remote
+@xfail_if_chmi_unavailable
+def test_chmi_observation_values_10_minutes() -> None:
+    """10-minute values at Cheb for 2020-01-01 00:00 match the CHMI reference values."""
+    df = _values("10_minutes", dt.datetime(2020, 1, 1, tzinfo=UTC), dt.datetime(2020, 1, 1, 0, 10, tzinfo=UTC))
+    when = dt.datetime(2020, 1, 1, tzinfo=UTC)
+    assert _value_of(df, "temperature_air_mean_2m", when) == pytest.approx(-2.8)
+    assert _value_of(df, "humidity", when) == pytest.approx(0.92)
+    assert _value_of(df, "pressure_air_site", when) == pytest.approx(975.8)
+    assert _value_of(df, "wind_speed", when) == pytest.approx(1.3)
+
+
+@pytest.mark.remote
+@xfail_if_chmi_unavailable
+def test_chmi_observation_values_hourly() -> None:
+    """Hourly values at Cheb for 2020-01-01 00:00 match the CHMI reference values."""
+    df = _values("hourly", dt.datetime(2020, 1, 1, tzinfo=UTC), dt.datetime(2020, 1, 1, 1, tzinfo=UTC))
+    when = dt.datetime(2020, 1, 1, tzinfo=UTC)
+    assert _value_of(df, "temperature_dew_point_mean_2m", when) == pytest.approx(-3.9)
+    assert _value_of(df, "pressure_air_site", when) == pytest.approx(975.8)
+    assert _value_of(df, "precipitation_height", when) == pytest.approx(0.0)
+
+
+@pytest.mark.remote
+@xfail_if_chmi_unavailable
+def test_chmi_observation_values_daily() -> None:
+    """Daily values at Cheb for 2020-01-01 match the CHMI reference values."""
+    df = _values("daily", dt.datetime(2020, 1, 1, tzinfo=UTC), dt.datetime(2020, 1, 2, tzinfo=UTC))
+    when = dt.datetime(2020, 1, 1, tzinfo=UTC)
+    assert df["station_id"].unique().to_list() == [CHEB]
+    assert _value_of(df, "temperature_air_mean_2m", when) == pytest.approx(-3.0)
+    assert _value_of(df, "temperature_air_max_2m", when) == pytest.approx(1.5)
+    assert _value_of(df, "temperature_air_min_2m", when) == pytest.approx(-6.9)
+    assert _value_of(df, "precipitation_height", when) == pytest.approx(0.0)
+    assert _value_of(df, "wind_speed", when) == pytest.approx(0.8)
+    assert _value_of(df, "wind_gust_max", when) == pytest.approx(3.7)
+    assert _value_of(df, "pressure_air_site", when) == pytest.approx(974.9)
+    assert _value_of(df, "snow_depth", when) == pytest.approx(0.0)
+    # CHMI reports humidity in percent; wetterdienst stores it as a fraction
+    assert _value_of(df, "humidity", when) == pytest.approx(0.92)
+    # CHMI reports sunshine in hours; wetterdienst stores it in seconds (5.9 h -> 21240 s)
+    assert _value_of(df, "sunshine_duration", when) == pytest.approx(21240.0)
+
+
+@pytest.mark.remote
+@xfail_if_chmi_unavailable
+def test_chmi_observation_values_monthly() -> None:
+    """Monthly values at Cheb for 2020-01 match the CHMI reference values (means and sum)."""
+    df = _values("monthly", dt.datetime(2020, 1, 1, tzinfo=UTC), dt.datetime(2020, 1, 2, tzinfo=UTC))
+    when = dt.datetime(2020, 1, 1, tzinfo=UTC)
+    assert _value_of(df, "temperature_air_mean_2m", when) == pytest.approx(1.1)
+    assert _value_of(df, "temperature_air_max_2m", when) == pytest.approx(3.7)
+    assert _value_of(df, "temperature_air_min_2m", when) == pytest.approx(-1.5)
+    # precipitation is the monthly total (MDFUNCTION SUM), not an average
+    assert _value_of(df, "precipitation_height", when) == pytest.approx(21.3)
+
+
+@pytest.mark.remote
+@xfail_if_chmi_unavailable
+def test_chmi_observation_values_annual() -> None:
+    """Annual values at Cheb for 2018 match the CHMI reference values (means and sum)."""
+    df = _values("annual", dt.datetime(2018, 1, 1, tzinfo=UTC), dt.datetime(2018, 1, 2, tzinfo=UTC))
+    when = dt.datetime(2018, 1, 1, tzinfo=UTC)
+    assert _value_of(df, "temperature_air_mean_2m", when) == pytest.approx(9.7)
+    assert _value_of(df, "temperature_air_max_2m", when) == pytest.approx(14.9)
+    assert _value_of(df, "temperature_air_min_2m", when) == pytest.approx(5.0)
+    assert _value_of(df, "precipitation_height", when) == pytest.approx(465.6)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,7 @@ from wetterdienst import Parameter, Settings
 from wetterdienst.api import Wetterdienst
 from wetterdienst.model.unit import UnitConverter
 from wetterdienst.provider.aemet.observation import AemetObservationMetadata, AemetObservationRequest
+from wetterdienst.provider.chmi.observation import ChmiObservationMetadata, ChmiObservationRequest
 from wetterdienst.provider.dmi.observation import DmiObservationMetadata, DmiObservationRequest
 from wetterdienst.provider.dwd.dmo import DwdDmoMetadata, DwdDmoRequest
 from wetterdienst.provider.dwd.mosmix import DwdMosmixMetadata, DwdMosmixRequest
@@ -101,6 +102,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
     "metadata",
     [
         AemetObservationMetadata,
+        ChmiObservationMetadata,
         DmiObservationMetadata,
         DwdDmoMetadata,
         DwdMosmixMetadata,
@@ -136,6 +138,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
     "metadata",
     [
         AemetObservationMetadata,
+        ChmiObservationMetadata,
         DmiObservationMetadata,
         DwdDmoMetadata,
         DwdMosmixMetadata,
@@ -654,6 +657,30 @@ def test_api_aemet_observation(default_settings: Settings) -> None:
     assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
     # AEMET's station inventory doesn't provide start_date/end_date at all.
     assert _is_complete_stations_df(request.df, exclude_columns={"start_date", "end_date"})
+    first_date = request.df.get_column("start_date").gather(0).to_list()[0]
+    if first_date:
+        assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")
+    values = next(request.values.query()).df
+    first_date = values.get_column("date").gather(0).to_list()[0]
+    assert first_date.tzinfo
+    assert set(values.columns).issuperset(DF_VALUES_MINIMUM_COLUMNS)
+    assert not values.drop_nulls(subset="value").is_empty()
+
+
+@pytest.mark.xfail(strict=False, reason="CHMI server intermittently unavailable")
+@pytest.mark.remote
+def test_api_chmi_observation(default_settings: Settings) -> None:
+    """Test CHMI observation API."""
+    request = ChmiObservationRequest(
+        parameters=[("daily", "data", "temperature_air_mean_2m")],
+        start_date="2020-01-01",
+        end_date="2020-01-02",
+        settings=default_settings,
+    ).filter_by_station_id("0-20000-0-11406")  # Cheb
+    assert not request.df.is_empty()
+    assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
+    # CHMI's station catalogue provides no state/region and no end_date for active stations.
+    assert _is_complete_stations_df(request.df, exclude_columns={"state", "end_date"})
     first_date = request.df.get_column("start_date").gather(0).to_list()[0]
     if first_date:
         assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -58,6 +58,7 @@ def test_coverage(client: TestClient) -> None:
     data = response.json()
     assert data.keys() == {
         "aemet",
+        "chmi",
         "dmi",
         "dwd",
         "ea",


### PR DESCRIPTION
## Summary

Adds a new key-less **CHMI (Czech Hydrometeorological Institute)** observation provider, sourced from CHMI's public open-data CSV portal (`opendata.chmi.cz`). Covers **five resolutions**: 10-minute, hourly, daily, monthly and annual.

- **Stations**: parsed from `metadata/meta1.csv` (1,562 stations). A station whose sensor was relocated appears under several operational periods; these are collapsed to one row (latest position for coordinates, full extent for dates). No region is exposed, so `state` is null; active stations have a null `end_date`.
- **Observations**: addressed per `(station, element)`. The provider handles **three file layouts and three value formats**:

| Resolution | Layout | Value selection |
|---|---|---|
| `10_minutes` | per `(station, element, month)` under a year dir (date range required) | native timestamp |
| `hourly` | same (year/month partitioned) | native timestamp |
| `daily` | one flat CSV per `(station, element)` | `TIMEFUNC`, day-truncated |
| `monthly` | flat | `TIMEFUNCTION`+`MDFUNCTION`, dated at month start |
| `annual` | flat | `TIMEFUNCTION`+`MDFUNCTION`, dated at year start |

### Parameters
- **10_minutes**: air temperature, humidity, site pressure, wind speed
- **hourly**: dew-point temperature, precipitation, site pressure
- **daily**: mean/max/min air temperature, humidity, precipitation, site pressure, wind speed, wind gust, snow depth, sunshine duration
- **monthly / annual**: mean/max/min air temperature, precipitation total

### Notable data handling
- The `daily` `T` file mixes the daily mean (`AVG`) with fixed-term readings, so the correct `TIMEFUNC` is selected per parameter.
- The `monthly`/`annual` files carry a **second** aggregation column (`MDFUNCTION`): temperature uses the climatological mean of daily means/maxima/minima (`AVG`), and **precipitation correctly uses the period total (`SUM`)**, not an average.
- Timestamps are normalised to the period start so parameters align.

## Test plan

- `tests/provider/chmi/observation/test_api.py`: station metadata test + one value test **per resolution**, each asserting exact values verified against the raw CHMI files (`@pytest.mark.remote`, xfail-if-unavailable). All pass live.
- Added CHMI to the metadata/units/registry parametrisations and a remote smoke test in `tests/test_api.py`.
- Full non-remote `test_api.py` (88 passed), `test_docs.py` coverage, `poe format` and `poe typecheck` all pass. Docs added per resolution under `docs/data/provider/chmi/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)