### PR TITLE
feat(rmi): add RMI (Belgium) observation provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Types of changes:
 
 ### Added
 
+- Add RMI (Belgium) observation provider with 10-minute, hourly and daily resolution
+  from the automatic weather station (AWS) network (no authentication required)
 - Add CHMI (Czechia) observation provider with 10-minute, hourly, daily, monthly and annual
   resolution (no authentication required)
 - Add FMI (Finland) observation provider with hourly and daily resolution

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -84,6 +84,11 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
     - Observation
         - recent observations (last week) of US weather stations
         - currently the list of stations is not completely right as we use a diverging source!
+- RMI (Koninklijk Meteorologisch Instituut / Royal Meteorological Institute of Belgium / Belgium)
+    - Observation
+        - observations from the automatic weather station (AWS) network in Belgium
+        - 10-minute, hourly and daily resolution
+        - ~14 stations, back to 1995; open data, no authentication required
 - WSV (Wasserstraßen- und Schifffahrtsverwaltung des Bundes / Federal Waterways and Shipping Administration)
     - Pegelonline
         - data of river network of Germany

--- a/docs/data/provider/index.md
+++ b/docs/data/provider/index.md
@@ -19,6 +19,7 @@ meteoswiss/index.md
 metno/index.md
 noaa/index.md
 nws/index.md
+rmi/index.md
 smhi/index.md
 wsv/index.md
 ```

--- a/docs/data/provider/rmi/index.md
+++ b/docs/data/provider/rmi/index.md
@@ -1,0 +1,10 @@
+# RMI
+
+Royal Meteorological Institute of Belgium (Koninklijk Meteorologisch Instituut / Institut
+Royal Météorologique)
+
+```{toctree}
+:hidden:
+
+observation/index.md
+```

--- a/docs/data/provider/rmi/observation/10_minutes.md
+++ b/docs/data/provider/rmi/observation/10_minutes.md
@@ -1,0 +1,31 @@
+# 10_minutes
+
+## metadata
+
+| property      | value      |
+|---------------|------------|
+| name          | 10_minutes |
+| original name | aws_10min  |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                        | original name            | unit type      | unit |
+|-----------------------------|--------------------------|----------------|------|
+| temperature_air_mean_2m     | temp_dry_shelter_avg     | temperature    | °C   |
+| precipitation_height        | precip_quantity          | precipitation  | mm   |
+| temperature_air_mean_0_05m  | temp_grass_pt100_avg     | temperature    | °C   |
+| temperature_soil_mean_0_05m | temp_soil_avg_5cm        | temperature    | °C   |
+| temperature_soil_mean_0_1m  | temp_soil_avg_10cm       | temperature    | °C   |
+| temperature_soil_mean_0_2m  | temp_soil_avg_20cm       | temperature    | °C   |
+| temperature_soil_mean_0_5m  | temp_soil_avg_50cm       | temperature    | °C   |
+| wind_speed                  | wind_speed_10m           | speed          | m/s  |
+| wind_gust_max               | wind_gusts_speed         | speed          | m/s  |
+| humidity                    | humidity_rel_shelter_avg | fraction       | %    |
+| pressure_air_site           | pressure                 | pressure       | hPa  |
+| sunshine_duration           | sun_duration             | time           | min  |
+| radiation_global            | short_wave_from_sky_avg  | power_per_area | W/m² |
+| wind_direction              | wind_direction           | angle          | °    |

--- a/docs/data/provider/rmi/observation/daily.md
+++ b/docs/data/provider/rmi/observation/daily.md
@@ -1,0 +1,32 @@
+# daily
+
+## metadata
+
+| property      | value    |
+|---------------|----------|
+| name          | daily    |
+| original name | aws_1day |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                        | original name            | unit type      | unit |
+|-----------------------------|--------------------------|----------------|------|
+| temperature_air_mean_2m     | temp_avg                 | temperature    | °C   |
+| temperature_air_max_2m      | temp_max                 | temperature    | °C   |
+| temperature_air_min_2m      | temp_min                 | temperature    | °C   |
+| precipitation_height        | precip_quantity          | precipitation  | mm   |
+| temperature_air_mean_0_05m  | temp_grass_pt100_avg     | temperature    | °C   |
+| temperature_soil_mean_0_05m | temp_soil_avg_5cm        | temperature    | °C   |
+| temperature_soil_mean_0_1m  | temp_soil_avg_10cm       | temperature    | °C   |
+| temperature_soil_mean_0_2m  | temp_soil_avg_20cm       | temperature    | °C   |
+| temperature_soil_mean_0_5m  | temp_soil_avg_50cm       | temperature    | °C   |
+| wind_speed                  | wind_speed_10m           | speed          | m/s  |
+| wind_gust_max               | wind_gusts_speed         | speed          | m/s  |
+| humidity                    | humidity_rel_shelter_avg | fraction       | %    |
+| pressure_air_site           | pressure                 | pressure       | hPa  |
+| sunshine_duration           | sun_duration             | time           | min  |
+| radiation_global            | short_wave_from_sky_avg  | power_per_area | W/m² |

--- a/docs/data/provider/rmi/observation/hourly.md
+++ b/docs/data/provider/rmi/observation/hourly.md
@@ -1,0 +1,30 @@
+# hourly
+
+## metadata
+
+| property      | value    |
+|---------------|----------|
+| name          | hourly   |
+| original name | aws_1hour |
+
+## datasets
+
+### data
+
+#### parameters
+
+| name                        | original name            | unit type      | unit |
+|-----------------------------|--------------------------|----------------|------|
+| temperature_air_mean_2m     | temp_dry_shelter_avg     | temperature    | °C   |
+| precipitation_height        | precip_quantity          | precipitation  | mm   |
+| temperature_air_mean_0_05m  | temp_grass_pt100_avg     | temperature    | °C   |
+| temperature_soil_mean_0_05m | temp_soil_avg_5cm        | temperature    | °C   |
+| temperature_soil_mean_0_1m  | temp_soil_avg_10cm       | temperature    | °C   |
+| temperature_soil_mean_0_2m  | temp_soil_avg_20cm       | temperature    | °C   |
+| temperature_soil_mean_0_5m  | temp_soil_avg_50cm       | temperature    | °C   |
+| wind_speed                  | wind_speed_10m           | speed          | m/s  |
+| wind_gust_max               | wind_gusts_speed         | speed          | m/s  |
+| humidity                    | humidity_rel_shelter_avg | fraction       | %    |
+| pressure_air_site           | pressure                 | pressure       | hPa  |
+| sunshine_duration           | sun_duration             | time           | min  |
+| radiation_global            | short_wave_from_sky_avg  | power_per_area | W/m² |

--- a/docs/data/provider/rmi/observation/index.md
+++ b/docs/data/provider/rmi/observation/index.md
@@ -14,6 +14,9 @@ wide feature per timestamp. Station metadata comes from the `aws_station` featur
 All timestamps are true UTC instants; daily aggregates are labelled at UTC midnight. The values
 therefore need no timezone adjustment.
 
+Each value carries a quality code derived from the source `qc_flags` validation map: `1.0` when
+the parameter is validated, `0.0` when it is not.
+
 ## License
 
 Data is © RMI (Royal Meteorological Institute of Belgium) and licensed under

--- a/docs/data/provider/rmi/observation/index.md
+++ b/docs/data/provider/rmi/observation/index.md
@@ -1,0 +1,30 @@
+# Observation
+
+## Overview
+
+RMI's open data service provides observations from its network of automatic weather stations
+(AWS) in Belgium, at 10-minute, hourly and daily resolution. Data is served through RMI's
+key-less GeoServer WFS endpoint (GeoJSON); no authentication is required.
+
+Each resolution is exposed as its own feature type (`aws_10min`, `aws_1hour`, `aws_1day`). The
+provider queries one feature type with a CQL filter (`code = <station> AND timestamp DURING
+<start>/<end>`), which returns every parameter for that station in the requested window as one
+wide feature per timestamp. Station metadata comes from the `aws_station` feature type.
+
+All timestamps are true UTC instants; daily aggregates are labelled at UTC midnight. The values
+therefore need no timezone adjustment.
+
+## License
+
+Data is © RMI (Royal Meteorological Institute of Belgium) and licensed under
+[Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
+See [geo.be — RMI AWS](https://www.geo.be/catalog/details/RMI_AWS_WFS) for further information
+and usage conditions.
+
+```{toctree}
+:hidden:
+
+10_minutes.md
+hourly.md
+daily.md
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,8 @@ keywords = [
     "national-oceanic-and-atmospheric-administration",
     # NWS
     "national-weather-service",
+    # RMI
+    "royal-meteorological-institute-of-belgium",
     "near-real-time",
     "observation",
     "open-data",

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -49,6 +49,9 @@ class Wetterdienst:
         "noaa": {
             "ghcn": "wetterdienst.provider.noaa.ghcn.NoaaGhcnRequest",
         },
+        "rmi": {
+            "observation": "wetterdienst.provider.rmi.observation.RmiObservationRequest",
+        },
         "wsv": {
             "pegel": "wetterdienst.provider.wsv.pegel.WsvPegelRequest",
         },

--- a/src/wetterdienst/provider/rmi/__init__.py
+++ b/src/wetterdienst/provider/rmi/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/src/wetterdienst/provider/rmi/observation/__init__.py
+++ b/src/wetterdienst/provider/rmi/observation/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+from wetterdienst.provider.rmi.observation.api import RmiObservationRequest
+from wetterdienst.provider.rmi.observation.metadata import RmiObservationMetadata
+
+__all__ = [
+    "RmiObservationMetadata",
+    "RmiObservationRequest",
+]

--- a/src/wetterdienst/provider/rmi/observation/api.py
+++ b/src/wetterdienst/provider/rmi/observation/api.py
@@ -182,12 +182,7 @@ class RmiObservationValues(TimeseriesValues):
             pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
             pl.col("parameter"),
             pl.lit(station_id, dtype=pl.String).alias("station_id"),
-            pl.col("timestamp")
-            .str.to_datetime("%Y-%m-%dT%H:%M:%SZ", time_unit="us")
-            .dt.replace_time_zone("UTC")
-            .alias(
-                "date",
-            ),
+            _parse_utc_z(pl.col("timestamp")).alias("date"),
             pl.col("value").cast(pl.Float64),
             pl.lit(None, dtype=pl.Float64).alias("quality"),
         )
@@ -225,9 +220,9 @@ class RmiObservationRequest(TimeseriesRequest):
             pl.col("geometry").struct.field("coordinates").list.get(1).alias("latitude"),
             pl.col("geometry").struct.field("coordinates").list.get(0).alias("longitude"),
             pl.col("properties").struct.field("altitude").alias("height"),
-            _parse_station_datetime("date_begin").alias("start_date"),
+            _parse_utc_z(pl.col("properties").struct.field("date_begin")).alias("start_date"),
             # a null date_end marks a still-active station
-            _parse_station_datetime("date_end").alias("end_date"),
+            _parse_utc_z(pl.col("properties").struct.field("date_end")).alias("end_date"),
         )
         resolutions_and_datasets = {
             (parameter.dataset.resolution.name, parameter.dataset.name)
@@ -249,11 +244,11 @@ class RmiObservationRequest(TimeseriesRequest):
         ).lazy()
 
 
-def _parse_station_datetime(field: str) -> pl.Expr:
-    """Parse an RMI station ``date_begin``/``date_end`` (UTC ``Z`` instant) to a UTC datetime."""
-    return (
-        pl.col("properties")
-        .struct.field(field)
-        .str.to_datetime("%Y-%m-%dT%H:%M:%SZ", time_unit="us")
-        .dt.replace_time_zone("UTC")
-    )
+def _parse_utc_z(expr: pl.Expr) -> pl.Expr:
+    """Parse an RMI UTC ``Z`` timestamp string (value ``timestamp`` or station date) to a UTC datetime.
+
+    ``%.f`` tolerates an optional fractional-seconds part: RMI timestamps are observed at second
+    precision (``...00Z``), but parsing defensively means a stray fractional part never raises and
+    aborts the whole query. A null input (e.g. an active station's ``date_end``) parses to null.
+    """
+    return expr.str.to_datetime("%Y-%m-%dT%H:%M:%S%.fZ", time_unit="us").dt.replace_time_zone("UTC")

--- a/src/wetterdienst/provider/rmi/observation/api.py
+++ b/src/wetterdienst/provider/rmi/observation/api.py
@@ -39,6 +39,11 @@ _UTC = ZoneInfo("UTC")
 # GeoServer serves the whole matched set in one page for realistic station/date windows, but
 # paginate defensively (startIndex/count) so a very long range can never hit a server-side cap.
 _PAGE_LIMIT = 500_000
+# Hard runaway guard on the paging loop. At _PAGE_LIMIT rows/page this bounds a single query to
+# billions of rows -- orders of magnitude beyond any real station/window -- so it never trims a
+# legitimate result, but guarantees termination even against a server that ignores startIndex or
+# omits numberMatched (which would otherwise loop forever fetching duplicate full pages).
+_MAX_PAGES = 10_000
 
 _EMPTY_VALUES_SCHEMA = {
     "resolution": pl.String,
@@ -113,11 +118,12 @@ class RmiObservationValues(TimeseriesValues):
         until the response's ``numberMatched`` total has been covered (or a page comes back
         empty). This is robust to a server-side page cap below ``_PAGE_LIMIT``: relying on a
         "short page" alone would stop early and silently drop rows if the server ever returns
-        fewer features than requested. Stops on the first download error.
+        fewer features than requested. The loop is bounded by ``_MAX_PAGES`` as a runaway guard.
+        Stops on the first download error.
         """
         start_index = 0
         number_matched: int | None = None
-        while True:
+        for _ in range(_MAX_PAGES):
             # `sortBy` is mandatory once `startIndex` paging is used: the feature types have no
             # primary key, so GeoServer otherwise rejects the request ("Cannot do natural order
             # without a primary key"). Sorting by timestamp also makes the paging deterministic.
@@ -157,6 +163,9 @@ class RmiObservationValues(TimeseriesValues):
             elif df.height < _PAGE_LIMIT:
                 # numberMatched absent (unexpected): fall back to the short-page heuristic
                 return
+        # only reached if the loop never hit a natural stop -- a misbehaving server (ignoring
+        # startIndex or omitting numberMatched). Bail out with a warning rather than loop forever.
+        log.warning(f"RMI pagination exceeded {_MAX_PAGES} pages (filter {cql_filter!r}); stopping early")
 
     def _collect_station_parameter_or_dataset(
         self,

--- a/src/wetterdienst/provider/rmi/observation/api.py
+++ b/src/wetterdienst/provider/rmi/observation/api.py
@@ -1,0 +1,259 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""RMI (Royal Meteorological Institute of Belgium) AWS observation provider.
+
+RMI publishes automatic weather station (AWS) observations through an open, key-less GeoServer
+WFS service (GeoJSON). Each resolution is exposed as its own feature type -- ``aws:aws_10min``,
+``aws:aws_1hour`` and ``aws:aws_1day`` -- plus a station layer ``aws:aws_station``. A single
+``GetFeature`` request filtered with a CQL predicate (``code = <station> AND timestamp DURING
+<start>/<end>``) returns every parameter for that station in the requested window as one wide
+feature per timestamp -- see https://www.geo.be/catalog/details/RMI_AWS_WFS.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+from urllib.parse import quote
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.model.metadata import DatasetModel, ParameterModel
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.rmi.observation.metadata import RmiObservationMetadata
+from wetterdienst.util.network import download_file
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Sequence
+
+    from wetterdienst.settings import Settings
+
+log = logging.getLogger(__name__)
+
+_BASE_URL = "https://opendata.meteo.be/service/aws/wfs"
+_UTC = ZoneInfo("UTC")
+# GeoServer serves the whole matched set in one page for realistic station/date windows, but
+# paginate defensively (startIndex/count) so a very long range can never hit a server-side cap.
+_PAGE_LIMIT = 500_000
+
+_EMPTY_VALUES_SCHEMA = {
+    "resolution": pl.String,
+    "dataset": pl.String,
+    "parameter": pl.String,
+    "station_id": pl.String,
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "value": pl.Float64,
+    "quality": pl.Float64,
+}
+
+_STATION_ENDPOINT = (
+    f"{_BASE_URL}?service=WFS&version=2.0.0&request=GetFeature&typeNames=aws:aws_station&outputFormat=application/json"
+)
+
+_STATION_SCHEMA = pl.Schema(
+    {
+        "features": pl.List(
+            pl.Struct(
+                {
+                    "geometry": pl.Struct({"coordinates": pl.List(pl.Float64)}),
+                    "properties": pl.Struct(
+                        {
+                            "code": pl.Int64,
+                            "name": pl.String,
+                            "date_begin": pl.String,
+                            "date_end": pl.String,
+                            "altitude": pl.Float64,
+                        }
+                    ),
+                }
+            )
+        ),
+    }
+)
+
+
+def _values_schema(parameters: Sequence[ParameterModel]) -> pl.Schema:
+    """Build the WFS feature schema for a dataset's parameters.
+
+    Only the ``timestamp`` and the mapped parameter columns are declared; ``read_json`` ignores
+    every other attribute (``code``, geometry, ``qc_flags``, unmapped parameters).
+    """
+    properties: dict[str, type[pl.DataType]] = {"timestamp": pl.String}
+    for parameter in parameters:
+        properties[parameter.name_original] = pl.Float64
+    return pl.Schema({"features": pl.List(pl.Struct({"properties": pl.Struct(properties)}))})
+
+
+class RmiObservationValues(TimeseriesValues):
+    """Values class for RMI AWS observations."""
+
+    def _iter_value_pages(
+        self,
+        layer: str,
+        cql_filter: str,
+        schema: pl.Schema,
+        settings: Settings,
+    ) -> Iterator[pl.DataFrame]:
+        """Yield each page of WFS features (as unnested ``properties`` frames) for a query.
+
+        Pages are walked via ``startIndex`` until a short (or empty) page marks the end; stops on
+        the first download error.
+        """
+        for start_index in itertools.count(0, _PAGE_LIMIT):
+            # `sortBy` is mandatory once `startIndex` paging is used: the feature types have no
+            # primary key, so GeoServer otherwise rejects the request ("Cannot do natural order
+            # without a primary key"). Sorting by timestamp also makes the paging deterministic.
+            url = (
+                f"{_BASE_URL}?service=WFS&version=2.0.0&request=GetFeature"
+                f"&typeNames=aws:{layer}&outputFormat=application/json"
+                f"&count={_PAGE_LIMIT}&startIndex={start_index}&sortBy=timestamp"
+                f"&cql_filter={quote(cql_filter, safe='')}"
+            )
+            file = download_file(
+                url=url,
+                cache_dir=settings.cache_dir,
+                ttl=CacheExpiry.FIVE_MINUTES,
+                client_kwargs=settings.fsspec_client_kwargs,
+                cache_disable=settings.cache_disable,
+                use_certifi=settings.use_certifi,
+            )
+            if isinstance(file.content, Exception):
+                # NoInternetError is already logged at debug by download_file and is an expected
+                # offline condition, so don't add a warning for it; warn only on real failures.
+                if not file.is_no_internet_error:
+                    log.warning(f"Failed to acquire RMI data (filter {cql_filter!r}): {file.content}")
+                return
+            df = pl.read_json(file.content, schema=schema)
+            df = df.select(pl.col("features").explode().struct.field("properties")).unnest("properties")
+            if not df.is_empty():
+                yield df
+            if df.height < _PAGE_LIMIT:
+                return
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        if isinstance(parameter_or_dataset, DatasetModel):
+            dataset = parameter_or_dataset
+        elif isinstance(parameter_or_dataset, ParameterModel):
+            dataset = parameter_or_dataset.dataset
+        else:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        settings = cast("Settings", self.sr.stations.settings)
+        start_date = self.sr.start_date
+        end_date = self.sr.end_date
+        if not start_date or not end_date:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        # Every RMI timestamp is a true UTC instant (label == the value CQL filters on), so the
+        # window needs no margin. Normalise to UTC so the "Z" bounds are correct even for callers
+        # that pass tz-aware, non-UTC dates; TimeseriesValues.query() trims to the exact range.
+        start = start_date.astimezone(_UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        end = end_date.astimezone(_UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        cql_filter = f"code = {station_id} AND timestamp DURING {start}/{end}"
+
+        layer = dataset.resolution.name_original
+        schema = _values_schema(dataset.parameters)
+        frames = list(self._iter_value_pages(layer, cql_filter, schema, settings))
+        if not frames:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        df = pl.concat(frames)
+        # Reshape the wide feature (one column per parameter) into the long value frame. The
+        # column name is already `name_original`, which `_process_dataset` filters against.
+        df = df.unpivot(
+            index="timestamp",
+            on=[parameter.name_original for parameter in dataset.parameters],
+            variable_name="parameter",
+            value_name="value",
+        ).drop_nulls("value")
+        if df.is_empty():
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            pl.col("parameter"),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            pl.col("timestamp")
+            .str.to_datetime("%Y-%m-%dT%H:%M:%SZ", time_unit="us")
+            .dt.replace_time_zone("UTC")
+            .alias(
+                "date",
+            ),
+            pl.col("value").cast(pl.Float64),
+            pl.lit(None, dtype=pl.Float64).alias("quality"),
+        )
+
+
+@dataclass
+class RmiObservationRequest(TimeseriesRequest):
+    """Request class for RMI (Royal Meteorological Institute of Belgium) AWS observations.
+
+    - https://www.meteo.be/en/about-rmi/observation-network/automatische-weerstations
+    - https://www.geo.be/catalog/details/RMI_AWS_WFS
+    """
+
+    metadata = RmiObservationMetadata
+    _values = RmiObservationValues
+
+    def _all(self) -> pl.LazyFrame:
+        settings = cast("Settings", self.settings)
+        file = download_file(
+            url=_STATION_ENDPOINT,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.METAINDEX,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        file.raise_if_exception()
+        if isinstance(file.content, Exception):
+            return pl.LazyFrame()
+        df = pl.read_json(file.content, schema=_STATION_SCHEMA)
+        df = df.select(pl.col("features").explode()).unnest("features")
+        df = df.select(
+            pl.col("properties").struct.field("code").cast(pl.String).alias("station_id"),
+            pl.col("properties").struct.field("name").alias("name"),
+            pl.col("geometry").struct.field("coordinates").list.get(1).alias("latitude"),
+            pl.col("geometry").struct.field("coordinates").list.get(0).alias("longitude"),
+            pl.col("properties").struct.field("altitude").alias("height"),
+            _parse_station_datetime("date_begin").alias("start_date"),
+            # a null date_end marks a still-active station
+            _parse_station_datetime("date_end").alias("end_date"),
+        )
+        resolutions_and_datasets = {
+            (parameter.dataset.resolution.name, parameter.dataset.name)
+            for parameter in self.parameters
+            if isinstance(parameter, ParameterModel)
+        }
+        if not resolutions_and_datasets:
+            return pl.LazyFrame()
+        data = [
+            df.with_columns(
+                pl.lit(resolution, pl.String).alias("resolution"),
+                pl.lit(dataset, pl.String).alias("dataset"),
+            )
+            for resolution, dataset in resolutions_and_datasets
+        ]
+        df = pl.concat(data)
+        return df.select(
+            pl.col(col) if col in df.columns else pl.lit(None).alias(col) for col in self._base_columns
+        ).lazy()
+
+
+def _parse_station_datetime(field: str) -> pl.Expr:
+    """Parse an RMI station ``date_begin``/``date_end`` (UTC ``Z`` instant) to a UTC datetime."""
+    return (
+        pl.col("properties")
+        .struct.field(field)
+        .str.to_datetime("%Y-%m-%dT%H:%M:%SZ", time_unit="us")
+        .dt.replace_time_zone("UTC")
+    )

--- a/src/wetterdienst/provider/rmi/observation/api.py
+++ b/src/wetterdienst/provider/rmi/observation/api.py
@@ -12,7 +12,6 @@ feature per timestamp -- see https://www.geo.be/catalog/details/RMI_AWS_WFS.
 
 from __future__ import annotations
 
-import itertools
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -86,7 +85,14 @@ def _values_schema(parameters: Sequence[ParameterModel]) -> pl.Schema:
     properties: dict[str, type[pl.DataType]] = {"timestamp": pl.String}
     for parameter in parameters:
         properties[parameter.name_original] = pl.Float64
-    return pl.Schema({"features": pl.List(pl.Struct({"properties": pl.Struct(properties)}))})
+    # `numberMatched` (total features matched by the filter) drives pagination independently of
+    # how many rows the server actually returns per page -- see `_iter_value_pages`.
+    return pl.Schema(
+        {
+            "numberMatched": pl.Int64,
+            "features": pl.List(pl.Struct({"properties": pl.Struct(properties)})),
+        },
+    )
 
 
 class RmiObservationValues(TimeseriesValues):
@@ -101,10 +107,15 @@ class RmiObservationValues(TimeseriesValues):
     ) -> Iterator[pl.DataFrame]:
         """Yield each page of WFS features (as unnested ``properties`` frames) for a query.
 
-        Pages are walked via ``startIndex`` until a short (or empty) page marks the end; stops on
-        the first download error.
+        ``startIndex`` is advanced by the number of features actually returned, and paging runs
+        until the response's ``numberMatched`` total has been covered (or a page comes back
+        empty). This is robust to a server-side page cap below ``_PAGE_LIMIT``: relying on a
+        "short page" alone would stop early and silently drop rows if the server ever returns
+        fewer features than requested. Stops on the first download error.
         """
-        for start_index in itertools.count(0, _PAGE_LIMIT):
+        start_index = 0
+        number_matched: int | None = None
+        while True:
             # `sortBy` is mandatory once `startIndex` paging is used: the feature types have no
             # primary key, so GeoServer otherwise rejects the request ("Cannot do natural order
             # without a primary key"). Sorting by timestamp also makes the paging deterministic.
@@ -128,11 +139,21 @@ class RmiObservationValues(TimeseriesValues):
                 if not file.is_no_internet_error:
                     log.warning(f"Failed to acquire RMI data (filter {cql_filter!r}): {file.content}")
                 return
-            df = pl.read_json(file.content, schema=schema)
-            df = df.select(pl.col("features").explode().struct.field("properties")).unnest("properties")
+            page = pl.read_json(file.content, schema=schema)
+            if number_matched is None:
+                number_matched = page.get_column("numberMatched").item()
+            df = page.select(pl.col("features").explode().struct.field("properties")).unnest("properties")
             if not df.is_empty():
                 yield df
-            if df.height < _PAGE_LIMIT:
+            # advance by what actually came back, never by the requested count
+            start_index += df.height
+            if df.is_empty():
+                return
+            if number_matched is not None:
+                if start_index >= number_matched:
+                    return
+            elif df.height < _PAGE_LIMIT:
+                # numberMatched absent (unexpected): fall back to the short-page heuristic
                 return
 
     def _collect_station_parameter_or_dataset(

--- a/src/wetterdienst/provider/rmi/observation/api.py
+++ b/src/wetterdienst/provider/rmi/observation/api.py
@@ -79,12 +79,14 @@ _STATION_SCHEMA = pl.Schema(
 def _values_schema(parameters: Sequence[ParameterModel]) -> pl.Schema:
     """Build the WFS feature schema for a dataset's parameters.
 
-    Only the ``timestamp`` and the mapped parameter columns are declared; ``read_json`` ignores
-    every other attribute (``code``, geometry, ``qc_flags``, unmapped parameters).
+    Only the ``timestamp``, the mapped parameter columns and ``qc_flags`` (the per-parameter
+    validation map, decoded into the ``quality`` column) are declared; ``read_json`` ignores every
+    other attribute (``code``, geometry, unmapped parameters).
     """
     properties: dict[str, type[pl.DataType]] = {"timestamp": pl.String}
     for parameter in parameters:
         properties[parameter.name_original] = pl.Float64
+    properties["qc_flags"] = pl.String
     # `numberMatched` (total features matched by the filter) drives pagination independently of
     # how many rows the server actually returns per page -- see `_iter_value_pages`.
     return pl.Schema(
@@ -188,14 +190,12 @@ class RmiObservationValues(TimeseriesValues):
             return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
 
         df = pl.concat(frames)
+        param_names = [parameter.name_original for parameter in dataset.parameters]
         # Reshape the wide feature (one column per parameter) into the long value frame. The
         # column name is already `name_original`, which `_process_dataset` filters against.
-        df = df.unpivot(
-            index="timestamp",
-            on=[parameter.name_original for parameter in dataset.parameters],
-            variable_name="parameter",
-            value_name="value",
-        ).drop_nulls("value")
+        values = df.unpivot(index="timestamp", on=param_names, variable_name="parameter", value_name="value")
+        # Attach the per-parameter validation flag from qc_flags as the native quality code.
+        df = values.join(_quality_long(df, param_names), on=["timestamp", "parameter"], how="left").drop_nulls("value")
         if df.is_empty():
             return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
         return df.select(
@@ -205,7 +205,7 @@ class RmiObservationValues(TimeseriesValues):
             pl.lit(station_id, dtype=pl.String).alias("station_id"),
             _parse_utc_z(pl.col("timestamp")).alias("date"),
             pl.col("value").cast(pl.Float64),
-            pl.lit(None, dtype=pl.Float64).alias("quality"),
+            pl.col("quality").cast(pl.Float64),
         )
 
 
@@ -252,17 +252,43 @@ class RmiObservationRequest(TimeseriesRequest):
         }
         if not resolutions_and_datasets:
             return pl.LazyFrame()
+        # sort the set so the concatenated station rows come out in a stable, deterministic order
         data = [
             df.with_columns(
                 pl.lit(resolution, pl.String).alias("resolution"),
                 pl.lit(dataset, pl.String).alias("dataset"),
             )
-            for resolution, dataset in resolutions_and_datasets
+            for resolution, dataset in sorted(resolutions_and_datasets)
         ]
         df = pl.concat(data)
         return df.select(
             pl.col(col) if col in df.columns else pl.lit(None).alias(col) for col in self._base_columns
         ).lazy()
+
+
+def _quality_long(df: pl.DataFrame, param_names: list[str]) -> pl.DataFrame:
+    """Build a long ``(timestamp, parameter, quality)`` frame from the ``qc_flags`` JSON.
+
+    RMI's ``qc_flags`` carries a per-parameter validated/not-validated boolean keyed by the
+    upper-cased attribute name (e.g. ``{"validated": {"TEMP_DRY_SHELTER_AVG": true, ...}}``). It is
+    exposed as the provider-native ``quality`` code: ``1.0`` validated, ``0.0`` not validated, and
+    null when the flag (or the whole ``qc_flags`` object) is absent.
+    """
+    validated_schema = pl.Struct({"validated": pl.Struct({name.upper(): pl.Boolean for name in param_names})})
+    return (
+        df.select(
+            "timestamp",
+            pl.col("qc_flags").str.json_decode(validated_schema).struct.field("validated").alias("validated"),
+        )
+        .unnest("validated")
+        .unpivot(
+            index="timestamp",
+            on=[name.upper() for name in param_names],
+            variable_name="parameter",
+            value_name="quality",
+        )
+        .with_columns(pl.col("parameter").str.to_lowercase(), pl.col("quality").cast(pl.Float64))
+    )
 
 
 def _parse_utc_z(expr: pl.Expr) -> pl.Expr:

--- a/src/wetterdienst/provider/rmi/observation/metadata.py
+++ b/src/wetterdienst/provider/rmi/observation/metadata.py
@@ -1,0 +1,199 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""RMI (Royal Meteorological Institute of Belgium) AWS observation metadata."""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, build_metadata_model
+
+# RMI publishes automatic weather station (AWS) observations through a key-less GeoServer WFS
+# (GeoJSON). Each resolution is a single feature type (aws_10min / aws_1hour / aws_1day) whose
+# features carry every parameter as its own column, so each resolution is modelled as one
+# grouped default dataset. `name_original` is the raw WFS attribute name.
+#
+# Only attributes with a clean canonical equivalent are mapped. Deliberately left out:
+#   - temp_soil_avg      -- soil temperature at an unspecified depth (the profile is already
+#                           covered by the explicit -5/-10/-20/-50 cm attributes).
+#   - wind_speed_avg_30m -- wind speed at a 30 m mast; there is no canonical wind-at-30m
+#                           parameter, and mixing it with the 10 m wind would be wrong.
+#   - sun_int_avg        -- direct/beam solar intensity without a clean canonical counterpart.
+#   - qc_flags           -- per-parameter validation flags (metadata, not an observation).
+
+# Soil temperature profile shared by every resolution.
+_SOIL_TEMPERATURE = [
+    {
+        "name": "temperature_soil_mean_0_05m",
+        "name_original": "temp_soil_avg_5cm",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+    {
+        "name": "temperature_soil_mean_0_1m",
+        "name_original": "temp_soil_avg_10cm",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+    {
+        "name": "temperature_soil_mean_0_2m",
+        "name_original": "temp_soil_avg_20cm",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+    {
+        "name": "temperature_soil_mean_0_5m",
+        "name_original": "temp_soil_avg_50cm",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+]
+
+# Parameters common to every resolution (both sub-daily and daily).
+_COMMON = [
+    {
+        "name": "precipitation_height",
+        "name_original": "precip_quantity",
+        "unit_type": "precipitation",
+        "unit": "millimeter",
+    },
+    {
+        # air temperature just above the grass surface (PT100 sensor at ~5 cm)
+        "name": "temperature_air_mean_0_05m",
+        "name_original": "temp_grass_pt100_avg",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+    *_SOIL_TEMPERATURE,
+    {
+        "name": "wind_speed",
+        "name_original": "wind_speed_10m",
+        "unit_type": "speed",
+        "unit": "meter_per_second",
+    },
+    {
+        "name": "wind_gust_max",
+        "name_original": "wind_gusts_speed",
+        "unit_type": "speed",
+        "unit": "meter_per_second",
+    },
+    {
+        "name": "humidity",
+        "name_original": "humidity_rel_shelter_avg",
+        "unit_type": "fraction",
+        "unit": "percent",
+    },
+    {
+        "name": "pressure_air_site",
+        "name_original": "pressure",
+        "unit_type": "pressure",
+        "unit": "hectopascal",
+    },
+    {
+        "name": "sunshine_duration",
+        "name_original": "sun_duration",
+        "unit_type": "time",
+        "unit": "minute",
+    },
+    {
+        "name": "radiation_global",
+        "name_original": "short_wave_from_sky_avg",
+        "unit_type": "power_per_area",
+        "unit": "watt_per_square_meter",
+    },
+]
+
+# The shelter (2 m) air temperature is reported as an interval mean at sub-daily resolution and
+# split into mean/max/min at daily resolution.
+_SUBDAILY = [
+    {
+        "name": "temperature_air_mean_2m",
+        "name_original": "temp_dry_shelter_avg",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+    *_COMMON,
+]
+
+# Wind direction is only published at 10-minute resolution.
+_MINUTE_10_PARAMETERS = [
+    *_SUBDAILY,
+    {
+        "name": "wind_direction",
+        "name_original": "wind_direction",
+        "unit_type": "angle",
+        "unit": "degree",
+    },
+]
+
+_HOURLY_PARAMETERS = _SUBDAILY
+
+_DAILY_PARAMETERS = [
+    {
+        "name": "temperature_air_mean_2m",
+        "name_original": "temp_avg",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+    {
+        "name": "temperature_air_max_2m",
+        "name_original": "temp_max",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+    {
+        "name": "temperature_air_min_2m",
+        "name_original": "temp_min",
+        "unit_type": "temperature",
+        "unit": "degree_celsius",
+    },
+    *_COMMON,
+]
+
+
+def _default_dataset(parameters: list[dict]) -> dict:
+    return {
+        "name": DATASET_NAME_DEFAULT,
+        "name_original": DATASET_NAME_DEFAULT,
+        "grouped": True,
+        "parameters": parameters,
+    }
+
+
+RmiObservationMetadata = {
+    "name_short": "RMI",
+    "name_english": "Royal Meteorological Institute of Belgium",
+    "name_local": "Koninklijk Meteorologisch Instituut / Institut Royal Météorologique",
+    "country": "Belgium",
+    "copyright": "© RMI (Royal Meteorological Institute of Belgium), CC BY 4.0",
+    "url": "https://opendata.meteo.be/",
+    "kind": "observation",
+    "timezone": "Europe/Brussels",
+    # All WFS timestamps are true UTC instants (the payload carries a trailing "Z"), including the
+    # daily aggregates which are labelled at UTC midnight. Emitted `date` labels are therefore
+    # UTC, so timezone_data (which drives the `ts_complete` base date grid) must be UTC to align.
+    "timezone_data": "UTC",
+    "auth": False,
+    "resolutions": [
+        {
+            "name": "10_minutes",
+            "name_original": "aws_10min",
+            "periods": ["historical"],
+            "date_required": True,
+            "datasets": [_default_dataset(_MINUTE_10_PARAMETERS)],
+        },
+        {
+            "name": "hourly",
+            "name_original": "aws_1hour",
+            "periods": ["historical"],
+            "date_required": True,
+            "datasets": [_default_dataset(_HOURLY_PARAMETERS)],
+        },
+        {
+            "name": "daily",
+            "name_original": "aws_1day",
+            "periods": ["historical"],
+            "date_required": True,
+            "datasets": [_default_dataset(_DAILY_PARAMETERS)],
+        },
+    ],
+}
+RmiObservationMetadata = build_metadata_model(RmiObservationMetadata, "RmiObservationMetadata")

--- a/tests/provider/rmi/__init__.py
+++ b/tests/provider/rmi/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/rmi/observation/__init__.py
+++ b/tests/provider/rmi/observation/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/rmi/observation/test_api.py
+++ b/tests/provider/rmi/observation/test_api.py
@@ -1,0 +1,252 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for RMI (Royal Meteorological Institute of Belgium) AWS observation provider."""
+
+import datetime as dt
+import json
+import logging
+from io import BytesIO
+from types import SimpleNamespace
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+import wetterdienst.provider.rmi.observation.api as rmi_api
+from wetterdienst.exceptions import NoInternetError
+from wetterdienst.settings import Settings
+from wetterdienst.util.network import File
+
+# Uccle (Ukkel) — RMI headquarters, the reference station used across the remote tests.
+UCCLE = "6447"
+UTC = ZoneInfo("UTC")
+
+# A minimal feature schema (timestamp + one parameter) for the pagination tests.
+_SCHEMA = pl.Schema(
+    {
+        "features": pl.List(
+            pl.Struct({"properties": pl.Struct({"timestamp": pl.String, "temp_dry_shelter_avg": pl.Float64})})
+        )
+    },
+)
+
+
+def _hourly_dataset() -> rmi_api.DatasetModel:
+    """Return the hourly grouped default dataset from the metadata model."""
+    resolution = next(
+        resolution for resolution in rmi_api.RmiObservationRequest.metadata if resolution.name == "hourly"
+    )
+    return next(iter(resolution))
+
+
+def _feature_file(count: int, start: int = 0) -> File:
+    """Build a WFS GeoJSON response File with ``count`` hourly feature records."""
+    features = [
+        {"properties": {"timestamp": "2023-06-01T00:00:00Z", "temp_dry_shelter_avg": float(index)}}
+        for index in range(start, start + count)
+    ]
+    return File(url="", content=BytesIO(json.dumps({"features": features}).encode()), status=200)
+
+
+def _iter_pages(values: rmi_api.RmiObservationValues) -> list[pl.DataFrame]:
+    return list(
+        values._iter_value_pages("aws_1hour", "code = 6447", _SCHEMA, Settings(cache_disable=True)),  # noqa: SLF001
+    )
+
+
+def test_metadata_resolutions() -> None:
+    """RMI exposes 10-minute, hourly and daily resolutions."""
+    resolutions = {resolution.name for resolution in rmi_api.RmiObservationRequest.metadata}
+    assert resolutions == {"10_minutes", "hourly", "daily"}
+
+
+def test_metadata_no_auth() -> None:
+    """RMI's open data service requires no authentication."""
+    assert rmi_api.RmiObservationRequest.metadata.auth is False
+
+
+def test_values_schema_parses_timestamp_and_mapped_parameters() -> None:
+    """The per-dataset feature schema parses the timestamp and every mapped parameter column."""
+    dataset = _hourly_dataset()
+    schema = rmi_api._values_schema(dataset.parameters)  # noqa: SLF001
+    content = BytesIO(
+        json.dumps(
+            {"features": [{"properties": {"timestamp": "2023-06-01T00:00:00Z", "temp_dry_shelter_avg": 15.27}}]},
+        ).encode(),
+    )
+    df = pl.read_json(content, schema=schema)
+    df = df.select(pl.col("features").explode().struct.field("properties")).unnest("properties")
+    assert "timestamp" in df.columns
+    assert {parameter.name_original for parameter in dataset.parameters} <= set(df.columns)
+    assert df.get_column("temp_dry_shelter_avg").to_list() == [15.27]
+
+
+def test_iter_value_pages_walks_all_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pagination advances startIndex until a short (< limit) page and yields every page."""
+    monkeypatch.setattr(rmi_api, "_PAGE_LIMIT", 2)
+    pages = {0: 2, 2: 2, 4: 1}
+    indices: list[int] = []
+
+    def fake_download_file(*, url: str, **_: object) -> File:
+        start_index = int(url.split("startIndex=")[1].split("&", maxsplit=1)[0])
+        indices.append(start_index)
+        return _feature_file(pages[start_index], start=start_index)
+
+    monkeypatch.setattr(rmi_api, "download_file", fake_download_file)
+    dfs = _iter_pages(object.__new__(rmi_api.RmiObservationValues))
+    assert indices == [0, 2, 4]
+    assert sum(df.height for df in dfs) == 5
+
+
+def test_iter_value_pages_single_short_page_stops_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A first page shorter than the limit ends pagination after one request."""
+    monkeypatch.setattr(rmi_api, "_PAGE_LIMIT", 100)
+    indices: list[int] = []
+
+    def fake_download_file(*, url: str, **_: object) -> File:
+        indices.append(int(url.split("startIndex=")[1].split("&", maxsplit=1)[0]))
+        return _feature_file(3)
+
+    monkeypatch.setattr(rmi_api, "download_file", fake_download_file)
+    dfs = _iter_pages(object.__new__(rmi_api.RmiObservationValues))
+    assert indices == [0]
+    assert [df.height for df in dfs] == [3]
+
+
+def test_iter_value_pages_stops_on_download_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A download error ends pagination without raising, keeps prior pages, and logs a warning."""
+    monkeypatch.setattr(rmi_api, "_PAGE_LIMIT", 2)
+
+    def fake_download_file(*, url: str, **_: object) -> File:
+        if "startIndex=0" in url:
+            return _feature_file(2)
+        return File(url=url, content=RuntimeError("boom"), status=500)
+
+    monkeypatch.setattr(rmi_api, "download_file", fake_download_file)
+    with caplog.at_level(logging.WARNING, logger=rmi_api.log.name):
+        dfs = _iter_pages(object.__new__(rmi_api.RmiObservationValues))
+    assert [df.height for df in dfs] == [2]
+    assert any("Failed to acquire RMI data" in record.message for record in caplog.records)
+
+
+def test_iter_value_pages_no_internet_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A NoInternetError ends pagination silently -- no warning (already logged at debug upstream)."""
+    monkeypatch.setattr(rmi_api, "_PAGE_LIMIT", 2)
+
+    def fake_download_file(*, url: str, **_: object) -> File:
+        return File(url=url, content=NoInternetError("offline"), status=503)
+
+    monkeypatch.setattr(rmi_api, "download_file", fake_download_file)
+    with caplog.at_level(logging.WARNING, logger=rmi_api.log.name):
+        dfs = _iter_pages(object.__new__(rmi_api.RmiObservationValues))
+    assert dfs == []
+    assert not any("Failed to acquire RMI data" in record.message for record in caplog.records)
+
+
+def test_collect_reshapes_wide_features_to_long_utc_values() -> None:
+    """The wide feature (one column per parameter) is reshaped to long, UTC-labelled values."""
+    dataset = _hourly_dataset()
+    names = [parameter.name_original for parameter in dataset.parameters]
+    wide = pl.DataFrame({"timestamp": ["2023-06-01T00:00:00Z", "2023-06-01T01:00:00Z"]}).with_columns(
+        [pl.lit(float(index)).alias(name) for index, name in enumerate(names)],
+    )
+
+    values = object.__new__(rmi_api.RmiObservationValues)
+    values.sr = SimpleNamespace(
+        stations=SimpleNamespace(settings=Settings(cache_disable=True)),
+        start_date=dt.datetime(2023, 6, 1, tzinfo=UTC),
+        end_date=dt.datetime(2023, 6, 1, 1, tzinfo=UTC),
+    )
+    # bypass the network: feed the reshape a single wide page
+    values._iter_value_pages = lambda *_args, **_kwargs: iter([wide])  # noqa: SLF001
+
+    df = values._collect_station_parameter_or_dataset(UCCLE, dataset)  # noqa: SLF001
+    assert df.columns == ["resolution", "dataset", "parameter", "station_id", "date", "value", "quality"]
+    assert df.get_column("resolution").unique().to_list() == ["hourly"]
+    assert df.get_column("station_id").unique().to_list() == [UCCLE]
+    assert set(df.get_column("parameter").unique().to_list()) == set(names)
+    # two timestamps x every parameter, none dropped (all non-null)
+    assert df.height == 2 * len(names)
+    assert str(df.schema["date"]).find("UTC") != -1
+    assert df.get_column("date").min() == dt.datetime(2023, 6, 1, tzinfo=UTC)
+
+
+@pytest.mark.remote
+def test_rmi_observation_stations() -> None:
+    """Station discovery returns one row per station with usable metadata."""
+    request = rmi_api.RmiObservationRequest(
+        parameters=[("hourly", "data", "temperature_air_mean_2m")],
+    ).all()
+    assert not request.df.is_empty()
+    assert request.df.get_column("station_id").n_unique() == request.df.height
+    station = request.df.filter(pl.col("station_id") == UCCLE)
+    assert station.height == 1
+    row = station.to_dicts()[0]
+    assert row["name"]
+    assert 49 < row["latitude"] < 52
+    assert 2 < row["longitude"] < 7
+
+
+@pytest.mark.remote
+def test_rmi_observation_values_hourly_utc() -> None:
+    """Hourly values include both range boundaries and are UTC-aligned to the start of the hour."""
+    request = rmi_api.RmiObservationRequest(
+        parameters=[("hourly", "data", "temperature_air_mean_2m")],
+        start_date=dt.datetime(2023, 6, 1, tzinfo=UTC),
+        end_date=dt.datetime(2023, 6, 1, 5, tzinfo=UTC),
+    ).filter_by_station_id([UCCLE])
+    values = request.values.all().df
+    dates = values.get_column("date").sort().to_list()
+    assert dates[0] == dt.datetime(2023, 6, 1, 0, 0, tzinfo=UTC)
+    assert dates[-1] == dt.datetime(2023, 6, 1, 5, 0, tzinfo=UTC)
+    assert "UTC" in str(values.schema["date"])
+    assert not values.drop_nulls(subset="value").is_empty()
+
+
+@pytest.mark.remote
+def test_rmi_observation_values_daily() -> None:
+    """Daily values are labelled at UTC midnight and include both range boundaries."""
+    request = rmi_api.RmiObservationRequest(
+        parameters=[("daily", "data", "temperature_air_mean_2m")],
+        start_date=dt.datetime(2023, 6, 1, tzinfo=UTC),
+        end_date=dt.datetime(2023, 6, 5, tzinfo=UTC),
+    ).filter_by_station_id([UCCLE])
+    values = request.values.all().df
+    dates = values.get_column("date").sort().to_list()
+    assert dates[0] == dt.datetime(2023, 6, 1, tzinfo=UTC)
+    assert dates[-1] == dt.datetime(2023, 6, 5, tzinfo=UTC)
+    assert values.get_column("date").dt.hour().unique().to_list() == [0]
+    assert not values.drop_nulls(subset="value").is_empty()
+
+
+@pytest.mark.remote
+def test_rmi_observation_values_10_minutes() -> None:
+    """10-minute values are UTC-aligned to the start of each interval."""
+    request = rmi_api.RmiObservationRequest(
+        parameters=[("10_minutes", "data", "temperature_air_mean_2m")],
+        start_date=dt.datetime(2023, 6, 1, tzinfo=UTC),
+        end_date=dt.datetime(2023, 6, 1, 0, 50, tzinfo=UTC),
+    ).filter_by_station_id([UCCLE])
+    values = request.values.all().df
+    assert values.get_column("date").min() == dt.datetime(2023, 6, 1, 0, 0, tzinfo=UTC)
+    assert not values.drop_nulls(subset="value").is_empty()
+
+
+@pytest.mark.remote
+def test_rmi_observation_values_empty_for_unknown_station() -> None:
+    """An unknown station id yields an empty, well-formed values frame."""
+    settings = Settings(cache_disable=True)
+    request = rmi_api.RmiObservationRequest(
+        parameters=[("hourly", "data", "temperature_air_mean_2m")],
+        start_date=dt.datetime(2023, 6, 1, tzinfo=UTC),
+        end_date=dt.datetime(2023, 6, 1, 5, tzinfo=UTC),
+        settings=settings,
+    ).filter_by_station_id(["99999"])
+    values = request.values.all().df
+    assert values.is_empty()

--- a/tests/provider/rmi/observation/test_api.py
+++ b/tests/provider/rmi/observation/test_api.py
@@ -65,6 +65,22 @@ def test_metadata_no_auth() -> None:
     assert rmi_api.RmiObservationRequest.metadata.auth is False
 
 
+@pytest.mark.parametrize(
+    "raw",
+    ["2023-06-01T00:00:00Z", "2023-06-01T00:00:00.000000Z"],
+)
+def test_parse_utc_z_tolerates_optional_fractional_seconds(raw: str) -> None:
+    """Both second-precision and fractional-seconds UTC-Z timestamps parse to the same UTC instant."""
+    date = pl.select(rmi_api._parse_utc_z(pl.lit(raw))).item()  # noqa: SLF001
+    assert date == dt.datetime(2023, 6, 1, tzinfo=UTC)
+
+
+def test_parse_utc_z_null_stays_null() -> None:
+    """A null timestamp (e.g. an active station's date_end) parses to null rather than raising."""
+    date = pl.select(rmi_api._parse_utc_z(pl.lit(None, dtype=pl.String))).item()  # noqa: SLF001
+    assert date is None
+
+
 def test_values_schema_parses_timestamp_and_mapped_parameters() -> None:
     """The per-dataset feature schema parses the timestamp and every mapped parameter column."""
     dataset = _hourly_dataset()

--- a/tests/provider/rmi/observation/test_api.py
+++ b/tests/provider/rmi/observation/test_api.py
@@ -21,12 +21,13 @@ from wetterdienst.util.network import File
 UCCLE = "6447"
 UTC = ZoneInfo("UTC")
 
-# A minimal feature schema (timestamp + one parameter) for the pagination tests.
+# A minimal feature schema (numberMatched + timestamp + one parameter) for the pagination tests.
 _SCHEMA = pl.Schema(
     {
+        "numberMatched": pl.Int64,
         "features": pl.List(
             pl.Struct({"properties": pl.Struct({"timestamp": pl.String, "temp_dry_shelter_avg": pl.Float64})})
-        )
+        ),
     },
 )
 
@@ -39,13 +40,20 @@ def _hourly_dataset() -> rmi_api.DatasetModel:
     return next(iter(resolution))
 
 
-def _feature_file(count: int, start: int = 0) -> File:
-    """Build a WFS GeoJSON response File with ``count`` hourly feature records."""
+def _feature_file(count: int, start: int = 0, number_matched: int | None = None) -> File:
+    """Build a WFS GeoJSON response File with ``count`` hourly feature records.
+
+    ``number_matched`` populates the response's ``numberMatched`` total; when omitted the key is
+    absent (exercising the short-page fallback).
+    """
     features = [
         {"properties": {"timestamp": "2023-06-01T00:00:00Z", "temp_dry_shelter_avg": float(index)}}
         for index in range(start, start + count)
     ]
-    return File(url="", content=BytesIO(json.dumps({"features": features}).encode()), status=200)
+    payload: dict = {"features": features}
+    if number_matched is not None:
+        payload["numberMatched"] = number_matched
+    return File(url="", content=BytesIO(json.dumps(payload).encode()), status=200)
 
 
 def _iter_pages(values: rmi_api.RmiObservationValues) -> list[pl.DataFrame]:
@@ -107,6 +115,30 @@ def test_iter_value_pages_walks_all_pages(monkeypatch: pytest.MonkeyPatch) -> No
         start_index = int(url.split("startIndex=")[1].split("&", maxsplit=1)[0])
         indices.append(start_index)
         return _feature_file(pages[start_index], start=start_index)
+
+    monkeypatch.setattr(rmi_api, "download_file", fake_download_file)
+    dfs = _iter_pages(object.__new__(rmi_api.RmiObservationValues))
+    assert indices == [0, 2, 4]
+    assert sum(df.height for df in dfs) == 5
+
+
+def test_iter_value_pages_numbermatched_drives_paging_when_server_caps_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A page shorter than the requested count does not end paging while numberMatched says more.
+
+    Simulates a server that caps each page at 2 features regardless of the requested count: the
+    short-page heuristic alone would stop after the first page and drop the remaining rows, but
+    numberMatched=5 keeps paging (advancing startIndex by the actual rows returned) until covered.
+    """
+    monkeypatch.setattr(rmi_api, "_PAGE_LIMIT", 500_000)
+    pages = {0: 2, 2: 2, 4: 1}
+    indices: list[int] = []
+
+    def fake_download_file(*, url: str, **_: object) -> File:
+        start_index = int(url.split("startIndex=")[1].split("&", maxsplit=1)[0])
+        indices.append(start_index)
+        return _feature_file(pages[start_index], start=start_index, number_matched=5)
 
     monkeypatch.setattr(rmi_api, "download_file", fake_download_file)
     dfs = _iter_pages(object.__new__(rmi_api.RmiObservationValues))

--- a/tests/provider/rmi/observation/test_api.py
+++ b/tests/provider/rmi/observation/test_api.py
@@ -198,12 +198,15 @@ def test_iter_value_pages_no_internet_is_silent(
 
 
 def test_collect_reshapes_wide_features_to_long_utc_values() -> None:
-    """The wide feature (one column per parameter) is reshaped to long, UTC-labelled values."""
+    """The wide feature is reshaped to long, UTC-labelled values with qc_flags mapped to quality."""
     dataset = _hourly_dataset()
     names = [parameter.name_original for parameter in dataset.parameters]
-    wide = pl.DataFrame({"timestamp": ["2023-06-01T00:00:00Z", "2023-06-01T01:00:00Z"]}).with_columns(
-        [pl.lit(float(index)).alias(name) for index, name in enumerate(names)],
-    )
+    # qc_flags marks the first parameter validated (1.0) and the second not (0.0) for both rows
+    validated = {names[0].upper(): True, names[1].upper(): False}
+    qc_flags = json.dumps({"validated": validated})
+    wide = pl.DataFrame(
+        {"timestamp": ["2023-06-01T00:00:00Z", "2023-06-01T01:00:00Z"], "qc_flags": [qc_flags, qc_flags]},
+    ).with_columns([pl.lit(float(index)).alias(name) for index, name in enumerate(names)])
 
     values = object.__new__(rmi_api.RmiObservationValues)
     values.sr = SimpleNamespace(
@@ -223,6 +226,10 @@ def test_collect_reshapes_wide_features_to_long_utc_values() -> None:
     assert df.height == 2 * len(names)
     assert str(df.schema["date"]).find("UTC") != -1
     assert df.get_column("date").min() == dt.datetime(2023, 6, 1, tzinfo=UTC)
+    # qc_flags validation maps to the quality code: validated -> 1.0, not validated -> 0.0
+    quality_by_parameter = dict(df.select("parameter", "quality").unique().iter_rows())
+    assert quality_by_parameter[names[0]] == 1.0
+    assert quality_by_parameter[names[1]] == 0.0
 
 
 @pytest.mark.remote

--- a/tests/provider/rmi/observation/test_api.py
+++ b/tests/provider/rmi/observation/test_api.py
@@ -146,6 +146,25 @@ def test_iter_value_pages_numbermatched_drives_paging_when_server_caps_page(
     assert sum(df.height for df in dfs) == 5
 
 
+def test_iter_value_pages_runaway_guard_stops_after_max_pages(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A server returning full pages forever without numberMatched stops after _MAX_PAGES, warning."""
+    monkeypatch.setattr(rmi_api, "_PAGE_LIMIT", 2)
+    monkeypatch.setattr(rmi_api, "_MAX_PAGES", 3)
+
+    def fake_download_file(*, url: str, **_: object) -> File:  # noqa: ARG001
+        # always a full page (== _PAGE_LIMIT), never an empty/short page, no numberMatched
+        return _feature_file(2)
+
+    monkeypatch.setattr(rmi_api, "download_file", fake_download_file)
+    with caplog.at_level(logging.WARNING, logger=rmi_api.log.name):
+        dfs = _iter_pages(object.__new__(rmi_api.RmiObservationValues))
+    assert len(dfs) == 3  # exactly _MAX_PAGES pages, then the guard bails out
+    assert any("exceeded 3 pages" in record.message for record in caplog.records)
+
+
 def test_iter_value_pages_single_short_page_stops_immediately(monkeypatch: pytest.MonkeyPatch) -> None:
     """A first page shorter than the limit ends pagination after one request."""
     monkeypatch.setattr(rmi_api, "_PAGE_LIMIT", 100)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,6 +34,7 @@ from wetterdienst.provider.meteoswiss.observation import MeteoswissObservationMe
 from wetterdienst.provider.metno.frost.api import MetnoFrostMetadata, MetnoFrostRequest
 from wetterdienst.provider.noaa.ghcn import NoaaGhcnMetadata, NoaaGhcnRequest
 from wetterdienst.provider.nws.observation import NwsObservationMetadata, NwsObservationRequest
+from wetterdienst.provider.rmi.observation import RmiObservationMetadata, RmiObservationRequest
 from wetterdienst.provider.smhi.observation import SmhiObservationMetadata, SmhiObservationRequest
 from wetterdienst.provider.wsv.pegel import WsvPegelMetadata, WsvPegelRequest
 from wetterdienst.util.eccodes import ensure_eccodes, ensure_pdbufr
@@ -122,6 +123,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
         MetnoFrostMetadata,
         NoaaGhcnMetadata,
         NwsObservationMetadata,
+        RmiObservationMetadata,
         SmhiObservationMetadata,
         WsvPegelMetadata,
     ],
@@ -158,6 +160,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
         MetnoFrostMetadata,
         NoaaGhcnMetadata,
         NwsObservationMetadata,
+        RmiObservationMetadata,
         SmhiObservationMetadata,
         WsvPegelMetadata,
     ],
@@ -344,6 +347,30 @@ def test_api_dmi_observation(default_settings: Settings) -> None:
     assert not request.df.is_empty()
     assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
     assert _is_complete_stations_df(request.df, exclude_columns={"end_date", "height"})
+    first_start_date = request.df.get_column("start_date").gather(0).to_list()[0]
+    if first_start_date:
+        assert first_start_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")
+    values = next(request.values.query()).df
+    assert set(values.columns).issuperset(DF_VALUES_MINIMUM_COLUMNS)
+    assert _is_complete_values_df(values)
+    first_date = values.get_column("date").gather(0).to_list()[0]
+    assert first_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")
+    assert not values.drop_nulls(subset="value").is_empty()
+
+
+@pytest.mark.remote
+def test_api_rmi_observation(default_settings: Settings) -> None:
+    """Test rmi observation API."""
+    request = RmiObservationRequest(
+        parameters=[("daily", "data", "temperature_air_mean_2m")],
+        start_date=datetime(2023, 6, 1, tzinfo=zoneinfo.ZoneInfo("UTC")),
+        end_date=datetime(2023, 6, 5, tzinfo=zoneinfo.ZoneInfo("UTC")),
+        settings=default_settings,
+    ).filter_by_station_id(["6447"])
+    assert not request.df.is_empty()
+    assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
+    # RMI stations carry no region/state, and Uccle is still active (null end_date).
+    assert _is_complete_stations_df(request.df, exclude_columns={"end_date", "state"})
     first_start_date = request.df.get_column("start_date").gather(0).to_list()[0]
     if first_start_date:
         assert first_start_date.tzinfo == zoneinfo.ZoneInfo(key="UTC")

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -73,6 +73,7 @@ def test_coverage(client: TestClient) -> None:
         "metno",
         "noaa",
         "nws",
+        "rmi",
         "smhi",
         "wsv",
     }


### PR DESCRIPTION
## Summary

Adds the **Royal Meteorological Institute of Belgium (RMI)** automatic weather station (AWS) network as a new observation provider, served through their key-less GeoServer WFS (GeoJSON) at **10-minute, hourly and daily** resolution. ~14 stations, data back to ~1995, no authentication required.

## How it works

- Each resolution is its own WFS feature type (`aws_10min` / `aws_1hour` / `aws_1day`); station metadata comes from `aws_station`.
- Values are fetched per station/date-range with a CQL filter (`code = <id> AND timestamp DURING <start>/<end>`) and **reshaped from the wide feature layout** (one column per parameter) into the long value frame via `unpivot`.
- All timestamps are true UTC instants (daily aggregates labelled at UTC midnight), so `timezone_data="UTC"` and no per-resolution civil-date handling is needed.
- Parameters mapped to canonical names: air temperature (mean/max/min 2 m + grass 5 cm), a 4-level soil-temperature profile, precipitation, humidity, station pressure, wind speed/gust/direction, sunshine duration and global radiation. Ambiguous source fields (`temp_soil_avg`, `wind_speed_avg_30m`, `sun_int_avg`) are intentionally skipped.
- The per-value `quality` code is derived from the source `qc_flags` validation map (`1.0` validated, `0.0` not validated, null if absent).

## Notable gotcha

Paging (`startIndex`) over these key-less feature types makes GeoServer return HTTP 400 *"Cannot do natural order without a primary key"* — fixed by adding `sortBy=timestamp` to the paginated request.

## Review fixes

Addressed in follow-up commits after a `/code-review` pass:

- **Defensive timestamp parsing** — a single shared `_parse_utc_z` helper (used for both value timestamps and station dates) parses with `%.f`, so an optional fractional-seconds part is tolerated instead of raising and aborting the whole query. Previously the strict `%Y-%m-%dT%H:%M:%SZ` format would crash on any deviation from second precision.
- **Robust pagination** — paging is driven by the response's `numberMatched` total and advances `startIndex` by the number of features actually returned, rather than assuming the requested `count` per page. This prevents silently dropping rows if the GeoServer instance ever caps a page below `_PAGE_LIMIT`; falls back to the short-page heuristic only when `numberMatched` is absent.
- **QC signal surfaced** — the per-parameter validated/not-validated flag in `qc_flags` is decoded into the `quality` column instead of being discarded as null.
- **Deterministic stations output** — the `(resolution, dataset)` set is sorted before concatenation so the stations frame row order is stable across runs rather than depending on hash iteration order.

## Tests

- Deterministic (non-remote): metadata, per-dataset feature schema, defensive UTC-Z parsing (fractional seconds + null), pagination (page walking, server-cap via `numberMatched`, short-page/error/no-internet handling), and the wide→long reshape incl. the `qc_flags`→`quality` mapping.
- Remote end-to-end: station discovery + values at all three resolutions, unknown-station empty frame, plus the shared `test_api_rmi_observation` and REST `test_coverage`.
- Parameter names and units validated by the existing `test_metadata_parameter_names` / `test_metadata_units` suites; `ty` typecheck and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)