### PR TITLE
feat(dwd/radar): parse radar BUFR products into a polars DataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Types of changes:
 
 ### Added
 
+- Parse DWD radar site BUFR products (echo top, reflectivity) into a polars DataFrame on
+  `RadarResult.df`, opt-in via the `read_bufr` setting (requires the `eccodes` and `bufr` extras)
 - Add RMI (Belgium) observation provider with 10-minute, hourly and daily resolution
   from the automatic weather station (AWS) network (no authentication required)
 - Add CHMI (Czechia) observation provider with 10-minute, hourly, daily, monthly and annual

--- a/docs/data/provider/dwd/radar/index.md
+++ b/docs/data/provider/dwd/radar/index.md
@@ -18,3 +18,28 @@ being frequently updated for the recent version and data for each concluded year
 stored in the historical version. The daily version offers gliding sums of the last 24
 hours while the hourly version offers hourly sums of precipitation. The precipitation
 amount is given in 1/10 mm.
+
+## BUFR products as DataFrame
+
+Site products published in BUFR format (echo top, reflectivity) can optionally be parsed
+into a [polars](https://pola.rs/) DataFrame. Enable the `read_bufr` setting and each
+`RadarResult` returned by `query()` will carry the parsed data on its `.df` attribute (a long
+frame with one row per grid pixel: station/grid metadata plus the pixel `value`, with missing
+pixels as null); the raw payload remains available on `.data`. This requires the optional
+`eccodes` and `bufr` dependency extras — without them, or with `read_bufr` disabled, `.df`
+stays `None`.
+
+```python
+from wetterdienst import Settings
+from wetterdienst.provider.dwd.radar import DwdRadarParameter, DwdRadarDataFormat, DwdRadarValues
+from wetterdienst.provider.dwd.radar.sites import DwdRadarSite
+
+request = DwdRadarValues(
+    parameter=DwdRadarParameter.PE_ECHO_TOP,
+    site=DwdRadarSite.BOO,
+    fmt=DwdRadarDataFormat.BUFR,
+    settings=Settings(read_bufr=True),
+)
+for result in request.query():
+    print(result.df)
+```

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -31,6 +31,7 @@ The following settings are available:
 | cache_dir            | set the directory where the cache is stored                           | platform specific / "wetterdienst" |
 | fsspec_client_kwargs | pass arguments to fsspec, especially for querying data behind a proxy | {}                                 |
 | use_certifi          | use certifi certificate bundle instead of system certificates         | False                              |
+| read_bufr            | parse DWD radar BUFR products into `RadarResult.df` (needs `eccodes` + `bufr` extras) | False               |
 
 **Timeseries**
 

--- a/src/wetterdienst/provider/dwd/radar/api.py
+++ b/src/wetterdienst/provider/dwd/radar/api.py
@@ -12,6 +12,7 @@ import re
 import tarfile
 from dataclasses import dataclass
 from io import BytesIO
+from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, cast
 from zoneinfo import ZoneInfo
 
@@ -41,6 +42,7 @@ from wetterdienst.provider.dwd.radar.util import RADAR_DT_PATTERN, get_date_stri
 from wetterdienst.provider.eumetnet.opera.sites import OperaRadarSites
 from wetterdienst.settings import Settings
 from wetterdienst.util.datetime import _parse_datetime_from_formats, raster_minutes, round_minutes
+from wetterdienst.util.eccodes import ensure_eccodes, ensure_pdbufr
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 from wetterdienst.util.network import download_file
 
@@ -59,6 +61,15 @@ log = logging.getLogger(__name__)
 
 DATETIME_FORMATS = ["%y%m%d%H%M", "%Y%m%d%H%M"]
 
+# The BUFR data descriptor that holds the pixel values for each site product, keyed by parameter.
+# Only the grid site products published as BUFR are covered; other formats/parameters have no entry.
+_BUFR_VALUE_FIELD = {
+    DwdRadarParameter.PE_ECHO_TOP: "echoTops",
+    DwdRadarParameter.PG_REFLECTIVITY: "horizontalReflectivity",
+    DwdRadarParameter.LMAX_VOLUME_SCAN: "horizontalReflectivity",
+    DwdRadarParameter.PX250_REFLECTIVITY: "horizontalReflectivity",
+}
+
 
 @dataclass
 class RadarResult:
@@ -68,6 +79,9 @@ class RadarResult:
     timestamp: dt.datetime | None = None
     url: str | None = None
     filename: str | None = None
+    # populated with the parsed BUFR contents (long polars frame) when Settings.read_bufr is enabled
+    # and eccodes + pdbufr are available; None otherwise -- see read_radar_bufr().
+    df: pl.DataFrame | None = None
 
     def __getitem__(self, index: int) -> dt.datetime | BytesIO | None:
         """Backward compatibility to address this instance as a tuple.
@@ -88,6 +102,47 @@ class RadarResult:
         # pragma: no cover
         msg = f"Index {index} undefined on RadarResult"
         raise KeyError(msg)
+
+
+def read_radar_bufr(data: BytesIO, parameter: DwdRadarParameter) -> pl.DataFrame:
+    """Parse a DWD radar site BUFR product into a long polars DataFrame.
+
+    Each BUFR message is a single grid product (one raster of pixel values for one timestamp), so
+    the returned frame has one row per grid pixel: the station/grid metadata (repeated) plus the
+    pixel ``value``. Missing pixels are null. ``parameter`` selects which BUFR data descriptor
+    carries the values (echo tops vs reflectivity) -- see ``_BUFR_VALUE_FIELD``.
+    """
+    import pdbufr  # noqa: PLC0415
+
+    value_field = _BUFR_VALUE_FIELD[parameter]
+    with NamedTemporaryFile("w+b", suffix=".bufr") as tf:
+        # getvalue() (not read()) leaves the caller's BytesIO position untouched, so result.data
+        # stays readable afterwards.
+        tf.write(data.getvalue())
+        tf.seek(0)
+        df = pdbufr.read_bufr(tf.name, columns="data", flat=True)
+    # a single BUFR subset -> one pandas row; leading metadata descriptors carry a "#1#" prefix
+    row = df.iloc[0]
+    date = dt.datetime(
+        int(row["#1#year"]),
+        int(row["#1#month"]),
+        int(row["#1#day"]),
+        int(row["#1#hour"]),
+        int(row["#1#minute"]),
+        tzinfo=ZoneInfo("UTC"),
+    )
+    value_columns = [column for column in df.columns if column.endswith(f"#{value_field}")]
+    values = row[value_columns].astype("float64").tolist()
+    return pl.DataFrame({"value": values}).select(
+        pl.lit(str(row["#1#shortStationName"])).alias("station_id"),
+        pl.lit(date).alias("date"),
+        pl.lit(float(row["#1#latitude"])).alias("latitude"),
+        pl.lit(float(row["#1#longitude"])).alias("longitude"),
+        pl.lit(float(row["#1#heightOfStation"])).alias("height"),
+        pl.lit(int(row["#1#projectionType"])).alias("projection_type"),
+        pl.lit(int(row["#1#pictureType"])).alias("picture_type"),
+        pl.col("value").fill_nan(None),
+    )
 
 
 # TODO: add core class information
@@ -315,6 +370,26 @@ class DwdRadarValues:  # noqa: PLW1641
             if self.end_date is None:
                 self.end_date = self.start_date + dt.timedelta(minutes=5) - dt.timedelta(seconds=1)
 
+    def _attach_bufr(self, result: RadarResult) -> None:
+        """Attach the parsed BUFR contents to ``result.df`` when ``read_bufr`` is enabled.
+
+        No-op unless the request is for BUFR data and ``Settings.read_bufr`` is set. Requires the
+        optional eccodes + pdbufr dependencies; a missing dependency or a parse error is logged and
+        leaves ``result.df`` as ``None`` rather than failing the whole query.
+        """
+        if self.format != DwdRadarDataFormat.BUFR or not self.settings.read_bufr:
+            return
+        if not (ensure_eccodes() and ensure_pdbufr()):
+            log.warning("read_bufr is enabled but eccodes/pdbufr are unavailable; skipping BUFR parsing.")
+            return
+        if self.parameter not in _BUFR_VALUE_FIELD:
+            log.warning(f"No BUFR value mapping for {self.parameter}; skipping BUFR parsing.")
+            return
+        try:
+            result.df = read_radar_bufr(result.data, self.parameter)
+        except Exception:  # pragma: no cover
+            log.exception("Unable to read BUFR file.")
+
     def query(self) -> Iterator[RadarResult]:  # noqa: C901
         """Query radar data from the DWD server."""
         log.info(f"acquiring radar data for {self!s}")
@@ -337,6 +412,7 @@ class DwdRadarValues:  # noqa: PLW1641
 
             # Yield single "RadarResult" item.
             result = next(self._download_generic_data(url=latest_file))
+            self._attach_bufr(result)
             yield result
 
         elif self.parameter == DwdRadarParameter.RADOLAN_CDC:
@@ -424,6 +500,7 @@ class DwdRadarValues:  # noqa: PLW1641
                             verify_hdf5(result.data)
                         except Exception:  # pragma: no cover
                             log.exception("Unable to read HDF5 file.")
+                    self._attach_bufr(result)
                     yield result
 
     @staticmethod

--- a/src/wetterdienst/settings.py
+++ b/src/wetterdienst/settings.py
@@ -107,6 +107,9 @@ class Settings(BaseSettings):
     )
     auth: Auth = Field(default_factory=Auth)
     use_certifi: bool = Field(default=False)
+    # opt-in: parse DWD radar BUFR files into a polars DataFrame (RadarResult.df). Requires the
+    # optional eccodes + pdbufr dependencies; off by default because parsing is expensive.
+    read_bufr: bool = Field(default=False)
     ts_humanize: bool = True
     ts_shape: Literal["wide", "long"] = "long"
     ts_convert_units: bool = True

--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -4,6 +4,7 @@
 
 import datetime as dt
 import re
+from io import BytesIO
 from zoneinfo import ZoneInfo
 
 import pybufrkit
@@ -19,8 +20,10 @@ from wetterdienst.provider.dwd.radar import (
     DwdRadarResolution,
     DwdRadarValues,
 )
+from wetterdienst.provider.dwd.radar.api import RadarResult
 from wetterdienst.provider.dwd.radar.sites import DwdRadarSite
 from wetterdienst.util.datetime import round_minutes
+from wetterdienst.util.eccodes import ensure_eccodes, ensure_pdbufr
 
 h5py = pytest.importorskip("h5py", reason="h5py not installed")
 wrl = pytest.importorskip("wradlib", reason="wradlib not installed")
@@ -519,6 +522,56 @@ def test_radar_request_site_historic_pe_bufr(default_settings: Settings) -> None
     # Read BUFR file.
     decoder = pybufrkit.decoder.Decoder()
     decoder.process(payload, info_only=True)
+
+
+def test_attach_bufr_noop_when_read_bufr_disabled() -> None:
+    """Without read_bufr, RadarResult.df stays None even for BUFR requests (no parsing, no deps)."""
+    request = object.__new__(DwdRadarValues)
+    request.format = DwdRadarDataFormat.BUFR
+    request.parameter = DwdRadarParameter.PE_ECHO_TOP
+    request.settings = Settings(read_bufr=False)
+    result = RadarResult(data=BytesIO(b"not-a-bufr-payload"))
+    request._attach_bufr(result)  # noqa: SLF001
+    assert result.df is None
+
+
+@pytest.mark.remote
+@pytest.mark.skipif(not (ensure_eccodes() and ensure_pdbufr()), reason="eccodes/pdbufr not installed")
+def test_radar_request_site_historic_pe_bufr_dataframe() -> None:
+    """With read_bufr enabled, PE_ECHO_TOP BUFR data is parsed into RadarResult.df as a long grid."""
+    timestamp = dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None) - dt.timedelta(days=1)
+    request = DwdRadarValues(
+        parameter=DwdRadarParameter.PE_ECHO_TOP,
+        start_date=timestamp,
+        site=DwdRadarSite.BOO,
+        fmt=DwdRadarDataFormat.BUFR,
+        settings=Settings(cache_disable=True, read_bufr=True),
+    )
+    results = list(request.query())
+    if not results:
+        pytest.skip("Data currently not available")
+    result = results[0]
+    # a placeholder/incomplete payload yields no parsed frame (parse error is swallowed) -> skip
+    if result.df is None:
+        pytest.skip("BUFR data currently not available")
+    # raw payload must remain readable after parsing (getvalue, not read)
+    assert result.data.getvalue()
+    df = result.df
+    assert df.columns == [
+        "station_id",
+        "date",
+        "latitude",
+        "longitude",
+        "height",
+        "projection_type",
+        "picture_type",
+        "value",
+    ]
+    assert df.get_column("station_id").unique().to_list() == ["BOO"]
+    assert "UTC" in str(df.schema["date"])
+    assert df.height > 0
+    # a real echo-top grid has at least some non-null pixel values
+    assert not df.drop_nulls("value").is_empty()
 
 
 @pytest.mark.remote

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -38,6 +38,7 @@ def test_default_settings(caplog: pytest.LogCaptureFixture, monkeypatch: pytest.
     assert default_settings.ts_geo_station_distance["foo"] == 40.0
     assert default_settings.ts_geo_use_nearby_station_distance == 1
     assert not default_settings.use_certifi
+    assert not default_settings.read_bufr
     assert (
         caplog.messages[0]
         == "option 'ts_complete' is only available with option 'ts_drop_nulls=False' and is thus ignored in this request."  # noqa: E501


### PR DESCRIPTION
## Summary

Reimplements the goal of #482 against the current polars / `src` codebase (the original PR predated the polars migration and no longer applies). When the new **`read_bufr`** setting is enabled, DWD radar **site BUFR products** (echo top, reflectivity) are parsed via `pdbufr` into a polars DataFrame attached to `RadarResult.df`.

Closes #364. Supersedes #482.

## Details

- **Opt-in** via `Settings(read_bufr=True)` — off by default because parsing is expensive and needs the optional `eccodes` + `bufr` extras. A missing dependency or a parse error is logged and leaves `.df` as `None` rather than failing the whole query.
- Each BUFR message is a single grid product, so `.df` is a **long frame: one row per grid pixel** — station/grid metadata (`station_id`, `date`, `latitude`, `longitude`, `height`, `projection_type`, `picture_type`) plus the pixel `value`, with missing pixels as null.
- The raw payload stays readable on `.data` (parsing uses `getvalue()`, not `read()`), so existing consumers are unaffected.
- Value descriptor is selected per parameter (`echoTops` for `PE_ECHO_TOP`, `horizontalReflectivity` for `PG`/`LMAX`/`PX250`).

## Note on the data model

DWD radar BUFR is a **raster grid**, not a timeseries — a single `PE_ECHO_TOP` message is a 200×200 grid, so `.df` has ~40,000 rows with only the station center coordinate (BUFR carries no per-pixel geolocation). This flattening matches the intent of the original #482, but reviewers should weigh whether a flat frame is the right long-term representation for gridded radar data.

## Tests

- Deterministic: `_attach_bufr` is a no-op (`.df` stays `None`) when `read_bufr` is disabled — no network, no optional deps.
- Remote (skipped without `eccodes`/`pdbufr`): fetches live `PE_ECHO_TOP` BUFR for site BOO with `read_bufr=True` and asserts the frame schema, UTC dates, non-null pixels, and that the raw payload is still readable. Verified passing against live DWD data in this environment.
- `test_default_settings` updated for the new `read_bufr` default.
- `ty` typecheck and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)