### PR TITLE
test(dwd/radar): stabilize flaky BUFR/HDF5 timerange scan-count tests

### DIFF
--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -693,7 +693,9 @@ def test_radar_request_site_historic_px250_bufr_timerange(default_settings: Sett
         msg = "Data currently not available"
         raise pytest.skip(msg)
 
-    assert len(results) == 12
+    # a 1-hour window holds ~12-13 five-minute scans; DWD occasionally drops a scan, so tolerate a
+    # small shortfall rather than asserting an exact count (which flakes on any gap)
+    assert len(results) == IsInt(ge=10, le=13)
 
 
 @pytest.mark.remote
@@ -805,7 +807,9 @@ def test_radar_request_site_historic_sweep_pcp_v_hdf5_timerange(default_settings
         msg = "Data currently not available"
         raise pytest.skip(msg)
 
-    assert len(results) in (12, 13)
+    # a 1-hour window holds ~12-13 five-minute scans; DWD occasionally drops a scan, so tolerate a
+    # small shortfall rather than asserting an exact count (which flakes on any gap)
+    assert len(results) == IsInt(ge=10, le=13)
 
     hdf = h5py.File(results[0].data, "r")
 


### PR DESCRIPTION
## Summary

Two remote radar tests assert an **exact** number of scans returned over a 1-hour window and flake whenever DWD drops a scan from that window. They failed CI on #1753 with `11` instead of `12` (unrelated to that PR's changes):

- `test_radar_request_site_historic_px250_bufr_timerange` — was `assert len(results) == 12`
- `test_radar_request_site_historic_sweep_pcp_v_hdf5_timerange` — was `assert len(results) in (12, 13)`

Both now use `assert len(results) == IsInt(ge=10, le=13)`, tolerating a small shortfall while still catching gross breakage (e.g. 0/1 results). This matches the tolerant-count idiom already used elsewhere in the same file (`IsInt(ge=18, le=19)`, `IsInt(ge=51, le=60)`).

## Not changed (flagged for consideration)

The same brittle exact-count-over-a-timerange pattern exists in a few sibling tests that happened to pass this run — they'd benefit from the same treatment but are left untouched here to keep this fix scoped to the observed failures:

- `test_radar_request_site_historic_generic_bufr_timerange` (0.5h window, `== 6`)
- the sweep-volume / precipitation timerange tests (`== 3 * 25`, `== 3 * 3`)

Happy to loosen those in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)