### PR TITLE
docs: install radar extras so wradlib is available in docs build

### DIFF
--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -16,6 +16,6 @@ if [ "${flavor}" = "testing" ]; then
   uv sync --active --extra bufr --extra export --extra influxdb --extra interpolation --extra knmi --extra pdf --extra plotting --extra radar --extra radarplus --extra restapi --extra sql
 
 elif [ "${flavor}" = "docs" ]; then
-  uv sync --active --extra interpolation --group docs
+  uv sync --active --extra interpolation --extra radar --extra radarplus --group docs
 
 fi


### PR DESCRIPTION
## Problem

The [Python Examples](https://wetterdienst.readthedocs.io/) page renders a `wradlib cannot be imported` traceback in the RADOLAN example.

## Root cause

`docs/usage/python-examples.md` is a MyST-NB notebook, and myst-nb executes code cells at build time (no `nb_execution_mode` override in `docs/conf.py`, so it defaults to executing). The RADOLAN example cell runs `import wradlib as wrl`, but `wradlib` lives in the `radarplus` optional-dependency group — and the docs build (`.readthedocs.yml` → `.github/workflows/install.sh docs`) only installed `--extra interpolation --group docs`. So the import failed and the error was baked into the published page.

## Fix

Add the radar extras to the docs install in `.github/workflows/install.sh`:

```bash
uv sync --active --extra interpolation --extra radar --extra radarplus --group docs
```

This is the shared install script used by both Read the Docs and CI, so a single change covers all docs builds. Verified locally that `wradlib` 2.8.0 imports and `wrl.io.read_radolan_composite` (used in the example) is available once the extras are installed. The radar API in the example is still current, so the example itself is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)