### PR TITLE
docs: repair build, correct content, and expand coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ htmlcov
 .nox
 /.pytest_cache
 /docs/_build
+/docs/apidocs
 /dist
 /tmp
 /geckodriver.log

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@
 
 # Details
 # - https://docs.readthedocs.io/en/stable/config-file/v2.html
-# - https://docs.readthedocs.io/en/stable/build-customization.html#install-dependencies-with-poetry
+# - https://docs.readthedocs.io/en/stable/build-customization.html#extend-the-build-process
 
 # Required
 version: 2
@@ -16,11 +16,10 @@ build:
   # https://docs.readthedocs.io/en/stable/build-customization.html#extend-the-build-process
   jobs:
     post_install:
-      # setuptools has been downgraded to 58.2.0, so upgrade again.
+      # RTD pins an old setuptools into the venv; upgrade it before installing.
       - pip install --upgrade setuptools
       - pip install uv
-      # Install project's dependencies.
-      # see https://github.com/python-poetry/poetry/issues/9025
+      # Install the project and the "docs" dependency group via uv (see install.sh).
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH .github/workflows/install.sh docs
 
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,8 +16,6 @@ build:
   # https://docs.readthedocs.io/en/stable/build-customization.html#extend-the-build-process
   jobs:
     post_install:
-      # RTD pins an old setuptools into the venv; upgrade it before installing.
-      - pip install --upgrade setuptools
       - pip install uv
       # Install the project and the "docs" dependency group via uv (see install.sh).
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH .github/workflows/install.sh docs

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,7 +11,7 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "3.12"
+    python: "3.14"
 
   # https://docs.readthedocs.io/en/stable/build-customization.html#extend-the-build-process
   jobs:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,15 +9,17 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.12"
 
   # https://docs.readthedocs.io/en/stable/build-customization.html#extend-the-build-process
   jobs:
-    post_install:
+    # Install the project and the "docs" dependency group via uv (see install.sh).
+    # uv sync --active installs into RTD's virtualenv so the default Sphinx build
+    # (including PDF) still finds the dependencies.
+    install:
       - pip install uv
-      # Install the project and the "docs" dependency group via uv (see install.sh).
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH .github/workflows/install.sh docs
 
 sphinx:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,15 +5,16 @@
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-import tomllib
+# Read metadata from the installed package so this works on any supported Python
+# version (tomllib is only available on 3.11+, while the project supports 3.10+).
+from importlib.metadata import metadata
 
-with open("../pyproject.toml", "rb") as f:
-    data = tomllib.load(f)["project"]
-    
-project = data["name"]
+_meta = metadata("wetterdienst")
+
+project = _meta["Name"]
 copyright = "earthobservations"
-author = ", ".join(author["name"] for author in data["authors"])
-version = str(data["version"])
+author = _meta["Author"]
+version = _meta["Version"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -24,17 +25,47 @@ latex_engine = "xelatex"
 extensions = [
     "myst_nb",
     "autodoc2",
-    'sphinx_copybutton',
+    "sphinx_copybutton",
 ]
+
+# -- MyST / MyST-NB configuration --------------------------------------------
+# https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
+myst_enable_extensions = [
+    "attrs_block",
+    "attrs_inline",
+    "colon_fence",
+    "deflist",
+    "substitution",
+    "tasklist",
+]
+# Generate anchor slugs for headings up to level 3 so pages can be cross-linked.
+myst_heading_anchors = 3
+
+# Execute notebook-style pages at build time and give remote data cells enough
+# time to fetch from the upstream weather services (default is 30s).
+nb_execution_timeout = 120
+nb_execution_show_tb = True
 
 autodoc2_packages = [
     {
-        "path": "../wetterdienst",
+        "path": "../src/wetterdienst",
     }
 ]
 
+# Providers re-export their `*Metadata` objects, so autodoc2's static analysis
+# sees the same object under two module paths. These duplicates are harmless.
+suppress_warnings = ["autodoc2.dup_item"]
+
+# -- sphinx-copybutton -------------------------------------------------------
+# Strip interactive prompts (>>>, ..., $) so copied snippets are runnable.
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
+
 templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+# autodoc2 writes a full auto-generated tree to "apidocs"; the documented API is
+# curated inline via {autodoc2-object} in library/*.md, so keep the generated
+# tree out of the build to avoid orphaned/duplicate-object warnings.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'apidocs']
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/contribution/development.md
+++ b/docs/contribution/development.md
@@ -34,9 +34,8 @@ sudo apt install git python3 python3-venv uv
 # - https://github.com/astral-sh/uv/releases
 ```
 
-Install required dependencies using `uv`:
-
-*with help of [poe](https://github.com/nat-n/poethepoet)
+Install required dependencies using `uv` (task shortcuts are provided via
+[poe](https://github.com/nat-n/poethepoet)):
 
 ```bash
 uv sync --all-extras --all-groups
@@ -51,11 +50,11 @@ geckodriver installed on your machine:
 uv run poe test
 ```
 
-If this does not work for some reason and you would like to skip ui-related
-tests on your machine, please invoke the test suite with:
+If this does not work for some reason and you would like to skip the explorer
+UI tests on your machine, please invoke the test suite with:
 
 ```bash
-uv run poe test -m "not ui"
+uv run poe test -m "not explorer"
 ```
 
 In order to run only specific tests, invoke:
@@ -114,11 +113,11 @@ docker build \
 
 ## Contributing
 
-1. Before committing your changes, please als run those steps in order to make
+1. Before committing your changes, please also run those steps in order to make
    the patch adhere to the coding standards used here.
 
    ```bash
-   uv run poe format  # black code formatting
+   uv run poe format  # ruff formatting and autofixes
    uv run poe lint    # lint checking
    ```
 

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -6,5 +6,4 @@
 overview.md
 parameters.md
 provider/index.md
-station_history.md
 ```

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -13,7 +13,7 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
         - Historical (last ~300 years), recent (500 days to yesterday), now (yesterday up to last hour)
         - Every minute to yearly resolution
         - Time series of stations in Germany
-        - see the rdwd pages for an interactive map_ and table_ of available datasets
+        - see the [rdwd](https://bookdown.org/brry/rdwd/) pages for an interactive map and table of available datasets
     - Mosmix - statistical optimized scalar forecasts extracted from weather models
         - Point forecast
         - 5400 stations worldwide
@@ -30,6 +30,16 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
         - All of Composite, Radolan, Radvor, Sites and Radolan_CDC
         - Radolan: calibrated radar precipitation
         - Radvor: radar precipitation forecast
+- AEMET (Agencia Estatal de Meteorología / State Meteorological Agency / Spain)
+    - Observation
+        - climatological data from the Spanish station network
+        - hourly, daily, monthly and annual resolution
+        - requires a free API key from opendata.aemet.es (`WD_AUTH__AEMET`)
+- CHMI (Český hydrometeorologický ústav / Czech Hydrometeorological Institute / Czechia)
+    - Observation
+        - observations from the Czech station network
+        - 10-minute, hourly, daily, monthly and annual resolution
+        - open data, no authentication required
 - DMI (Danmarks Meteorologiske Institut / Danish Meteorological Institute / Denmark)
     - Observation
         - quality-controlled climate data from stations in Denmark, Greenland and the Faroe Islands
@@ -48,6 +58,11 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
         - Historical (last ~180 years)
         - Hourly, daily, monthly, (annual) resolution
         - Time series of stations in Canada
+- FMI (Ilmatieteen laitos / Finnish Meteorological Institute / Finland)
+    - Observation
+        - observations from the Finnish station network via the open WFS interface
+        - hourly and daily resolution
+        - open data, no authentication required
 - Geosphere (Geosphere Austria, formerly Central Institution for Meteorology and Geodynamics)
     - Observation
         - historical meteorological data of Austrian stations
@@ -58,6 +73,11 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
     - Hydrology
         - hydrological data of polish river stations
         - daily and monthly summaries
+- KNMI (Koninklijk Nederlands Meteorologisch Instituut / Royal Netherlands Meteorological Institute / Netherlands)
+    - Observation
+        - observations from the Dutch station network
+        - 10-minute, hourly and daily resolution
+        - requires a free API key from developer.dataplatform.knmi.nl (`WD_AUTH__KNMI`)
 - Météo-France (French National Meteorological Service / France)
     - Synop
         - SYNOP observations at the native 3-hourly reporting interval
@@ -75,20 +95,25 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
         - Historical and recent observations from Norwegian station network
         - 10-minute, hourly, 6-hourly (historical only), daily, monthly and annual resolution
         - ~2200 stations; requires free API key from frost.met.no
-- NOAA (National Oceanic And Atmospheric Administration / National Oceanic And Atmospheric Administration / United States Of America)
-    - Global Historical Climatology Network
-        - Historical, hourly (ISD) and daily weather observations from around the globe
-        - more then 100k stations
+- NOAA (National Oceanic and Atmospheric Administration / United States of America)
+    - Global Historical Climatology Network (GHCN)
+        - hourly (GHCNh) and daily weather observations from around the globe
+        - more than 100k stations
         - data for weather services which don't publish data themselves
-- NWS (NOAA National Weather Service)
+- NWS (NOAA National Weather Service / United States of America)
     - Observation
         - recent observations (last week) of US weather stations
-        - currently the list of stations is not completely right as we use a diverging source!
+        - note: the station list is currently sourced from a diverging source and may be incomplete
 - RMI (Koninklijk Meteorologisch Instituut / Royal Meteorological Institute of Belgium / Belgium)
     - Observation
         - observations from the automatic weather station (AWS) network in Belgium
         - 10-minute, hourly and daily resolution
         - ~14 stations, back to 1995; open data, no authentication required
+- SMHI (Sveriges meteorologiska och hydrologiska institut / Swedish Meteorological and Hydrological Institute / Sweden)
+    - Observation
+        - observations from the Swedish station network
+        - 1-minute, hourly, daily and monthly resolution
+        - open data, no authentication required
 - WSV (Wasserstraßen- und Schifffahrtsverwaltung des Bundes / Federal Waterways and Shipping Administration)
     - Pegelonline
         - data of river network of Germany

--- a/docs/data/provider/aemet/index.md
+++ b/docs/data/provider/aemet/index.md
@@ -2,6 +2,20 @@
 
 State Meteorological Agency of Spain (Agencia Estatal de Meteorología)
 
+## Overview
+
+AEMET publishes climatological data from the Spanish weather station network through its
+OpenData portal, covering hourly, daily, monthly and annual resolution. Access requires a
+free API key, which you can request at
+[opendata.aemet.es](https://opendata.aemet.es/centrodedescargas/altaUsuario) and provide via
+the `WD_AUTH__AEMET` environment variable (or `Settings(auth={"aemet": "<api_key>"})`).
+
+## License
+
+AEMET provides its data as open data; please attribute AEMET as the source. See the
+[legal notice](https://www.aemet.es/en/nota_legal) and the
+[OpenData portal](https://opendata.aemet.es/) for the applicable terms.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/chmi/index.md
+++ b/docs/data/provider/chmi/index.md
@@ -2,6 +2,18 @@
 
 Czech Hydrometeorological Institute (Český hydrometeorologický ústav)
 
+## Overview
+
+CHMI publishes observations from the Czech weather station network as open CSV data,
+covering 10-minute, hourly, daily, monthly and annual resolution. No authentication is
+required.
+
+## License
+
+CHMI data is provided as open data through the
+[CHMI open data portal](https://opendata.chmi.cz/). Check the portal for the applicable
+usage conditions and attribution requirements.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/dmi/index.md
+++ b/docs/data/provider/dmi/index.md
@@ -2,6 +2,18 @@
 
 Danish Meteorological Institute (Danmarks Meteorologiske Institut)
 
+## Overview
+
+DMI publishes quality-controlled climate data from stations in Denmark, Greenland and the
+Faroe Islands (~280 stations), covering hourly, daily, monthly and annual resolution,
+through its Open Data climateData API. No authentication is required.
+
+## License
+
+DMI provides its data as free/open data. See the
+[DMI Open Data documentation](https://opendatadocs.dmi.govcloud.dk/) and the
+[DMI frie data](https://www.dmi.dk/friedata/) pages for licensing and attribution.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/dwd/index.md
+++ b/docs/data/provider/dwd/index.md
@@ -4,34 +4,27 @@
 
 The data as offered by the DWD through ``wetterdienst`` includes:
 
-- Historical Weather Observations
-    - Historical (last ~300 years), recent (500 days to yesterday), now (yesterday up to last hour)
+- [Observation](observation/index.md) — historical weather observations
+    - historical (reaching back to the 19th century), recent (~500 days to yesterday) and now
+      (yesterday up to the last hour) periods
     - every minute to yearly resolution
-    - Time series of stations in Germany
-- Mosmix 
-    - statistical optimized scalar forecasts extracted from weather models
-    - Point forecast
-    - 5400 stations worldwide
-    - Both MOSMIX-L and MOSMIX-S is supported
-    - Up to 115 parameters
-- DMO
-    - scalar forecasts extracted from weather models
-    - Point forecast
-    - ICON and ICON-EU model
-    - 78 hours lead time
-    - Hourly and 3-hourly resolution
-    - 115 parameters
-    - 5400 stations worldwide
-- Radar
-    - 16 locations in Germany
-    - All of composite, radolan, radvor, sites and radolan_cdc
-    - Radolan: calibrated radar precipitation
-    - Radvor: radar precipitation forecast
-- derived technical products
-    - Secondary data products from primary weather observations
-    - Currently only data product heating_degreedays supported
-    - Monthly resolution
-    - From stations in Germany
+    - time series of over 1000 stations in Germany
+- [Mosmix](mosmix/index.md) — statistically optimized point forecasts derived from weather models
+    - MOSMIX-S (~40 parameters, updated hourly) and MOSMIX-L (~115 parameters, updated every 6 hours)
+    - over 5000 stations worldwide, forecast horizon up to 240 hours
+- [DMO](dmo/index.md) — raw point forecasts extracted from weather models (no statistical postprocessing)
+    - ICON (global) and ICON-EU (regional) models
+    - hourly resolution (78 h lead time) and, for ICON, additional 3-hourly resolution (168 h lead time)
+    - over 5000 stations worldwide
+- [Road](road/index.md) — weather observations from German motorway ("road") stations
+    - 15-minute resolution, distributed in BUFR format
+- [Radar](radar/index.md) — radar-based precipitation products
+    - composite, radolan, radvor, sites and radolan_cdc
+    - RADOLAN: gauge-calibrated areal precipitation; RADVOR: radar-based precipitation forecast
+- [Derived products](derived/index.md) — secondary products computed from primary observations
+    - technical products (heating/cooling degree days, climate correction factor) and climate
+      products (radiation & sunshine duration, soil data)
+    - hourly, daily and monthly resolution, for stations in Germany
 
 For a quick overview of the work of the DWD check the current 
 [dwd report](https://www.dwd.de/SharedDocs/downloads/DE/allgemein/zahlen_und_fakten.pdf?__blob=publicationFile&v=14) 

--- a/docs/data/provider/dwd/observation/index.md
+++ b/docs/data/provider/dwd/observation/index.md
@@ -55,7 +55,7 @@ how the DWD calls the dataset e.g. "precipitation".
 | `PRESSURE = "pressure"`                             | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
 | `TEMPERATURE_SOIL = "soil_temperature"`             | ❌        | ❌         | ❌          | ✅      | ❌        | ✅     | ❌       | ❌      |
 | `SUNSHINE_DURATION = "sun"`                         | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `VISBILITY = "visibility"`                          | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
+| `VISIBILITY = "visibility"`                         | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
 | `WIND_SYNOPTIC = "wind_synop"`                      | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
 | `MOISTURE = "moisture"`                             | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
 | `CLIMATE_SUMMARY = "kl"`                            | ❌        | ❌         | ❌          | ❌      | ✅        | ✅     | ✅       | ✅      |
@@ -123,15 +123,18 @@ server like [data set description for historical hourly station observations of 
 Wetterdienst provides convenient access to the relevant details
 by using routines to parse specific sections of the PDF documents.
 
-For example, use commands like these for accessing this information::
+For example, use the `describe_fields` helper to access this information:
 
-    # Historical hourly station observations of precipitation for Germany.
-    # English language.
-    wetterdienst dwd about fields --parameter=precipitation --resolution=hourly --period=historical
+```python
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
 
-    # Historical 10-minute station observations of pressure, air temperature (at 5cm and 2m height), humidity and dew point for Germany.
-    # German language.
-    wetterdienst dwd about fields --parameter=air_temperature --resolution=10_minutes --period=historical --language=de
+# Historical hourly station observations of precipitation for Germany.
+fields = DwdObservationRequest.describe_fields(
+    dataset="hourly/precipitation",
+    period="historical",
+    language="en",  # or "de" for the German descriptions
+)
+```
 
 or have a look at the example program [dwd_obs_climate_summary_describe_fields.py](https://github.com/earthobservations/wetterdienst/blob/main/examples/provider/dwd/observation/dwd_obs_climate_summary_describe_fields.py).
 

--- a/docs/data/provider/dwd/road/index.md
+++ b/docs/data/provider/dwd/road/index.md
@@ -2,9 +2,16 @@
 
 ## Overview
 
-- weather data from German highway "road" stations.
-- 15 minute resolution
-- historical period
+The DWD operates a network of road weather stations along German motorways ("Straßenwetter")
+that report conditions relevant to traffic and road safety. Wetterdienst exposes their
+observations at 15-minute resolution.
+
+The data is published as
+[weather reports](https://opendata.dwd.de/weather/weather_reports/road_weather_stations/) in
+BUFR format, so parsing requires the optional `eccodes`/`bufr` dependency extras. Station
+metadata is resolved from the DWD
+[station list](https://www.dwd.de/DE/leistungen/opendata/help/stationen/sws_stations_xls.xlsx).
+No authentication is required.
 
 ```{toctree}
 :hidden:

--- a/docs/data/provider/eaufrance/hubeau/index.md
+++ b/docs/data/provider/eaufrance/hubeau/index.md
@@ -2,6 +2,18 @@
 
 ## Overview
 
+Hubeau is the open API platform of Eaufrance, the French public water-information service.
+Wetterdienst uses its hydrometry API to provide real-time river observations for the French
+river network, covering roughly the last 30 days.
+
+Two parameters are available — water level (`stage`) and discharge (`flow`) — served from the
+`hydrometrie/observations_tr` ("temps réel") endpoint as JSON, with station metadata coming
+from the `hydrometrie/referentiel/stations` endpoint. The API is key-less; no authentication
+is required.
+
+Because only real-time data is exposed, there is a single "dynamic" resolution rather than the
+fixed resolutions used by the observation providers.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/eccc/observation/index.md
+++ b/docs/data/provider/eccc/observation/index.md
@@ -2,6 +2,16 @@
 
 ## Overview
 
+Environment and Climate Change Canada (ECCC) publishes historical weather observations for the
+Canadian station network at hourly, daily, monthly and annual resolution. The network is large
+and reaches back to the 19th century, though the parameters and period covered vary strongly
+between stations.
+
+Data is retrieved as bulk CSV exports from the ECCC climate data service
+([bulk data](https://climate.weather.gc.ca/climate_data/bulk_data_e.html)), with station
+metadata resolved from the same service. No authentication is required. As only historical data
+is offered, a date range is required when requesting values.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/fmi/index.md
+++ b/docs/data/provider/fmi/index.md
@@ -2,6 +2,18 @@
 
 Finnish Meteorological Institute (Ilmatieteen laitos)
 
+## Overview
+
+FMI publishes observations from the Finnish weather station network through its open WFS
+interface, covering hourly and daily resolution. No authentication is required.
+
+## License
+
+FMI open data is licensed under
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). See the
+[FMI open data manual](https://en.ilmatieteenlaitos.fi/open-data-manual) for attribution
+requirements.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/geosphere/observation/index.md
+++ b/docs/data/provider/geosphere/observation/index.md
@@ -2,6 +2,14 @@
 
 ## Overview
 
+Geosphere Austria (formerly ZAMG) publishes historical observations from its Austrian station
+network at 10-minute, hourly, daily and monthly resolution.
+
+Data is served through the Geosphere data hub API (`dataset.api.hub.geosphere.at`) as GeoJSON,
+one request per dataset and station over the requested time window. The API is key-less; no
+authentication is required. As only historical data is offered, a date range is required when
+requesting values.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/imgw/hydrology/index.md
+++ b/docs/data/provider/imgw/hydrology/index.md
@@ -2,6 +2,16 @@
 
 ## Overview
 
+IMGW publishes hydrological observations for the Polish river-gauge network at daily and monthly
+resolution, as open data from the
+[public data portal](https://danepubliczne.imgw.pl/data/dane_pomiarowo_obserwacyjne/dane_hydrologiczne/).
+No authentication is required.
+
+Values are downloaded as zipped CSV archives and decoded as `latin-1`. The archive layout has
+changed over time — daily data is split into per-month files (`codz_YYYY_MM.zip`) historically
+and consolidated into a single per-year file (`codz_YYYY.zip`) from 2023 onwards — which
+wetterdienst normalizes transparently.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/imgw/meteorology/index.md
+++ b/docs/data/provider/imgw/meteorology/index.md
@@ -2,6 +2,14 @@
 
 ## Overview
 
+IMGW publishes meteorological observations for the Polish weather-station network at daily and
+monthly resolution, as open data from the
+[public data portal](https://danepubliczne.imgw.pl/data/dane_pomiarowo_obserwacyjne/dane_meteorologiczne/).
+No authentication is required.
+
+Values are downloaded as zipped CSV archives (decoded as `latin-1`), with station metadata
+resolved from the accompanying station-code list. Both daily and monthly summaries are provided.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/knmi/index.md
+++ b/docs/data/provider/knmi/index.md
@@ -3,6 +3,20 @@
 Royal Netherlands Meteorological Institute (Koninklijk Nederlands Meteorologisch
 Instituut)
 
+## Overview
+
+KNMI publishes observations from the Dutch weather station network through its Data
+Platform, covering 10-minute, hourly and daily resolution. Access requires a free API key,
+which you can request at
+[developer.dataplatform.knmi.nl](https://developer.dataplatform.knmi.nl/) and provide via
+the `WD_AUTH__KNMI` environment variable (or `Settings(auth={"knmi": "<api_key>"})`).
+
+## License
+
+KNMI data is published as open data through the
+[KNMI Data Platform](https://dataplatform.knmi.nl/); see the platform for the applicable
+license and attribution requirements.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/metno/index.md
+++ b/docs/data/provider/metno/index.md
@@ -2,6 +2,20 @@
 
 Norwegian Meteorological Institute (Meteorologisk institutt)
 
+## Overview
+
+MET Norway publishes historical and recent observations from the Norwegian station network
+(~2200 stations) through its Frost API, covering 10-minute, hourly, 6-hourly (historical
+only), daily, monthly and annual resolution. Access requires free client credentials, which
+you can request at [frost.met.no](https://frost.met.no/auth/requestCredentials.html) and
+provide via the `WD_AUTH__METNO_FROST` environment variable.
+
+## License
+
+MET Norway publishes its data under
+[CC BY 4.0 / the Norwegian Licence for Open Government Data (NLOD)](https://www.met.no/en/free-meteorological-data).
+See the [Frost API](https://frost.met.no/) documentation for details.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/noaa/index.md
+++ b/docs/data/provider/noaa/index.md
@@ -2,6 +2,18 @@
 
 ## Overview
 
+NOAA's Global Historical Climatology Network (GHCN) provides hourly (GHCNh) and daily
+weather observations from more than 100,000 stations around the globe, making it a valuable
+source for weather services that do not publish their data themselves. No authentication is
+required.
+
+## License
+
+GHCN data is provided by NOAA's National Centers for Environmental Information (NCEI) as
+open data. See the
+[GHCN daily product page](https://www.ncei.noaa.gov/products/land-based-station/global-historical-climatology-network-daily)
+for citation and usage information.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/rmi/index.md
+++ b/docs/data/provider/rmi/index.md
@@ -3,6 +3,19 @@
 Royal Meteorological Institute of Belgium (Koninklijk Meteorologisch Instituut / Institut
 Royal Météorologique)
 
+## Overview
+
+RMI publishes observations from the automatic weather station (AWS) network in Belgium
+(~14 stations, back to 1995) through its open GeoServer WFS, covering 10-minute, hourly and
+daily resolution. No authentication is required.
+
+## License
+
+RMI AWS open data is published under
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). See the
+[dataset catalog entry](https://www.geo.be/catalog/details/RMI_AWS_WFS) and the
+[opendata.meteo.be](https://opendata.meteo.be/) portal for details.
+
 ```{toctree}
 :hidden:
 

--- a/docs/data/provider/smhi/index.md
+++ b/docs/data/provider/smhi/index.md
@@ -2,6 +2,17 @@
 
 Swedish Meteorological and Hydrological Institute (Sveriges meteorologiska och hydrologiska institut)
 
+## Overview
+
+SMHI publishes observations from the Swedish weather station network through its open data
+API, covering 1-minute, hourly, daily and monthly resolution. No authentication is required.
+
+## License
+
+SMHI open data is published under
+[CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). See the
+[SMHI open data explorer](https://www.smhi.se/data/utforskaren-oppna-data) for details.
+
 ```{toctree}
 :hidden:
 

--- a/docs/library/core.md
+++ b/docs/library/core.md
@@ -5,7 +5,22 @@ render_plugin = "myst"
 no_index = true
 ```
 
-```{autodoc2-object} wetterdienst.model
+```{autodoc2-object} wetterdienst.model.request
+render_plugin = "myst"
+no_index = true
+```
+
+```{autodoc2-object} wetterdienst.model.values
+render_plugin = "myst"
+no_index = true
+```
+
+```{autodoc2-object} wetterdienst.model.result
+render_plugin = "myst"
+no_index = true
+```
+
+```{autodoc2-object} wetterdienst.model.metadata
 render_plugin = "myst"
 no_index = true
 ```

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -34,9 +34,3 @@ Run Wetterdienst HTTP REST API service:
 ```bash
 docker run -it --rm --publish=7890:7890 ghcr.io/earthobservations/wetterdienst wetterdienst restapi --listen 0.0.0.0:7890
 ```
-
-Run Wetterdienst Explorer UI service:
-
-```bash
-docker run -it --rm --publish=7891:7891 ghcr.io/earthobservations/wetterdienst wetterdienst explorer --listen 0.0.0.0:7891
-```

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -3,9 +3,12 @@
 ```{toctree}
 :hidden:
 
+quickstart.md
 python-api.md
 python-examples.md
+interpolation.md
 station_history.md
+stripes.md
 cli.md
 restapi.md
 docker.md

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -1,0 +1,241 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+---
+
+# Interpolation & Summary
+
+Weather stations rarely sit exactly where you need data. Wetterdienst offers two ways to
+derive a time series for an arbitrary location from the surrounding station network:
+
+- **Interpolation** — estimate values *at your exact coordinates* by combining the nearest
+  stations with a spatial interpolation method. Use this when you want a physically
+  plausible value for a point with no station.
+- **Summary** — stitch together the *single closest available* station value at each
+  timestamp, walking outwards through nearby stations to fill gaps. Use this when you want
+  the most complete real-measurement series near a location, rather than a computed blend.
+
+Both features currently work with `DwdObservationRequest` and require the `interpolation`
+extra (`scipy`, `shapely`, `utm`):
+
+```bash
+pip install "wetterdienst[interpolation]"
+```
+
+## Interpolation
+
+The interpolation feature leverages the four closest stations to your specified latitude
+and longitude and employs the bilinear interpolation method provided by the scipy package
+to interpolate the given parameter values.
+
+The graphic below shows values of the parameter ``temperature_air_mean_2m`` from multiple
+stations measured at the same time. The blue points represent the position of a station and
+include the measured value. The red point represents the position of the interpolation and
+includes the interpolated value.
+
+![interpolation example](../assets/interpolation.png)
+
+Values represented as a table:
+
+| station_id | resolution | dataset         | parameter               | date                      | value  |
+|------------|------------|-----------------|-------------------------|---------------------------|--------|
+| 02480      | daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 278.15 |
+| 04411      | daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 277.15 |
+| 07341      | daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 278.35 |
+| 00917      | daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 276.25 |
+
+The interpolated value looks like this:
+
+| resolution | dataset         | parameter               | date                      | value  |
+|------------|-----------------|-------------------------|---------------------------|--------|
+| daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 277.65 |
+
+Pass your target coordinates as `latlon` to `.interpolate()`:
+
+```{code-cell}
+---
+mystnb:
+  number_source_lines: true
+---
+import datetime as dt
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
+
+request = DwdObservationRequest(
+    parameters=("hourly", "temperature_air", "temperature_air_mean_2m"),
+    start_date=dt.datetime(2022, 1, 1),
+    end_date=dt.datetime(2022, 1, 20),
+)
+values = request.interpolate(latlon=(50.0, 8.9))
+df = values.df
+df
+```
+
+Instead of a latlon you may alternatively use an existing station id for which to
+interpolate values in a manner of getting a more complete dataset:
+
+```{code-cell}
+---
+mystnb:
+  number_source_lines: true
+---
+import datetime as dt
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
+
+request = DwdObservationRequest(
+    parameters=("hourly", "temperature_air", "temperature_air_mean_2m"),
+    start_date=dt.datetime(2022, 1, 1),
+    end_date=dt.datetime(2022, 1, 20),
+)
+values = request.interpolate_by_station_id(station_id="02480")
+df = values.df
+df
+```
+
+### Supported parameters
+
+Interpolation is only meaningful for parameters whose fields vary smoothly in space. Two
+default search radii apply depending on how strongly a parameter is spatially correlated:
+
+**Large spatial correlation (~40 km default search radius)** — homogeneous fields that vary
+slowly across regions: air, soil, dew-point, wet-bulb and surface temperatures, humidity,
+wind speed/gust, snow depth (accumulated), sunshine and radiation, air pressure, cloud
+cover and evapotranspiration/evaporation.
+
+**Short spatial correlation (~20 km default search radius)** — heterogeneous fields that
+vary more locally: precipitation (all variants) and new-snow-per-period parameters.
+
+### Settings
+
+Several settings control the interpolation behaviour (see also the
+[settings](settings.md) chapter):
+
+| Name                               | Type             | Default                                                       | Description                                                                                                                     |
+|------------------------------------|------------------|--------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| ts_geo_station_distance            | dict[str, float] | 20.0 (precipitation and new-snow variants)<br/>40.0 (other)  | Max distance for stations used for interpolation (in km).                                                                       |
+| ts_geo_use_nearby_station_distance | float            | 1.0                                                          | Distance (in km) up to which a nearby station's value is used directly instead of interpolating.                               |
+| ts_geo_min_gain_of_value_pairs     | float            | 0.1                                                          | Minimum gain of value pairs for an additional station to be included, to avoid using every station in a dense network.         |
+| ts_geo_num_additional_stations     | int              | 3                                                            | Number of additional stations used regardless of the gain, to guarantee a minimum number of stations.                          |
+
+For example, to increase the maximum distance for precipitation interpolation:
+
+```{code-cell}
+---
+mystnb:
+  number_source_lines: true
+---
+import datetime as dt
+from wetterdienst import Settings
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
+
+settings = Settings(ts_geo_station_distance={"precipitation_height": 25.0})
+request = DwdObservationRequest(
+    parameters=("hourly", "precipitation", "precipitation_height"),
+    start_date=dt.datetime(2022, 1, 1),
+    end_date=dt.datetime(2022, 1, 20),
+    settings=settings,
+)
+values = request.interpolate(latlon=(52.8, 12.9))
+df = values.df
+df
+```
+
+Interpolation is still in its early stages, we welcome feedback to enhance and refine its
+functionality.
+
+## Summary
+
+Similar to interpolation you may sometimes want to combine multiple stations to get a
+complete list of data. For that reason you can use `.summarize(latlon)`, which walks
+through the nearest stations and combines their data meaningfully. The figure below shows
+the summarized values of the parameter ``temperature_air_mean_2m`` from multiple stations.
+
+![summary example](../assets/summary.png)
+
+It currently only works for ``DwdObservationRequest`` and individual parameters. Currently
+the following parameters are supported (more will be added if useful):
+``temperature_air_mean_2m``, ``wind_speed``, ``precipitation_height``.
+
+```{code-cell}
+---
+mystnb:
+  number_source_lines: true
+---
+import datetime as dt
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
+
+request = DwdObservationRequest(
+    parameters=("hourly", "temperature_air", "temperature_air_mean_2m"),
+    start_date=dt.datetime(2022, 1, 1),
+    end_date=dt.datetime(2022, 1, 20),
+)
+values = request.summarize(latlon=(50.0, 8.9))
+df = values.df
+df
+```
+
+Instead of a latlon you may alternatively use an existing station id for which to summarize
+values in a manner of getting a more complete dataset:
+
+```{code-cell}
+---
+mystnb:
+  number_source_lines: true
+---
+import datetime as dt
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
+
+request = DwdObservationRequest(
+    parameters=("hourly", "temperature_air", "temperature_air_mean_2m"),
+    start_date=dt.datetime(2022, 1, 1),
+    end_date=dt.datetime(2022, 1, 20),
+)
+values = request.summarize_by_station_id(station_id="02480")
+df = values.df
+df
+```
+
+Summary is still in its early stages, we welcome feedback to enhance and refine its
+functionality.
+
+## Command line
+
+Both features are also available as CLI commands. The reference location is given either by
+`--station` (a station id) or by `--latitude`/`--longitude`:
+
+```bash
+# Interpolate to a coordinate.
+wetterdienst interpolate \
+  --provider dwd --network observation \
+  --parameters hourly/temperature_air/temperature_air_mean_2m \
+  --latitude 50.0 --longitude 8.9 \
+  --start-date 2022-01-01 --end-date 2022-01-20
+
+# Summarize around a reference station.
+wetterdienst summarize \
+  --provider dwd --network observation \
+  --parameters hourly/temperature_air/temperature_air_mean_2m \
+  --station 02480 \
+  --start-date 2022-01-01 --end-date 2022-01-20
+```
+
+## REST API
+
+When the [REST API](restapi.md) is running, use the `/api/interpolate` and `/api/summarize`
+endpoints (examples use [httpie](https://github.com/httpie/cli)):
+
+```bash
+# Interpolate to a coordinate.
+http localhost:7890/api/interpolate \
+  provider==dwd network==observation \
+  parameters==hourly/temperature_air/temperature_air_mean_2m \
+  latitude==50.0 longitude==8.9 \
+  date==2022-01-01/2022-01-20
+
+# Summarize around a reference station.
+http localhost:7890/api/summarize \
+  provider==dwd network==observation \
+  parameters==hourly/temperature_air/temperature_air_mean_2m \
+  station==02480 \
+  date==2022-01-01/2022-01-20
+```

--- a/docs/usage/python-api.md
+++ b/docs/usage/python-api.md
@@ -479,228 +479,12 @@ print(values.df.head())
 values.df_stations
 ```
 
-### Interpolation
+### Interpolation & Summary
 
-Occasionally, you may require data specific to your precise location rather than relying on values measured at a
-station's location. To address this need, we have introduced an interpolation feature, enabling you to interpolate data
-from nearby stations to your exact coordinates. The function leverages the four closest stations to your specified
-latitude and longitude and employs the bilinear interpolation method provided by the scipy package (interp2d) to
-interpolate the given parameter values. Currently, this interpolation feature supports the following parameters:
-
-**Large spatial correlation (~40 km default search radius)** — homogeneous fields that vary slowly across regions:
-
-*Temperature:*
-``temperature_air_2m``, ``temperature_air_mean_2m``, ``temperature_air_mean_2m_last_24h``,
-``temperature_air_max_2m``, ``temperature_air_max_2m_last_24h``, ``temperature_air_max_2m_mean``, ``temperature_air_max_2m_multiday``,
-``temperature_air_min_2m``, ``temperature_air_min_2m_last_24h``, ``temperature_air_min_2m_mean``, ``temperature_air_min_2m_multiday``,
-``temperature_air_mean_0_05m``, ``temperature_air_max_0_05m``, ``temperature_air_min_0_05m``, ``temperature_air_min_0_05m_last_12h``,
-``temperature_dew_point_mean_2m``, ``temperature_wet_mean_2m``, ``temperature_wind_chill``, ``temperature_surface_mean``,
-``temperature_soil_mean_0_02m``, ``temperature_soil_mean_0_05m``, ``temperature_soil_mean_0_1m``, ``temperature_soil_mean_0_2m``,
-``temperature_soil_mean_0_5m``, ``temperature_soil_mean_1m``, ``temperature_soil_mean_2m``,
-``temperature_soil_min_0_1m``, ``temperature_soil_min_0_2m``, ``temperature_soil_min_0_5m``, ``temperature_soil_min_1m``, ``temperature_soil_min_2m``,
-``temperature_soil_max_0_1m``, ``temperature_soil_max_0_2m``, ``temperature_soil_max_0_5m``, ``temperature_soil_max_1m``, ``temperature_soil_max_2m``,
-``heating_degree_day``, ``cooling_degree_hour``
-
-*Humidity:*
-``humidity``, ``humidity_absolute``, ``humidity_max``, ``humidity_min``, ``humidex``
-
-*Wind:*
-``wind_speed``, ``wind_speed_arithmetic``, ``wind_speed_min``, ``wind_speed_rolling_mean_max``, ``wind_force_beaufort``,
-``wind_movement_24h``, ``wind_movement_multiday``,
-``wind_gust_max``, ``wind_gust_max_last_1h``, ``wind_gust_max_last_3h``, ``wind_gust_max_last_6h``, ``wind_gust_max_last_12h``,
-``wind_gust_max_5sec``, ``wind_gust_max_1min``, ``wind_gust_max_2min``, ``wind_gust_max_instant``, ``wind_gust_max_1mile``
-
-*Snow (accumulated depth):*
-``snow_depth``, ``snow_depth_excelled``, ``snow_depth_manual``, ``snow_depth_max``,
-``water_equivalent_snow_depth``, ``water_equivalent_snow_depth_excelled``
-
-*Solar / Radiation:*
-``sunshine_duration``, ``sunshine_duration_last_3h``, ``sunshine_duration_yesterday``,
-``sunshine_duration_relative``, ``sunshine_duration_relative_last_24h``,
-``radiation_global``, ``radiation_global_last_3h``,
-``radiation_sky_short_wave_diffuse``, ``radiation_sky_short_wave_direct``,
-``radiation_sky_long_wave``, ``radiation_sky_long_wave_last_3h``
-
-*Pressure:*
-``pressure_air_sea_level``, ``pressure_air_site``, ``pressure_air_site_reduced``,
-``pressure_air_site_max``, ``pressure_air_site_min``, ``pressure_air_site_delta_last_3h``, ``pressure_vapor``
-
-*Cloud cover:*
-``cloud_cover_total``, ``cloud_cover_total_midnight_to_midnight``, ``cloud_cover_total_sunrise_to_sunset``, ``cloud_cover_effective``
-
-*Evapotranspiration / Evaporation:*
-``evapotranspiration_potential_last_24h``, ``evapotranspiration_potential_gras_fao_last_24h``,
-``evapotranspiration_potential_gras_haude_last_24h``, ``evaporation_height``, ``evaporation_height_multiday``
-
-**Short spatial correlation (~20 km default search radius)** — heterogeneous fields that vary more locally:
-
-*Precipitation:*
-``precipitation_height``, ``precipitation_height_day``, ``precipitation_height_night``,
-``precipitation_height_liquid``, ``precipitation_height_droplet``, ``precipitation_height_rocker``,
-``precipitation_height_last_1h``, ``precipitation_height_last_3h``, ``precipitation_height_last_6h``,
-``precipitation_height_last_9h``, ``precipitation_height_last_12h``, ``precipitation_height_last_15h``,
-``precipitation_height_last_18h``, ``precipitation_height_last_21h``, ``precipitation_height_last_24h``,
-``precipitation_height_multiday``,
-``precipitation_height_significant_weather_last_1h``, ``precipitation_height_significant_weather_last_3h``,
-``precipitation_height_significant_weather_last_6h``, ``precipitation_height_significant_weather_last_12h``,
-``precipitation_height_significant_weather_last_24h``,
-``precipitation_height_liquid_significant_weather_last_1h``,
-``precipitation_height_max``, ``precipitation_height_liquid_max``, ``precipitation_duration``
-
-*New snow per period:*
-``snow_depth_new``, ``snow_depth_new_multiday``, ``snow_depth_new_max``,
-``water_equivalent_snow_depth_new``, ``water_equivalent_snow_depth_new_last_1h``, ``water_equivalent_snow_depth_new_last_3h``
-
-
-There are several settings that can be used to control the interpolation behavior:
-
-| Name                               | Type             | Default                                      | Description                                                                                                                                                                                                             |
-|------------------------------------|------------------|----------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ts_geo_station_distance            | dict[str, float] | 20.0 (precipitation and new-snow variants)<br/>40.0 (other) | Max distance for stations used for interpolation (in km)                                                                                                                                                                |
-| ts_geo_use_nearby_station_distance | float            | 1.0                                          | Distance (in km) until which the value of a nearby station is used instead of interpolation.                                                                                                                            |
-| ts_geo_min_gain_of_value_pairs     | float            | 0.1                                          | Minimum gain of value pairs [for an additional station] to be included in the list of stations used. This is to prevent taking all stations into account in case of a dense station network.                            |
-| ts_geo_num_additional_stations     | int              | 3                                            | Number of additional stations to be used for interpolation regardless of min_gain_of_value_pairs. This is to ensure that at least a certain number of stations are used for interpolation, even if the gain is not met. |
-
-The graphic below shows values of the parameter ``temperature_air_mean_2m`` from multiple stations measured at the same
-time.
-The blue points represent the position of a station and includes the measured value.
-The red point represents the position of the interpolation and includes the interpolated value.
-
-![interpolation example](../assets/interpolation.png)
-
-Values represented as a table:
-
-| station_id | resolution | dataset         | parameter               | date                      | value  |
-|------------|------------|-----------------|-------------------------|---------------------------|--------|
-| 02480      | daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 278.15 |
-| 04411      | daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 277.15 |
-| 07341      | daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 278.35 |
-| 00917      | daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 276.25 |
-
-The interpolated value looks like this:
-
-| resolution | dataset         | parameter               | date                      | value  |
-|------------|-----------------|-------------------------|---------------------------|--------|
-| daily      | climate_summary | temperature_air_mean_2m | 2022-01-02 00:00:00+00:00 | 277.65 |
-
-```{code-cell}
----
-mystnb:
-  number_source_lines: true
----
-import datetime as dt
-from wetterdienst.provider.dwd.observation import DwdObservationRequest
-
-request = DwdObservationRequest(
-    parameters=("hourly", "temperature_air", "temperature_air_mean_2m"),
-    start_date=dt.datetime(2022, 1, 1),
-    end_date=dt.datetime(2022, 1, 20),
-)
-values = request.interpolate(latlon=(50.0, 8.9))
-df = values.df
-df
-```
-
-Instead of a latlon you may alternatively use an existing station id for which to interpolate values in a manner of
-getting a more complete dataset:
-
-```{code-cell}
----
-mystnb:
-  number_source_lines: true
----
-import datetime as dt
-from wetterdienst.provider.dwd.observation import DwdObservationRequest
-
-request = DwdObservationRequest(
-    parameters=("hourly", "temperature_air", "temperature_air_mean_2m"),
-    start_date=dt.datetime(2022, 1, 1),
-    end_date=dt.datetime(2022, 1, 20),
-)
-values = request.interpolate_by_station_id(station_id="02480")
-df = values.df
-df
-```
-
-Increase maximum distance for interpolation:
-
-```{code-cell}
----
-mystnb:
-  number_source_lines: true
----
-import datetime as dt
-from wetterdienst.provider.dwd.observation import DwdObservationRequest
-from wetterdienst import Settings
-
-settings = Settings(ts_interpolation_station_distance={"precipitation_height": 25.0})
-request = DwdObservationRequest(
-    parameters=("hourly", "precipitation", "precipitation_height"),
-    start_date=dt.datetime(2022, 1, 1),
-    end_date=dt.datetime(2022, 1, 20),
-    settings=settings
-)
-values = request.interpolate(latlon=(52.8, 12.9))
-df = values.df
-df
-```
-
-Interpolation is still in its early stages, we welcome feedback to enhance and refine its functionality.
-
-### Summary
-
-Similar to interpolation you may sometimes want to combine multiple stations to get a complete list of data. For that
-reason you can use `.summary(latlon)`, which goes through nearest stations and combines data from them meaningful. The
-following figure visualizes how summary works. The first graph shows the summarized values of the parameter
-``temperature_air_mean_2m`` from multiple stations.
-
-![summary example](../assets/summary.png)
-
-The code to execute the summary is given below. It currently only works for ``DwdObservationRequest`` and individual
-parameters.
-Currently, the following parameters are supported (more will be added if useful): ``temperature_air_mean_2m``,
-``wind_speed``, ``precipitation_height``.
-
-```{code-cell}
----
-mystnb:
-  number_source_lines: true
----
-import datetime as dt
-from wetterdienst.provider.dwd.observation import DwdObservationRequest
-
-request = DwdObservationRequest(
-    parameters=("hourly", "temperature_air", "temperature_air_mean_2m"),
-    start_date=dt.datetime(2022, 1, 1),
-    end_date=dt.datetime(2022, 1, 20),
-)
-values = request.summarize(latlon=(50.0, 8.9))
-df = values.df
-df
-```
-
-Instead of a latlon you may alternatively use an existing station id for which to summarize values in a manner of
-getting a more complete dataset:
-
-```{code-cell}
----
-mystnb:
-  number_source_lines: true
----
-import datetime as dt
-from wetterdienst.provider.dwd.observation import DwdObservationRequest
-
-request = DwdObservationRequest(
-    parameters=("hourly", "temperature_air", "temperature_air_mean_2m"),
-    start_date=dt.datetime(2022, 1, 1),
-    end_date=dt.datetime(2022, 1, 20),
-)
-values = request.summarize_by_station_id(station_id="02480")
-df = values.df
-df
-```
-
-Summary is still in its early stages, we welcome feedback to enhance and refine its functionality.
+Wetterdienst can derive a time series for an arbitrary location from the surrounding
+station network, either by spatial interpolation or by combining the nearest available
+stations. See the dedicated [Interpolation & Summary](interpolation.md) chapter for the
+full explanation, supported parameters, settings, CLI and REST usage.
 
 ### Format
 
@@ -901,7 +685,7 @@ The argument `if_exists` supports the following modes:
 - `append`: Insert new values to the existing table (not supported by files).
 - `skip`: Do nothing if the table/file already exists.
 
-### Caching
+## Caching
 
 The backbone of wetterdienst uses fsspec caching. It requires to create a directory under ``/home`` for the
 most cases. If you are not allowed to write into ``/home`` you will run into ``OSError``. For this purpose you can set
@@ -927,7 +711,7 @@ Or similarly with the cli:
 !wetterdienst cache
 ```
 
-### FSSPEC
+## FSSPEC
 
 FSSPEC is used for flexible file caching. It relies on the two libraries requests and aiohttp. Aiohttp is used for
 asynchronous requests and may swallow some errors related to proxies, ssl or similar. Use the defined variable

--- a/docs/usage/python-examples.md
+++ b/docs/usage/python-examples.md
@@ -131,7 +131,7 @@ mystnb:
 ---
 from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
 
-stations = DwdMosmixRequest(
+request = DwdMosmixRequest(
     parameters=("hourly", "large"),
 )
 

--- a/docs/usage/quickstart.md
+++ b/docs/usage/quickstart.md
@@ -1,0 +1,85 @@
+---
+file_format: mystnb
+kernelspec:
+  name: python3
+---
+
+# Quickstart
+
+This page takes you from a fresh install to your first weather time series in a few minutes.
+For the full feature set, continue with the [Python API](python-api.md) chapter.
+
+## Installation
+
+Wetterdienst is available on PyPI and requires Python 3.10 or newer:
+
+```bash
+pip install wetterdienst
+```
+
+The base install keeps dependencies light. Optional features live behind
+[extras](docker.md) — for example the interpolation feature or exporting to databases:
+
+```bash
+pip install "wetterdienst[interpolation,export]"
+```
+
+## Your first request
+
+A request is defined by the data you want (`parameters`) and, optionally, a time range.
+Here we ask the German Weather Service (DWD) for the daily climate summary and then pick a
+single station by its id — `1048`, Dresden-Klotzsche:
+
+```{code-cell}
+---
+mystnb:
+  number_source_lines: true
+---
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
+
+request = DwdObservationRequest(
+    parameters=[("daily", "climate_summary", "temperature_air_mean_2m")],
+    periods="recent",
+)
+stations = request.filter_by_station_id(station_id="1048")
+stations.df
+```
+
+`stations.df` holds the station metadata. To fetch the actual measurements, ask the
+associated values result:
+
+```{code-cell}
+---
+mystnb:
+  number_source_lines: true
+---
+values = stations.values.all()
+values.df
+```
+
+That's it — `values.df` is a [polars](https://pola.rs/) DataFrame you can filter, plot or
+export.
+
+## The same request on the command line
+
+Everything the Python API can do is also available via the CLI:
+
+```bash
+# List the station's metadata.
+wetterdienst stations --provider dwd --network observation \
+  --parameters daily/climate_summary --periods recent --station 1048
+
+# Fetch the values.
+wetterdienst values --provider dwd --network observation \
+  --parameters daily/climate_summary/temperature_air_mean_2m --periods recent --station 1048
+```
+
+## Where to go next
+
+- [Python API](python-api.md) — the full request/stations/values workflow, filtering,
+  formatting, SQL and export.
+- [Python Examples](python-examples.md) — ready-to-run snippets per provider and network.
+- [Data / Overview](../data/overview.md) — every supported provider and what it offers.
+- [Interpolation & Summary](interpolation.md) — derive a series for an arbitrary location.
+- [Climate Stripes](stripes.md) — generate warming-stripes visualizations.
+- [Settings](settings.md) — units, caching, proxies and interpolation knobs.

--- a/docs/usage/settings.md
+++ b/docs/usage/settings.md
@@ -27,7 +27,7 @@ The following settings are available:
 
 | name                 | description                                                           | default                            |
 |----------------------|-----------------------------------------------------------------------|------------------------------------|
-| cache_disable        | switch of caching                                                     | False                              |
+| cache_disable        | switch off caching                                                    | False                              |
 | cache_dir            | set the directory where the cache is stored                           | platform specific / "wetterdienst" |
 | fsspec_client_kwargs | pass arguments to fsspec, especially for querying data behind a proxy | {}                                 |
 | use_certifi          | use certifi certificate bundle instead of system certificates         | False                              |

--- a/docs/usage/station_history.md
+++ b/docs/usage/station_history.md
@@ -4,7 +4,7 @@ This section documents the station history feature implemented in the project.
 
 ## Overview
 
-Wetterdienst now includes station history retrieval and metadata versioning. The feature provides:
+Wetterdienst includes station history retrieval and metadata versioning. The feature provides:
 
 - Historical station snapshots: retrieve station metadata as it was at a given date or over a date range.
 - Lifecycle events: query events such as created, updated, decommissioned for stations.
@@ -16,8 +16,8 @@ Wetterdienst now includes station history retrieval and metadata versioning. The
 Example usage via the Python API:
 
 ```python
-from src.wetterdienst import Settings
-from src.wetterdienst.provider.dwd.observation import DwdObservationRequest
+from wetterdienst import Settings
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
 
 settings = Settings()
 
@@ -43,6 +43,25 @@ print(history.history.parameter)
 # missing data periods
 print(history.history.missing_data)
 ```
+
+## Command line
+
+The same history is available through the `history` command. Select stations the same way
+as for `stations`/`values` (via `--station` or `--all`) and optionally narrow the result to
+specific `--sections`:
+
+```bash
+# Full history for station 1048 (Dresden-Klotzsche).
+wetterdienst history --provider dwd --network observation --parameters daily/kl --station 1048
+
+# Only the naming and geography sections.
+wetterdienst history --provider dwd --network observation --parameters daily/kl \
+  --station 1048 --sections name,geography
+```
+
+Available `--sections` are `name`, `parameter`, `device`, `geography` and `missing_data`.
+The result is returned as JSON; use `--target file://history.json` to write it to a file
+(the target must end with `.json`).
 
 ## REST API
 

--- a/docs/usage/stripes.md
+++ b/docs/usage/stripes.md
@@ -1,0 +1,91 @@
+# Climate Stripes
+
+Climate stripes (also known as
+["warming stripes"](https://en.wikipedia.org/wiki/Warming_stripes)) are a minimalistic
+visualization popularized by Ed Hawkins that encodes the long-term trend of a climate
+variable as a sequence of coloured bars — one bar per year, coloured from blue (cooler /
+drier) to red (warmer / wetter).
+
+Wetterdienst can generate climate stripes from **DWD** daily observations for two kinds:
+
+- `temperature` — based on the annual mean air temperature
+- `precipitation` — based on the annual precipitation sum
+
+The feature is exposed via the [command line interface](#command-line-interface) and the
+[REST API](#rest-api). The hosted [web frontend](https://www.wetterdienst.eobs.org) also
+offers an interactive Climate Stripes view.
+
+## Command Line Interface
+
+The `stripes` command group has two subcommands: `stations` and `values`.
+
+### Stations
+
+List the stations for which climate stripes can be generated:
+
+```bash
+# Stations available for temperature stripes.
+wetterdienst stripes stations --kind temperature
+
+# Only currently active stations, as CSV.
+wetterdienst stripes stations --kind precipitation --active true --format csv
+```
+
+Options:
+
+| option      | description                                          | default |
+|-------------|------------------------------------------------------|---------|
+| `--kind`    | `temperature` or `precipitation` (required)          | —       |
+| `--active`  | only include stations that are still reporting       | `true`  |
+| `--format`  | output format, one of `json`, `geojson`, `csv`       | `json`  |
+| `--pretty`  | pretty-print the output                              | `false` |
+
+### Values
+
+Render the stripes image for a single station, selected either by `--station` (station id)
+or by `--name` (fuzzy name match):
+
+```bash
+# Temperature stripes for station 1048 (Dresden-Klotzsche) written to a PNG file.
+wetterdienst stripes values --kind temperature --station 1048 --target dresden.png
+
+# Precipitation stripes selected by name, restricted to a year range, as SVG to stdout.
+wetterdienst stripes values --kind precipitation --name Hohenpeissenberg \
+  --start_year 1900 --end_year 2020 --format svg
+```
+
+Options:
+
+| option                     | description                                                    | default |
+|----------------------------|----------------------------------------------------------------|---------|
+| `--kind`                   | `temperature` or `precipitation` (required)                    | —       |
+| `--station`                | station id to plot                                             | —       |
+| `--name`                   | station name to plot (fuzzy match)                             | —       |
+| `--start_year`             | first year to include                                         | —       |
+| `--end_year`               | last year to include                                          | —       |
+| `--name_threshold`         | similarity threshold (0–1) for `--name` matching             | `0.80`  |
+| `--show_title`             | draw the station name as a title                             | `true`  |
+| `--show_years`             | draw the first and last year as axis labels                  | `true`  |
+| `--show_data_availability` | draw a marker for the data availability                      | `true`  |
+| `--format`                 | image format, one of `png`, `jpg`, `svg`, `pdf`              | `png`   |
+| `--dpi`                    | image resolution in dots per inch                            | `300`   |
+| `--target`                 | write the image to this file instead of stdout               | —       |
+
+## REST API
+
+When the [REST API](restapi.md) is running, the same functionality is available via three
+endpoints (the examples below use [httpie](https://github.com/httpie/cli)):
+
+```bash
+# List stations available for temperature stripes.
+http localhost:7890/api/stripes/stations kind==temperature
+
+# Get the underlying yearly values for a station.
+http localhost:7890/api/stripes/values kind==temperature station==1048
+
+# Render the stripes image for a station (write the binary body to a file).
+http --download localhost:7890/api/stripes/image kind==temperature station==1048
+```
+
+The `image` endpoint accepts the same rendering options as the CLI (`start_year`,
+`end_year`, `show_title`, `show_years`, `show_data_availability`, `format`, `dpi`).


### PR DESCRIPTION
## Summary

A documentation pass that fixes the broken docs build, corrects inaccurate content, adds pages for previously undocumented features, and brings the thin provider intro pages up to a consistent baseline. Split into four logical commits.

The docs build was verified with Sphinx after every change; warnings went from ~40 down to a single pre-existing one (an H1→H3 jump in the public `README.md`, left alone since changing it affects the README's GitHub/PyPI rendering). New executable cells were run against live provider data to confirm they don't ship tracebacks.

## Commits

1. **`fix(docs): repair Sphinx build configuration`** — the autodoc2 package path still pointed at the pre-`src/`-layout location, so the **entire API reference rendered empty**. Repointed to `../src/wetterdienst` and resolved the follow-on issues: read project metadata via `importlib.metadata` (works on Python 3.10, unlike `tomllib`), fixed the `library/core.md` package reference, kept the auto-generated `apidocs` tree out of the build, suppressed benign autodoc2 duplicate warnings, enabled useful MyST extensions, and cleaned up `.readthedocs.yml`/`.gitignore`.

2. **`docs: correct outdated and inaccurate content`** — added the 5 missing providers to the data overview, removed a documented `wetterdienst explorer` command that doesn't exist, fixed a broken toctree reference, a MOSMIX example that silently showed the wrong data, the test marker (`explorer` not `ui`), black→ruff, and assorted typos/broken links.

3. **`docs: add quickstart, interpolation/summary and climate stripes pages`** — new **Quickstart**, a dedicated **Interpolation & Summary** chapter (moved out of the oversized `python-api.md`, plus previously-undocumented CLI/REST usage, and a fixed settings field name), and a **Climate Stripes** page (the README centerpiece had zero docs). Also documented the `wetterdienst history` CLI command.

4. **`docs: flesh out thin provider intro pages`** — 8 provider pages were only a title + toctree, and NOAA lacked a License section. All now have consistent Overview + License sections, with auth requirements and licenses verified against the provider code.

## Notes

- No new runtime dependencies; changes are confined to `docs/`, `.readthedocs.yml`, and `.gitignore`.
- Opened as a draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)