### PR TITLE
docs: clarify filter_by_rank returns all stations in .df (#1353)

### DIFF
--- a/docs/usage/python-api.md
+++ b/docs/usage/python-api.md
@@ -330,6 +330,16 @@ df = stations.df
 df
 ```
 
+```{note}
+Unlike `filter_by_distance`, `filter_by_rank` returns **all** stations sorted by
+distance in `stations.df`, not just `rank` rows. The `rank` limit is applied lazily
+during value collection: Wetterdienst walks the distance-sorted stations and stops
+once `rank` stations *with data* have been consumed (see `ts_skip_empty` and related
+settings below). To see the `rank` closest stations that actually returned data, use
+`stations.values.all().df_stations` rather than `stations.df`. Set
+`ts_skip_empty=False` to take the `rank` closest stations regardless of availability.
+```
+
 #### filter by bbox
 
 ```{code-cell}

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -551,14 +551,26 @@ class TimeseriesRequest:
     ) -> StationsResult:
         """Filter stations by rank.
 
-        Rank is defined by distance to the requested point.
+        Rank is defined by distance to the requested point. The resulting
+        ``StationsResult.df`` holds **all** stations sorted by distance, not just
+        ``rank`` rows: because we cannot know upfront which stations actually carry
+        data for the request, the ``rank`` limit is applied lazily while collecting
+        values. Value collection walks the distance-sorted stations and stops once
+        ``rank`` stations with data (per the ``ts_skip_empty`` / ``ts_skip_threshold``
+        / ``ts_skip_criteria`` settings) have been consumed. The stations that ended
+        up contributing values are then exposed via ``ValuesResult.df_stations``.
+
+        In other words, use ``stations.values.all().df_stations`` (not
+        ``stations.df``) to see the ``rank`` closest stations that actually returned
+        data. Set ``ts_skip_empty=False`` to simply take the ``rank`` closest
+        stations regardless of data availability.
 
         Args:
             latlon: Latitude and longitude for the requested point.
             rank: Number of stations requested.
 
         Returns:
-            StationsResult: Filtered stations.
+            StationsResult: Stations sorted by distance (see note above on ``rank``).
 
         """
         from wetterdienst.util.geo import derive_nearest_neighbours  # noqa: PLC0415


### PR DESCRIPTION
## Summary

Closes #1353.

`filter_by_rank` sorts stations by distance but does **not** slice `StationsResult.df` down to `rank` rows. The `rank` limit is applied lazily during value collection (`TimeseriesValues.query`), which walks the distance-sorted stations and stops once `rank` stations *with data* have been consumed (per `ts_skip_empty` / `ts_skip_threshold` / `ts_skip_criteria`). The stations that actually contributed values are exposed via `ValuesResult.df_stations`.

This surprises users who expect `stations.df` to hold only `rank` rows the way `filter_by_distance` slices its result — the exact confusion reported in #1353.

## Changes

- Expand the `filter_by_rank` docstring to explain that `.df` holds all distance-sorted candidates and that `df_stations` (after value collection) reflects the `rank` stations with data.
- Add a `note` admonition in the Python API guide's "filter by rank" section pointing to `stations.values.all().df_stations` and `ts_skip_empty=False`.

Docs-only / docstring change — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)