### PR TITLE
feat(dwd): add DWD weather alerts (CAP warnings) provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Types of changes:
 
 ### Added
 
+- Add DWD weather alerts (CAP warnings) provider (`dwd/alerts`) with Python API, CLI `alerts`
+  command and REST `/api/alerts` endpoint: all active warnings, one row per alert, with a GeoJSON
+  MultiPolygon geometry, on community (Gemeinde) or district (Landkreis) granularity; a `date`
+  selects a historical snapshot from DWD's rolling ~48-hour window
 - Parse DWD radar site BUFR products (echo top, reflectivity) into a polars DataFrame on
   `RadarResult.df`, opt-in via the `read_bufr` setting (requires the `eccodes` and `bufr` extras)
 - Add RMI (Belgium) observation provider with 10-minute, hourly and daily resolution
@@ -38,6 +42,9 @@ Types of changes:
   reconstructing them from separate year/month/day/hour/minute fields
 - Fix the `about fields` CLI command, which crashed with a `TypeError` because it forwarded
   `resolution` as a separate argument to `describe_fields()`
+- Report coverage cleanly for metadata-less standalone networks (`dwd/radar`, `dwd/alerts`):
+  `about coverage` and `/api/coverage` now return a clear message instead of crashing with an
+  `AttributeError` / HTTP 500
 
 ## [0.128.0] - 2026-07-22
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ or the [table](https://bookdown.org/brry/rdwd/available-datasets.html) provided 
 ## Features
 
 - APIs for stations, values and history (station metadata changes)
+- DWD weather alerts (CAP warnings) with GeoJSON geometry, on community or district basis
 - Get stations nearby a selected location
 - Define your request by arguments such as `parameters`, `periods`, `start date`, `end date`
 - Define general settings in Settings context

--- a/docs/data/provider/dwd/alerts/index.md
+++ b/docs/data/provider/dwd/alerts/index.md
@@ -1,0 +1,90 @@
+# Alerts
+
+## Overview
+
+The DWD publishes its public weather warnings ("Warnungen") in the
+[Common Alerting Protocol (CAP)](https://opendata.dwd.de/weather/alerts/cap/) v1.2 format. Each
+warning is a CAP XML document describing a single alert — its event, severity, timing, texts and
+affected areas. `wetterdienst` exposes the DWD full-snapshot products, which bundle one CAP file per
+currently active warning, and flattens every alert into a single row.
+
+Warnings are available on two spatial granularities, selected via the `granularity` argument:
+
+- `community` (default) — per municipality (Gemeinde, `COMMUNEUNION` products)
+- `district` — per district (Landkreis, `DISTRICT` products)
+
+and in several languages via the `language` argument (`de`, `en` (default), `es`, `fr`, `mul`).
+
+Because the products are full snapshots, an empty result simply means there are currently no active
+warnings. The data faithfully follows the official
+[CAP DWD Profile](https://www.dwd.de/DE/leistungen/opendata/help/warnungen/cap_dwd_profile_en_pdf_1_12.pdf).
+
+## Historical snapshots
+
+DWD keeps a rolling **~48-hour** window of timestamped snapshots (there is no long-term archive).
+Pass a `date` to select the warnings that were active at a point in time — the newest snapshot
+produced at or before that moment is used. A naive datetime or ISO string is interpreted as UTC. A
+`date` outside the rolling window raises an error. Omit `date` for the current (latest) snapshot.
+
+```python
+from wetterdienst.provider.dwd.alerts import DwdWeatherAlertRequest
+
+# warnings that were active ~6 hours ago
+request = DwdWeatherAlertRequest(granularity="district", date="2026-07-26T10:00:00")
+result = request.query()
+print(result.snapshot)  # UTC production time of the selected snapshot
+```
+
+## As DataFrame
+
+`DwdWeatherAlertRequest.query()` returns a `DwdWeatherAlertResult` whose `.df` attribute is a
+[polars](https://pola.rs/) DataFrame with one row per alert. Each row carries the alert/info fields
+(event, severity, urgency, certainty, timing, headline, description, ...), the DWD event code and
+groups, the `parameters` (an ordered list of `{name, value}`, since a name such as `wind direction`
+may repeat), the affected `warncell_ids` / area names, and a GeoJSON `MultiPolygon` `geometry`
+combining all of the alert's polygon areas (`null` for alerts that only reference warn cells without
+polygons). The result's `.snapshot` attribute holds the UTC production time of the selected snapshot
+(`None` for the latest one).
+
+```python
+from wetterdienst.provider.dwd.alerts import DwdWeatherAlertRequest
+
+request = DwdWeatherAlertRequest(granularity="community", language="en")
+result = request.query()
+print(result.df)
+```
+
+The result can also be rendered directly:
+
+```python
+result.to_dict()                    # {"snapshot": ..., "alerts": [...]} with nested geometry/parameters
+result.to_ogc_feature_collection()  # GeoJSON FeatureCollection (geometry = MultiPolygon, + snapshot)
+result.to_geojson()                 # GeoJSON string
+result.to_csv()                     # CSV (list columns comma-joined, nested fields JSON-encoded)
+```
+
+## CLI
+
+```bash
+# all current warnings on community basis as JSON
+wetterdienst alerts
+
+# district basis, German, as GeoJSON
+wetterdienst alerts --granularity=district --language=de --format=geojson
+
+# warnings active at a past point in time (within the rolling ~48h window)
+wetterdienst alerts --granularity=district --date=2026-07-26T10:00:00
+
+# write current warnings to a GeoJSON file
+wetterdienst alerts --format=geojson --target=file://alerts.geojson
+```
+
+## REST API
+
+```bash
+wetterdienst restapi --listen 0.0.0.0:3000
+```
+
+```bash
+curl "http://localhost:3000/api/alerts?granularity=community&format=geojson"
+```

--- a/docs/data/provider/dwd/index.md
+++ b/docs/data/provider/dwd/index.md
@@ -25,6 +25,9 @@ The data as offered by the DWD through ``wetterdienst`` includes:
     - technical products (heating/cooling degree days, climate correction factor) and climate
       products (radiation & sunshine duration, soil data)
     - hourly, daily and monthly resolution, for stations in Germany
+- [Alerts](alerts/index.md) — public weather warnings in Common Alerting Protocol (CAP) format
+    - all currently active warnings, one row per alert, with GeoJSON MultiPolygon geometry
+    - community (Gemeinde) or district (Landkreis) granularity, several languages
 
 For a quick overview of the work of the DWD check the current 
 [dwd report](https://www.dwd.de/SharedDocs/downloads/DE/allgemein/zahlen_und_fakten.pdf?__blob=publicationFile&v=14) 
@@ -47,4 +50,5 @@ observation/index.md
 road/index.md
 radar/index.md
 derived/index.md
+alerts/index.md
 ```

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -31,6 +31,7 @@ class Wetterdienst:
             "dmo": "wetterdienst.provider.dwd.dmo.DwdDmoRequest",
             "road": "wetterdienst.provider.dwd.road.DwdRoadRequest",
             "radar": "wetterdienst.provider.dwd.radar.DwdRadarValues",
+            "alerts": "wetterdienst.provider.dwd.alerts.DwdWeatherAlertRequest",
             "derived": "wetterdienst.provider.dwd.derived.DwdDerivedRequest",
         },
         "eccc": {

--- a/src/wetterdienst/provider/dwd/alerts/__init__.py
+++ b/src/wetterdienst/provider/dwd/alerts/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""DWD CAP weather alerts (warnings) provider."""
+
+from wetterdienst.provider.dwd.alerts.api import DwdWeatherAlertRequest, DwdWeatherAlertResult
+from wetterdienst.provider.dwd.alerts.metadata import (
+    DwdWeatherAlertGranularity,
+    DwdWeatherAlertLanguage,
+)
+
+__all__ = [
+    "DwdWeatherAlertGranularity",
+    "DwdWeatherAlertLanguage",
+    "DwdWeatherAlertRequest",
+    "DwdWeatherAlertResult",
+]

--- a/src/wetterdienst/provider/dwd/alerts/api.py
+++ b/src/wetterdienst/provider/dwd/alerts/api.py
@@ -1,0 +1,373 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""API for DWD CAP weather alerts (warnings).
+
+DWD publishes its public warnings as zipped Common Alerting Protocol (CAP) v1.2 documents at
+https://opendata.dwd.de/weather/alerts/cap/ . This module exposes the DWD full-snapshot products
+(one CAP file per active warning) on community (Gemeinde) or district (Landkreis) basis and
+flattens each alert into a single row, including a GeoJSON ``MultiPolygon`` geometry.
+
+Alerts do not fit the station/timeseries model, so -- like ``DwdRadarValues`` -- this is a
+standalone request class returning its own result object rather than a ``TimeseriesRequest``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import re
+import zipfile
+from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.provider.dwd.alerts.metadata import (
+    DWD_ALERTS_BASE_URL,
+    DwdWeatherAlertGranularity,
+    DwdWeatherAlertLanguage,
+)
+from wetterdienst.provider.dwd.alerts.parser import parse_cap_alert
+from wetterdienst.settings import Settings
+from wetterdienst.util.network import download_file, list_remote_directory_fsspec
+
+if TYPE_CHECKING:
+    from io import BytesIO
+
+log = logging.getLogger(__name__)
+
+# The alert row columns whose values are nested structures; stored as JSON strings in the DataFrame
+# but returned as native objects by ``to_dict``/``to_ogc_feature_collection``.
+_JSON_COLUMNS = ("parameters", "geometry")
+
+# List-valued alert row columns.
+_LIST_COLUMNS = ("groups", "warncell_ids", "area_names")
+
+# Column order / schema of the flat alert DataFrame (``.df``).
+_SCHEMA = {
+    "alert_id": pl.String,
+    "status": pl.String,
+    "msg_type": pl.String,
+    "category": pl.String,
+    "event": pl.String,
+    "event_code": pl.String,
+    "groups": pl.List(pl.String),
+    "response_type": pl.String,
+    "urgency": pl.String,
+    "severity": pl.String,
+    "certainty": pl.String,
+    "effective": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "onset": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "expires": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "sent": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "headline": pl.String,
+    "description": pl.String,
+    "instruction": pl.String,
+    "sender_name": pl.String,
+    "web": pl.String,
+    "contact": pl.String,
+    "area_color": pl.String,
+    "parameters": pl.String,
+    "warncell_ids": pl.List(pl.String),
+    "area_names": pl.List(pl.String),
+    "geometry": pl.String,
+    "references": pl.String,
+    "language": pl.String,
+}
+
+
+class DwdWeatherAlertResult:
+    """Result of a :class:`DwdWeatherAlertRequest`, wrapping the parsed alerts as a polars DataFrame."""
+
+    def __init__(
+        self,
+        df: pl.DataFrame,
+        granularity: DwdWeatherAlertGranularity,
+        language: DwdWeatherAlertLanguage,
+        snapshot: dt.datetime | None = None,
+    ) -> None:
+        """Initialize the result.
+
+        Args:
+            df: the flat alert DataFrame following ``_SCHEMA`` (nested fields JSON-encoded).
+            granularity: the requested granularity.
+            language: the requested language.
+            snapshot: production time (UTC) of the selected snapshot, or ``None`` for the latest one.
+
+        """
+        self.df = df
+        self.granularity = granularity
+        self.language = language
+        self.snapshot = snapshot
+
+    def _alerts(self) -> list[dict[str, Any]]:
+        """Return the alert rows with nested fields (parameters, geometry) decoded to native objects."""
+        alerts = []
+        for row in self.df.iter_rows(named=True):
+            alert = dict(row)
+            for column in _JSON_COLUMNS:
+                alert[column] = json.loads(row[column]) if row[column] is not None else None
+            for column in ("effective", "onset", "expires", "sent"):
+                value: dt.datetime | None = row[column]
+                alert[column] = value.isoformat() if value is not None else None
+            alerts.append(alert)
+        return alerts
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the alerts as ``{"snapshot": ..., "alerts": [...]}`` with nested geometry/parameters.
+
+        ``snapshot`` is the UTC production time (ISO string) of the selected snapshot, or ``None``
+        for the latest one, so callers can tell which point-in-time snapshot they received.
+        """
+        return {
+            "snapshot": self.snapshot.isoformat() if self.snapshot is not None else None,
+            "alerts": self._alerts(),
+        }
+
+    def to_json(self, indent: bool = False) -> str:  # noqa: FBT001, FBT002
+        """Return the alerts as a JSON string."""
+        return json.dumps(self.to_dict(), indent=4 if indent else None, ensure_ascii=False)
+
+    def to_ogc_feature_collection(self) -> dict[str, Any]:
+        """Return the alerts as a GeoJSON ``FeatureCollection``.
+
+        Each alert becomes a ``Feature`` whose geometry is its ``MultiPolygon`` (``null`` when the
+        alert only carries entity/``WARNCELLID`` areas without polygons) and whose properties are the
+        remaining alert fields.
+        """
+        features = []
+        for alert in self._alerts():
+            geometry = alert.pop("geometry")
+            features.append({"type": "Feature", "geometry": geometry, "properties": alert})
+        # "snapshot" is a GeoJSON foreign member carrying the selected snapshot's UTC production time.
+        return {
+            "type": "FeatureCollection",
+            "snapshot": self.snapshot.isoformat() if self.snapshot is not None else None,
+            "features": features,
+        }
+
+    def to_geojson(self, indent: bool = False) -> str:  # noqa: FBT001, FBT002
+        """Return the alerts as a GeoJSON ``FeatureCollection`` string."""
+        return json.dumps(self.to_ogc_feature_collection(), indent=4 if indent else None, ensure_ascii=False)
+
+    def to_csv(self) -> str:
+        """Return the flat alert DataFrame as CSV.
+
+        List columns are comma-joined and the ``parameters``/``geometry`` structures stay
+        JSON-encoded, since CSV cannot represent nested data.
+        """
+        df = self.df.with_columns(pl.col(column).list.join(",") for column in _LIST_COLUMNS)
+        return df.write_csv()
+
+    def to_format(self, fmt: str, *, indent: bool = False) -> str:
+        """Render the result in the requested format (``json``, ``geojson`` or ``csv``)."""
+        if fmt == "json":
+            return self.to_json(indent=indent)
+        if fmt == "geojson":
+            return self.to_geojson(indent=indent)
+        if fmt == "csv":
+            return self.to_csv()
+        msg = f"format {fmt!r} not supported, use one of json, geojson, csv"
+        raise ValueError(msg)
+
+
+class DwdWeatherAlertRequest:
+    """API for DWD CAP weather alerts (warnings).
+
+    Fetches a DWD warning snapshot (all warnings active at a point in time) for a given granularity
+    and language and parses it into a :class:`DwdWeatherAlertResult`. By default the latest snapshot
+    is used; a ``date`` selects a historical snapshot from DWD's rolling ~48-hour archive instead.
+    """
+
+    def __init__(
+        self,
+        granularity: str | DwdWeatherAlertGranularity = DwdWeatherAlertGranularity.COMMUNITY,
+        language: str | DwdWeatherAlertLanguage = DwdWeatherAlertLanguage.ENGLISH,
+        date: str | dt.datetime | None = None,
+        settings: Settings | None = None,
+    ) -> None:
+        """Initialize the request.
+
+        Args:
+            granularity: ``community`` (per Gemeinde, default) or ``district`` (per Landkreis).
+            language: one of ``de``, ``en`` (default), ``es``, ``fr``, ``mul``.
+            date: point in time to select the active-warnings snapshot for. ``None`` (default) uses
+                the latest snapshot. Otherwise the newest snapshot produced at or before ``date`` is
+                used; it must fall within DWD's rolling ~48-hour window. A naive datetime or ISO
+                string is interpreted as UTC.
+            settings: settings for the request.
+
+        """
+        self.granularity = self._parse_granularity(granularity)
+        self.language = self._parse_language(language)
+        self.date = self._parse_date(date)
+        self.settings = settings or Settings()
+
+    def __repr__(self) -> str:
+        """Return a string representation of the request."""
+        return (
+            f"DwdWeatherAlertRequest(granularity={self.granularity.value}, "
+            f"language={self.language.value}, date={self.date.isoformat() if self.date else None})"
+        )
+
+    @staticmethod
+    def _parse_granularity(granularity: str | DwdWeatherAlertGranularity) -> DwdWeatherAlertGranularity:
+        if isinstance(granularity, DwdWeatherAlertGranularity):
+            return granularity
+        value = str(granularity).strip().lower()
+        mapping = {
+            "community": DwdWeatherAlertGranularity.COMMUNITY,
+            "communeunion": DwdWeatherAlertGranularity.COMMUNITY,
+            "commune": DwdWeatherAlertGranularity.COMMUNITY,
+            "gemeinde": DwdWeatherAlertGranularity.COMMUNITY,
+            "district": DwdWeatherAlertGranularity.DISTRICT,
+            "landkreis": DwdWeatherAlertGranularity.DISTRICT,
+        }
+        try:
+            return mapping[value]
+        except KeyError as e:
+            msg = f"granularity {granularity!r} not supported, use 'community' or 'district'"
+            raise ValueError(msg) from e
+
+    @staticmethod
+    def _parse_language(language: str | DwdWeatherAlertLanguage) -> DwdWeatherAlertLanguage:
+        if isinstance(language, DwdWeatherAlertLanguage):
+            return language
+        value = str(language).strip().lower()
+        try:
+            return DwdWeatherAlertLanguage(value)
+        except ValueError as e:
+            supported = ", ".join(item.value for item in DwdWeatherAlertLanguage)
+            msg = f"language {language!r} not supported, use one of {supported}"
+            raise ValueError(msg) from e
+
+    @staticmethod
+    def _parse_date(date: str | dt.datetime | None) -> dt.datetime | None:
+        if date is None:
+            return None
+        if isinstance(date, str):
+            # An empty/whitespace date (e.g. from an omitted-but-present ``?date=`` query param)
+            # means "latest", not an invalid timestamp.
+            date = date.strip()
+            if not date:
+                return None
+            parsed = dt.datetime.fromisoformat(date)
+        else:
+            parsed = date
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=ZoneInfo("UTC"))
+        return parsed.astimezone(ZoneInfo("UTC"))
+
+    @property
+    def _directory_url(self) -> str:
+        """Return the URL of the snapshot directory for this granularity."""
+        return f"{DWD_ALERTS_BASE_URL}/{self.granularity.product}/"
+
+    @property
+    def _filename_pattern(self) -> re.Pattern[str]:
+        """Return a regex matching this granularity/language's timestamped snapshot filenames."""
+        return re.compile(
+            rf"Z_CAP_C_EDZW_(\d{{14}})_PVW_STATUS_PREMIUMDWD_{self.granularity.token}_{self.language.suffix}\.zip$",
+        )
+
+    @property
+    def url(self) -> str:
+        """Return the URL of the ``LATEST`` CAP snapshot zip for this granularity and language."""
+        filename = f"Z_CAP_C_EDZW_LATEST_PVW_STATUS_PREMIUMDWD_{self.granularity.token}_{self.language.suffix}.zip"
+        return f"{self._directory_url}{filename}"
+
+    def _resolve_snapshot(self) -> tuple[str, dt.datetime | None]:
+        """Resolve the request to a concrete snapshot ``(url, production_time)``.
+
+        For a dateless request this is the ``LATEST`` alias (production time unknown -> ``None``).
+        For a dated request the newest snapshot produced at or before ``date`` is selected from the
+        directory listing; the filename timestamps are UTC. Raises ``ValueError`` if ``date`` falls
+        before DWD's rolling window (no snapshot at or before it is available).
+        """
+        if self.date is None:
+            return self.url, None
+
+        pattern = self._filename_pattern
+        snapshots: list[tuple[dt.datetime, str]] = []
+        for entry in list_remote_directory_fsspec(self._directory_url, settings=self.settings):
+            match = pattern.search(entry["name"].rsplit("/", 1)[-1])
+            if match:
+                timestamp = dt.datetime.strptime(match.group(1), "%Y%m%d%H%M%S").replace(tzinfo=ZoneInfo("UTC"))
+                snapshots.append((timestamp, entry["name"]))
+
+        candidates = [(timestamp, name) for timestamp, name in snapshots if timestamp <= self.date]
+        if not candidates:
+            earliest = min((timestamp for timestamp, _ in snapshots), default=None)
+            hint = f" earliest available is {earliest.isoformat()}." if earliest else ""
+            msg = (
+                f"no weather-alerts snapshot available at or before {self.date.isoformat()} "
+                f"(DWD only keeps a rolling ~48-hour window).{hint}"
+            )
+            raise ValueError(msg)
+
+        timestamp, name = max(candidates)
+        url = name if name.startswith("http") else f"{self._directory_url}{name.rsplit('/', 1)[-1]}"
+        return url, timestamp
+
+    def query(self) -> DwdWeatherAlertResult:
+        """Download and parse the selected DWD warning snapshot (latest by default)."""
+        url, snapshot = self._resolve_snapshot()
+        # LATEST is a moving alias -> short TTL; a timestamped snapshot is immutable -> cache longer.
+        ttl = CacheExpiry.FIVE_MINUTES if snapshot is None else CacheExpiry.TWELVE_HOURS
+        log.info(f"acquiring weather alerts from {url}")
+        file = download_file(
+            url=url,
+            cache_dir=self.settings.cache_dir,
+            ttl=ttl,
+            client_kwargs=self.settings.fsspec_client_kwargs,
+            cache_disable=self.settings.cache_disable,
+            use_certifi=self.settings.use_certifi,
+        )
+        # A download failure (e.g. HTTP 404 from a snapshot that rolled off the window between the
+        # directory listing and this download, a timeout, or no internet) is surfaced as content
+        # being an Exception; wrap it with context instead of leaking the raw fsspec error.
+        if isinstance(file.content, Exception):
+            msg = f"could not download weather alerts snapshot from {url}"
+            raise OSError(msg) from file.content
+        try:
+            alerts = self._parse_archive(file.content)
+        except zipfile.BadZipFile as e:
+            msg = f"weather alerts snapshot from {url} is not a valid zip archive"
+            raise OSError(msg) from e
+        df = self._build_dataframe(alerts)
+        return DwdWeatherAlertResult(df=df, granularity=self.granularity, language=self.language, snapshot=snapshot)
+
+    @staticmethod
+    def _parse_archive(content: BytesIO) -> list[dict[str, Any]]:
+        """Parse every CAP XML file inside the snapshot zip into an alert row.
+
+        An empty archive (~22 bytes) means there are currently no active warnings.
+        """
+        alerts = []
+        with zipfile.ZipFile(content) as archive:
+            for name in archive.namelist():
+                if not name.lower().endswith(".xml"):
+                    continue
+                alert = parse_cap_alert(archive.read(name))
+                if alert is not None:
+                    alerts.append(alert)
+        return alerts
+
+    @staticmethod
+    def _build_dataframe(alerts: list[dict[str, Any]]) -> pl.DataFrame:
+        """Build the flat alert DataFrame, JSON-encoding the nested (parameters, geometry) fields."""
+        if not alerts:
+            return pl.DataFrame(schema=_SCHEMA)
+        rows = []
+        for alert in alerts:
+            row = {column: alert.get(column) for column in _SCHEMA}
+            for column in _JSON_COLUMNS:
+                row[column] = (
+                    json.dumps(alert.get(column), ensure_ascii=False) if alert.get(column) is not None else None
+                )
+            for column in _LIST_COLUMNS:
+                row[column] = alert.get(column) or []
+            rows.append(row)
+        return pl.DataFrame(rows, schema=_SCHEMA)

--- a/src/wetterdienst/provider/dwd/alerts/metadata.py
+++ b/src/wetterdienst/provider/dwd/alerts/metadata.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Metadata and enums for DWD CAP weather alerts.
+
+The alert products are published as zipped Common Alerting Protocol (CAP) v1.2 documents at
+https://opendata.dwd.de/weather/alerts/cap/ . We only expose the DWD full-snapshot ("_DWD_STAT")
+products, which contain one CAP XML file per currently active warning, on either community
+(Gemeinde / ``COMMUNEUNION``) or district (Landkreis / ``DISTRICT``) basis. See the official
+"CAP DWD Profile" documentation for the full schema.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+DWD_ALERTS_BASE_URL = "https://opendata.dwd.de/weather/alerts/cap"
+
+
+class DwdWeatherAlertGranularity(Enum):
+    """Spatial granularity of the DWD CAP alert products.
+
+    - ``community`` maps to the ``COMMUNEUNION`` products (per Gemeinde).
+    - ``district`` maps to the ``DISTRICT`` products (per Landkreis).
+    """
+
+    COMMUNITY = "community"
+    DISTRICT = "district"
+
+    @property
+    def product(self) -> str:
+        """Return the DWD full-snapshot product directory for this granularity."""
+        return {
+            DwdWeatherAlertGranularity.COMMUNITY: "COMMUNEUNION_DWD_STAT",
+            DwdWeatherAlertGranularity.DISTRICT: "DISTRICT_DWD_STAT",
+        }[self]
+
+    @property
+    def token(self) -> str:
+        """Return the granularity token used in the CAP zip filename."""
+        return {
+            DwdWeatherAlertGranularity.COMMUNITY: "COMMUNEUNION",
+            DwdWeatherAlertGranularity.DISTRICT: "DISTRICT",
+        }[self]
+
+
+class DwdWeatherAlertLanguage(Enum):
+    """Language of the DWD CAP alert products.
+
+    ``multi`` (``MUL``) bundles every language into one file; only its first ``<info>`` block per
+    alert is honoured by the parser, so prefer a single language for one-row-per-alert output.
+    """
+
+    GERMAN = "de"
+    ENGLISH = "en"
+    SPANISH = "es"
+    FRENCH = "fr"
+    MULTI = "mul"
+
+    @property
+    def suffix(self) -> str:
+        """Return the language suffix used in the CAP zip filename (e.g. ``EN``)."""
+        return self.value.upper()

--- a/src/wetterdienst/provider/dwd/alerts/parser.py
+++ b/src/wetterdienst/provider/dwd/alerts/parser.py
@@ -1,0 +1,231 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Parser for DWD Common Alerting Protocol (CAP) v1.2 warning documents.
+
+Each CAP file holds exactly one ``<alert>`` with one or more ``<info>`` blocks (one per language)
+and one or more ``<area>`` blocks. We flatten a single alert into one row: the alert/info fields
+plus the union of all polygon areas as a GeoJSON ``MultiPolygon`` geometry, and the list of the
+entity areas' ``WARNCELLID`` geocodes and names. See the official "CAP DWD Profile" for the schema.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import TYPE_CHECKING, Any
+from zoneinfo import ZoneInfo
+
+from lxml.etree import XMLParser, fromstring
+
+if TYPE_CHECKING:
+    from lxml.etree import _Element
+
+# Disable entity resolution and network access -- DWD is first-party, but there is no reason to
+# fetch external entities/DTDs and it guards against XXE (matching the DWD mosmix KML reader and
+# the FMI parser).
+_XML_PARSER = XMLParser(resolve_entities=False, no_network=True)
+
+
+def _local_name(tag: object) -> str:
+    """Return an element's local name, stripping lxml's ``{namespace}`` prefix.
+
+    lxml yields non-element nodes (comments, processing instructions) with a callable ``tag``
+    during iteration; those are reported as an empty local name so callers skip them.
+    """
+    if not isinstance(tag, str):
+        return ""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _text(element: _Element | None) -> str | None:
+    """Return the stripped text of an element, or ``None`` if empty/absent."""
+    if element is None or element.text is None:
+        return None
+    return element.text.strip() or None
+
+
+def _parse_datetime(text: str | None) -> dt.datetime | None:
+    """Parse a CAP timestamp (local time with offset, e.g. ``2026-07-26T09:23:00+02:00``) to UTC."""
+    if not text:
+        return None
+    parsed = dt.datetime.fromisoformat(text)
+    return parsed.astimezone(ZoneInfo("UTC"))
+
+
+def _parse_polygon(text: str) -> list[list[float]]:
+    """Parse a CAP polygon (whitespace-delimited ``lat,lon`` pairs) into a GeoJSON ring.
+
+    CAP orders coordinates as ``latitude,longitude`` while GeoJSON expects ``[longitude, latitude]``,
+    so the pair is swapped here.
+    """
+    ring = []
+    for pair in text.split():
+        lat, lon = pair.split(",")
+        ring.append([float(lon), float(lat)])
+    return ring
+
+
+def _collect_key_values(info: _Element, container: str) -> list[tuple[str, str]]:
+    """Return the ``(valueName, value)`` pairs of every ``container`` child of ``info``.
+
+    Used for both ``<eventCode>`` and ``<parameter>`` elements, which share the same
+    ``<valueName>``/``<value>`` layout.
+    """
+    pairs = []
+    for element in info:
+        if _local_name(element.tag) != container:
+            continue
+        name = value = None
+        for child in element:
+            tag = _local_name(child.tag)
+            if tag == "valueName":
+                name = _text(child)
+            elif tag == "value":
+                value = _text(child)
+        if name is not None:
+            pairs.append((name, value or ""))
+    return pairs
+
+
+def _parse_area(area: _Element) -> dict[str, Any]:  # noqa: C901
+    """Parse a single ``<area>`` block.
+
+    Returns its ``areaDesc``, the exterior polygon rings it defines, the ``EXCLUDE_POLYGON`` holes,
+    and any ``WARNCELLID`` geocodes. A DWD area is either polygon-based (``areaDesc`` = "polygonal
+    event area") or entity-based (a named Gemeinde/Landkreis carrying a ``WARNCELLID``).
+    """
+    area_desc = None
+    polygons: list[list[list[float]]] = []
+    holes: list[list[list[float]]] = []
+    warncell_ids: list[str] = []
+    for element in area:
+        tag = _local_name(element.tag)
+        if tag == "areaDesc":
+            area_desc = _text(element)
+        elif tag == "polygon":
+            text = _text(element)
+            if text:
+                polygons.append(_parse_polygon(text))
+        elif tag == "geocode":
+            name = value = None
+            for child in element:
+                child_tag = _local_name(child.tag)
+                if child_tag == "valueName":
+                    name = _text(child)
+                elif child_tag == "value":
+                    value = _text(child)
+            if name == "WARNCELLID" and value:
+                warncell_ids.append(value)
+            elif name == "EXCLUDE_POLYGON" and value:
+                holes.append(_parse_polygon(value))
+    return {
+        "area_desc": area_desc,
+        "polygons": polygons,
+        "holes": holes,
+        "warncell_ids": warncell_ids,
+    }
+
+
+def _build_multipolygon(areas: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Combine all polygon areas into a single GeoJSON ``MultiPolygon`` (or ``None`` if there are none).
+
+    Per the DWD profile, an area with a hole (``EXCLUDE_POLYGON``) carries exactly one ``<polygon>``,
+    so holes are attached to that polygon; areas with multiple polygons get one GeoJSON polygon each
+    without holes.
+    """
+    coordinates: list[list[list[list[float]]]] = []
+    for area in areas:
+        polygons = area["polygons"]
+        holes = area["holes"]
+        if not polygons:
+            continue
+        if len(polygons) == 1:
+            coordinates.append([polygons[0], *holes])
+        else:
+            coordinates.extend([polygon] for polygon in polygons)
+    if not coordinates:
+        return None
+    return {"type": "MultiPolygon", "coordinates": coordinates}
+
+
+def parse_cap_alert(content: bytes) -> dict[str, Any] | None:  # noqa: C901
+    """Parse one CAP XML document into a flat alert row, or ``None`` if it is not an alert.
+
+    Only the first ``<info>`` block is honoured, which for the single-language products is the only
+    one; for the ``MUL`` product it is the first bundled language.
+    """
+    root = fromstring(content, parser=_XML_PARSER)
+    if _local_name(root.tag) != "alert":
+        return None
+
+    alert: dict[str, Any] = {
+        "alert_id": None,
+        "status": None,
+        "msg_type": None,
+        "references": None,
+    }
+    info = None
+    for element in root:
+        tag = _local_name(element.tag)
+        if tag == "identifier":
+            alert["alert_id"] = _text(element)
+        elif tag == "status":
+            alert["status"] = _text(element)
+        elif tag == "msgType":
+            alert["msg_type"] = _text(element)
+        elif tag == "sent":
+            alert["sent"] = _parse_datetime(_text(element))
+        elif tag == "references":
+            alert["references"] = _text(element)
+        elif tag == "info" and info is None:
+            info = element
+
+    if info is None:
+        return alert
+
+    simple_fields = {
+        "language": "language",
+        "category": "category",
+        "event": "event",
+        "responseType": "response_type",
+        "urgency": "urgency",
+        "severity": "severity",
+        "certainty": "certainty",
+        "senderName": "sender_name",
+        "headline": "headline",
+        "description": "description",
+        "instruction": "instruction",
+        "web": "web",
+        "contact": "contact",
+    }
+    datetime_fields = {"effective": "effective", "onset": "onset", "expires": "expires"}
+    for key in (*simple_fields.values(), *datetime_fields.values()):
+        alert.setdefault(key, None)
+
+    areas: list[dict[str, Any]] = []
+    for element in info:
+        tag = _local_name(element.tag)
+        if tag in simple_fields:
+            alert[simple_fields[tag]] = _text(element)
+        elif tag in datetime_fields:
+            alert[datetime_fields[tag]] = _parse_datetime(_text(element))
+        elif tag == "area":
+            areas.append(_parse_area(element))
+
+    event_codes = _collect_key_values(info, "eventCode")
+    groups = [value for name, value in event_codes if name == "GROUP"]
+    event_code_map = dict(event_codes)
+    alert["event_code"] = event_code_map.get("II")
+    alert["groups"] = groups
+    alert["area_color"] = event_code_map.get("AREA_COLOR")
+    # Kept as an ordered list of {name, value} rather than a dict: the DWD profile allows a
+    # <parameter> valueName to repeat within one alert (e.g. a veering "wind direction" given
+    # several times), which a dict would silently collapse to the last value.
+    alert["parameters"] = [{"name": name, "value": value} for name, value in _collect_key_values(info, "parameter")]
+
+    warncell_ids = [warncell_id for area in areas for warncell_id in area["warncell_ids"]]
+    area_names = [area["area_desc"] for area in areas if area["warncell_ids"] and area["area_desc"] is not None]
+    alert["warncell_ids"] = warncell_ids
+    alert["area_names"] = area_names
+    alert["geometry"] = _build_multipolygon(areas)
+
+    return alert

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -624,6 +624,20 @@ Explore OPERA radar stations:
     wetterdienst radar --odim-code=deasb
     wetterdienst radar --wmo-code=10103
 
+Acquire DWD weather alerts (CAP warnings):
+
+    # Get all current warnings on community (Gemeinde) basis as JSON
+    wetterdienst alerts
+
+    # Get warnings on district (Landkreis) basis as GeoJSON, in German
+    wetterdienst alerts --granularity=district --language=de --format=geojson
+
+    # Get warnings active at a past point in time (within DWD's rolling ~48h window)
+    wetterdienst alerts --granularity=district --date=2026-07-26T10:00:00
+
+    # Write current warnings to a GeoJSON file
+    wetterdienst alerts --format=geojson --target=file://alerts.geojson
+
 Create warming stripes (only DWD Observation data):
 
     # Create warming stripes for a specific station
@@ -741,6 +755,12 @@ def coverage(
     datasets_list = read_list(datasets)
 
     api = get_api(provider=provider, network=network)
+
+    # Standalone networks (e.g. dwd/radar, dwd/alerts) have no metadata model and thus no per-network
+    # discover(); report that cleanly instead of crashing with an AttributeError.
+    if not hasattr(api, "discover"):
+        log.error(f"Coverage is not available for provider '{provider}' and network '{network}'.")
+        sys.exit(1)
 
     cov = api.discover(
         resolutions=resolutions_list,
@@ -1645,6 +1665,100 @@ def radar(
         raise KeyError(msg)
 
     output = json.dumps(data, indent=indent)
+
+    print(output)  # noqa: T201
+
+
+@cli.command("alerts", section=data_section)
+@cloup.option(
+    "--granularity",
+    type=click.Choice(["community", "district"], case_sensitive=False),
+    default="community",
+    help="Spatial granularity: 'community' (per Gemeinde, default) or 'district' (per Landkreis).",
+)
+@cloup.option(
+    "--language",
+    type=click.Choice(["de", "en", "es", "fr", "mul"], case_sensitive=False),
+    default="en",
+    help="Language of the warning texts. Default: en",
+)
+@cloup.option(
+    "--date",
+    type=click.STRING,
+    default=None,
+    help=(
+        "Point in time (ISO 8601, UTC if no offset) to select the active-warnings snapshot for. "
+        "Defaults to the latest snapshot. Must fall within DWD's rolling ~48-hour window."
+    ),
+)
+@cloup.option_group(
+    "Format/Target",
+    cloup.option(
+        "--format",
+        "fmt",
+        type=click.Choice(["json", "geojson", "csv"], case_sensitive=False),
+        default="json",
+        help="Output format. Default: json",
+    ),
+    cloup.option(
+        "--target",
+        type=click.STRING,
+        help="Write output to this file instead of stdout. Example: file://alerts.geojson",
+    ),
+)
+@cloup.option(
+    "--pretty",
+    type=click.BOOL,
+    default=False,
+    help="Pretty-print JSON/GeoJSON with 4-space indentation. Default: false",
+)
+@debug_opt
+def alerts(
+    granularity: str,
+    language: str,
+    date: str,
+    fmt: str,
+    target: str,
+    pretty: bool,  # noqa: FBT001
+    debug: bool,  # noqa: FBT001
+) -> None:
+    """Acquire DWD weather alerts (CAP warnings).
+
+    Returns all warnings active at the selected time (the latest snapshot by default), one row per
+    alert, with a GeoJSON MultiPolygon geometry. An empty result means there were no active warnings.
+    """
+    set_logging_level(debug=debug)
+
+    from wetterdienst.provider.dwd.alerts import DwdWeatherAlertRequest  # noqa: PLC0415
+
+    # Validate the target up front (before the network fetch): alerts output is plain text, so only a
+    # local path / file:// URI is supported (unlike the timeseries commands' to_target()); reject
+    # other schemes instead of writing a file literally named e.g. "duckdb://...".
+    if target and "://" in target and not target.startswith("file://"):
+        msg = "--target only supports a local path or a file:// URI for alerts."
+        raise click.BadParameter(msg)
+
+    # Invalid input (granularity/language/format, or a date outside the rolling window) is a
+    # BadParameter; a runtime download/parse failure is a clean ClickException, not a traceback.
+    try:
+        request = DwdWeatherAlertRequest(granularity=granularity, language=language, date=date, settings=Settings())
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from e
+
+    try:
+        result = request.query()
+    except ValueError as e:
+        raise click.BadParameter(str(e)) from e
+    except Exception as e:
+        log.exception("Failed to acquire weather alerts")
+        raise click.ClickException(str(e)) from e
+
+    output = result.to_format(fmt, indent=pretty)
+
+    if target:
+        path = target.removeprefix("file://")
+        Path(path).write_text(output, encoding="utf-8")
+        return
 
     print(output)  # noqa: T201
 

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -62,6 +62,7 @@ REQUEST_EXAMPLES = {
     "dwd_observation_daily_climate_stripes_image": "api/stripes/image?kind=temperature&station=1048",
     "dwd_mosmix_issues": "api/issues?provider=dwd&network=mosmix&station=10147",
     "dwd_dmo_issues": "api/issues?provider=dwd&network=dmo&station=10147",
+    "dwd_weather_alerts": "api/alerts?granularity=community&format=geojson",
 }
 
 
@@ -165,6 +166,7 @@ def index() -> HTMLResponse:
                     <li><a href="api/stripes/stations" target="_blank" rel="noopener">stripes stations</a></li>
                     <li><a href="api/stripes/values" target="_blank" rel="noopener">stripes values</a></li>
                     <li><a href="api/stripes/image" target="_blank" rel="noopener">stripes image</a></li>
+                    <li><a href="api/alerts" target="_blank" rel="noopener">weather alerts</a></li>
                 </ul>
                 <h2>Examples</h2>
                 <ul>
@@ -176,6 +178,7 @@ def index() -> HTMLResponse:
                     <li><a href="{REQUEST_EXAMPLES["dwd_observation_daily_climate_stripes_stations"]}" target="_blank" rel="noopener">DWD Observation Daily Climate Stripes Stations</a></li>
                     <li><a href="{REQUEST_EXAMPLES["dwd_observation_daily_climate_stripes_values"]}" target="_blank" rel="noopener">DWD Observation Daily Climate Stripes Values</a></li>
                     <li><a href="{REQUEST_EXAMPLES["dwd_observation_daily_climate_stripes_image"]}" target="_blank" rel="noopener">DWD Observation Daily Climate Stripes Image</a></li>
+                    <li><a href="{REQUEST_EXAMPLES["dwd_weather_alerts"]}" target="_blank" rel="noopener">DWD Weather Alerts</a></li>
                 </ul>
                 <h2>Producer</h2>
                 <ul>
@@ -302,6 +305,14 @@ def coverage(
             status_code=404,
             detail=f"Choose provider and network from {app.url_path_for('coverage')}",
         ) from e
+
+    # Standalone networks (e.g. dwd/radar, dwd/alerts) have no metadata model and thus no per-network
+    # discover(); report that cleanly instead of raising an uncaught AttributeError (HTTP 500).
+    if not hasattr(api, "discover"):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Coverage is not available for provider '{provider}' and network '{network}'.",
+        )
 
     resolutions_list: list[str] | None = read_list(resolutions) if resolutions else None
     datasets_list: list[str] | None = read_list(datasets) if datasets else None
@@ -843,6 +854,44 @@ def history(  # noqa: C901
         ),
         media_type="application/json",
     )
+
+
+@app.get("/api/alerts")
+def alerts(
+    granularity: Annotated[Literal["community", "district"], Query()] = "community",
+    language: Annotated[Literal["de", "en", "es", "fr", "mul"], Query()] = "en",
+    date: Annotated[str | None, Query()] = None,
+    fmt: Annotated[Literal["json", "geojson", "csv"], Query(alias="format")] = "json",
+    pretty: Annotated[bool, Query()] = False,  # noqa: FBT002
+    debug: Annotated[bool, Query()] = False,  # noqa: FBT002
+) -> Response:
+    """Provide DWD weather alerts (CAP warnings) via restapi.
+
+    Returns all warnings active at the selected time, one entry per alert, with a GeoJSON
+    MultiPolygon geometry. ``date`` (ISO 8601, UTC if no offset) selects a historical snapshot from
+    DWD's rolling ~48-hour window; omit it for the latest snapshot. An empty result simply means
+    there were no active warnings.
+    """
+    from wetterdienst.provider.dwd.alerts import DwdWeatherAlertRequest  # noqa: PLC0415
+
+    set_logging_level(debug=debug)
+
+    try:
+        request = DwdWeatherAlertRequest(granularity=granularity, language=language, date=date, settings=Settings())
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    try:
+        result = request.query()
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        log.exception("Failed to get weather alerts")
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    content = result.to_format(fmt, indent=pretty)
+    media_type = "text/csv" if fmt == "csv" else "application/json"
+    return Response(content=content, media_type=media_type)
 
 
 def start_service(listen_address: str | None = None, *, reload: bool | None = False) -> None:

--- a/tests/provider/dwd/alerts/test_api.py
+++ b/tests/provider/dwd/alerts/test_api.py
@@ -1,0 +1,276 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for the DWD CAP weather-alerts request/result API."""
+
+from __future__ import annotations
+
+import datetime as dt
+import io
+import json
+import zipfile
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from wetterdienst import Wetterdienst
+from wetterdienst.provider.dwd.alerts import (
+    DwdWeatherAlertGranularity,
+    DwdWeatherAlertLanguage,
+    DwdWeatherAlertRequest,
+    DwdWeatherAlertResult,
+)
+from wetterdienst.provider.dwd.alerts.api import _SCHEMA
+
+from .test_parser import CAP_XML
+
+UTC = ZoneInfo("UTC")
+
+
+def test_registry_resolves_dwd_alerts() -> None:
+    """Verify the provider is registered and resolvable via the Wetterdienst factory."""
+    assert Wetterdienst("dwd", "alerts") is DwdWeatherAlertRequest
+
+
+def test_url_community_english_default() -> None:
+    """Verify the default request targets the community LATEST English snapshot."""
+    request = DwdWeatherAlertRequest()
+    assert request.granularity is DwdWeatherAlertGranularity.COMMUNITY
+    assert request.language is DwdWeatherAlertLanguage.ENGLISH
+    assert request.url == (
+        "https://opendata.dwd.de/weather/alerts/cap/COMMUNEUNION_DWD_STAT/"
+        "Z_CAP_C_EDZW_LATEST_PVW_STATUS_PREMIUMDWD_COMMUNEUNION_EN.zip"
+    )
+
+
+def test_url_district_german() -> None:
+    """Verify the district/German request targets the correct snapshot."""
+    request = DwdWeatherAlertRequest(granularity="district", language="de")
+    assert request.url == (
+        "https://opendata.dwd.de/weather/alerts/cap/DISTRICT_DWD_STAT/"
+        "Z_CAP_C_EDZW_LATEST_PVW_STATUS_PREMIUMDWD_DISTRICT_DE.zip"
+    )
+
+
+def test_dateless_request_resolves_to_latest() -> None:
+    """Verify a request without a date resolves to the LATEST alias with an unknown production time."""
+    url, snapshot = DwdWeatherAlertRequest()._resolve_snapshot()  # noqa: SLF001
+    assert url.endswith("Z_CAP_C_EDZW_LATEST_PVW_STATUS_PREMIUMDWD_COMMUNEUNION_EN.zip")
+    assert snapshot is None
+
+
+def test_date_parsing_assumes_utc() -> None:
+    """Verify naive date input is interpreted as UTC and tz-aware input is converted to UTC."""
+    naive = DwdWeatherAlertRequest(date="2026-07-26T10:00:00")
+    assert naive.date == dt.datetime(2026, 7, 26, 10, 0, tzinfo=UTC)
+    aware = DwdWeatherAlertRequest(date="2026-07-26T12:00:00+02:00")
+    assert aware.date == dt.datetime(2026, 7, 26, 10, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_empty_date_means_latest(value: str) -> None:
+    """Verify an empty/whitespace date string is treated as 'latest' (None), not an invalid date."""
+    request = DwdWeatherAlertRequest(date=value)
+    assert request.date is None
+    url, snapshot = request._resolve_snapshot()  # noqa: SLF001
+    assert url.endswith("_COMMUNEUNION_EN.zip")
+    assert snapshot is None
+
+
+def _fake_listing(*timestamps: str) -> list[dict[str, str]]:
+    return [
+        {
+            "name": (
+                "https://opendata.dwd.de/weather/alerts/cap/COMMUNEUNION_DWD_STAT/"
+                f"Z_CAP_C_EDZW_{ts}_PVW_STATUS_PREMIUMDWD_COMMUNEUNION_EN.zip"
+            ),
+            "type": "file",
+        }
+        for ts in timestamps
+    ]
+
+
+def test_resolve_snapshot_selects_newest_at_or_before_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify the newest snapshot produced at or before the requested date is chosen."""
+    listing = _fake_listing("20260726100000", "20260726103220", "20260726110000")
+    monkeypatch.setattr("wetterdienst.provider.dwd.alerts.api.list_remote_directory_fsspec", lambda *_a, **_k: listing)
+
+    request = DwdWeatherAlertRequest(date="2026-07-26T10:45:00")
+    url, snapshot = request._resolve_snapshot()  # noqa: SLF001
+    assert snapshot == dt.datetime(2026, 7, 26, 10, 32, 20, tzinfo=UTC)
+    assert url.endswith("Z_CAP_C_EDZW_20260726103220_PVW_STATUS_PREMIUMDWD_COMMUNEUNION_EN.zip")
+
+
+def test_resolve_snapshot_before_window_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify a date older than the whole rolling window raises a helpful error."""
+    listing = _fake_listing("20260726100000", "20260726110000")
+    monkeypatch.setattr("wetterdienst.provider.dwd.alerts.api.list_remote_directory_fsspec", lambda *_a, **_k: listing)
+
+    request = DwdWeatherAlertRequest(date="2026-07-01T00:00:00")
+    with pytest.raises(ValueError, match="rolling ~48-hour window"):
+        request._resolve_snapshot()  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("community", DwdWeatherAlertGranularity.COMMUNITY),
+        ("communeunion", DwdWeatherAlertGranularity.COMMUNITY),
+        ("gemeinde", DwdWeatherAlertGranularity.COMMUNITY),
+        ("DISTRICT", DwdWeatherAlertGranularity.DISTRICT),
+        ("landkreis", DwdWeatherAlertGranularity.DISTRICT),
+    ],
+)
+def test_granularity_parsing(value: str, expected: DwdWeatherAlertGranularity) -> None:
+    """Verify granularity aliases are accepted case-insensitively."""
+    assert DwdWeatherAlertRequest(granularity=value).granularity is expected
+
+
+def test_invalid_granularity_raises() -> None:
+    """Verify an unknown granularity is rejected."""
+    with pytest.raises(ValueError, match="granularity"):
+        DwdWeatherAlertRequest(granularity="bogus")
+
+
+def test_invalid_language_raises() -> None:
+    """Verify an unknown language is rejected."""
+    with pytest.raises(ValueError, match="language"):
+        DwdWeatherAlertRequest(language="it")
+
+
+def _make_zip(*files: bytes) -> io.BytesIO:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for index, content in enumerate(files):
+            archive.writestr(f"alert_{index}.xml", content)
+    buffer.seek(0)
+    return buffer
+
+
+def test_parse_archive_builds_dataframe() -> None:
+    """Verify an archive of CAP files is flattened into the schema-conformant DataFrame."""
+    alerts = DwdWeatherAlertRequest._parse_archive(_make_zip(CAP_XML, CAP_XML))  # noqa: SLF001
+    df = DwdWeatherAlertRequest._build_dataframe(alerts)  # noqa: SLF001
+    assert df.height == 2
+    assert df.schema == pl.Schema(_SCHEMA)
+    assert df["event"].to_list() == ["gale-force gusts", "gale-force gusts"]
+    assert df["warncell_ids"].to_list()[0] == ["809272121", "809276148"]
+    # nested fields are JSON-encoded in the frame
+    assert json.loads(df["parameters"][0]) == [
+        {"name": "gusts", "value": "65-75 [km/h]"},
+        {"name": "wind direction", "value": "west"},
+    ]
+    assert json.loads(df["geometry"][0])["type"] == "MultiPolygon"
+
+
+def test_empty_archive_yields_empty_frame() -> None:
+    """Verify an empty snapshot (no active warnings) produces an empty, schema-conformant frame."""
+    df = DwdWeatherAlertRequest._build_dataframe(DwdWeatherAlertRequest._parse_archive(_make_zip()))  # noqa: SLF001
+    assert df.is_empty()
+    assert df.schema == pl.Schema(_SCHEMA)
+
+
+def test_query_wraps_download_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify a download failure (e.g. a 404 from a rolled-off snapshot) becomes a clean OSError."""
+    from wetterdienst.util.network import File  # noqa: PLC0415
+
+    def fake_download(*_a: object, **_k: object) -> File:
+        return File(url="http://x", content=FileNotFoundError("404"), status=404)
+
+    monkeypatch.setattr("wetterdienst.provider.dwd.alerts.api.download_file", fake_download)
+    with pytest.raises(OSError, match="could not download weather alerts snapshot"):
+        DwdWeatherAlertRequest().query()
+
+
+def test_query_wraps_bad_zip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify a non-zip 200 body becomes a clean OSError instead of a raw BadZipFile."""
+    from wetterdienst.util.network import File  # noqa: PLC0415
+
+    def fake_download(*_a: object, **_k: object) -> File:
+        return File(url="http://x", content=io.BytesIO(b"<html>error</html>"), status=200)
+
+    monkeypatch.setattr("wetterdienst.provider.dwd.alerts.api.download_file", fake_download)
+    with pytest.raises(OSError, match="not a valid zip archive"):
+        DwdWeatherAlertRequest().query()
+
+
+def test_result_formats_round_trip() -> None:
+    """Verify to_dict/to_geojson/to_csv render the parsed alerts consistently."""
+    alerts = DwdWeatherAlertRequest._parse_archive(_make_zip(CAP_XML))  # noqa: SLF001
+    df = DwdWeatherAlertRequest._build_dataframe(alerts)  # noqa: SLF001
+    snapshot = dt.datetime(2026, 7, 26, 8, 0, tzinfo=UTC)
+    result = DwdWeatherAlertResult(df, DwdWeatherAlertGranularity.COMMUNITY, DwdWeatherAlertLanguage.ENGLISH, snapshot)
+
+    data = result.to_dict()
+    assert data["snapshot"] == "2026-07-26T08:00:00+00:00"
+    assert len(data["alerts"]) == 1
+    alert = data["alerts"][0]
+    assert alert["event"] == "gale-force gusts"
+    assert alert["geometry"]["type"] == "MultiPolygon"
+    assert alert["parameters"] == [
+        {"name": "gusts", "value": "65-75 [km/h]"},
+        {"name": "wind direction", "value": "west"},
+    ]
+    # timestamps are serialised as ISO strings
+    assert alert["sent"].startswith("2026-07-26T07:23:00")
+
+    fc = json.loads(result.to_geojson())
+    assert fc["type"] == "FeatureCollection"
+    assert fc["snapshot"] == "2026-07-26T08:00:00+00:00"
+    feature = fc["features"][0]
+    assert feature["geometry"]["type"] == "MultiPolygon"
+    assert "geometry" not in feature["properties"]
+    assert feature["properties"]["event"] == "gale-force gusts"
+
+    csv = result.to_csv()
+    header, first = csv.splitlines()[0], csv.splitlines()[1]
+    assert "warncell_ids" in header
+    # list column is comma-joined for CSV
+    assert "809272121,809276148" in first
+
+
+def test_to_format_invalid_raises() -> None:
+    """Verify an unsupported output format is rejected."""
+    result = DwdWeatherAlertResult(
+        pl.DataFrame(schema=_SCHEMA),
+        DwdWeatherAlertGranularity.COMMUNITY,
+        DwdWeatherAlertLanguage.ENGLISH,
+    )
+    with pytest.raises(ValueError, match="format"):
+        result.to_format("xml")
+
+
+@pytest.mark.remote
+@pytest.mark.parametrize("granularity", ["community", "district"])
+def test_query_live_snapshot(granularity: str) -> None:
+    """Verify a live snapshot downloads and parses into the expected schema.
+
+    The number of active warnings is weather-dependent (possibly zero), so only structural
+    invariants are asserted.
+    """
+    result = DwdWeatherAlertRequest(granularity=granularity).query()
+    assert result.df.schema == pl.Schema(_SCHEMA)
+    assert result.snapshot is None
+    for alert in result.to_dict()["alerts"]:
+        assert alert["alert_id"]
+        geometry = alert["geometry"]
+        if geometry is not None:
+            assert geometry["type"] == "MultiPolygon"
+            assert geometry["coordinates"]
+
+
+@pytest.mark.remote
+def test_query_live_timestamped_snapshot() -> None:
+    """Verify selecting a snapshot from the rolling window returns a snapshot at or before the date."""
+    target = dt.datetime.now(UTC) - dt.timedelta(hours=6)
+    result = DwdWeatherAlertRequest(granularity="district", date=target).query()
+    assert result.df.schema == pl.Schema(_SCHEMA)
+    assert result.snapshot is not None
+    assert result.snapshot <= target
+
+
+@pytest.mark.remote
+def test_query_live_date_before_window_raises() -> None:
+    """Verify a date older than the rolling window raises a helpful error against the live listing."""
+    with pytest.raises(ValueError, match="rolling ~48-hour window"):
+        DwdWeatherAlertRequest(date="2000-01-01T00:00:00").query()

--- a/tests/provider/dwd/alerts/test_parser.py
+++ b/tests/provider/dwd/alerts/test_parser.py
@@ -1,0 +1,178 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Offline tests for the DWD CAP weather-alerts parser."""
+
+from __future__ import annotations
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+from wetterdienst.provider.dwd.alerts.parser import parse_cap_alert
+
+# A minimal but representative CAP v1.2 document following the DWD profile: one polygon area (with a
+# hole), two named entity areas carrying WARNCELLIDs, event codes and parameters, and an expires.
+CAP_XML = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+  <identifier>2.49.0.0.276.0.DWD.PVW.1785050580000.6bd1534c-24c8-4860-84a8-e89bab416fcd.ENG</identifier>
+  <sender>opendata@dwd.de</sender>
+  <sent>2026-07-26T09:23:00+02:00</sent>
+  <status>Actual</status>
+  <msgType>Alert</msgType>
+  <source>PVW</source>
+  <scope>Public</scope>
+  <code>id:2.49.0.0.276.0.DWD.PVW.1785050580000.6bd1534c-24c8-4860-84a8-e89bab416fcd</code>
+  <references>opendata@dwd.de,2.49.0.0.276.0.DWD.PVW.1.x.ENG,2026-07-26T09:00:00+02:00</references>
+  <info>
+    <language>en</language>
+    <category>Met</category>
+    <event>gale-force gusts</event>
+    <responseType>Prepare</responseType>
+    <urgency>Immediate</urgency>
+    <severity>Moderate</severity>
+    <certainty>Likely</certainty>
+    <eventCode><valueName>PROFILE_VERSION</valueName><value>2.1.14</value></eventCode>
+    <eventCode><valueName>II</valueName><value>52</value></eventCode>
+    <eventCode><valueName>GROUP</valueName><value>WIND</value></eventCode>
+    <eventCode><valueName>AREA_COLOR</valueName><value>251 140 0</value></eventCode>
+    <effective>2026-07-26T09:23:00+02:00</effective>
+    <onset>2026-07-26T21:00:00+02:00</onset>
+    <expires>2026-07-27T14:00:00+02:00</expires>
+    <senderName>Deutscher Wetterdienst</senderName>
+    <headline>Official WARNING of GALE-FORCE GUSTS</headline>
+    <description>There is a risk of gale-force gusts (level 2 of 4).</description>
+    <instruction>Secure free-standing objects.</instruction>
+    <web>https://dwd.de/warnungen</web>
+    <contact>Deutscher Wetterdienst</contact>
+    <parameter><valueName>gusts</valueName><value>65-75 [km/h]</value></parameter>
+    <parameter><valueName>wind direction</valueName><value>west</value></parameter>
+    <area>
+      <areaDesc>polygonal event area</areaDesc>
+      <polygon>49.0,12.0 49.0,13.0 50.0,13.0 50.0,12.0 49.0,12.0</polygon>
+      <geocode>
+        <valueName>EXCLUDE_POLYGON</valueName>
+        <value>49.4,12.4 49.4,12.6 49.6,12.6 49.6,12.4 49.4,12.4</value>
+      </geocode>
+    </area>
+    <area>
+      <areaDesc>Gemeinde Grainet</areaDesc>
+      <geocode><valueName>WARNCELLID</valueName><value>809272121</value></geocode>
+    </area>
+    <area>
+      <areaDesc>Stadt Zwiesel</areaDesc>
+      <geocode><valueName>WARNCELLID</valueName><value>809276148</value></geocode>
+    </area>
+  </info>
+</alert>
+"""
+
+UTC = ZoneInfo("UTC")
+
+
+def test_parse_cap_alert_scalar_fields() -> None:
+    """Verify the alert/info scalar fields are extracted and timestamps normalised to UTC."""
+    alert = parse_cap_alert(CAP_XML)
+    assert alert is not None
+    assert alert["alert_id"] == "2.49.0.0.276.0.DWD.PVW.1785050580000.6bd1534c-24c8-4860-84a8-e89bab416fcd.ENG"
+    assert alert["status"] == "Actual"
+    assert alert["msg_type"] == "Alert"
+    assert alert["language"] == "en"
+    assert alert["category"] == "Met"
+    assert alert["event"] == "gale-force gusts"
+    assert alert["response_type"] == "Prepare"
+    assert alert["urgency"] == "Immediate"
+    assert alert["severity"] == "Moderate"
+    assert alert["certainty"] == "Likely"
+    assert alert["headline"] == "Official WARNING of GALE-FORCE GUSTS"
+    assert alert["sender_name"] == "Deutscher Wetterdienst"
+    assert alert["references"].startswith("opendata@dwd.de,")
+    # 09:23:00+02:00 -> 07:23:00Z
+    assert alert["sent"] == dt.datetime(2026, 7, 26, 7, 23, tzinfo=UTC)
+    assert alert["effective"] == dt.datetime(2026, 7, 26, 7, 23, tzinfo=UTC)
+    assert alert["onset"] == dt.datetime(2026, 7, 26, 19, 0, tzinfo=UTC)
+    assert alert["expires"] == dt.datetime(2026, 7, 27, 12, 0, tzinfo=UTC)
+
+
+def test_parse_cap_alert_event_codes_and_parameters() -> None:
+    """Verify event codes (II, GROUP, AREA_COLOR) and parameters are mapped correctly."""
+    alert = parse_cap_alert(CAP_XML)
+    assert alert is not None
+    assert alert["event_code"] == "52"
+    assert alert["groups"] == ["WIND"]
+    assert alert["area_color"] == "251 140 0"
+    assert alert["parameters"] == [
+        {"name": "gusts", "value": "65-75 [km/h]"},
+        {"name": "wind direction", "value": "west"},
+    ]
+
+
+def test_parse_cap_alert_areas_and_warncells() -> None:
+    """Verify entity areas expose their WARNCELLIDs and names, in document order."""
+    alert = parse_cap_alert(CAP_XML)
+    assert alert is not None
+    assert alert["warncell_ids"] == ["809272121", "809276148"]
+    assert alert["area_names"] == ["Gemeinde Grainet", "Stadt Zwiesel"]
+
+
+def test_parse_cap_alert_geometry_is_multipolygon_with_hole() -> None:
+    """Verify polygon areas become a GeoJSON MultiPolygon with lon/lat order and the hole attached."""
+    alert = parse_cap_alert(CAP_XML)
+    assert alert is not None
+    geometry = alert["geometry"]
+    assert geometry["type"] == "MultiPolygon"
+    # one polygon area -> one member polygon, with exterior ring + one hole ring
+    assert len(geometry["coordinates"]) == 1
+    polygon = geometry["coordinates"][0]
+    assert len(polygon) == 2  # exterior + hole
+    exterior = polygon[0]
+    # CAP "49.0,12.0" (lat,lon) -> GeoJSON [12.0, 49.0] (lon,lat)
+    assert exterior[0] == [12.0, 49.0]
+    assert exterior[0] == exterior[-1]  # ring is closed
+    hole = polygon[1]
+    assert hole[0] == [12.4, 49.4]
+
+
+def test_parse_cap_alert_without_polygon_has_null_geometry() -> None:
+    """Verify an alert with only entity (WARNCELLID) areas yields a null geometry."""
+    xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+  <identifier>x</identifier>
+  <status>Actual</status>
+  <msgType>Alert</msgType>
+  <info>
+    <event>near gale</event>
+    <area>
+      <areaDesc>Ostlich Rugen</areaDesc>
+      <geocode><valueName>WARNCELLID</valueName><value>501000008</value></geocode>
+    </area>
+  </info>
+</alert>"""
+    alert = parse_cap_alert(xml)
+    assert alert is not None
+    assert alert["geometry"] is None
+    assert alert["warncell_ids"] == ["501000008"]
+
+
+def test_parse_cap_alert_keeps_repeated_parameters() -> None:
+    """Verify a <parameter> valueName repeated within one alert is preserved (not collapsed)."""
+    xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<alert xmlns="urn:oasis:names:tc:emergency:cap:1.2">
+  <identifier>x</identifier>
+  <info>
+    <event>gale-force gusts</event>
+    <parameter><valueName>wind direction</valueName><value>west</value></parameter>
+    <parameter><valueName>wind direction</valueName><value>north-west</value></parameter>
+    <parameter><valueName>wind direction</valueName><value>north</value></parameter>
+  </info>
+</alert>"""
+    alert = parse_cap_alert(xml)
+    assert alert is not None
+    assert alert["parameters"] == [
+        {"name": "wind direction", "value": "west"},
+        {"name": "wind direction", "value": "north-west"},
+        {"name": "wind direction", "value": "north"},
+    ]
+
+
+def test_parse_cap_alert_non_alert_returns_none() -> None:
+    """Verify a non-alert document is rejected."""
+    assert parse_cap_alert(b"<something xmlns='urn:x'><child/></something>") is None

--- a/tests/ui/cli/test_cli.py
+++ b/tests/ui/cli/test_cli.py
@@ -111,6 +111,15 @@ def test_coverage() -> None:
     ]
 
 
+@pytest.mark.parametrize("network", ["alerts", "radar"])
+def test_coverage_standalone_network_reports_cleanly(network: str) -> None:
+    """Test coverage for a metadata-less standalone network fails cleanly instead of crashing."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["about", "coverage", "--provider=dwd", f"--network={network}"])
+    assert result.exit_code == 1
+    assert not isinstance(result.exception, AttributeError)
+
+
 def test_coverage_resolution_1_minute() -> None:
     """Test coverage for resolution 1_minute."""
     runner = CliRunner()

--- a/tests/ui/cli/test_cli.py
+++ b/tests/ui/cli/test_cli.py
@@ -36,6 +36,7 @@ def test_cli_help() -> None:
           interpolate  Interpolate data.
           summarize    Summarize data.
           radar        List radar stations.
+          alerts       Acquire DWD weather alerts (CAP warnings).
           stripes      Climate stripes.
         """,
     )

--- a/tests/ui/cli/test_cli_alerts.py
+++ b/tests/ui/cli/test_cli_alerts.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for the CLI alerts command."""
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from wetterdienst.ui.cli import cli
+
+
+def test_cli_alerts_help() -> None:
+    """Test the alerts command help lists its options."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["alerts", "--help"])
+    assert result.exit_code == 0
+    assert "--granularity" in result.output
+    assert "--language" in result.output
+
+
+def test_cli_alerts_invalid_granularity() -> None:
+    """Test the alerts command rejects an unknown granularity."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["alerts", "--granularity=bogus"])
+    assert result.exit_code != 0
+
+
+def test_cli_alerts_rejects_non_file_target() -> None:
+    """Test the alerts command rejects a non-file:// target scheme instead of writing a stray file."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["alerts", "--target=duckdb:///x.duckdb?table=t"])
+    assert result.exit_code != 0
+    assert "file://" in result.output
+
+
+@pytest.mark.remote
+def test_cli_alerts_json() -> None:
+    """Test the alerts command returns a JSON alert collection."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["alerts", "--granularity=community"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert "alerts" in data
+
+
+@pytest.mark.remote
+def test_cli_alerts_geojson() -> None:
+    """Test the alerts command returns a GeoJSON FeatureCollection."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["alerts", "--granularity=district", "--format=geojson"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["type"] == "FeatureCollection"
+
+
+@pytest.mark.remote
+def test_cli_alerts_date_snapshot() -> None:
+    """Test the alerts command accepts a historical date within the rolling window."""
+    import datetime as dt  # noqa: PLC0415
+    from zoneinfo import ZoneInfo  # noqa: PLC0415
+
+    target = dt.datetime.now(ZoneInfo("UTC")) - dt.timedelta(hours=6)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["alerts", "--granularity=district", f"--date={target.strftime('%Y-%m-%dT%H:%M:%S')}"])
+    assert result.exit_code == 0
+    assert "alerts" in json.loads(result.output)
+
+
+@pytest.mark.remote
+def test_cli_alerts_date_before_window() -> None:
+    """Test the alerts command rejects a date older than the rolling window."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["alerts", "--date=2000-01-01T00:00:00"])
+    assert result.exit_code != 0
+
+
+@pytest.mark.remote
+def test_cli_alerts_target_file(tmp_path) -> None:  # noqa: ANN001
+    """Test the alerts command writes output to a file target."""
+    runner = CliRunner()
+    target = tmp_path / "alerts.geojson"
+    result = runner.invoke(
+        cli,
+        ["alerts", "--format=geojson", f"--target=file://{target}"],
+    )
+    assert result.exit_code == 0
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["type"] == "FeatureCollection"

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -28,9 +28,13 @@ def test_index(client: TestClient) -> None:
     assert "wetterdienst - open weather data for humans" in response.text
 
 
+@pytest.mark.remote
 @pytest.mark.parametrize("url", REQUEST_EXAMPLES.values())
 def test_index_examples(client: TestClient, url: str) -> None:
-    """Test index examples."""
+    """Test index examples.
+
+    Every example URL fetches live provider data, so this is marked ``remote``.
+    """
     response = client.get(url)
     assert response.status_code == 200
 
@@ -86,6 +90,14 @@ def test_coverage(client: TestClient) -> None:
     # `road` requires a date range for value queries, other DWD networks don't
     assert dwd["observation"]["date_required"] is False
     assert dwd["road"]["date_required"] is True
+
+
+@pytest.mark.parametrize("network", ["alerts", "radar"])
+def test_coverage_standalone_network_returns_404(client: TestClient, network: str) -> None:
+    """Coverage for a metadata-less standalone network returns 404, not an uncaught 500."""
+    response = client.get("/api/coverage", params={"provider": "dwd", "network": network})
+    assert response.status_code == 404
+    assert "not available" in response.json()["detail"]
 
 
 def test_auth_no_auth_required(client: TestClient) -> None:
@@ -1654,3 +1666,66 @@ def test_issues_unknown_provider(client: TestClient) -> None:
         params={"provider": "unknown", "network": "unknown", "station": "00011"},
     )
     assert response.status_code == 404
+
+
+@pytest.mark.remote
+@pytest.mark.parametrize("granularity", ["community", "district"])
+def test_alerts_default_json(client: TestClient, granularity: str) -> None:
+    """Test /api/alerts returns a JSON alert collection."""
+    response = client.get("/api/alerts", params={"granularity": granularity})
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    data = response.json()
+    assert "alerts" in data
+    for alert in data["alerts"]:
+        assert alert["alert_id"]
+
+
+@pytest.mark.remote
+def test_alerts_geojson(client: TestClient) -> None:
+    """Test /api/alerts returns a GeoJSON FeatureCollection."""
+    response = client.get("/api/alerts", params={"granularity": "district", "format": "geojson"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["type"] == "FeatureCollection"
+    for feature in data["features"]:
+        assert feature["type"] == "Feature"
+        if feature["geometry"] is not None:
+            assert feature["geometry"]["type"] == "MultiPolygon"
+
+
+@pytest.mark.remote
+def test_alerts_csv(client: TestClient) -> None:
+    """Test /api/alerts returns CSV."""
+    response = client.get("/api/alerts", params={"format": "csv"})
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/csv")
+    assert "alert_id" in response.text.splitlines()[0]
+
+
+def test_alerts_invalid_granularity(client: TestClient) -> None:
+    """Test /api/alerts rejects an unknown granularity."""
+    response = client.get("/api/alerts", params={"granularity": "bogus"})
+    assert response.status_code == 422
+
+
+@pytest.mark.remote
+def test_alerts_date_snapshot(client: TestClient) -> None:
+    """Test /api/alerts accepts a historical date within the rolling window."""
+    import datetime as dt  # noqa: PLC0415
+    from zoneinfo import ZoneInfo  # noqa: PLC0415
+
+    target = dt.datetime.now(ZoneInfo("UTC")) - dt.timedelta(hours=6)
+    response = client.get(
+        "/api/alerts",
+        params={"granularity": "district", "date": target.strftime("%Y-%m-%dT%H:%M:%S")},
+    )
+    assert response.status_code == 200
+    assert "alerts" in response.json()
+
+
+@pytest.mark.remote
+def test_alerts_date_before_window(client: TestClient) -> None:
+    """Test /api/alerts returns 400 for a date older than the rolling window."""
+    response = client.get("/api/alerts", params={"date": "2000-01-01T00:00:00"})
+    assert response.status_code == 400

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -82,7 +82,7 @@ def test_coverage(client: TestClient) -> None:
         "wsv",
     }
     dwd = data["dwd"]
-    assert list(dwd.keys()) == ["observation", "mosmix", "dmo", "road", "radar", "derived"]
+    assert list(dwd.keys()) == ["observation", "mosmix", "dmo", "road", "radar", "alerts", "derived"]
     for network_info in dwd.values():
         assert network_info["auth"] is False
         assert network_info["configured"] is True


### PR DESCRIPTION
Closes #342.

Adds a DWD weather-alerts provider exposing the [Common Alerting Protocol (CAP)](https://opendata.dwd.de/weather/alerts/cap/) warnings published by the DWD. Alerts don't fit the station/timeseries model, so — like the radar provider — this is a standalone request class (not a `TimeseriesRequest`) registered as `dwd/alerts`, returning its own result object.

## Features

- **Full surface parity**: Python API (`DwdWeatherAlertRequest` / `DwdWeatherAlertResult`), CLI `alerts` command, and REST `GET /api/alerts` endpoint.
- **Granularity**: community (Gemeinde / `COMMUNEUNION`) and district (Landkreis / `DISTRICT`) via a parameter defaulting to community.
- **Languages**: `de`, `en` (default), `es`, `fr`, `mul`.
- **One row per alert**, with a GeoJSON **MultiPolygon** `geometry` combining the alert's polygon areas (`null` for alerts that only reference warn cells without polygons).
- **Timestamped snapshot selection**: `date` selects the newest snapshot produced at or before that time from DWD's rolling **~48h** window (DWD keeps no long-term archive). Out-of-window dates error clearly; the result exposes the selected snapshot's UTC production time (`snapshot`).
- Hardened lxml CAP parser (XXE-safe, matching the FMI/mosmix pattern); `parameters` are an ordered list of `{name, value}` since a name such as `wind direction` may legitimately repeat within one alert.

## Output

```bash
# latest community warnings as JSON
wetterdienst alerts

# district basis, German, GeoJSON
wetterdienst alerts --granularity=district --language=de --format=geojson

# warnings active at a past point in time (within the rolling ~48h window)
wetterdienst alerts --granularity=district --date=2026-07-26T10:00:00
```

```
GET /api/alerts?granularity=community&format=geojson
```

## Incidental hardening

`about coverage` and `/api/coverage` previously crashed (AttributeError / HTTP 500) for metadata-less standalone networks; they now report cleanly. This also fixes the pre-existing crash for `dwd/radar`.

## Notes

- The assembled MultiPolygons are valid GeoJSON but not OGC-*simple*: adjacent DWD area patches share borders, which shapely flags as member "self-intersection". Each member polygon is individually valid — this is faithful to the source; consumers needing OGC-simple geometry can run a union.

## Tests

New offline + `remote` tests for the parser, request/result API, CLI, and REST endpoint (plus coverage-standalone regression tests for alerts and radar). `ruff` and `ty` typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)