### PR TITLE
feat(ui)!: default with_metadata/with_stations to false (compact output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Types of changes:
 
 ### Changed
 
+- REST API and CLI: the `with_metadata` and `with_stations` options now default to `false` on the
+  `stations`, `values`, `interpolate`, `summarize` and `history` commands/endpoints, so output
+  contains just the requested data by default. Pass `with_metadata=true` / `with_stations=true`
+  (or `--with_metadata=true` / `--with_stations=true`) to include the provider-metadata and station
+  blocks as before.
 - Reduce DWD MOSMIX/DMO KML parsing memory by streaming the zipped KML instead of
   decompressing it fully in memory (~6.5x lower peak RSS on MOSMIX-S)
 

--- a/docs/usage/restapi.md
+++ b/docs/usage/restapi.md
@@ -31,6 +31,10 @@ The REST API is complemented by a modern web frontend built with Nuxt.js, provid
 
 Visit [wetterdienst.eobs.org](https://www.wetterdienst.eobs.org) to use the web interface.
 
+By default the `stations`, `values`, `interpolate`, `summarize` and `history` endpoints return only
+the requested data. Add `with_metadata=true` to include the provider-metadata block, and (for the
+value endpoints) `with_stations=true` to include the queried stations' metadata.
+
 The following examples use [httpie](https://github.com/httpie/cli) to demonstrate the usage of the REST API.
 
 ## Examples

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -842,8 +842,8 @@ def fields(
 @cloup.option(
     "--with_metadata",
     type=click.BOOL,
-    default=True,
-    help="Include provider metadata block in JSON/GeoJSON output. Default: true",
+    default=False,
+    help="Include provider metadata block in JSON/GeoJSON output. Default: false",
 )
 @cloup.option(
     "--pretty",
@@ -1010,8 +1010,8 @@ def issues_cmd(provider: str, network: str, station: str, debug: bool) -> None: 
         help="Export target URI (instead of stdout). Examples: file://data.csv, duckdb:///obs.duckdb?table=weather",
     ),
 )
-@cloup.option("--with_metadata", type=click.BOOL, default=True)
-@cloup.option("--with_stations", type=click.BOOL, default=True)
+@cloup.option("--with_metadata", type=click.BOOL, default=False)
+@cloup.option("--with_stations", type=click.BOOL, default=False)
 @cloup.option("--pretty", type=click.BOOL, default=False)
 @debug_opt
 def history(
@@ -1187,14 +1187,14 @@ def history(
 @cloup.option(
     "--with_metadata",
     type=click.BOOL,
-    default=True,
-    help="Include provider metadata block in JSON/GeoJSON output. Default: true",
+    default=False,
+    help="Include provider metadata block in JSON/GeoJSON output. Default: false",
 )
 @cloup.option(
     "--with_stations",
     type=click.BOOL,
-    default=True,
-    help="Include station list in JSON/GeoJSON output. Default: true",
+    default=False,
+    help="Include station list in JSON/GeoJSON output. Default: false",
 )
 @cloup.option(
     "--pretty",
@@ -1373,8 +1373,8 @@ def values(
 @cloup.option("--unit_targets", type=click.STRING, default=None)
 @cloup.option("--humanize", type=click.BOOL, default=True)
 @cloup.option("--pretty", is_flag=True)
-@cloup.option("--with_metadata", type=click.BOOL, default=True)
-@cloup.option("--with_stations", type=click.BOOL, default=True)
+@cloup.option("--with_metadata", type=click.BOOL, default=False)
+@cloup.option("--with_stations", type=click.BOOL, default=False)
 @debug_opt
 def interpolate(
     provider: str,
@@ -1520,8 +1520,8 @@ def interpolate(
 @cloup.option("--unit_targets", type=click.STRING, default=None)
 @cloup.option("--humanize", type=click.BOOL, default=True)
 @cloup.option("--pretty", is_flag=True)
-@cloup.option("--with_metadata", type=click.BOOL, default=True)
-@cloup.option("--with_stations", type=click.BOOL, default=True)
+@cloup.option("--with_metadata", type=click.BOOL, default=False)
+@cloup.option("--with_stations", type=click.BOOL, default=False)
 @debug_opt
 def summarize(
     provider: str,

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -119,8 +119,8 @@ class StationsRequest(BaseModel):
     # sql
     sql: str | None = None
 
-    with_metadata: bool = True
-    with_stations: bool = True
+    with_metadata: bool = False
+    with_stations: bool = False
 
     format: Literal["json", "geojson", "csv", "html", "png", "jpg", "webp", "svg", "pdf"] = "json"
     pretty: bool = False
@@ -199,8 +199,8 @@ class HistoryRequest(BaseModel):
                 parameters.append(item)
         return set(parameters)
 
-    with_metadata: bool = True
-    with_stations: bool = True
+    with_metadata: bool = False
+    with_stations: bool = False
 
     pretty: bool = False
     debug: bool = False
@@ -289,8 +289,8 @@ class ValuesRequest(BaseModel):
     # sql
     sql: str | None = None
 
-    with_metadata: bool = True
-    with_stations: bool = True
+    with_metadata: bool = False
+    with_stations: bool = False
 
     format: Literal["json", "geojson", "csv", "html", "png", "jpg", "webp", "svg", "pdf"] = "json"
     pretty: bool = False
@@ -409,8 +409,8 @@ class InterpolationRequest(BaseModel):
     num_additional_stations: Annotated[int, Field(ge=0)] = 3
     format: Literal["json", "geojson", "csv", "html", "png", "jpg", "webp", "svg", "pdf"] = "json"
 
-    with_metadata: bool = True
-    with_stations: bool = True
+    with_metadata: bool = False
+    with_stations: bool = False
 
     pretty: bool = False
     debug: bool = False
@@ -504,8 +504,8 @@ class SummaryRequest(BaseModel):
     num_additional_stations: Annotated[int, Field(ge=0)] = 3
     format: Literal["json", "geojson", "csv", "html", "png", "jpg", "webp", "svg", "pdf"] = "json"
 
-    with_metadata: bool = True
-    with_stations: bool = True
+    with_metadata: bool = False
+    with_stations: bool = False
 
     pretty: bool = False
     debug: bool = False

--- a/tests/ui/cli/test_cli_history.py
+++ b/tests/ui/cli/test_cli_history.py
@@ -25,6 +25,9 @@ def test_history_dwd_observation() -> None:
             "daily/climate_summary",
             "--station",
             "02564",
+            # with_metadata/with_stations now default to false; request them explicitly here
+            "--with_metadata=true",
+            "--with_stations=true",
         ],
     )
     assert result.exit_code == 0

--- a/tests/ui/cli/test_cli_interpolate.py
+++ b/tests/ui/cli/test_cli_interpolate.py
@@ -71,6 +71,8 @@ def test_cli_interpolate_with_metadata_with_stations(metadata: dict) -> None:
             "--station=00071",
             "--date=1986-10-31/1986-11-01",
             "--format=json",
+            "--with_metadata=true",
+            "--with_stations=true",
         ],
     )
     if result.exit_code != 0:
@@ -156,6 +158,7 @@ def test_cli_interpolate_geojson(metadata: dict) -> None:
             "--station=00071",
             "--date=1986-10-31/1986-11-01",
             "--format=geojson",
+            "--with_metadata=true",
         ],
     )
     if result.exit_code != 0:

--- a/tests/ui/cli/test_cli_summarize.py
+++ b/tests/ui/cli/test_cli_summarize.py
@@ -70,6 +70,8 @@ def test_cli_summarize_geojson(metadata: dict) -> None:
             "--station=00071",
             "--date=1986-10-31/1986-11-01",
             "--format=geojson",
+            # with_metadata now defaults to false; request it explicitly to test the metadata block
+            "--with_metadata=true",
         ],
     )
     if result.exit_code != 0:

--- a/tests/ui/cli/test_cli_values.py
+++ b/tests/ui/cli/test_cli_values.py
@@ -356,6 +356,8 @@ def test_cli_values_geojson(metadata: dict) -> None:
         ],
         station="01048",
         fmt="geojson",
+        # with_metadata now defaults to false; request it explicitly to test the metadata block
+        additional=["--with_metadata=true"],
     )
     response = json.loads(result.output)
     assert response.keys() == {"metadata", "data"}

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -1533,6 +1533,9 @@ def test_history_dwd_observation(client: TestClient) -> None:
             "network": "observation",
             "parameters": "daily/climate_summary",
             "station": "02564",
+            # with_metadata/with_stations now default to false; request them explicitly here
+            "with_metadata": True,
+            "with_stations": True,
         },
     )
     assert response.status_code == 200
@@ -1729,3 +1732,18 @@ def test_alerts_date_before_window(client: TestClient) -> None:
     """Test /api/alerts returns 400 for a date older than the rolling window."""
     response = client.get("/api/alerts", params={"date": "2000-01-01T00:00:00"})
     assert response.status_code == 400
+
+
+def test_value_endpoints_default_to_compact_output() -> None:
+    """with_metadata/with_stations default to false on the REST request models (compact output)."""
+    from wetterdienst.ui.core import (  # noqa: PLC0415
+        HistoryRequest,
+        InterpolationRequest,
+        StationsRequest,
+        SummaryRequest,
+        ValuesRequest,
+    )
+
+    for model in (StationsRequest, HistoryRequest, ValuesRequest, InterpolationRequest, SummaryRequest):
+        assert model.model_fields["with_metadata"].default is False
+        assert model.model_fields["with_stations"].default is False


### PR DESCRIPTION
Make the REST API and CLI return **just the requested data by default**.

`with_metadata` and `with_stations` now default to `false` on the `stations`, `values`, `interpolate`, `summarize` and `history` commands/endpoints. Previously every response carried a provider-metadata block and (for the value endpoints) a stations block, which bloated responses — most visibly for MCP/LLM agents driving `/api/values`, but also for any consumer that just wants the data.

Opt back in per request:

```bash
# REST
http localhost:7890/api/values provider==dwd network==observation parameters==daily/kl periods==recent station==01048 with_metadata==true with_stations==true

# CLI
wetterdienst values --provider=dwd --network=observation --parameters=daily/kl --periods=recent --station=01048 --with_metadata=true --with_stations=true
```

## Blast radius (checked)
- **Frontend: unaffected.** The DataViewer reads only the `values` array; the meteogram/map read the `stations` endpoint's own payload (always present). No frontend code consumes the value-response `metadata`/`stations` blocks.
- **Result classes already default to compact internally** (`to_dict(with_metadata=False, with_stations=False)`); this only flips the UI request-model / CLI-option defaults that were forcing the blocks on.
- Tests updated: the metadata/geojson/history tests now request the blocks explicitly (1 REST + 4 CLI). A new offline test locks in the compact defaults. All affected CLI suites pass (106).

## ⚠️ Breaking change
REST and CLI responses no longer include the `metadata`/`stations` blocks unless explicitly requested. Documented in the changelog (`Changed`) and the REST API docs.

Motivated by making the MCP tools (#1761) usable by small models — compact-by-default is the clean, single-source-of-truth way to get there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)