### PR TITLE
fix(mcp): return 404 for OAuth discovery so /mcp is treated as no-auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- Return `404` for the OAuth discovery paths (`/.well-known/oauth-authorization-server`,
+  `/.well-known/oauth-protected-resource`) on the REST API so MCP clients treat the open `/mcp`
+  server as no-auth instead of attempting (and failing) OAuth Dynamic Client Registration
+
 ## [0.129.0] - 2026-07-27
 
 ### Added

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -16,6 +16,12 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[API]` Return `404` for `/.well-known/oauth-*` on the app origin instead of letting the SPA
+  catch-all serve a `200` HTML page there, so MCP clients such as Claude Desktop treat the proxied
+  `/mcp` server as no-auth and connect without failing OAuth Dynamic Client Registration.
+
 ## [0.11.0] - 2026-07-27
 
 ### Added

--- a/frontend/server/middleware/well-known-oauth.ts
+++ b/frontend/server/middleware/well-known-oauth.ts
@@ -1,0 +1,12 @@
+// MCP clients (e.g. Claude Desktop) probe `/.well-known/oauth-*` before connecting to `/mcp` to
+// discover an OAuth authorization server. The wetterdienst `/mcp` server is open (no auth), so those
+// paths must return 404 -- that is how a client concludes "no OAuth here" and connects anonymously.
+//
+// Without this, the Nuxt SPA catch-all answers `/.well-known/oauth-*` with a 200 `index.html`, which
+// the client mistakes for OAuth metadata and then fails Dynamic Client Registration against (the
+// "Registrierung beim Anmeldedienst ... fehlgeschlagen" error). Returning 404 fixes the connect flow.
+export default defineEventHandler((event) => {
+  if (event.path.startsWith('/.well-known/oauth-')) {
+    throw createError({ statusCode: 404, statusMessage: 'Not Found' })
+  }
+})

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -230,6 +230,20 @@ def version() -> JSONResponse:
     return JSONResponse(content={"version": __version__})
 
 
+# OAuth discovery endpoints. The `/mcp` server is open (no auth), so MCP clients such as Claude
+# Desktop must receive a 404 here to conclude "no authorization server" and connect anonymously;
+# a 200 (e.g. from a catch-all serving HTML) makes them attempt -- and fail -- Dynamic Client
+# Registration. FastAPI already 404s unknown paths (including the resource-specific sub-paths like
+# `.../oauth-protected-resource/mcp`), but declaring these explicitly documents the no-auth contract
+# and keeps it correct if a static/SPA catch-all is ever mounted ahead of these routes.
+# `include_in_schema=False` keeps them out of the OpenAPI schema so they do not become MCP tools.
+@app.get("/.well-known/oauth-authorization-server", include_in_schema=False)
+@app.get("/.well-known/oauth-protected-resource", include_in_schema=False)
+def oauth_metadata_not_found() -> None:
+    """Return 404 for OAuth discovery so the open `/mcp` server is treated as no-auth."""
+    raise HTTPException(status_code=404, detail="Not Found")
+
+
 @app.get("/api/auth")
 def auth(
     provider: str,


### PR DESCRIPTION
## Problem

Connecting Claude Desktop to the hosted MCP server (`https://wetterdienst.eobs.org/mcp`) fails with:

> Registrierung beim Anmeldedienst von wetterdienst fehlgeschlagen. … eine OAuth Client ID in den Connector-Einstellungen hinzufügen.

Per the MCP auth spec, a client probes `/.well-known/oauth-*` before connecting. For an **open** server (no auth) those must return `404`, which tells the client "no authorization server — connect anonymously". The `/mcp` endpoint itself is open and returns `200` with no `WWW-Authenticate`:

```
POST /mcp  (initialize)                        -> 200, no WWW-Authenticate   OK (open)
GET  /.well-known/oauth-protected-resource     -> 200 text/html              should be 404
GET  /.well-known/oauth-protected-resource/mcp -> 200 text/html              should be 404
GET  /.well-known/oauth-authorization-server   -> 200 text/html              should be 404
```

The Nuxt SPA catch-all was serving `index.html` (`200`) for those paths. Claude Desktop read the `200` as "an authorization server exists here", tried to parse the (HTML) metadata and run Dynamic Client Registration against it, and failed.

## Fix

- **Frontend** (`frontend/server/middleware/well-known-oauth.ts`): Nitro middleware returning `404` for `/.well-known/oauth-*` so those paths no longer fall through to the SPA. **This is what fixes the reported error**, since it comes from the app origin.
- **Backend** (`src/wetterdienst/ui/restapi.py`): explicit `404` routes for the two OAuth discovery paths. FastAPI already 404s unknown paths (including sub-paths like `.../oauth-protected-resource/mcp`), so this is defense-in-depth + documentation of the "`/mcp` is open, no-auth" contract, and stays correct if a static/SPA catch-all is ever mounted ahead of these routes. `include_in_schema=False` keeps them out of the OpenAPI schema so they don't become MCP tools.

## Verification

Backend, via `TestClient`:

```
404  /.well-known/oauth-authorization-server      -> {'detail': 'Not Found'}
404  /.well-known/oauth-protected-resource         -> {'detail': 'Not Found'}
404  /.well-known/oauth-protected-resource/mcp     -> {'detail': 'Not Found'}
well-known paths in OpenAPI schema: none
```

Once the frontend change is deployed, the Claude Desktop connector attaches to `/mcp` with no OAuth step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)