### PR TITLE
docs(mcp): clearer history/summarize/interpolate tool descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Types of changes:
 
 ## [Unreleased]
 
+### Changed
+
+- Rewrite the `history`, `summarize` and `interpolate` endpoint descriptions (which become the MCP
+  tool descriptions) so small models stop mis-routing plain weather questions to them: they now say
+  what each returns and that it is not measured weather -- `history` is station *metadata* history
+  (name/location/sensor changes), `summarize`/`interpolate` estimate a value for a point *between*
+  stations. Add a "Choosing a tool" note to the MCP instructions pointing weather questions at the
+  `stations` -> `values` workflow
+
 ### Fixed
 
 - Match station names with `WRatio` (was `token_sort_ratio`) in `filter_by_name`, so a bare place

--- a/src/wetterdienst/ui/mcp.py
+++ b/src/wetterdienst/ui/mcp.py
@@ -41,6 +41,14 @@ default, plus NOAA, ECCC, Météo-France and more). These tools mirror its REST 
             parameters="daily/climate_summary/temperature_air_mean_2m",
             station="01975", periods="recent")
 
+## Choosing a tool
+For "what was/is the weather at <place>" always use `stations` then `values` -- that is the only \
+path to measured weather. The similarly named tools are for other jobs: `history` returns a \
+station's *metadata* history (name/location/sensor changes), not weather; `summarize` and \
+`interpolate` estimate values for a point *between* stations (nearest-station and spatial \
+interpolation respectively), not a plain-language summary. Reach for those only when explicitly \
+asked for a between-stations estimate or station-change audit.
+
 ## Conventions
 - provider/network: use "dwd"/"observation" for German ground observations (the common case). Call \
 `coverage` with no arguments to list every provider/network.

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -544,7 +544,13 @@ def values(
 def interpolate(
     request: Annotated[InterpolationRequest, Query()],
 ) -> Response:
-    """Wrap around get_interpolate to provide results via restapi."""
+    """Estimate a value series at a point between stations by spatial interpolation.
+
+    For a `latitude`/`longitude` (or reference `station`) that has no station of its own, this
+    interpolates each parameter from up to four surrounding stations. Requires provider, network,
+    parameters and a `date`. Use this only to estimate values at an arbitrary location -- for the
+    actual measured weather at a place, use the stations -> values workflow instead.
+    """
     set_logging_level(debug=request.debug)
 
     try:
@@ -617,7 +623,14 @@ def interpolate(
 def summarize(
     request: Annotated[SummaryRequest, Query()],
 ) -> Response:
-    """Wrap around get_summarize to provide results via restapi."""
+    """Build a value series at a point from the nearest stations with data (not a text summary).
+
+    For a `latitude`/`longitude` (or reference `station`) without its own measurements, this takes --
+    per parameter and date -- the value of the closest station that reported it (the result names the
+    `taken_station_id` and its `distance`). Requires provider, network, parameters and a `date`. This
+    is NOT a weather summary: for the actual weather at a place use the stations -> values workflow;
+    use this only to fill a point between stations.
+    """
     set_logging_level(debug=request.debug)
 
     try:
@@ -828,10 +841,12 @@ def stripes_image(
 def history(  # noqa: C901
     request: Annotated[HistoryRequest, Query()],
 ) -> Response:
-    """Wrap get_history to provide station history via restapi.
+    """Return a station's metadata history -- how the station itself changed over time (not weather).
 
-    Support querying multiple stations or using 'all' to collect histories for
-    multiple stations.
+    Provides the record of a station's name, position, sensors/devices and data-gap sections across
+    its lifetime, for auditing station changes. This is NOT weather or measurement history: for past
+    measurements use the stations -> values workflow with a `date` or interval. Requires provider,
+    network, parameters and either `station` id(s) or all=true.
     """
     set_logging_level(debug=request.debug)
 


### PR DESCRIPTION
These endpoint docstrings become the MCP tool descriptions, and read "Wrap get_history…" / "Wrap around get_summarize…" — no user-facing semantics. So small models mis-route plain weather questions to them (picking `history` for "weather history", `summarize` for "weather summary"), as seen reproducing a Haiku session for *"Wie war das Wetter in Kiel…"*.

Rewrite all three to state what they return and that it is **not** measured weather:
- `history` → station *metadata* history (name/location/sensor changes)
- `summarize` → value at a point from the nearest station with data
- `interpolate` → spatial interpolation from surrounding stations

Also add a "Choosing a tool" note to the MCP `instructions` steering weather questions to the `stations` → `values` workflow.

The `stations` rank-listing fix that was originally part of this branch is now split out into its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)