### PR TITLE
fix(ui): limit the stations listing to the requested rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ Types of changes:
 - Honor the `rank` argument in `filter_by_name` (it was silently ignored, always returning up to 5
   matches): it now returns the `rank` best matches, best score first (default 1). The `stations`
   REST/CLI listing requests several name candidates by default and passes through an explicit `rank`
+- Limit the `stations` listing to the requested `rank` on the REST API (`/api/stations`) and CLI
+  (`stations`). A rank filter keeps every station in the frame (the `rank` limit is applied lazily
+  during value collection), so a listing that asked for the N closest returned all stations instead
+  -- e.g. `rank=3` near Kiel returned all 1284 DWD stations (a ~365 KB response that overwhelmed MCP
+  clients). Listings now return the `rank` closest by distance
 - Return `404` for the OAuth discovery paths (`/.well-known/oauth-authorization-server`,
   `/.well-known/oauth-protected-resource`) on the REST API so MCP clients treat the open `/mcp`
   server as no-auth instead of attempting (and failing) OAuth Dynamic Client Registration

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -33,6 +33,7 @@ from wetterdienst.ui.core import (
     get_stations,
     get_summarize,
     get_values,
+    limit_stations_to_rank,
     set_logging_level,
 )
 from wetterdienst.util.cli import docstring_format_verbatim, setup_logging
@@ -919,6 +920,10 @@ def stations(
     if stations_.df.is_empty():
         log.error("No stations available for given constraints")
         sys.exit(1)
+
+    # A rank filter keeps all stations in the frame (rank is applied lazily during value collection);
+    # for a plain listing return just the N closest the caller asked for instead of every station.
+    stations_ = limit_stations_to_rank(stations_)
 
     if target:
         stations_.to_target(target)

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -804,6 +804,26 @@ def get_stations(
     raise KeyError(msg)
 
 
+def limit_stations_to_rank(stations: StationsResult) -> StationsResult:
+    """Trim a rank-filtered stations *listing* to the requested ``rank`` rows.
+
+    ``filter_by_rank`` intentionally keeps *all* stations (distance-sorted) in ``df`` because the real
+    ``rank`` limit is applied later, during value collection: that walk takes the ``rank`` closest
+    stations that actually carry data (governed by ``ts_skip_empty`` / ``ts_skip_threshold`` /
+    ``ts_skip_criteria``) and exposes them via ``ValuesResult.df_stations``.
+
+    A plain stations listing does no value collection, so it cannot apply that data-aware selection --
+    but returning every station (e.g. 1284 for DWD) when the caller asked for the N closest is both
+    surprising and huge. Here we slice to the ``rank`` closest *by distance* (data availability
+    unknown at listing time); leave other filters untouched.
+    """
+    from wetterdienst.model.result import StationsFilter  # noqa: PLC0415
+
+    if stations.stations_filter is StationsFilter.BY_RANK and stations.rank:
+        stations.df = stations.df.head(stations.rank)
+    return stations
+
+
 def get_values(
     api: type[TimeseriesRequest],
     request: ValuesRequest,

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -39,6 +39,7 @@ from wetterdienst.ui.core import (
     get_stations,
     get_summarize,
     get_values,
+    limit_stations_to_rank,
     set_logging_level,
 )
 from wetterdienst.util.cli import setup_logging
@@ -392,6 +393,10 @@ def stations(
     except Exception as e:
         log.exception("Failed to get stations.")
         raise HTTPException(status_code=400, detail=str(e)) from e
+
+    # A rank filter keeps all stations in the frame (rank is applied lazily during value collection);
+    # for a plain listing return just the N closest the caller asked for instead of every station.
+    stations_ = limit_stations_to_rank(stations_)
 
     # build kwargs dynamically
     kwargs: dict[str, Any] = {


### PR DESCRIPTION
`filter_by_rank` intentionally keeps **all** stations in the result frame — the `rank` limit is applied lazily during value collection (it takes the `rank` closest stations that actually carry data, governed by `ts_skip_empty`). But the `stations` REST/CLI listing does no value collection, so it formatted the full frame: asking for the 3 nearest stations to Kiel returned **all 1284 DWD stations** (~365 KB), which overwhelmed MCP clients and produced a confusing giant dump.

Add `limit_stations_to_rank()` and apply it in the REST (`/api/stations`) and CLI `stations` listings so they return the `rank` closest by distance (data availability is unknown at listing time). Value collection is unchanged.

Found while reproducing a Haiku MCP session for *"Wie war das Wetter in Kiel am 26.12.2025?"*. Split out of #1774.

🤖 Generated with [Claude Code](https://claude.com/claude-code)