### PR TITLE
fix(mcp): correct values output schema so validation can stay on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ Types of changes:
 - Return `404` for the OAuth discovery paths (`/.well-known/oauth-authorization-server`,
   `/.well-known/oauth-protected-resource`) on the REST API so MCP clients treat the open `/mcp`
   server as no-auth instead of attempting (and failing) OAuth Dynamic Client Registration
+- Type `value`/`quality` as `float | None` (was `str`) in the `_ValuesItemDict` response model, so
+  the `/api/values` OpenAPI schema matches the numbers actually serialised. The MCP `values` tool
+  derives its output schema from that model, and the wrong `str` type made FastMCP reject valid
+  results with `9.0 is not of type 'string'`. This fixes the real schema instead of the previous
+  workaround (`validate_output=False`), so MCP output validation is now enabled again
 
 ## [0.129.0] - 2026-07-27
 

--- a/src/wetterdienst/model/result.py
+++ b/src/wetterdienst/model/result.py
@@ -416,8 +416,8 @@ class _ValuesItemDict(TypedDict):
     dataset: str
     parameter: str
     date: str
-    value: str
-    quality: str
+    value: float | None
+    quality: float | None
 
 
 class _ValuesDict(TypedDict):

--- a/src/wetterdienst/ui/mcp.py
+++ b/src/wetterdienst/ui/mcp.py
@@ -102,12 +102,10 @@ def build_mcp_server(rest_app: FastAPI) -> FastMCP:
     Wraps every data endpoint as an MCP tool and attaches the workflow ``instructions``, clean tool
     names and the noise-endpoint exclusions described in the module docstring.
 
-    This drives the ``OpenAPIProvider`` directly (rather than ``FastMCP.from_fastapi``) so it can pass
-    ``validate_output=False``: the REST endpoints return a raw JSON string but declare rich
-    ``response_model`` unions, which FastMCP turns into inaccurate output schemas (numeric measurement
-    values typed as strings). With the default validation that makes ``values`` reject perfectly good
-    results with "9.0 is not of type 'string'"; ``validate_output=False`` replaces those schemas with
-    a permissive object schema so the tools work.
+    This drives the ``OpenAPIProvider`` directly (rather than ``FastMCP.from_fastapi``) so the route
+    maps, tool names and lifespan can be configured in one place. Output validation is left on (the
+    default): the endpoints' ``response_model`` types match what they actually serialise, so FastMCP
+    derives accurate output schemas and validating the results catches real drift.
     """
     from contextlib import asynccontextmanager  # noqa: PLC0415
 
@@ -122,7 +120,6 @@ def build_mcp_server(rest_app: FastAPI) -> FastMCP:
         client=client,
         route_maps=route_maps,
         mcp_names=_TOOL_NAMES,
-        validate_output=False,
     )
 
     @asynccontextmanager


### PR DESCRIPTION
## Problem

When the MCP endpoint was added, `build_mcp_server` passed `validate_output=False` to work around the `values` tool rejecting valid results with `9.0 is not of type 'string'`. That disabled **all** MCP output validation to silence a symptom. This PR fixes the actual cause and turns validation back on.

## Root cause

It wasn't a FastMCP quirk — it was a wrong type annotation. In `_ValuesItemDict` (`model/result.py`, the `response_model` for `/api/values`):

```python
value: str
quality: str
```

But both columns are `pl.Float64` (nullable) — `to_dicts()` emits real floats like `9.0`. So FastAPI generated an OpenAPI schema declaring `value`/`quality` as `string`; FastMCP derives its tool output schema from that spec, then validated the real float against it and correctly rejected it.

(The sibling `_InterpolatedValuesItemDict` / `_SummarizedValuesItemDict` already used `value: float`, which is why only `values` broke.)

## Fix

- `result.py` — annotate `value`/`quality` as `float | None` (nullable because `value` is only null-dropped when `ts_drop_nulls=True`, and `quality` is never dropped). The generated schema is now `anyOf: [number, null]`, matching the data.
- `mcp.py` — remove `validate_output=False` and update the docstring, so output validation is enabled again and guards against future schema drift.

## Verification

- Generated OpenAPI schema for `value`/`quality` is now `anyOf: [number, null]` (was `string`).
- The remote regression test `test_mcp_values_tool_returns_data` passes **with validation enabled** — previously it only passed because validation was off.
- Full non-remote `tests/ui/test_restapi.py` (24 tests), `poe format`, ruff lint, and `ty` typecheck all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)