### PR TITLE
fix(mcp): correct interpolate/summarize output schemas and steer away from them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Types of changes:
 
 ## [Unreleased]
 
+### Changed
+
+- Sharpen the `interpolate`/`summarize` endpoint descriptions (which become the MCP tool
+  descriptions) and the MCP instructions so agents stop routing plain weather questions to them.
+  `stations` -> `values` is now stated as the default for weather at a named place even when a
+  specific past date is given, and interpolate/summarize are called out as opt-in estimates -- used
+  only on explicit request or when no station with data is near the point -- because they add
+  inaccuracy
+
 ### Fixed
 
 - Type the `interpolate`/`summarize` response-model items to match what the endpoints serialise, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- Type the `interpolate`/`summarize` response-model items to match what the endpoints serialise, so
+  their MCP output schemas stop rejecting valid results. `_InterpolatedValuesItemDict` and
+  `_SummarizedValuesItemDict` now include the `resolution`/`dataset` keys (always present in the
+  rows) and type `value`/`distance_mean`/`distance`/`taken_station_id` as nullable: interpolating or
+  summarizing a point with no station in reach serialises `null` for those fields, which the previous
+  non-null schema rejected (the same schema drift fixed for `values` in 0.130.0)
+
 ## [0.130.0] - 2026-07-30
 
 ### Changed

--- a/src/wetterdienst/model/result.py
+++ b/src/wetterdienst/model/result.py
@@ -684,10 +684,12 @@ class _InterpolatedValuesItemDict(TypedDict):
     """Type definition for dictionary of interpolated values."""
 
     station_id: str
+    resolution: str
+    dataset: str
     parameter: str
     date: str
-    value: float
-    distance_mean: float
+    value: float | None
+    distance_mean: float | None
     taken_station_ids: list[str]
 
 
@@ -884,11 +886,13 @@ class _SummarizedValuesItemDict(TypedDict):
     """Format summarized values as dictionary."""
 
     station_id: str
+    resolution: str
+    dataset: str
     parameter: str
     date: str
-    value: float
-    distance: float
-    taken_station_id: str
+    value: float | None
+    distance: float | None
+    taken_station_id: str | None
 
 
 class _SummarizedValuesDict(TypedDict):

--- a/src/wetterdienst/ui/mcp.py
+++ b/src/wetterdienst/ui/mcp.py
@@ -42,12 +42,18 @@ default, plus NOAA, ECCC, Météo-France and more). These tools mirror its REST 
             station="01975", periods="recent")
 
 ## Choosing a tool
-For "what was/is the weather at <place>" always use `stations` then `values` -- that is the only \
-path to measured weather. The similarly named tools are for other jobs: `history` returns a \
-station's *metadata* history (name/location/sensor changes), not weather; `summarize` and \
-`interpolate` estimate values for a point *between* stations (nearest-station and spatial \
-interpolation respectively), not a plain-language summary. Reach for those only when explicitly \
-asked for a between-stations estimate or station-change audit.
+For "what was/is the weather at <place>" ALWAYS use `stations` then `values` -- that is the only \
+path to measured weather, and the correct default. This holds even when the request names a \
+specific past date (e.g. "how was the weather in Kiel on 26.12.2025"): find Kiel's nearest station \
+with `stations`, then read its `values` for that date. Do NOT reach for `interpolate` or \
+`summarize` here.
+
+`interpolate` and `summarize` estimate values for a point *between* stations (spatial interpolation \
+and nearest-station-with-data respectively); both introduce inaccuracy and are opt-in. Use them \
+ONLY when the user explicitly asks for an interpolated / between-stations estimate, or when \
+`stations` -> `values` genuinely returns no station with data near the location. They are not a \
+plain-language "summary". `history` is different again: it returns a station's *metadata* history \
+(name/location/sensor changes), not weather.
 
 ## Conventions
 - provider/network: use "dwd"/"observation" for German ground observations (the common case). Call \

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -549,12 +549,16 @@ def values(
 def interpolate(
     request: Annotated[InterpolationRequest, Query()],
 ) -> Response:
-    """Estimate a value series at a point between stations by spatial interpolation.
+    """Estimate a value series at a point between stations by spatial interpolation (opt-in; adds inaccuracy).
 
-    For a `latitude`/`longitude` (or reference `station`) that has no station of its own, this
-    interpolates each parameter from up to four surrounding stations. Requires provider, network,
-    parameters and a `date`. Use this only to estimate values at an arbitrary location -- for the
-    actual measured weather at a place, use the stations -> values workflow instead.
+    Do NOT use this for the weather at a named place (city, town, station) -- that is ALWAYS the
+    `stations` -> `values` workflow, even when a specific past date is given (e.g. "the weather in
+    Kiel on 26.12.2025": find Kiel's nearest station, then read its values for that date). Only reach
+    for interpolate when the user explicitly asks for an interpolated / between-stations estimate, or
+    when `stations` -> `values` genuinely finds no station with data near the location. It blends up
+    to four surrounding stations for a `latitude`/`longitude` (or reference `station`) that has no
+    station of its own, so the result is a modelled estimate, not a measurement. Requires provider,
+    network, parameters and a `date`.
     """
     set_logging_level(debug=request.debug)
 
@@ -628,13 +632,16 @@ def interpolate(
 def summarize(
     request: Annotated[SummaryRequest, Query()],
 ) -> Response:
-    """Build a value series at a point from the nearest stations with data (not a text summary).
+    """Build a value series at a point from the nearest stations with data (opt-in; not a text summary).
 
-    For a `latitude`/`longitude` (or reference `station`) without its own measurements, this takes --
-    per parameter and date -- the value of the closest station that reported it (the result names the
-    `taken_station_id` and its `distance`). Requires provider, network, parameters and a `date`. This
-    is NOT a weather summary: for the actual weather at a place use the stations -> values workflow;
-    use this only to fill a point between stations.
+    Do NOT use this for the weather at a named place (city, town, station) -- that is ALWAYS the
+    `stations` -> `values` workflow, even when a specific past date is given. Despite the name this
+    is NOT a plain-language weather summary. Only reach for it when the user explicitly asks for a
+    nearest-station estimate at an arbitrary point, or when `stations` -> `values` genuinely finds no
+    station with data near the location. Per parameter and date it takes the value of the closest
+    station that reported it (the result names the `taken_station_id` and its `distance`), so the
+    result may stitch together different stations. Requires provider, network, parameters and a
+    `date`.
     """
     set_logging_level(debug=request.debug)
 

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -1852,6 +1852,9 @@ def test_mcp_server_is_agent_friendly() -> None:
     assert instructions is not None
     assert "stations" in instructions
     assert "values" in instructions
+    # interpolate/summarize are steered as opt-in, not the default for weather at a place
+    assert "interpolate" in instructions
+    assert "opt-in" in instructions or "explicitly" in instructions
 
 
 @pytest.mark.parametrize(

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -1854,6 +1854,34 @@ def test_mcp_server_is_agent_friendly() -> None:
     assert "values" in instructions
 
 
+@pytest.mark.parametrize(
+    ("schema_name", "nullable_numeric"),
+    [
+        ("_ValuesItemDict", ("value", "quality")),
+        ("_InterpolatedValuesItemDict", ("value", "distance_mean")),
+        ("_SummarizedValuesItemDict", ("value", "distance")),
+    ],
+)
+def test_values_item_output_schemas_match_payload(schema_name: str, nullable_numeric: tuple[str, ...]) -> None:
+    """The values/interpolate/summarize item schemas match what the endpoints serialise (regression).
+
+    Guards the MCP output-schema drift behind #1776: every item carries `resolution` and `dataset`,
+    and the numeric fields that go null when no station is in reach (e.g. an out-of-range
+    interpolation point) must be typed nullable, or FastMCP output validation rejects the response.
+    """
+    from wetterdienst.ui.restapi import app  # noqa: PLC0415
+
+    schema = app.openapi()["components"]["schemas"][schema_name]
+    properties = schema["properties"]
+    # resolution and dataset are always present in the serialised rows
+    assert {"resolution", "dataset"} <= properties.keys()
+    # nullable numeric fields are typed as number-or-null (anyOf includes a null branch)
+    for field in nullable_numeric:
+        branches = properties[field].get("anyOf", [properties[field]])
+        assert any(branch.get("type") == "null" for branch in branches), f"{schema_name}.{field} not nullable"
+        assert any(branch.get("type") == "number" for branch in branches), f"{schema_name}.{field} not numeric"
+
+
 @pytest.mark.remote
 def test_mcp_values_tool_returns_data() -> None:
     """The values MCP tool returns data instead of failing output-schema validation (regression)."""
@@ -1877,6 +1905,43 @@ def test_mcp_values_tool_returns_data() -> None:
                     "parameters": "daily/climate_summary/temperature_air_mean_2m",
                     "station": "01975",
                     "periods": "recent",
+                },
+            )
+            return result.data
+
+    data = asyncio.run(_call())
+    assert data is not None
+
+
+@pytest.mark.remote
+def test_mcp_interpolate_tool_returns_data() -> None:
+    """The interpolate MCP tool passes output-schema validation, including null out-of-range rows.
+
+    Interpolation of a point with no station in reach serialises null `value`/`distance_mean`; this
+    exercises that the item schema types them nullable (regression for the interpolate/summarize
+    counterpart of #1776).
+    """
+    pytest.importorskip("fastmcp")
+    pytest.importorskip("utm")
+    import asyncio  # noqa: PLC0415
+
+    from fastmcp import Client  # noqa: PLC0415
+
+    from wetterdienst.ui import restapi  # noqa: PLC0415
+    from wetterdienst.ui.mcp import build_mcp_server  # noqa: PLC0415
+
+    mcp = build_mcp_server(restapi.app)
+
+    async def _call() -> object:
+        async with Client(mcp) as client:
+            result = await client.call_tool(
+                "interpolate",
+                {
+                    "provider": "dwd",
+                    "network": "observation",
+                    "parameters": "daily/climate_summary/temperature_air_mean_2m",
+                    "station": "00071",
+                    "date": "1986-10-31/1986-11-01",
                 },
             )
             return result.data


### PR DESCRIPTION
## Problem

Two MCP issues surfaced while benchmarking small-model agents:

1. **`interpolate`/`summarize` could fail FastMCP output-schema validation** — the same drift #1776 fixed for `values`, never propagated to these two. Their item response models (`_InterpolatedValuesItemDict`, `_SummarizedValuesItemDict`) omitted `resolution`/`dataset` (always present in the serialised rows) and typed `value`/`distance_mean`/`distance`/`taken_station_id` as non-null. When interpolation/summary finds **no station in reach** it serialises `null` for exactly those fields, so the generated `number`/`string` schema rejected the real payload (e.g. "None is not of type 'number'"). This is the common "weather at a place" misuse case, so it hit often.

2. **Agents picked `interpolate`/`summarize` for "weather at &lt;place&gt;"** (even for a specific past date, e.g. "how was the weather in Kiel on 26.12.2025") instead of the `stations` → `values` workflow, pulling in avoidable inaccuracy.

## Fix

- **Schemas** (`model/result.py`): add `resolution`/`dataset` and make `value`/`distance_mean`/`distance`/`taken_station_id` nullable, matching what the endpoints actually emit (verified against the interpolate/summarize core schemas — `apply_summary` literally returns `(res, ds, param, None, None, None)`). Generated OpenAPI item schemas now match the payloads.
- **Steering** (`ui/restapi.py` docstrings + `ui/mcp.py` INSTRUCTIONS): make `stations` → `values` the explicit default for weather at a named place **even for a past date**, and mark `interpolate`/`summarize` as opt-in (only on explicit request or when no station with data is near the point).

## Tests

- Offline `test_values_item_output_schemas_match_payload` (3 params) asserts all three item schemas carry `resolution`/`dataset` and nullable numerics — no network/extras needed, guards against re-drift.
- Remote `test_mcp_interpolate_tool_returns_data` calls the interpolate tool through FastMCP end-to-end with output validation on (would have failed before this change).
- Existing `values` MCP test still passes; `test_mcp_server_is_agent_friendly` now also asserts the opt-in steering language.

ruff + ty clean; offline (4) and remote (2) tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)