### PR TITLE
feat(metoffice): add Met Office (UK) observation provider via MIDAS Open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,13 @@ Types of changes:
   speed/gust/direction, cloud cover, sea-level pressure, precipitation, snow depth) from ~52
   stations, with historical data back to roughly 2016 fetched per station and day. Settled past days
   are cached indefinitely while the current day uses a short cache
+- Add a Met Office (UK) observation provider (`metoffice`/`observation`) backed by the MIDAS Open
+  archive on CEDA (UK Open Government Licence). Covers eight datasets across daily and hourly
+  resolution (rain, temperature, weather, wind, radiation, soil temperature). Requires a free CEDA
+  account (`WD_AUTH__CEDA=<username>:<password>`); the bearer token is minted from those credentials
+  and cached in-process until shortly before it expires. Multiple report types per day are collapsed
+  to one value per calendar day, multi-day rain accumulations are dropped, and native units are
+  normalised (e.g. visibility from decametres to metres)
 
 ### Changed
 

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -108,6 +108,13 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
         - Historical and recent observations from Norwegian station network
         - 10-minute, hourly, 6-hourly (historical only), daily, monthly and annual resolution
         - ~2200 stations; requires free API key from frost.met.no
+- Met Office (UK Met Office / United Kingdom)
+    - Observation
+        - historical UK land surface observations from the MIDAS Open archive on CEDA
+        - daily and hourly resolution across eight datasets (rain, temperature, weather, wind,
+          radiation, soil temperature); some stations back to the 19th century
+        - annual releases, so the most recent ~6-12 months are not yet available
+        - requires a free CEDA account (`WD_AUTH__CEDA=<username>:<password>`)
 - NOAA (National Oceanic and Atmospheric Administration / United States of America)
     - Global Historical Climatology Network (GHCN)
         - hourly (GHCNh) and daily weather observations from around the globe

--- a/docs/data/provider/index.md
+++ b/docs/data/provider/index.md
@@ -19,6 +19,7 @@ lhmt/index.md
 meteofrance/index.md
 meteoswiss/index.md
 metno/index.md
+metoffice/index.md
 noaa/index.md
 nws/index.md
 rmi/index.md

--- a/docs/data/provider/metoffice/index.md
+++ b/docs/data/provider/metoffice/index.md
@@ -1,0 +1,23 @@
+# Met Office
+
+UK Met Office (MIDAS Open)
+
+## Overview
+
+The Met Office provider serves UK land surface observations from the **MIDAS Open** archive
+hosted at CEDA (the Centre for Environmental Data Analysis), covering daily and hourly
+resolution. A free CEDA account is required.
+
+## License
+
+MIDAS Open is © Crown Copyright, Met Office and published under the
+[UK Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/),
+which permits copying, adaptation and commercial use with attribution. See the
+[MIDAS Open dataset catalogue record](https://catalogue.ceda.ac.uk/uuid/dbd451271eb04662beade68da43546e1/)
+for further information and the required citation.
+
+```{toctree}
+:hidden:
+
+observation/index.md
+```

--- a/docs/data/provider/metoffice/observation/daily.md
+++ b/docs/data/provider/metoffice/observation/daily.md
@@ -1,0 +1,59 @@
+# daily
+
+## metadata
+
+| property      | value |
+|---------------|-------|
+| name          | daily |
+| original name | daily |
+
+## datasets
+
+### rain
+
+#### metadata
+
+| property      | value             |
+|---------------|-------------------|
+| name          | rain              |
+| original name | uk-daily-rain-obs |
+
+#### parameters
+
+| name                 | original name | unit type     | unit |
+|----------------------|---------------|---------------|------|
+| precipitation_height | prcp_amt      | precipitation | mm   |
+
+### temperature
+
+#### metadata
+
+| property      | value                    |
+|---------------|--------------------------|
+| name          | temperature              |
+| original name | uk-daily-temperature-obs |
+
+#### parameters
+
+| name                      | original name | unit type   | unit |
+|---------------------------|---------------|-------------|------|
+| temperature_air_max_2m    | max_air_temp  | temperature | °C   |
+| temperature_air_min_2m    | min_air_temp  | temperature | °C   |
+| temperature_air_min_0_05m | min_grss_temp | temperature | °C   |
+
+### weather
+
+#### metadata
+
+| property      | value                |
+|---------------|----------------------|
+| name          | weather              |
+| original name | uk-daily-weather-obs |
+
+#### parameters
+
+| name              | original name    | unit type    | unit |
+|-------------------|------------------|--------------|------|
+| sunshine_duration | drv_24hr_sun_dur | time         | h    |
+| snow_depth        | snow_depth       | length_short | cm   |
+| snow_depth_new    | frsh_snw_amt     | length_short | cm   |

--- a/docs/data/provider/metoffice/observation/hourly.md
+++ b/docs/data/provider/metoffice/observation/hourly.md
@@ -1,0 +1,107 @@
+# hourly
+
+## metadata
+
+| property      | value  |
+|---------------|--------|
+| name          | hourly |
+| original name | hourly |
+
+## datasets
+
+### rain
+
+#### metadata
+
+| property      | value              |
+|---------------|--------------------|
+| name          | rain               |
+| original name | uk-hourly-rain-obs |
+
+#### parameters
+
+| name                   | original name | unit type     | unit |
+|------------------------|---------------|---------------|------|
+| precipitation_height   | prcp_amt      | precipitation | mm   |
+| precipitation_duration | prcp_dur      | time          | min  |
+
+### weather
+
+#### metadata
+
+| property      | value                 |
+|---------------|-----------------------|
+| name          | weather               |
+| original name | uk-hourly-weather-obs |
+
+#### parameters
+
+| name                          | original name    | unit type     | unit |
+|-------------------------------|------------------|---------------|------|
+| wind_direction                | wind_direction   | angle         | °    |
+| wind_speed                    | wind_speed       | speed         | kn   |
+| wind_gust_max                 | q10mnt_mxgst_spd | speed         | kn   |
+| visibility_range              | visibility       | length_medium | m    |
+| pressure_air_sea_level        | msl_pressure     | pressure      | hPa  |
+| pressure_air_site             | stn_pres         | pressure      | hPa  |
+| temperature_air_mean_2m       | air_temperature  | temperature   | °C   |
+| temperature_dew_point_mean_2m | dewpoint         | temperature   | °C   |
+| humidity                      | rltv_hum         | fraction      | %    |
+| sunshine_duration             | wmo_hr_sun_dur   | time          | h    |
+| snow_depth                    | snow_depth       | length_short  | cm   |
+| cloud_cover_total             | cld_ttl_amt_id   | fraction      | 1/8  |
+| weather                       | prst_wx_id       | dimensionless | -    |
+
+### wind
+
+#### metadata
+
+| property      | value            |
+|---------------|------------------|
+| name          | wind             |
+| original name | uk-mean-wind-obs |
+
+#### parameters
+
+| name                    | original name   | unit type | unit |
+|-------------------------|-----------------|-----------|------|
+| wind_direction          | mean_wind_dir   | angle     | °    |
+| wind_speed              | mean_wind_speed | speed     | kn   |
+| wind_direction_gust_max | max_gust_dir    | angle     | °    |
+| wind_gust_max           | max_gust_speed  | speed     | kn   |
+
+### radiation
+
+#### metadata
+
+| property      | value            |
+|---------------|------------------|
+| name          | radiation        |
+| original name | uk-radiation-obs |
+
+#### parameters
+
+| name                             | original name | unit type       | unit  |
+|----------------------------------|---------------|-----------------|-------|
+| radiation_global                 | glbl_irad_amt | energy_per_area | kJ/m² |
+| radiation_sky_short_wave_diffuse | difu_irad_amt | energy_per_area | kJ/m² |
+| radiation_sky_short_wave_direct  | direct_irad   | energy_per_area | kJ/m² |
+
+### soil_temperature
+
+#### metadata
+
+| property      | value                   |
+|---------------|-------------------------|
+| name          | soil_temperature        |
+| original name | uk-soil-temperature-obs |
+
+#### parameters
+
+| name                        | original name    | unit type   | unit |
+|-----------------------------|------------------|-------------|------|
+| temperature_soil_mean_0_05m | q5cm_soil_temp   | temperature | °C   |
+| temperature_soil_mean_0_1m  | q10cm_soil_temp  | temperature | °C   |
+| temperature_soil_mean_0_2m  | q20cm_soil_temp  | temperature | °C   |
+| temperature_soil_mean_0_5m  | q50cm_soil_temp  | temperature | °C   |
+| temperature_soil_mean_1m    | q100cm_soil_temp | temperature | °C   |

--- a/docs/data/provider/metoffice/observation/index.md
+++ b/docs/data/provider/metoffice/observation/index.md
@@ -21,8 +21,11 @@ at [services.ceda.ac.uk](https://services.ceda.ac.uk) and configure the credenti
 Station metadata comes from each dataset's `station-metadata.csv` catalogue. Observations are one
 BADC-CSV file per station and year. A station may transmit several report types for the same period
 (for example an overnight and a daytime 12-hour reading alongside a 24-hour one); these are
-collapsed to a single value per calendar day (maximum for max-type parameters, minimum for min-type
-ones), which matches the true daily extreme. Hourly datasets carry one reading per hour.
+collapsed to a single value per calendar day (maximum for max-type parameters such as
+`temperature_air_max_2m`, minimum for min-type ones). For the daily temperature extremes this
+recovers the true daily extreme regardless of which report types a station transmits; the other
+daily quantities (sunshine, snow depth, precipitation) are reported once per day, so the aggregation
+is effectively a de-duplication there. Hourly datasets carry one reading per hour.
 
 Not every station measures every parameter — a station/parameter combination MIDAS doesn't have
 simply contributes no rows.

--- a/docs/data/provider/metoffice/observation/index.md
+++ b/docs/data/provider/metoffice/observation/index.md
@@ -1,0 +1,47 @@
+# Observation
+
+## Overview
+
+The Met Office MIDAS Open archive provides quality-controlled UK land surface station
+observations at daily and hourly resolution, spanning eight datasets (daily rain, temperature
+and weather; hourly rain, weather, mean wind, radiation and soil temperature). Data reaches back
+to the 19th century for some stations.
+
+MIDAS Open is *not* the (paid, forecast-oriented) Met Office Weather DataHub. It is the historical
+archive, published as annual releases: each release covers data up to the end of the previous
+complete year, so the most recent ~6–12 months are not yet available. The provider always reads
+the latest release.
+
+Access requires a free CEDA account. The archive is browsable anonymously, but downloading files
+needs a bearer token, which the provider mints automatically from your CEDA credentials. Register
+at [services.ceda.ac.uk](https://services.ceda.ac.uk) and configure the credentials via
+`WD_AUTH__CEDA=<username>:<password>` (environment variable) or
+`Settings(auth={"ceda": "<username>:<password>"})` (Python).
+
+Station metadata comes from each dataset's `station-metadata.csv` catalogue. Observations are one
+BADC-CSV file per station and year. A station may transmit several report types for the same period
+(for example an overnight and a daytime 12-hour reading alongside a 24-hour one); these are
+collapsed to a single value per calendar day (maximum for max-type parameters, minimum for min-type
+ones), which matches the true daily extreme. Hourly datasets carry one reading per hour.
+
+Not every station measures every parameter — a station/parameter combination MIDAS doesn't have
+simply contributes no rows.
+
+The `quality` column carries MIDAS's raw five-digit `MESQL` quality-control flag verbatim; each
+digit encodes a different aspect of the observation's quality (see the
+[MIDAS QC flag documentation](https://dap.ceda.ac.uk/badc/ukmo-midas/metadata/doc/QC_J_flags.html)),
+so a larger number is not "worse".
+
+## License
+
+MIDAS Open is © Crown Copyright, Met Office, published under the
+[UK Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+See the [dataset catalogue record](https://catalogue.ceda.ac.uk/uuid/dbd451271eb04662beade68da43546e1/)
+for further information and usage conditions.
+
+```{toctree}
+:hidden:
+
+daily.md
+hourly.md
+```

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -85,6 +85,9 @@ class Wetterdienst:
         "metno": {
             "frost": "wetterdienst.provider.metno.frost.MetnoFrostRequest",
         },
+        "metoffice": {
+            "observation": "wetterdienst.provider.metoffice.observation.MetOfficeObservationRequest",
+        },
         "smhi": {
             "observation": "wetterdienst.provider.smhi.observation.SmhiObservationRequest",
         },

--- a/src/wetterdienst/provider/metoffice/__init__.py
+++ b/src/wetterdienst/provider/metoffice/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Met Office (UK) provider."""

--- a/src/wetterdienst/provider/metoffice/observation/__init__.py
+++ b/src/wetterdienst/provider/metoffice/observation/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Met Office (UK) observation provider."""
+
+from wetterdienst.provider.metoffice.observation.api import MetOfficeObservationRequest
+from wetterdienst.provider.metoffice.observation.metadata import MetOfficeObservationMetadata
+
+__all__ = ["MetOfficeObservationMetadata", "MetOfficeObservationRequest"]

--- a/src/wetterdienst/provider/metoffice/observation/api.py
+++ b/src/wetterdienst/provider/metoffice/observation/api.py
@@ -264,6 +264,15 @@ class MetOfficeObservationRequest(TimeseriesRequest):
     def _all(self) -> pl.LazyFrame:
         settings = cast("Settings", self.settings)
         token = get_ceda_token(settings)
+        if token is None:
+            # MIDAS Open's download host only serves a login redirect without a token, so every
+            # station-catalogue fetch below would fail; surface an empty result once instead
+            return pl.LazyFrame()
+        # the release version is the same for every dataset in a request, so resolve it once rather
+        # than re-reading the (cached) archive listing per dataset
+        version = latest_release_version(settings, token)
+        if version is None:
+            return pl.LazyFrame()
 
         # DatasetModel isn't hashable, so dedupe on (resolution, name) like CHMI does
         datasets = {
@@ -274,9 +283,6 @@ class MetOfficeObservationRequest(TimeseriesRequest):
         frames = []
         for dataset in datasets:
             midas_dataset = dataset.name_original
-            version = latest_release_version(settings, token)
-            if version is None:
-                continue
             content = None
             headers = {**settings.fsspec_client_kwargs.get("headers", {})}
             if token:

--- a/src/wetterdienst/provider/metoffice/observation/api.py
+++ b/src/wetterdienst/provider/metoffice/observation/api.py
@@ -1,0 +1,311 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Met Office (UK) observation provider -- MIDAS Open on CEDA.
+
+Data is the Met Office MIDAS Open archive (UK Open Government Licence) on CEDA. See ``metadata.py``
+for the archive/licensing background and ``download.py``/``fileindex.py`` for the auth and
+file-layout details.
+
+Provider-specific handling, each established by live testing against the real archive:
+
+- **Multiple report types per period.** A daily station may transmit an overnight and a daytime
+  12-hour reading (``NCM``/``AWSDLY``) *and* a 24-hour one (``DLY3208``/``SYNOP``) for the same day.
+  ``parser.parse_values`` collapses these to one value per calendar day (``max`` for max-type
+  parameters, ``min`` for ``_MIN_COLUMNS``), which is idempotent over the 12h/24h duplication.
+  Hourly datasets have one reading per hour, so the aggregation is a no-op there.
+- **Multi-day accumulations.** Daily rain gauges read every N days post an N-day accumulated total
+  on the read date with ``ob_day_cnt=N``; only ``ob_day_cnt==1`` rows are kept (see
+  ``_DATASET_CONFIG``).
+- **Units.** Verified against real values / the Met Office GL-table docs -- wind in knots,
+  temperatures °C, pressure hPa, precipitation mm, radiation kJ/m². ``visibility`` is native
+  decametres and is scaled to metres via ``_SCALE``.
+- **Quality.** The ``*_q`` column is MIDAS's raw ``MESQL`` five-digit compound QC flag (each digit a
+  separate aspect; see https://dap.ceda.ac.uk/badc/ukmo-midas/metadata/doc/QC_J_flags.html), *not* a
+  linear quality level. It is passed through unchanged into ``quality`` -- do not treat a larger
+  value as "worse".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import cast
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.model.metadata import DatasetModel, ParameterModel
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.metoffice.observation.download import get_ceda_token
+from wetterdienst.provider.metoffice.observation.fileindex import download_url, latest_release_version
+from wetterdienst.provider.metoffice.observation.metadata import MetOfficeObservationMetadata
+from wetterdienst.provider.metoffice.observation.parser import parse_station_metadata, parse_values
+from wetterdienst.settings import Settings
+from wetterdienst.util.network import download_file
+
+log = logging.getLogger(__name__)
+
+_EMPTY_VALUES_SCHEMA = {
+    "resolution": pl.String,
+    "dataset": pl.String,
+    "parameter": pl.String,
+    "station_id": pl.String,
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "value": pl.Float64,
+    "quality": pl.Float64,
+}
+
+# per MIDAS dataset slug: the timestamp column and the ``ob_day_cnt``-style multi-period-accumulation
+# column (only daily rain has one -- see parser.parse_values). ``granularity`` is derived from the
+# resolution in _collect_year. The timestamp columns were read off the real file headers during
+# scoping; the uk-daily-rain-obs ob_day_cnt=1 filter is confirmed live.
+_DATASET_CONFIG: dict[str, dict] = {
+    "uk-daily-rain-obs": {"time_column": "ob_date", "period_count_column": "ob_day_cnt"},
+    "uk-daily-temperature-obs": {"time_column": "ob_end_time", "period_count_column": None},
+    "uk-daily-weather-obs": {"time_column": "ob_end_time", "period_count_column": None},
+    "uk-hourly-rain-obs": {"time_column": "ob_end_time", "period_count_column": None},
+    "uk-hourly-weather-obs": {"time_column": "ob_time", "period_count_column": None},
+    "uk-mean-wind-obs": {"time_column": "ob_end_time", "period_count_column": None},
+    "uk-radiation-obs": {"time_column": "ob_end_time", "period_count_column": None},
+    "uk-soil-temperature-obs": {"time_column": "ob_time", "period_count_column": None},
+}
+
+# raw MIDAS columns aggregated with ``min`` rather than ``max`` when collapsing a day's multiple
+# report types (see parser.parse_values). Only the daily-temperature min-type readings qualify.
+_MIN_COLUMNS = frozenset({"min_air_temp", "min_grss_temp"})
+
+# raw MIDAS columns whose native unit differs from the one declared in metadata.py, with the factor
+# that reconciles them. Confirmed live: visibility is stored in decametres, scaled to metres.
+_SCALE = {"visibility": 10.0}
+
+
+def _station_path_url(
+    midas_dataset: str,
+    version: str,
+    county: str,
+    station_id: str,
+    slug: str,
+    qc_version: int,
+    year: int,
+) -> str:
+    stem = f"midas-open_{midas_dataset}_dv-{version}_{county}_{station_id}_{slug}_qcv-{qc_version}_{year}"
+    return download_url(
+        f"data/{midas_dataset}/dataset-version-{version}/{county}/{station_id}_{slug}/"
+        f"qc-version-{qc_version}/{stem}.csv",
+    )
+
+
+def _station_metadata_url(midas_dataset: str, version: str) -> str:
+    return download_url(
+        f"data/{midas_dataset}/dataset-version-{version}/midas-open_{midas_dataset}_dv-{version}_station-metadata.csv",
+    )
+
+
+class MetOfficeObservationValues(TimeseriesValues):
+    """Values class for Met Office (MIDAS Open) observation data."""
+
+    def _token(self, settings: Settings) -> str | None:
+        # minted fresh per values-collection run rather than persisted: simplest correct behaviour
+        # given the 3-day token TTL and no refresh endpoint (see download.py). Re-minting per
+        # station would be wasteful; consider caching on the request/settings instance if this
+        # turns out to be a bottleneck.
+        return get_ceda_token(settings)
+
+    def _download(self, url: str, settings: Settings, token: str | None) -> bytes | None:
+        headers = {**settings.fsspec_client_kwargs.get("headers", {})}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        file = download_file(
+            url=url,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.TWELVE_HOURS,
+            client_kwargs={**settings.fsspec_client_kwargs, "headers": headers},
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            if not file.is_no_internet_error:
+                log.debug(f"No MetOffice file {url}: {file.content}")
+            return None
+        return file.content.read()
+
+    def _station_slug_and_county(
+        self,
+        station_id: str,
+        midas_dataset: str,
+        version: str,
+        settings: Settings,
+        token: str | None,
+    ) -> tuple[str, str] | None:
+        """Resolve a station's (historic_county, station_file_name) for URL building.
+
+        Re-downloads (cache-hit after the first call) the same ``station-metadata.csv`` used in
+        ``_all()`` -- ``_base_columns`` only keeps the framework's fixed station columns, so
+        provider-specific fields like the MIDAS path components don't survive into ``self.sr.df``.
+        """
+        content = self._download(_station_metadata_url(midas_dataset, version), settings, token)
+        if content is None:
+            return None
+        stations = parse_station_metadata(content)
+        row = stations.filter(pl.col("station_id") == station_id)
+        if row.is_empty():
+            return None
+        return row.item(0, "historic_county"), row.item(0, "station_file_name")
+
+    def _collect_year(
+        self,
+        midas_dataset: str,
+        version: str,
+        county: str,
+        station_id: str,
+        slug: str,
+        year: int,
+        config: dict,
+        columns: list[str],
+        granularity: str,
+        settings: Settings,
+        token: str | None,
+    ) -> pl.DataFrame | None:
+        content = None
+        for qc_version in (1, 0):  # prefer the QC'd version, fall back to the raw one
+            url = _station_path_url(midas_dataset, version, county, station_id, slug, qc_version, year)
+            content = self._download(url, settings, token)
+            if content is not None:
+                break
+        if content is None:
+            return None
+        df = parse_values(
+            content,
+            time_column=config["time_column"],
+            columns=columns,
+            granularity=granularity,
+            min_columns=_MIN_COLUMNS,
+            scale=_SCALE,
+            period_count_column=config["period_count_column"],
+        )
+        return df if not df.is_empty() else None
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        if not isinstance(parameter_or_dataset, DatasetModel):
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        dataset = parameter_or_dataset
+        midas_dataset = dataset.name_original
+        config = _DATASET_CONFIG[midas_dataset]
+
+        settings = cast("Settings", self.sr.stations.settings)
+        token = self._token(settings)
+        version = latest_release_version(settings, token)
+        if version is None:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        located = self._station_slug_and_county(station_id, midas_dataset, version, settings, token)
+        if located is None:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        county, slug = located
+
+        station_row = self.sr.df.filter(pl.col("station_id") == station_id)
+        start = self.sr.start_date or station_row.item(0, "start_date")
+        end = self.sr.end_date or station_row.item(0, "end_date")
+        if start is None or end is None:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        columns = [p.name_original for p in dataset.parameters]
+        granularity = "1d" if dataset.resolution.name == "daily" else "1h"
+        frames = [
+            df
+            for year in range(start.year, end.year + 1)
+            if (
+                df := self._collect_year(
+                    midas_dataset,
+                    version,
+                    county,
+                    station_id,
+                    slug,
+                    year,
+                    config,
+                    columns,
+                    granularity,
+                    settings,
+                    token,
+                )
+            )
+            is not None
+        ]
+        if not frames:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        df = pl.concat(frames)
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            pl.col("parameter"),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            pl.col("date"),
+            pl.col("value"),
+            pl.col("quality"),
+        )
+
+
+@dataclass
+class MetOfficeObservationRequest(TimeseriesRequest):
+    """Request class for Met Office (MIDAS Open) observation data."""
+
+    metadata = MetOfficeObservationMetadata
+    _values = MetOfficeObservationValues
+
+    @classmethod
+    def is_configured(cls) -> bool:
+        """Whether CEDA credentials are available (needed for any MIDAS Open request)."""
+        return bool(Settings().auth.ceda)
+
+    def _all(self) -> pl.LazyFrame:
+        settings = cast("Settings", self.settings)
+        token = get_ceda_token(settings)
+
+        # DatasetModel isn't hashable, so dedupe on (resolution, name) like CHMI does
+        datasets = {
+            (parameter.dataset.resolution.name, parameter.dataset.name): parameter.dataset
+            for parameter in self.parameters
+            if isinstance(parameter, ParameterModel)
+        }.values()
+        frames = []
+        for dataset in datasets:
+            midas_dataset = dataset.name_original
+            version = latest_release_version(settings, token)
+            if version is None:
+                continue
+            content = None
+            headers = {**settings.fsspec_client_kwargs.get("headers", {})}
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+            file = download_file(
+                url=_station_metadata_url(midas_dataset, version),
+                cache_dir=settings.cache_dir,
+                ttl=CacheExpiry.METAINDEX,
+                client_kwargs={**settings.fsspec_client_kwargs, "headers": headers},
+                cache_disable=settings.cache_disable,
+                use_certifi=settings.use_certifi,
+            )
+            if isinstance(file.content, Exception):
+                log.warning(f"Failed to fetch MetOffice station catalogue for {midas_dataset}: {file.content}")
+                continue
+            content = file.content.read()
+            stations = parse_station_metadata(content)
+            if stations.is_empty():
+                continue
+            frames.append(
+                stations.with_columns(
+                    pl.lit(dataset.resolution.name, pl.String).alias("resolution"),
+                    pl.lit(dataset.name, pl.String).alias("dataset"),
+                ),
+            )
+        if not frames:
+            return pl.LazyFrame()
+        # TimeseriesRequest.all() selects _base_columns and fills any the catalogue omits (state)
+        # with null; historic_county/station_file_name are dropped there and re-resolved from the
+        # same station-metadata.csv (cached) in MetOfficeObservationValues when needed.
+        return pl.concat(frames).lazy()

--- a/src/wetterdienst/provider/metoffice/observation/api.py
+++ b/src/wetterdienst/provider/metoffice/observation/api.py
@@ -106,10 +106,9 @@ class MetOfficeObservationValues(TimeseriesValues):
     """Values class for Met Office (MIDAS Open) observation data."""
 
     def _token(self, settings: Settings) -> str | None:
-        # minted fresh per values-collection run rather than persisted: simplest correct behaviour
-        # given the 3-day token TTL and no refresh endpoint (see download.py). Re-minting per
-        # station would be wasteful; consider caching on the request/settings instance if this
-        # turns out to be a bottleneck.
+        # get_ceda_token caches the minted token in-process until shortly before its own expiry, so
+        # calling this once per station (as the values collection does) reuses one token rather than
+        # re-minting per station (see download.py).
         return get_ceda_token(settings)
 
     def _download(self, url: str, settings: Settings, token: str | None) -> bytes | None:

--- a/src/wetterdienst/provider/metoffice/observation/download.py
+++ b/src/wetterdienst/provider/metoffice/observation/download.py
@@ -56,14 +56,13 @@ def _token_valid_until(token: str) -> float:
     as an opaque bearer; CEDA is the authority on validity). Falls back to a short TTL if the token
     is not a readable JWT.
     """
-    now = time.time()
     # TypeError covers a payload that is valid JSON but not a dict (e.g. ``null``/list/number)
     with contextlib.suppress(IndexError, ValueError, TypeError, binascii.Error, json.JSONDecodeError, KeyError):
         payload_b64 = token.split(".")[1]
         payload_b64 += "=" * (-len(payload_b64) % 4)  # restore base64 padding
         exp = json.loads(base64.urlsafe_b64decode(payload_b64))["exp"]
         return float(exp) - _EXPIRY_MARGIN_SECONDS
-    return now + _FALLBACK_TTL_SECONDS
+    return time.time() + _FALLBACK_TTL_SECONDS
 
 
 def get_ceda_token(settings: Settings) -> str | None:
@@ -97,6 +96,12 @@ def get_ceda_token(settings: Settings) -> str | None:
         except httpx.HTTPError as e:
             log.warning(f"Failed to obtain CEDA access token: {e}")
             return None
-        token = response.json()["access_token"]
+        try:
+            # a 200 with a non-JSON body (e.g. an HTML login/error page) or a JSON body missing the
+            # access_token field is an exchange failure, not data -- surface it as "not authenticated"
+            token = response.json()["access_token"]
+        except (json.JSONDecodeError, KeyError, TypeError) as e:
+            log.warning(f"Unexpected CEDA token response: {e}")
+            return None
         _TOKEN_CACHE[credentials] = (token, _token_valid_until(token))
         return token

--- a/src/wetterdienst/provider/metoffice/observation/download.py
+++ b/src/wetterdienst/provider/metoffice/observation/download.py
@@ -10,11 +10,20 @@ CEDA requires the token exchange below). The token is minted from the user's CED
 CEDA's token API and is a Keycloak-issued JWT, confirmed 3 days validity for both browser- and
 API-issued tokens -- there is no refresh endpoint, so an expired token is simply replaced by
 minting a new one.
+
+The minted token is cached in-process (keyed by credentials) until shortly before its own ``exp``
+claim, so a values query spanning many stations reuses one token instead of hitting CEDA's token
+endpoint once per station (which is slow and risks rate-limiting the free account).
 """
 
 from __future__ import annotations
 
+import base64
+import binascii
+import contextlib
+import json
 import logging
+import time
 from typing import TYPE_CHECKING
 
 import httpx
@@ -26,12 +35,39 @@ log = logging.getLogger(__name__)
 
 _TOKEN_URL = "https://services.ceda.ac.uk/api/token/create/"  # noqa: S105 -- URL, not a credential
 
+# re-mint this many seconds before the token's own expiry, to avoid handing out a token that expires
+# mid-request.
+_EXPIRY_MARGIN_SECONDS = 300
+# used only if the token's ``exp`` claim can't be read; comfortably under the ~3-day real lifetime.
+_FALLBACK_TTL_SECONDS = 3600
+
+# in-process cache: (username, password) -> (token, epoch seconds after which it must be re-minted).
+_TOKEN_CACHE: dict[tuple[str, str], tuple[str, float]] = {}
+
+
+def _token_valid_until(token: str) -> float:
+    """Return the epoch second up to which ``token`` may be reused (its ``exp`` minus a margin).
+
+    Reads the ``exp`` claim from the JWT payload without verifying the signature (the token is used
+    as an opaque bearer; CEDA is the authority on validity). Falls back to a short TTL if the token
+    is not a readable JWT.
+    """
+    now = time.time()
+    with contextlib.suppress(IndexError, ValueError, binascii.Error, json.JSONDecodeError, KeyError):
+        payload_b64 = token.split(".")[1]
+        payload_b64 += "=" * (-len(payload_b64) % 4)  # restore base64 padding
+        exp = json.loads(base64.urlsafe_b64decode(payload_b64))["exp"]
+        return float(exp) - _EXPIRY_MARGIN_SECONDS
+    return now + _FALLBACK_TTL_SECONDS
+
 
 def get_ceda_token(settings: Settings) -> str | None:
-    """Mint a fresh CEDA bearer token from the configured (username, password) credentials.
+    """Return a valid CEDA bearer token for the configured (username, password) credentials.
 
-    Returns None (rather than raising) if no credentials are configured or the exchange fails, so
-    callers can surface a clear "not authenticated" data gap instead of a hard crash.
+    A cached token is reused while it is still valid; otherwise a fresh one is minted from the
+    credentials and cached. Returns None (rather than raising) if no credentials are configured or
+    the exchange fails, so callers can surface a clear "not authenticated" data gap instead of a
+    hard crash.
     """
     credentials = settings.auth.ceda
     if not credentials:
@@ -41,6 +77,9 @@ def get_ceda_token(settings: Settings) -> str | None:
             "or Settings(auth={'ceda': '<username>:<password>'}) (Python).",
         )
         return None
+    cached = _TOKEN_CACHE.get(credentials)
+    if cached is not None and cached[1] > time.time():
+        return cached[0]
     username, password = credentials
     try:
         response = httpx.post(_TOKEN_URL, auth=(username, password), timeout=30)
@@ -48,4 +87,6 @@ def get_ceda_token(settings: Settings) -> str | None:
     except httpx.HTTPError as e:
         log.warning(f"Failed to obtain CEDA access token: {e}")
         return None
-    return response.json()["access_token"]
+    token = response.json()["access_token"]
+    _TOKEN_CACHE[credentials] = (token, _token_valid_until(token))
+    return token

--- a/src/wetterdienst/provider/metoffice/observation/download.py
+++ b/src/wetterdienst/provider/metoffice/observation/download.py
@@ -23,6 +23,7 @@ import binascii
 import contextlib
 import json
 import logging
+import threading
 import time
 from typing import TYPE_CHECKING
 
@@ -43,6 +44,9 @@ _FALLBACK_TTL_SECONDS = 3600
 
 # in-process cache: (username, password) -> (token, epoch seconds after which it must be re-minted).
 _TOKEN_CACHE: dict[tuple[str, str], tuple[str, float]] = {}
+# serialises the check-then-mint so concurrent callers (e.g. the REST API's thread pool) don't each
+# mint a redundant token on a cold cache.
+_TOKEN_LOCK = threading.Lock()
 
 
 def _token_valid_until(token: str) -> float:
@@ -53,7 +57,8 @@ def _token_valid_until(token: str) -> float:
     is not a readable JWT.
     """
     now = time.time()
-    with contextlib.suppress(IndexError, ValueError, binascii.Error, json.JSONDecodeError, KeyError):
+    # TypeError covers a payload that is valid JSON but not a dict (e.g. ``null``/list/number)
+    with contextlib.suppress(IndexError, ValueError, TypeError, binascii.Error, json.JSONDecodeError, KeyError):
         payload_b64 = token.split(".")[1]
         payload_b64 += "=" * (-len(payload_b64) % 4)  # restore base64 padding
         exp = json.loads(base64.urlsafe_b64decode(payload_b64))["exp"]
@@ -81,12 +86,17 @@ def get_ceda_token(settings: Settings) -> str | None:
     if cached is not None and cached[1] > time.time():
         return cached[0]
     username, password = credentials
-    try:
-        response = httpx.post(_TOKEN_URL, auth=(username, password), timeout=30)
-        response.raise_for_status()
-    except httpx.HTTPError as e:
-        log.warning(f"Failed to obtain CEDA access token: {e}")
-        return None
-    token = response.json()["access_token"]
-    _TOKEN_CACHE[credentials] = (token, _token_valid_until(token))
-    return token
+    with _TOKEN_LOCK:
+        # re-check under the lock: another thread may have minted while we waited
+        cached = _TOKEN_CACHE.get(credentials)
+        if cached is not None and cached[1] > time.time():
+            return cached[0]
+        try:
+            response = httpx.post(_TOKEN_URL, auth=(username, password), timeout=30)
+            response.raise_for_status()
+        except httpx.HTTPError as e:
+            log.warning(f"Failed to obtain CEDA access token: {e}")
+            return None
+        token = response.json()["access_token"]
+        _TOKEN_CACHE[credentials] = (token, _token_valid_until(token))
+        return token

--- a/src/wetterdienst/provider/metoffice/observation/download.py
+++ b/src/wetterdienst/provider/metoffice/observation/download.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""CEDA authentication for the Met Office MIDAS Open archive.
+
+MIDAS Open files are only reachable with a bearer token (confirmed live: browsing
+``data.ceda.ac.uk`` is anonymous, but downloading from ``dap.ceda.ac.uk`` 302-redirects to a login
+page without one, and plain HTTP Basic auth against the download host does *not* work either --
+CEDA requires the token exchange below). The token is minted from the user's CEDA username/password
+(``Settings(auth={"ceda": "username:password"})`` / ``WD_AUTH__CEDA=username:password``) via
+CEDA's token API and is a Keycloak-issued JWT, confirmed 3 days validity for both browser- and
+API-issued tokens -- there is no refresh endpoint, so an expired token is simply replaced by
+minting a new one.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from wetterdienst.settings import Settings
+
+log = logging.getLogger(__name__)
+
+_TOKEN_URL = "https://services.ceda.ac.uk/api/token/create/"  # noqa: S105 -- URL, not a credential
+
+
+def get_ceda_token(settings: Settings) -> str | None:
+    """Mint a fresh CEDA bearer token from the configured (username, password) credentials.
+
+    Returns None (rather than raising) if no credentials are configured or the exchange fails, so
+    callers can surface a clear "not authenticated" data gap instead of a hard crash.
+    """
+    credentials = settings.auth.ceda
+    if not credentials:
+        log.warning(
+            "No CEDA credentials configured. Register a free account at https://services.ceda.ac.uk "
+            "and set WD_AUTH__CEDA=<username>:<password> (env var) "
+            "or Settings(auth={'ceda': '<username>:<password>'}) (Python).",
+        )
+        return None
+    username, password = credentials
+    try:
+        response = httpx.post(_TOKEN_URL, auth=(username, password), timeout=30)
+        response.raise_for_status()
+    except httpx.HTTPError as e:
+        log.warning(f"Failed to obtain CEDA access token: {e}")
+        return None
+    return response.json()["access_token"]

--- a/src/wetterdienst/provider/metoffice/observation/fileindex.py
+++ b/src/wetterdienst/provider/metoffice/observation/fileindex.py
@@ -49,7 +49,14 @@ def latest_release_version(settings: Settings, token: str | None) -> str | None:
     )
     if isinstance(file.content, Exception):
         return None
-    listing = json.loads(file.content.read())
+    try:
+        # the listing is a network boundary: a non-JSON body (e.g. a temporary HTML error page) or an
+        # unexpected shape should read as "no release found", not crash the request
+        listing = json.loads(file.content.read())
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(listing, dict):
+        return None
     versions = [m.group(1) for item in listing.get("items", []) if (m := _MANIFEST_NAME_RE.match(item.get("name", "")))]
     return max(versions) if versions else None
 

--- a/src/wetterdienst/provider/metoffice/observation/fileindex.py
+++ b/src/wetterdienst/provider/metoffice/observation/fileindex.py
@@ -2,17 +2,13 @@
 # Distributed under the MIT License. See LICENSE for more info.
 """File index for the MIDAS Open archive on CEDA.
 
-Confirmed live against the real archive: MIDAS Open has no single combined station-list file.
-Instead, CEDA publishes one flat manifest per annual release --
-``https://dap.ceda.ac.uk/badc/ukmo-midas-open/midas-open-v<version>-md5s.txt`` -- listing every
-file path (with its md5) across *all* datasets for that release in one ~700k-line text file. All 8
-datasets share the same ``dataset-version-<version>`` tag within a release, so one manifest is
-enough to index the whole archive: no per-station or per-county directory walking required.
-
-Each station directory (``.../<dataset>/dataset-version-<v>/<county>/<src_id>_<slug>/``) holds a
-``*_capability.csv`` (the station's BADC-CSV header block: name, lat/lon, height, operating dates
--- no data rows) plus one ``qc-version-<n>/*_<year>.csv`` per year of data. The capability file is
-the cheapest way to get a station's metadata without downloading a full data file.
+MIDAS Open is published as annual releases tagged ``dataset-version-<version>`` (e.g.
+``202607``). The set of releases is discoverable from the archive root listing
+(``https://data.ceda.ac.uk/badc/ukmo-midas-open/?json``), which names one
+``midas-open-v<version>-md5s.txt`` manifest per release; ``latest_release_version`` reads the newest
+version tag from there. Within a release, every dataset shares that same version tag, so the
+per-station file URLs are built directly in ``api.py`` from the station-metadata catalogue (county +
+slug) rather than by walking the archive tree.
 """
 
 from __future__ import annotations
@@ -20,8 +16,6 @@ from __future__ import annotations
 import json
 import re
 from typing import TYPE_CHECKING
-
-import polars as pl
 
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.util.network import download_file
@@ -33,27 +27,7 @@ _ARCHIVE_ROOT = "https://data.ceda.ac.uk/badc/ukmo-midas-open"
 _DOWNLOAD_ROOT = "https://dap.ceda.ac.uk/badc/ukmo-midas-open"
 
 _RELEASE_LISTING_URL = f"{_ARCHIVE_ROOT}/?json"
-_MANIFEST_URL_TEMPLATE = f"{_DOWNLOAD_ROOT}/midas-open-v{{version}}-md5s.txt?download=1"
-
 _MANIFEST_NAME_RE = re.compile(r"^midas-open-v(\d{6})-md5s\.txt$")
-
-# ``./data/<dataset>/dataset-version-<version>/<county>/<src_id>_<slug>/[qc-version-<qc>/]<filename>``
-_PATH_RE = re.compile(
-    r"^\./data/(?P<dataset>[^/]+)/dataset-version-(?P<version>\d+)/(?P<county>[^/]+)/"
-    r"(?P<src_id>\d+)_(?P<slug>[^/]+)/(?:qc-version-(?P<qc_version>\d+)/)?(?P<filename>[^/]+)$",
-)
-_DATA_FILENAME_RE = re.compile(r"_(?P<year>\d{4})\.csv$")
-
-_EMPTY_MANIFEST_SCHEMA = {
-    "dataset": pl.String,
-    "county": pl.String,
-    "station_id": pl.String,
-    "station_slug": pl.String,
-    "qc_version": pl.Int64,
-    "kind": pl.String,
-    "year": pl.Int64,
-    "path": pl.String,
-}
 
 
 def _headers(settings: Settings, token: str | None) -> dict:
@@ -80,52 +54,6 @@ def latest_release_version(settings: Settings, token: str | None) -> str | None:
     return max(versions) if versions else None
 
 
-def load_manifest(version: str, settings: Settings, token: str | None) -> pl.DataFrame:
-    """Download and parse the release-wide file manifest into one row per archive file.
-
-    Cached for twelve hours: the manifest is ~30 MB and only changes once a year, but a token
-    that's gone stale mid-session (3-day TTL) should not keep serving a request built with it, so
-    this deliberately does not use the long-lived ``METAINDEX`` expiry.
-    """
-    file = download_file(
-        url=_MANIFEST_URL_TEMPLATE.format(version=version),
-        cache_dir=settings.cache_dir,
-        ttl=CacheExpiry.TWELVE_HOURS,
-        client_kwargs={**settings.fsspec_client_kwargs, "headers": _headers(settings, token)},
-        cache_disable=settings.cache_disable,
-        use_certifi=settings.use_certifi,
-    )
-    if isinstance(file.content, Exception):
-        return pl.DataFrame(schema=_EMPTY_MANIFEST_SCHEMA)
-    rows = []
-    for line in file.content.read().decode("utf-8").splitlines():
-        # lines are "<md5>  <path>"; skip the two blank/comment lines files like this sometimes end with
-        parts = line.split(None, 1)
-        if len(parts) != 2:
-            continue
-        match = _PATH_RE.match(parts[1])
-        if not match:
-            continue
-        filename = match.group("filename")
-        is_capability = filename.endswith("_capability.csv")
-        year_match = _DATA_FILENAME_RE.search(filename)
-        rows.append(
-            {
-                "dataset": match.group("dataset"),
-                "county": match.group("county"),
-                "station_id": match.group("src_id"),
-                "station_slug": match.group("slug"),
-                "qc_version": int(match.group("qc_version")) if match.group("qc_version") else None,
-                "kind": "capability" if is_capability else "data",
-                "year": int(year_match.group("year")) if year_match else None,
-                "path": parts[1].removeprefix("./"),
-            },
-        )
-    if not rows:
-        return pl.DataFrame(schema=_EMPTY_MANIFEST_SCHEMA)
-    return pl.DataFrame(rows, schema=_EMPTY_MANIFEST_SCHEMA)
-
-
 def download_url(path: str) -> str:
-    """Build the authenticated-download URL for a manifest ``path`` entry."""
+    """Build the authenticated-download URL for an archive ``path`` (relative to the archive root)."""
     return f"{_DOWNLOAD_ROOT}/{path}?download=1"

--- a/src/wetterdienst/provider/metoffice/observation/fileindex.py
+++ b/src/wetterdienst/provider/metoffice/observation/fileindex.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""File index for the MIDAS Open archive on CEDA.
+
+Confirmed live against the real archive: MIDAS Open has no single combined station-list file.
+Instead, CEDA publishes one flat manifest per annual release --
+``https://dap.ceda.ac.uk/badc/ukmo-midas-open/midas-open-v<version>-md5s.txt`` -- listing every
+file path (with its md5) across *all* datasets for that release in one ~700k-line text file. All 8
+datasets share the same ``dataset-version-<version>`` tag within a release, so one manifest is
+enough to index the whole archive: no per-station or per-county directory walking required.
+
+Each station directory (``.../<dataset>/dataset-version-<v>/<county>/<src_id>_<slug>/``) holds a
+``*_capability.csv`` (the station's BADC-CSV header block: name, lat/lon, height, operating dates
+-- no data rows) plus one ``qc-version-<n>/*_<year>.csv`` per year of data. The capability file is
+the cheapest way to get a station's metadata without downloading a full data file.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.util.network import download_file
+
+if TYPE_CHECKING:
+    from wetterdienst.settings import Settings
+
+_ARCHIVE_ROOT = "https://data.ceda.ac.uk/badc/ukmo-midas-open"
+_DOWNLOAD_ROOT = "https://dap.ceda.ac.uk/badc/ukmo-midas-open"
+
+_RELEASE_LISTING_URL = f"{_ARCHIVE_ROOT}/?json"
+_MANIFEST_URL_TEMPLATE = f"{_DOWNLOAD_ROOT}/midas-open-v{{version}}-md5s.txt?download=1"
+
+_MANIFEST_NAME_RE = re.compile(r"^midas-open-v(\d{6})-md5s\.txt$")
+
+# ``./data/<dataset>/dataset-version-<version>/<county>/<src_id>_<slug>/[qc-version-<qc>/]<filename>``
+_PATH_RE = re.compile(
+    r"^\./data/(?P<dataset>[^/]+)/dataset-version-(?P<version>\d+)/(?P<county>[^/]+)/"
+    r"(?P<src_id>\d+)_(?P<slug>[^/]+)/(?:qc-version-(?P<qc_version>\d+)/)?(?P<filename>[^/]+)$",
+)
+_DATA_FILENAME_RE = re.compile(r"_(?P<year>\d{4})\.csv$")
+
+_EMPTY_MANIFEST_SCHEMA = {
+    "dataset": pl.String,
+    "county": pl.String,
+    "station_id": pl.String,
+    "station_slug": pl.String,
+    "qc_version": pl.Int64,
+    "kind": pl.String,
+    "year": pl.Int64,
+    "path": pl.String,
+}
+
+
+def _headers(settings: Settings, token: str | None) -> dict:
+    headers = dict(settings.fsspec_client_kwargs.get("headers", {}))
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def latest_release_version(settings: Settings, token: str | None) -> str | None:
+    """Return the most recent MIDAS Open release version tag, e.g. ``"202607"``."""
+    file = download_file(
+        url=_RELEASE_LISTING_URL,
+        cache_dir=settings.cache_dir,
+        ttl=CacheExpiry.TWELVE_HOURS,
+        client_kwargs={**settings.fsspec_client_kwargs, "headers": _headers(settings, token)},
+        cache_disable=settings.cache_disable,
+        use_certifi=settings.use_certifi,
+    )
+    if isinstance(file.content, Exception):
+        return None
+    listing = json.loads(file.content.read())
+    versions = [m.group(1) for item in listing.get("items", []) if (m := _MANIFEST_NAME_RE.match(item.get("name", "")))]
+    return max(versions) if versions else None
+
+
+def load_manifest(version: str, settings: Settings, token: str | None) -> pl.DataFrame:
+    """Download and parse the release-wide file manifest into one row per archive file.
+
+    Cached for twelve hours: the manifest is ~30 MB and only changes once a year, but a token
+    that's gone stale mid-session (3-day TTL) should not keep serving a request built with it, so
+    this deliberately does not use the long-lived ``METAINDEX`` expiry.
+    """
+    file = download_file(
+        url=_MANIFEST_URL_TEMPLATE.format(version=version),
+        cache_dir=settings.cache_dir,
+        ttl=CacheExpiry.TWELVE_HOURS,
+        client_kwargs={**settings.fsspec_client_kwargs, "headers": _headers(settings, token)},
+        cache_disable=settings.cache_disable,
+        use_certifi=settings.use_certifi,
+    )
+    if isinstance(file.content, Exception):
+        return pl.DataFrame(schema=_EMPTY_MANIFEST_SCHEMA)
+    rows = []
+    for line in file.content.read().decode("utf-8").splitlines():
+        # lines are "<md5>  <path>"; skip the two blank/comment lines files like this sometimes end with
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            continue
+        match = _PATH_RE.match(parts[1])
+        if not match:
+            continue
+        filename = match.group("filename")
+        is_capability = filename.endswith("_capability.csv")
+        year_match = _DATA_FILENAME_RE.search(filename)
+        rows.append(
+            {
+                "dataset": match.group("dataset"),
+                "county": match.group("county"),
+                "station_id": match.group("src_id"),
+                "station_slug": match.group("slug"),
+                "qc_version": int(match.group("qc_version")) if match.group("qc_version") else None,
+                "kind": "capability" if is_capability else "data",
+                "year": int(year_match.group("year")) if year_match else None,
+                "path": parts[1].removeprefix("./"),
+            },
+        )
+    if not rows:
+        return pl.DataFrame(schema=_EMPTY_MANIFEST_SCHEMA)
+    return pl.DataFrame(rows, schema=_EMPTY_MANIFEST_SCHEMA)
+
+
+def download_url(path: str) -> str:
+    """Build the authenticated-download URL for a manifest ``path`` entry."""
+    return f"{_DOWNLOAD_ROOT}/{path}?download=1"

--- a/src/wetterdienst/provider/metoffice/observation/metadata.py
+++ b/src/wetterdienst/provider/metoffice/observation/metadata.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Met Office (UK) observation metadata.
+
+Data comes from **MIDAS Open**, the Met Office's UK Open Government Licence subset of its land
+surface station archive, hosted at CEDA (https://catalogue.ceda.ac.uk/uuid/dbd451271eb04662beade68da43546e1/).
+It is *not* the (paid, forecast-only) Met Office Weather DataHub -- MIDAS Open is the historical
+archive: annual releases, each covering data up to the end of the previous complete year, so
+"recent" data lags roughly 6-12 months behind real time.
+
+Each of the 8 MIDAS Open datasets is one flat CSV per (station, year) in BADC-CSV format (a header
+metadata block, then a bare ``data`` line, then a normal CSV table), and all datasets are either
+``daily`` or ``hourly``. Every dataset carries far more raw columns than are mapped below --
+quality-control flags (``*_q``), estimation/interpolation flags (``*_j``), housekeeping columns
+(``id``, ``id_type``, ``met_domain_name``, ``src_id``, ``rec_st_ind``, ``version_num``,
+``meto_stmp_time``, ``midas_stmp_etime``) and a handful of columns with no clean canonical
+``Parameter`` match (e.g. ``min_conc_temp`` concrete minimum temperature, ``q30cm_soil_temp`` --
+no ``TEMPERATURE_SOIL_MEAN_0_3M`` exists) are intentionally left unmapped rather than guessing a
+canonical name. ``*_q`` columns are wired up as the per-value ``quality`` column in ``api.py`` (a
+raw MIDAS ``MESQL`` compound QC flag -- see api.py -- not a linear quality level), not as separate
+parameters.
+
+Native units below were verified against real numeric values from the archive and the Met Office
+GL-table column documentation (https://artefacts.ceda.ac.uk/badc_datadocs/ukmo-midas/GL_Table.html):
+temperatures in °C, pressures in hPa, humidity in %, precipitation in mm, and **wind speed/gust in
+knots** (confirmed: a 32-value hourly mean is a plausible ~59 km/h, absurd as m/s). ``visibility``
+is stored in *decametres* and is scaled to metres in ``api.py`` (there is no decametre unit to
+declare here). Radiation (``glbl_irad_amt`` etc.) is kJ/m² per the Open Data User Guide
+(https://doi.org/10.5281/zenodo.7357335) and the GL-table docs, and checks out against real values
+(a summer hourly peak of ~2000 kJ/m² is ~560 W/m², plausible for UK midday).
+"""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import build_metadata_model
+
+_TEMPERATURE = {"unit_type": "temperature", "unit": "degree_celsius"}
+_PRECIPITATION = {"unit_type": "precipitation", "unit": "millimeter"}
+_PRESSURE = {"unit_type": "pressure", "unit": "hectopascal"}
+_HUMIDITY = {"unit_type": "fraction", "unit": "percent"}
+_WIND_SPEED = {"unit_type": "speed", "unit": "knots"}
+_WIND_DIRECTION = {"unit_type": "angle", "unit": "degree"}
+_SUNSHINE = {"unit_type": "time", "unit": "hour"}
+_SNOW_DEPTH = {"unit_type": "length_short", "unit": "centimeter"}
+_RADIATION = {"unit_type": "energy_per_area", "unit": "kilojoule_per_square_meter"}
+
+_DAILY_RAIN_PARAMETERS = [
+    {"name": "precipitation_height", "name_original": "prcp_amt", **_PRECIPITATION},
+]
+
+_DAILY_TEMPERATURE_PARAMETERS = [
+    {"name": "temperature_air_max_2m", "name_original": "max_air_temp", **_TEMPERATURE},
+    {"name": "temperature_air_min_2m", "name_original": "min_air_temp", **_TEMPERATURE},
+    {"name": "temperature_air_min_0_05m", "name_original": "min_grss_temp", **_TEMPERATURE},
+]
+
+# hail_day_id / thunder_day_flag are deliberately not mapped: confirmed live they carry opaque
+# codes (e.g. 0/9), not the boolean occurrence the WEATHER_TYPE_* parameters denote, so exposing
+# them would misrepresent the data.
+_DAILY_WEATHER_PARAMETERS = [
+    {"name": "sunshine_duration", "name_original": "drv_24hr_sun_dur", **_SUNSHINE},
+    {"name": "snow_depth", "name_original": "snow_depth", **_SNOW_DEPTH},
+    {"name": "snow_depth_new", "name_original": "frsh_snw_amt", **_SNOW_DEPTH},
+]
+
+_HOURLY_RAIN_PARAMETERS = [
+    {"name": "precipitation_height", "name_original": "prcp_amt", **_PRECIPITATION},
+    {"name": "precipitation_duration", "name_original": "prcp_dur", "unit_type": "time", "unit": "minute"},
+]
+
+_HOURLY_WEATHER_PARAMETERS = [
+    {"name": "wind_direction", "name_original": "wind_direction", **_WIND_DIRECTION},
+    {"name": "wind_speed", "name_original": "wind_speed", **_WIND_SPEED},
+    {"name": "wind_gust_max", "name_original": "q10mnt_mxgst_spd", **_WIND_SPEED},
+    # native decametres; scaled to metres in api.py (_SCALE)
+    {"name": "visibility_range", "name_original": "visibility", "unit_type": "length_medium", "unit": "meter"},
+    {"name": "pressure_air_sea_level", "name_original": "msl_pressure", **_PRESSURE},
+    {"name": "pressure_air_site", "name_original": "stn_pres", **_PRESSURE},
+    {"name": "temperature_air_mean_2m", "name_original": "air_temperature", **_TEMPERATURE},
+    {"name": "temperature_dew_point_mean_2m", "name_original": "dewpoint", **_TEMPERATURE},
+    {"name": "humidity", "name_original": "rltv_hum", **_HUMIDITY},
+    {"name": "sunshine_duration", "name_original": "wmo_hr_sun_dur", **_SUNSHINE},
+    {"name": "snow_depth", "name_original": "snow_depth", **_SNOW_DEPTH},
+    {"name": "cloud_cover_total", "name_original": "cld_ttl_amt_id", "unit_type": "fraction", "unit": "one_eighth"},
+    {"name": "weather", "name_original": "prst_wx_id", "unit_type": "dimensionless", "unit": "dimensionless"},
+]
+
+_MEAN_WIND_PARAMETERS = [
+    {"name": "wind_direction", "name_original": "mean_wind_dir", **_WIND_DIRECTION},
+    {"name": "wind_speed", "name_original": "mean_wind_speed", **_WIND_SPEED},
+    {"name": "wind_direction_gust_max", "name_original": "max_gust_dir", **_WIND_DIRECTION},
+    {"name": "wind_gust_max", "name_original": "max_gust_speed", **_WIND_SPEED},
+]
+
+_RADIATION_PARAMETERS = [
+    {"name": "radiation_global", "name_original": "glbl_irad_amt", **_RADIATION},
+    {"name": "radiation_sky_short_wave_diffuse", "name_original": "difu_irad_amt", **_RADIATION},
+    {"name": "radiation_sky_short_wave_direct", "name_original": "direct_irad", **_RADIATION},
+]
+
+_SOIL_TEMPERATURE_PARAMETERS = [
+    {"name": "temperature_soil_mean_0_05m", "name_original": "q5cm_soil_temp", **_TEMPERATURE},
+    {"name": "temperature_soil_mean_0_1m", "name_original": "q10cm_soil_temp", **_TEMPERATURE},
+    {"name": "temperature_soil_mean_0_2m", "name_original": "q20cm_soil_temp", **_TEMPERATURE},
+    {"name": "temperature_soil_mean_0_5m", "name_original": "q50cm_soil_temp", **_TEMPERATURE},
+    {"name": "temperature_soil_mean_1m", "name_original": "q100cm_soil_temp", **_TEMPERATURE},
+]
+
+
+def _dataset(name: str, midas_dataset: str, parameters: list[dict]) -> dict:
+    return {
+        "name": name,
+        # the MIDAS Open dataset slug, e.g. "uk-daily-rain-obs" -- used to build archive paths
+        "name_original": midas_dataset,
+        "grouped": True,
+        "parameters": parameters,
+    }
+
+
+def _resolution(name: str, datasets: list[dict]) -> dict:
+    return {
+        "name": name,
+        "name_original": name,
+        "periods": ["historical"],
+        "date_required": False,
+        "datasets": datasets,
+    }
+
+
+MetOfficeObservationMetadata = {
+    "name_short": "MetOffice",
+    "name_english": "Met Office",
+    "name_local": "Met Office",
+    "country": "United Kingdom",
+    "copyright": "© Crown Copyright, Met Office, MIDAS Open, Open Government Licence v3.0",
+    "url": "https://catalogue.ceda.ac.uk/uuid/dbd451271eb04662beade68da43546e1/",
+    "kind": "observation",
+    "timezone": "Europe/London",
+    "timezone_data": "UTC",
+    "resolutions": [
+        _resolution(
+            "daily",
+            [
+                _dataset("rain", "uk-daily-rain-obs", _DAILY_RAIN_PARAMETERS),
+                _dataset("temperature", "uk-daily-temperature-obs", _DAILY_TEMPERATURE_PARAMETERS),
+                _dataset("weather", "uk-daily-weather-obs", _DAILY_WEATHER_PARAMETERS),
+            ],
+        ),
+        _resolution(
+            "hourly",
+            [
+                _dataset("rain", "uk-hourly-rain-obs", _HOURLY_RAIN_PARAMETERS),
+                _dataset("weather", "uk-hourly-weather-obs", _HOURLY_WEATHER_PARAMETERS),
+                _dataset("wind", "uk-mean-wind-obs", _MEAN_WIND_PARAMETERS),
+                _dataset("radiation", "uk-radiation-obs", _RADIATION_PARAMETERS),
+                _dataset("soil_temperature", "uk-soil-temperature-obs", _SOIL_TEMPERATURE_PARAMETERS),
+            ],
+        ),
+    ],
+}
+MetOfficeObservationMetadata = build_metadata_model(MetOfficeObservationMetadata, "MetOfficeObservationMetadata")

--- a/src/wetterdienst/provider/metoffice/observation/parser.py
+++ b/src/wetterdienst/provider/metoffice/observation/parser.py
@@ -1,0 +1,180 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Parsers for MIDAS Open's BADC-CSV files.
+
+Every MIDAS Open file (station-metadata, capability, and per-station-year data files alike) shares
+the BADC-CSV shape: a block of ``<field>,G,<value>...`` global-attribute header rows, a bare
+``data`` line, a plain CSV table, and a trailing ``end data`` line. Confirmed against real files
+downloaded from the archive during scoping (see ``fileindex.py``).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+_EMPTY_STATIONS_SCHEMA = {
+    "station_id": pl.String,
+    "name": pl.String,
+    "historic_county": pl.String,
+    "station_file_name": pl.String,
+    "latitude": pl.Float64,
+    "longitude": pl.Float64,
+    "height": pl.Float64,
+    "start_date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "end_date": pl.Datetime(time_unit="us", time_zone="UTC"),
+}
+
+_EMPTY_VALUES_SCHEMA = {
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "parameter": pl.String,
+    "value": pl.Float64,
+    "quality": pl.Float64,
+}
+
+
+def _data_section(content: bytes) -> pl.DataFrame:
+    """Split off the CSV table between the bare ``data`` and ``end data`` lines."""
+    text = content.decode("utf-8")
+    lines = text.splitlines()
+    try:
+        start = lines.index("data") + 1
+    except ValueError:
+        return pl.DataFrame()
+    end = next((i for i in range(start, len(lines)) if lines[i].strip() == "end data"), len(lines))
+    body = "\n".join(lines[start:end])
+    if not body.strip():
+        return pl.DataFrame()
+    return pl.read_csv(body.encode("utf-8"), has_header=True, infer_schema_length=0, null_values=["NA"])
+
+
+def parse_station_metadata(content: bytes) -> pl.DataFrame:
+    """Parse a dataset's ``*_station-metadata.csv`` catalogue into one row per station.
+
+    ``first_year``/``last_year`` mark the operational range *for this dataset*; a station may cover
+    a different range in another MIDAS Open dataset.
+    """
+    df = _data_section(content)
+    if df.is_empty():
+        return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
+    return df.select(
+        pl.col("src_id").cast(pl.String).alias("station_id"),
+        pl.col("station_name").cast(pl.String).alias("name"),
+        pl.col("historic_county").cast(pl.String),
+        pl.col("station_file_name").cast(pl.String),
+        pl.col("station_latitude").cast(pl.Float64, strict=False).alias("latitude"),
+        pl.col("station_longitude").cast(pl.Float64, strict=False).alias("longitude"),
+        pl.col("station_elevation").cast(pl.Float64, strict=False).alias("height"),
+        pl.date(pl.col("first_year").cast(pl.Int32, strict=False), 1, 1)
+        .cast(pl.Datetime(time_unit="us"))
+        .dt.replace_time_zone("UTC")
+        .alias("start_date"),
+        pl.date(pl.col("last_year").cast(pl.Int32, strict=False), 12, 31)
+        .cast(pl.Datetime(time_unit="us"))
+        .dt.replace_time_zone("UTC")
+        .alias("end_date"),
+    )
+
+
+def parse_values(
+    content: bytes,
+    time_column: str,
+    columns: list[str],
+    granularity: str,
+    min_columns: frozenset[str] = frozenset(),
+    scale: dict[str, float] | None = None,
+    period_count_column: str | None = None,
+) -> pl.DataFrame:
+    """Parse a per-station-year data file into long ``(date, parameter, value, quality)`` rows.
+
+    Every reading is truncated to ``granularity`` (``1d`` for daily datasets, ``1h`` for hourly)
+    and aggregated to one value per ``(timestamp, parameter)``. This collapses MIDAS's *multiple
+    report types per period* -- confirmed live: a daily station may transmit an overnight and a
+    daytime 12-hour reading (``NCM``/``AWSDLY``) alongside a 24-hour one (``DLY3208``/``SYNOP``),
+    all for the same calendar day. Taking ``max`` for max-type parameters and ``min`` for
+    ``min_columns`` is idempotent over that duplication (``max(4.8, 5.4, 5.1)`` is exactly the
+    24-hour value ``5.4``) and yields one clean daily extreme per station-day. Hourly datasets have
+    a single reading per hour, so the aggregation is a no-op there.
+
+    The calendar day is defined by the reading's ``ob_end_time`` date (a simple, documented choice;
+    MIDAS's climatological day can run 09-09, so a day's min is the low of the night that ended that
+    morning and its max the high of that afternoon).
+
+    Args:
+        content: the raw file bytes.
+        time_column: the timestamp column for this dataset (``ob_date``, ``ob_time`` or
+            ``ob_end_time`` -- it varies by dataset, see the per-dataset headers noted in
+            ``metadata.py``).
+        columns: the raw (``name_original``) value columns to extract -- kept as the raw MIDAS
+            column name in the output ``parameter`` column, *not* humanized to the canonical name:
+            ``model/values.py``'s ``_process_dataset()`` filters this column against the requested
+            ``name_original`` values before humanizing it itself.
+        granularity: polars truncation unit for the timestamp (``1d`` or ``1h``).
+        min_columns: the subset of ``columns`` aggregated with ``min`` (the min-type parameters);
+            all others use ``max``. The retained ``quality`` is the flag of the row that supplied
+            the aggregated extreme.
+        scale: optional ``{raw_column: factor}`` applied to a column's values to reach the unit
+            declared in ``metadata.py``. Confirmed live: MIDAS ``visibility`` is stored in
+            *decametres* (max ~7500 = 75 km at Heathrow), so it is scaled by 10 to metres -- there
+            is no decametre unit in the shared unit converter to declare instead.
+        period_count_column: the dataset's period-count column (``ob_day_cnt`` for daily rain), if
+            it has one. Confirmed live: rain gauges are not always read every day -- a station read
+            every 31 days posts its *31-day accumulated total* on the read date with this column set
+            to 31, not 1. Rows where it isn't exactly 1 are dropped so a multi-day accumulation is
+            never mistaken for a single-day value. (Not the same as temperature's ``ob_hour_count``,
+            which is the 12/24-hour observation window, not a count of accumulated periods.)
+
+    """
+    df = _data_section(content)
+    if df.is_empty():
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    if period_count_column and period_count_column in df.columns:
+        df = df.filter(pl.col(period_count_column).cast(pl.Float64, strict=False) == 1)
+        if df.is_empty():
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    date = (
+        pl.col(time_column)
+        .str.to_datetime("%Y-%m-%d %H:%M:%S", time_unit="us")
+        .dt.replace_time_zone("UTC")
+        .dt.truncate(granularity)
+    )
+    scale = scale or {}
+    frames = []
+    for raw_column in columns:
+        if raw_column not in df.columns:
+            continue
+        quality_column = f"{raw_column}_q"
+        value = pl.col(raw_column).cast(pl.Float64, strict=False)
+        if raw_column in scale:
+            value = value * scale[raw_column]
+        sub = df.select(
+            date.alias("date"),
+            value.alias("value"),
+            (
+                pl.col(quality_column).cast(pl.Float64, strict=False)
+                if quality_column in df.columns
+                else pl.lit(None, dtype=pl.Float64)
+            ).alias("quality"),
+        ).filter(pl.col("value").is_not_null())
+        if sub.is_empty():
+            continue
+        if raw_column in min_columns:
+            aggregated = sub.group_by("date").agg(
+                pl.col("value").min().alias("value"),
+                pl.col("quality").sort_by("value").first().alias("quality"),
+            )
+        else:
+            aggregated = sub.group_by("date").agg(
+                pl.col("value").max().alias("value"),
+                pl.col("quality").sort_by("value").last().alias("quality"),
+            )
+        frames.append(
+            aggregated.select(
+                pl.col("date"),
+                pl.lit(raw_column, dtype=pl.String).alias("parameter"),
+                pl.col("value"),
+                pl.col("quality"),
+            ),
+        )
+    if not frames:
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    return pl.concat(frames)

--- a/src/wetterdienst/settings.py
+++ b/src/wetterdienst/settings.py
@@ -29,6 +29,7 @@ class Auth(BaseModel):
     aemet: str | None = Field(default=None)
     knmi: str | None = Field(default=None)
     metno_frost: tuple[str, str] | None = Field(default=None)
+    ceda: tuple[str, str] | None = Field(default=None)
 
     @field_validator("metno_frost", mode="before")
     @classmethod
@@ -40,6 +41,24 @@ class Auth(BaseModel):
         as_tuple = tuple(value)
         if len(as_tuple) != 2:
             msg = f"metno_frost must be a (client_id, secret) pair, got {len(as_tuple)} element(s)"
+            raise ValueError(msg)
+        return str(as_tuple[0]), str(as_tuple[1])
+
+    @field_validator("ceda", mode="before")
+    @classmethod
+    def validate_ceda(cls, value: tuple[str, str] | str | None) -> tuple[str, str] | None:
+        """Parse the CEDA (username, password) pair, e.g. from ``WD_AUTH__CEDA=username:password``."""
+        if value is None:
+            return None
+        if isinstance(value, str):
+            username, sep, password = value.partition(":")
+            if not sep:
+                msg = "ceda must be given as 'username:password'"
+                raise ValueError(msg)
+            return username, password
+        as_tuple = tuple(value)
+        if len(as_tuple) != 2:
+            msg = f"ceda must be a (username, password) pair, got {len(as_tuple)} element(s)"
             raise ValueError(msg)
         return str(as_tuple[0]), str(as_tuple[1])
 

--- a/tests/provider/metoffice/__init__.py
+++ b/tests/provider/metoffice/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/metoffice/observation/__init__.py
+++ b/tests/provider/metoffice/observation/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/metoffice/observation/test_api.py
+++ b/tests/provider/metoffice/observation/test_api.py
@@ -130,6 +130,61 @@ def test_parse_values_empty_input() -> None:
     assert df.columns == ["date", "parameter", "value", "quality"]
 
 
+def _fake_jwt(exp: float) -> str:
+    """Build a minimal unsigned JWT string carrying just an ``exp`` claim (base64url payload)."""
+    import base64  # noqa: PLC0415
+    import json  # noqa: PLC0415
+
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
+    return f"header.{payload}.signature"
+
+
+def test_ceda_token_is_cached_until_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CEDA token is minted once and reused from cache until shortly before its ``exp`` claim."""
+    import time  # noqa: PLC0415
+
+    from wetterdienst.provider.metoffice.observation import download  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+
+    creds = ("user", "pass")
+    download._TOKEN_CACHE.clear()  # noqa: SLF001
+    settings = Settings(auth={"ceda": "user:pass"})
+
+    calls = {"n": 0}
+
+    def _fake_post(*_args: object, **_kwargs: object) -> object:
+        calls["n"] += 1
+
+        class _Resp:
+            def raise_for_status(self) -> None: ...
+            def json(self) -> dict:
+                return {"access_token": _fake_jwt(time.time() + 3 * 24 * 3600)}
+
+        return _Resp()
+
+    monkeypatch.setattr(download.httpx, "post", _fake_post)
+
+    first = download.get_ceda_token(settings)
+    second = download.get_ceda_token(settings)
+    assert first == second
+    assert calls["n"] == 1  # second call served from cache, no re-mint
+
+    # an expired cache entry forces a fresh mint
+    token, _ = download._TOKEN_CACHE[creds]  # noqa: SLF001
+    download._TOKEN_CACHE[creds] = (token, time.time() - 1)  # noqa: SLF001
+    download.get_ceda_token(settings)
+    assert calls["n"] == 2
+    download._TOKEN_CACHE.clear()  # noqa: SLF001
+
+
+def test_ceda_token_missing_credentials_returns_none() -> None:
+    """With no CEDA credentials configured, token retrieval returns None rather than raising."""
+    from wetterdienst.provider.metoffice.observation.download import get_ceda_token  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+
+    assert get_ceda_token(Settings(auth={"ceda": None})) is None
+
+
 # ---------------------------------------------------------------------------
 # Remote tests -- require a free CEDA account (WD_AUTH__CEDA=<username>:<password>).
 # ---------------------------------------------------------------------------

--- a/tests/provider/metoffice/observation/test_api.py
+++ b/tests/provider/metoffice/observation/test_api.py
@@ -1,0 +1,206 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for Met Office (MIDAS Open) observation provider."""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from wetterdienst.provider.metoffice.observation import MetOfficeObservationRequest
+from wetterdienst.provider.metoffice.observation.parser import (
+    parse_station_metadata,
+    parse_values,
+)
+
+UTC = ZoneInfo("UTC")
+
+# a busy long-running station (Lerwick, Shetland) present across most MIDAS Open datasets
+LERWICK = "00009"
+
+
+def _badc(header_rows: bytes, columns: str, data_rows: bytes) -> bytes:
+    """Assemble a minimal BADC-CSV file: G-attribute header, a bare ``data`` line, table, trailer."""
+    return header_rows + b"data\n" + columns.encode() + b"\n" + data_rows + b"end data\n"
+
+
+def test_parse_station_metadata() -> None:
+    """The station-metadata catalogue maps to one row per station with year-bounded dates."""
+    content = _badc(
+        b"Conventions,G,BADC-CSV,1\ntitle,G,Midas-open: Station site metadata\n",
+        "src_id,station_name,station_file_name,historic_county,authority,"
+        "station_latitude,station_longitude,station_elevation,first_year,last_year",
+        b"00001,FOULA,foula,shetland,Met Office,60.154,-2.074,22,1989,2003\n",
+    )
+    df = parse_station_metadata(content)
+    assert df.to_dicts() == [
+        {
+            "station_id": "00001",
+            "name": "FOULA",
+            "historic_county": "shetland",
+            "station_file_name": "foula",
+            "latitude": 60.154,
+            "longitude": -2.074,
+            "height": 22.0,
+            "start_date": dt.datetime(1989, 1, 1, tzinfo=UTC),
+            "end_date": dt.datetime(2003, 12, 31, tzinfo=UTC),
+        },
+    ]
+
+
+def test_parse_values_collapses_multiple_report_types() -> None:
+    """A day with 12h night/day readings plus a 24h reading collapses to one daily extreme.
+
+    ``max`` for max-type, ``min`` for ``min_columns`` is idempotent over the duplication, so the
+    result equals the true 24-hour value regardless of which report types a station transmits.
+    """
+    content = _badc(
+        b"Conventions,G,BADC-CSV,1\n",
+        "ob_end_time,ob_hour_count,met_domain_name,max_air_temp,max_air_temp_q,min_air_temp,min_air_temp_q",
+        # night 12h (ends 09:00), full-day 24h (ends 09:00), day 12h (ends 21:00)
+        b"2000-01-01 09:00:00,12,AWSDLY,4.8,6,0.3,6\n"
+        b"2000-01-01 09:00:00,24,DLY3208,5.4,4,0.3,4\n"
+        b"2000-01-01 21:00:00,12,AWSDLY,5.1,6,2.8,6\n",
+    )
+    df = parse_values(
+        content,
+        time_column="ob_end_time",
+        columns=["max_air_temp", "min_air_temp"],
+        granularity="1d",
+        min_columns=frozenset({"min_air_temp"}),
+    ).sort("parameter")
+    assert df.to_dicts() == [
+        # max over {4.8, 5.4, 5.1} == the 24h value 5.4; quality is that of the extreme row
+        {"date": dt.datetime(2000, 1, 1, tzinfo=UTC), "parameter": "max_air_temp", "value": 5.4, "quality": 4.0},
+        # min over {0.3, 0.3, 2.8} == 0.3
+        {"date": dt.datetime(2000, 1, 1, tzinfo=UTC), "parameter": "min_air_temp", "value": 0.3, "quality": 6.0},
+    ]
+
+
+def test_parse_values_drops_multiday_accumulations() -> None:
+    """Rows whose period-count column isn't 1 are dropped (multi-day rain accumulations)."""
+    content = _badc(
+        b"Conventions,G,BADC-CSV,1\n",
+        "ob_date,ob_day_cnt,prcp_amt,prcp_amt_q",
+        b"2000-01-01 00:00:00,31,146.7,22576\n"  # 31-day accumulation -> dropped
+        b"2000-01-02 00:00:00,1,3.7,2576\n",  # genuine single-day value -> kept
+    )
+    df = parse_values(
+        content,
+        time_column="ob_date",
+        columns=["prcp_amt"],
+        granularity="1d",
+        period_count_column="ob_day_cnt",
+    )
+    assert df.to_dicts() == [
+        {"date": dt.datetime(2000, 1, 2, tzinfo=UTC), "parameter": "prcp_amt", "value": 3.7, "quality": 2576.0},
+    ]
+
+
+def test_parse_values_scales_visibility_to_metres() -> None:
+    """Visibility is stored in decametres and scaled to metres; hourly timestamps are preserved."""
+    content = _badc(
+        b"Conventions,G,BADC-CSV,1\n",
+        "ob_time,visibility,visibility_q",
+        b"2015-07-01 13:00:00,1900,6\n",  # 1900 decametres -> 19000 metres (19 km)
+    )
+    df = parse_values(
+        content,
+        time_column="ob_time",
+        columns=["visibility"],
+        granularity="1h",
+        scale={"visibility": 10.0},
+    )
+    assert df.to_dicts() == [
+        {
+            "date": dt.datetime(2015, 7, 1, 13, 0, tzinfo=UTC),
+            "parameter": "visibility",
+            "value": 19000.0,
+            "quality": 6.0,
+        },
+    ]
+
+
+def test_parse_values_empty_input() -> None:
+    """A file with no data rows yields an empty frame with the expected schema."""
+    content = _badc(b"Conventions,G,BADC-CSV,1\n", "ob_date,prcp_amt", b"")
+    df = parse_values(content, time_column="ob_date", columns=["prcp_amt"], granularity="1d")
+    assert df.is_empty()
+    assert df.columns == ["date", "parameter", "value", "quality"]
+
+
+# ---------------------------------------------------------------------------
+# Remote tests -- require a free CEDA account (WD_AUTH__CEDA=<username>:<password>).
+# ---------------------------------------------------------------------------
+
+pytest_credentials = pytest.mark.skipif(
+    not MetOfficeObservationRequest.is_configured(),
+    reason="CEDA credentials not set -- provide WD_AUTH__CEDA=<username>:<password>",
+)
+
+
+@pytest.mark.remote
+@pytest_credentials
+def test_metoffice_observation_stations() -> None:
+    """The daily-rain catalogue resolves and contains the reference station."""
+    df = (
+        MetOfficeObservationRequest(parameters=[("daily", "rain", "precipitation_height")])
+        .filter_by_station_id(LERWICK)
+        .df
+    )
+    assert df.height == 1
+    row = df.row(0, named=True)
+    assert row["station_id"] == LERWICK
+    assert row["resolution"] == "daily"
+    assert row["dataset"] == "rain"
+    assert row["name"]  # a non-empty station name
+    assert 59.0 < row["latitude"] < 61.0  # Shetland
+    assert -2.0 < row["longitude"] < -1.0
+
+
+@pytest.mark.remote
+@pytest_credentials
+def test_metoffice_observation_values_daily_rain() -> None:
+    """Daily precipitation returns one day-truncated row per day, all non-negative."""
+    df = (
+        MetOfficeObservationRequest(
+            parameters=[("daily", "rain", "precipitation_height")],
+            start_date=dt.datetime(2023, 7, 1, tzinfo=UTC),
+            end_date=dt.datetime(2023, 7, 10, tzinfo=UTC),
+        )
+        .filter_by_station_id(LERWICK)
+        .values.all()
+        .df
+    )
+    assert not df.is_empty()
+    assert df["resolution"].unique().to_list() == ["daily"]
+    assert df["parameter"].unique().to_list() == ["precipitation_height"]
+    # one value per day, timestamps truncated to midnight
+    assert (df["date"] == df["date"].dt.truncate("1d")).all()
+    assert df["date"].n_unique() == df.height
+    assert df["value"].min() >= 0.0
+
+
+@pytest.mark.remote
+@pytest_credentials
+def test_metoffice_observation_values_daily_temperature_one_row_per_day() -> None:
+    """Daily temperature collapses multiple report types to a single row per day/parameter."""
+    df = (
+        MetOfficeObservationRequest(
+            parameters=[("daily", "temperature")],
+            start_date=dt.datetime(2023, 7, 1, tzinfo=UTC),
+            end_date=dt.datetime(2023, 7, 5, tzinfo=UTC),
+        )
+        .filter_by_station_id(LERWICK)
+        .values.all()
+        .df
+    )
+    assert not df.is_empty()
+    # no (date, parameter) duplicates -> report types were collapsed
+    assert df.select("date", "parameter").is_unique().all()
+    maxes = df.filter(pl.col("parameter") == "temperature_air_max_2m")
+    mins = df.filter(pl.col("parameter") == "temperature_air_min_2m")
+    if not maxes.is_empty() and not mins.is_empty():
+        joined = maxes.join(mins, on="date", suffix="_min")
+        assert (joined["value"] >= joined["value_min"]).all()

--- a/tests/provider/metoffice/observation/test_api.py
+++ b/tests/provider/metoffice/observation/test_api.py
@@ -185,6 +185,20 @@ def test_ceda_token_missing_credentials_returns_none() -> None:
     assert get_ceda_token(Settings(auth={"ceda": None})) is None
 
 
+def test_ceda_token_valid_until_falls_back_on_unreadable_payload() -> None:
+    """A JWT whose payload is valid JSON but not a dict falls back to a short TTL, not a crash."""
+    import base64  # noqa: PLC0415
+    import json  # noqa: PLC0415
+    import time  # noqa: PLC0415
+
+    from wetterdienst.provider.metoffice.observation import download  # noqa: PLC0415
+
+    # payload decodes to JSON ``null`` -> ["exp"] would be a TypeError; must fall back, not raise
+    payload = base64.urlsafe_b64encode(json.dumps(None).encode()).rstrip(b"=").decode()
+    valid_until = download._token_valid_until(f"header.{payload}.signature")  # noqa: SLF001
+    assert time.time() < valid_until <= time.time() + download._FALLBACK_TTL_SECONDS + 5  # noqa: SLF001
+
+
 # ---------------------------------------------------------------------------
 # Remote tests -- require a free CEDA account (WD_AUTH__CEDA=<username>:<password>).
 # ---------------------------------------------------------------------------

--- a/tests/provider/metoffice/observation/test_api.py
+++ b/tests/provider/metoffice/observation/test_api.py
@@ -185,6 +185,38 @@ def test_ceda_token_missing_credentials_returns_none() -> None:
     assert get_ceda_token(Settings(auth={"ceda": None})) is None
 
 
+@pytest.mark.parametrize(
+    "body",
+    [
+        "<html>login page</html>",  # non-JSON body on a 200 (e.g. redirected login page)
+        {"detail": "no token here"},  # JSON body missing the access_token field
+        ["unexpected"],  # JSON that is not even an object
+    ],
+)
+def test_ceda_token_bad_response_returns_none(body: object, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 200 whose body is not usable JSON with an access_token is an auth failure, not a crash."""
+    import json  # noqa: PLC0415
+
+    from wetterdienst.provider.metoffice.observation import download  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+
+    download._TOKEN_CACHE.clear()  # noqa: SLF001
+
+    def _fake_post(*_args: object, **_kwargs: object) -> object:
+        class _Resp:
+            def raise_for_status(self) -> None: ...
+            def json(self) -> object:
+                if isinstance(body, str):
+                    return json.loads(body)  # invalid JSON raises JSONDecodeError, like httpx does
+                return body
+
+        return _Resp()
+
+    monkeypatch.setattr(download.httpx, "post", _fake_post)
+    assert download.get_ceda_token(Settings(auth={"ceda": "user:pass"})) is None
+    download._TOKEN_CACHE.clear()  # noqa: SLF001
+
+
 def test_ceda_token_valid_until_falls_back_on_unreadable_payload() -> None:
     """A JWT whose payload is valid JSON but not a dict falls back to a short TTL, not a crash."""
     import base64  # noqa: PLC0415
@@ -197,6 +229,23 @@ def test_ceda_token_valid_until_falls_back_on_unreadable_payload() -> None:
     payload = base64.urlsafe_b64encode(json.dumps(None).encode()).rstrip(b"=").decode()
     valid_until = download._token_valid_until(f"header.{payload}.signature")  # noqa: SLF001
     assert time.time() < valid_until <= time.time() + download._FALLBACK_TTL_SECONDS + 5  # noqa: SLF001
+
+
+@pytest.mark.parametrize("body", [b"<html>temporary error</html>", b'["not", "a", "dict"]'])
+def test_latest_release_version_bad_listing_returns_none(body: bytes, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-JSON or unexpectedly-shaped archive listing reads as 'no release', not a crash."""
+    from wetterdienst.provider.metoffice.observation import fileindex  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+
+    class _Content:
+        def read(self) -> bytes:
+            return body
+
+    class _File:
+        content = _Content()
+
+    monkeypatch.setattr(fileindex, "download_file", lambda **_kwargs: _File())
+    assert fileindex.latest_release_version(Settings(), token="t") is None  # noqa: S106
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,6 +35,7 @@ from wetterdienst.provider.meteofrance.observation import MeteoFranceObservation
 from wetterdienst.provider.meteofrance.synop import MeteoFranceSynopMetadata, MeteoFranceSynopRequest
 from wetterdienst.provider.meteoswiss.observation import MeteoswissObservationMetadata, MeteoswissObservationRequest
 from wetterdienst.provider.metno.frost.api import MetnoFrostMetadata, MetnoFrostRequest
+from wetterdienst.provider.metoffice.observation import MetOfficeObservationMetadata
 from wetterdienst.provider.noaa.ghcn import NoaaGhcnMetadata, NoaaGhcnRequest
 from wetterdienst.provider.nws.observation import NwsObservationMetadata, NwsObservationRequest
 from wetterdienst.provider.rmi.observation import RmiObservationMetadata, RmiObservationRequest
@@ -127,6 +128,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
         MeteoFranceSynopMetadata,
         MeteoswissObservationMetadata,
         MetnoFrostMetadata,
+        MetOfficeObservationMetadata,
         NoaaGhcnMetadata,
         NwsObservationMetadata,
         RmiObservationMetadata,
@@ -167,6 +169,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
         MeteoFranceSynopMetadata,
         MeteoswissObservationMetadata,
         MetnoFrostMetadata,
+        MetOfficeObservationMetadata,
         NoaaGhcnMetadata,
         NwsObservationMetadata,
         RmiObservationMetadata,

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -77,6 +77,7 @@ def test_coverage(client: TestClient) -> None:
         "meteofrance",
         "meteoswiss",
         "metno",
+        "metoffice",
         "noaa",
         "nws",
         "rmi",


### PR DESCRIPTION
## Summary

Adds a UK meteorology provider backed by the Met Office **MIDAS Open** archive on CEDA (UK Open Government Licence v3.0). Fills the UK gap — previously only EA hydrology was covered, no UK meteorology.

- 8 datasets across `daily` and `hourly` resolution (rain, temperature, weather, wind, radiation, soil temperature)
- ~13.5k stations (~2.5k currently active)
- Registered as `metoffice`/`observation`

## Notable handling (established by live testing against the archive)

- **CEDA bearer-token auth** (`WD_AUTH__CEDA=username:password`), minted per run from a 3-day Keycloak JWT. Browsing is anonymous but file download needs the token.
- **Multiple report types per day** (12h day/night + 24h) collapsed to one value per calendar day — `max` for max-type params, `min` for min-type; idempotent over the 12h/24h duplication.
- **Multi-day rain accumulations** dropped (`ob_day_cnt != 1`).
- **Units**: verified against real values / the Met Office GL-table docs — wind in knots, temps °C, pressure hPa, precip mm, radiation kJ/m². `visibility` is native decametres, scaled to metres.
- **Quality**: the raw MESQL compound QC flag is passed through unchanged (not a linear level).

## Tests

Offline parser tests (aggregation, multi-day filter, visibility scaling, station metadata) that always run, plus credential-gated remote tests. `IpmaObservationMetadata`-style entry added to the metadata name/unit test lists (`test_api.py`).

Only `daily/rain` is fully live-verified end-to-end; the module docstring notes the datasets whose per-dataset quirks are less exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)