### PR TITLE
feat(ipma): add IPMA (Portugal) observation provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ Types of changes:
   `urban_wind` and `urban_wind_extreme`. These complement the existing hourly urban datasets. The
   urban station-description lists are parsed by content because they frequently leave the optional
   date and Bundesland fields blank
+- Add an IPMA (Portugal) observation provider (`ipma`/`observation`) backed by the key-less
+  `api.ipma.pt` open-data JSON feeds. Provides near-real-time hourly observations (temperature,
+  humidity, sea-level pressure, wind speed/direction, precipitation, global radiation) from ~222
+  stations. Recent-only (a rolling ~1-day window), so a date range within the last day is required.
+  The `-99.0` missing sentinel becomes null and the 8-point wind-direction code is converted to
+  degrees
 
 ### Changed
 

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -76,6 +76,11 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
     - Hydrology
         - hydrological data of polish river stations
         - daily and monthly summaries
+- IPMA (Instituto Português do Mar e da Atmosfera / Portuguese Institute for Sea and Atmosphere / Portugal)
+    - Observation
+        - near-real-time hourly observations from the Portuguese automatic station network
+        - ~222 stations; recent only (rolling ~last day, no historical archive)
+        - open data, no authentication required
 - KNMI (Koninklijk Nederlands Meteorologisch Instituut / Royal Netherlands Meteorological Institute / Netherlands)
     - Observation
         - observations from the Dutch station network

--- a/docs/data/provider/index.md
+++ b/docs/data/provider/index.md
@@ -13,6 +13,7 @@ eccc/index.md
 fmi/index.md
 geosphere/index.md
 imgw/index.md
+ipma/index.md
 knmi/index.md
 meteofrance/index.md
 meteoswiss/index.md

--- a/docs/data/provider/ipma/index.md
+++ b/docs/data/provider/ipma/index.md
@@ -1,0 +1,19 @@
+# IPMA
+
+Instituto Português do Mar e da Atmosfera (Portuguese Institute for Sea and Atmosphere)
+
+## Overview
+
+IPMA publishes near-real-time hourly observations from the Portuguese automatic weather station
+network as key-less JSON open data. No authentication is required.
+
+## License
+
+IPMA data is provided as open data through the [IPMA API](https://api.ipma.pt/). Check the portal
+for the applicable usage conditions and attribution requirements.
+
+```{toctree}
+:hidden:
+
+observation/index.md
+```

--- a/docs/data/provider/ipma/observation/hourly.md
+++ b/docs/data/provider/ipma/observation/hourly.md
@@ -1,0 +1,31 @@
+# hourly
+
+## metadata
+
+| property      | value  |
+|---------------|--------|
+| name          | hourly |
+| original name | hourly |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | data  |
+| original name | data  |
+
+#### parameters
+
+| name                    | original name    | unit type       | unit  |
+|-------------------------|------------------|-----------------|-------|
+| temperature_air_mean_2m | temperatura      | temperature     | °C    |
+| humidity                | humidade         | fraction        | %     |
+| pressure_air_sea_level  | pressao          | pressure        | hPa   |
+| wind_speed              | intensidadeVento | speed           | m/s   |
+| wind_direction          | idDireccVento    | angle           | °     |
+| precipitation_height    | precAcumulada    | precipitation   | mm    |
+| radiation_global        | radiacao         | energy_per_area | kJ/m² |

--- a/docs/data/provider/ipma/observation/index.md
+++ b/docs/data/provider/ipma/observation/index.md
@@ -6,7 +6,7 @@ IPMA's open-data API provides near-real-time hourly observations from the Portug
 weather station network (~222 stations across mainland Portugal, the Azores and Madeira). No API key
 or registration is required — the feed is fully public.
 
-Two JSON feeds are used: a station catalogue (`stations.json`, a GeoJSON FeatureCollection giving
+Two JSON feeds are used: a station catalogue (`stations.json`, a bare array of GeoJSON Feature objects giving
 each station's id, name and coordinates) and a single all-stations observation feed
 (`observations.json`) holding roughly the last day of hourly readings. Because the feed is a rolling
 window, only the `recent` period is available — there is no historical archive, so a date range

--- a/docs/data/provider/ipma/observation/index.md
+++ b/docs/data/provider/ipma/observation/index.md
@@ -1,0 +1,30 @@
+# Observation
+
+## Overview
+
+IPMA's open-data API provides near-real-time hourly observations from the Portuguese automatic
+weather station network (~222 stations across mainland Portugal, the Azores and Madeira). No API key
+or registration is required — the feed is fully public.
+
+Two JSON feeds are used: a station catalogue (`stations.json`, a GeoJSON FeatureCollection giving
+each station's id, name and coordinates) and a single all-stations observation feed
+(`observations.json`) holding roughly the last day of hourly readings. Because the feed is a rolling
+window, only the `recent` period is available — there is no historical archive, so a date range
+within roughly the last 24 hours must be given.
+
+The catalogue exposes no elevation, so `height` is always null, and — being a live feed — there is
+no operational start/end date per station. Wind direction is published as an 8-point code and is
+converted to degrees; pressure is reduced to mean sea level; radiation is global solar radiation in
+kJ/m². The value `-99.0` marks missing data and becomes null. The `intensidadeVentoKM` field (the
+same wind speed in km/h) is not exposed, as it duplicates `intensidadeVento` (m/s).
+
+## License
+
+Data is © IPMA (Instituto Português do Mar e da Atmosfera). See the [IPMA API](https://api.ipma.pt/)
+for further information and usage conditions.
+
+```{toctree}
+:hidden:
+
+hourly.md
+```

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -45,6 +45,9 @@ class Wetterdienst:
             "hydrology": "wetterdienst.provider.imgw.hydrology.ImgwHydrologyRequest",
             "meteorology": "wetterdienst.provider.imgw.meteorology.ImgwMeteorologyRequest",
         },
+        "ipma": {
+            "observation": "wetterdienst.provider.ipma.observation.IpmaObservationRequest",
+        },
         "knmi": {
             "observation": "wetterdienst.provider.knmi.observation.KnmiObservationRequest",
         },

--- a/src/wetterdienst/provider/ipma/__init__.py
+++ b/src/wetterdienst/provider/ipma/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""IPMA (Portugal) provider."""

--- a/src/wetterdienst/provider/ipma/observation/__init__.py
+++ b/src/wetterdienst/provider/ipma/observation/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""IPMA (Portugal) observation provider."""
+
+from wetterdienst.provider.ipma.observation.api import IpmaObservationRequest
+from wetterdienst.provider.ipma.observation.metadata import IpmaObservationMetadata
+
+__all__ = ["IpmaObservationMetadata", "IpmaObservationRequest"]

--- a/src/wetterdienst/provider/ipma/observation/api.py
+++ b/src/wetterdienst/provider/ipma/observation/api.py
@@ -3,7 +3,7 @@
 """IPMA (Instituto Português do Mar e da Atmosfera) observation provider.
 
 IPMA publishes near-real-time hourly observations from its Portuguese automatic station network as
-two key-less JSON feeds: a station catalogue (``stations.json``, a GeoJSON FeatureCollection) and a
+two key-less JSON feeds: a station catalogue (``stations.json``, a bare array of GeoJSON Feature objects) and a
 single all-stations observation feed (``observations.json``) holding roughly the last day of hourly
 readings. Only the ``recent`` period exists; there is no historical archive.
 

--- a/src/wetterdienst/provider/ipma/observation/api.py
+++ b/src/wetterdienst/provider/ipma/observation/api.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""IPMA (Instituto Português do Mar e da Atmosfera) observation provider.
+
+IPMA publishes near-real-time hourly observations from its Portuguese automatic station network as
+two key-less JSON feeds: a station catalogue (``stations.json``, a GeoJSON FeatureCollection) and a
+single all-stations observation feed (``observations.json``) holding roughly the last day of hourly
+readings. Only the ``recent`` period exists; there is no historical archive.
+
+See ``metadata.py`` for the field/unit background and ``parser.py`` for the (wind-direction code,
+``-99`` sentinel) handling.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.model.metadata import DatasetModel, ParameterModel
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.ipma.observation.metadata import IpmaObservationMetadata
+from wetterdienst.provider.ipma.observation.parser import parse_ipma_observations, parse_ipma_stations
+from wetterdienst.util.network import download_file
+
+if TYPE_CHECKING:
+    from wetterdienst.settings import Settings
+
+log = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.ipma.pt/open-data/observation/meteorology/stations"
+_STATIONS_URL = f"{_BASE_URL}/stations.json"
+_OBSERVATIONS_URL = f"{_BASE_URL}/observations.json"
+
+_EMPTY_VALUES_SCHEMA = {
+    "resolution": pl.String,
+    "dataset": pl.String,
+    "parameter": pl.String,
+    "station_id": pl.String,
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "value": pl.Float64,
+    "quality": pl.Float64,
+}
+
+
+class IpmaObservationValues(TimeseriesValues):
+    """Values class for IPMA observation data."""
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        if isinstance(parameter_or_dataset, ParameterModel):
+            dataset = parameter_or_dataset.dataset
+        elif isinstance(parameter_or_dataset, DatasetModel):
+            dataset = parameter_or_dataset
+        else:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        settings = cast("Settings", self.sr.stations.settings)
+        # one all-stations feed serves every station; a five-minute cache means the concurrent
+        # per-station queries in a rank loop download it once.
+        file = download_file(
+            url=_OBSERVATIONS_URL,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.FIVE_MINUTES,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            if not file.is_no_internet_error:
+                log.warning(f"Failed to fetch IPMA observations: {file.content}")
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        df = parse_ipma_observations(file.content.read(), station_id=station_id)
+        if df.is_empty():
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            pl.col("parameter"),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            pl.col("date"),
+            pl.col("value"),
+            pl.lit(None, dtype=pl.Float64).alias("quality"),
+        )
+
+
+@dataclass
+class IpmaObservationRequest(TimeseriesRequest):
+    """Request class for IPMA (Instituto Português do Mar e da Atmosfera) observation data."""
+
+    metadata = IpmaObservationMetadata
+    _values = IpmaObservationValues
+
+    def _all(self) -> pl.LazyFrame:
+        settings = cast("Settings", self.settings)
+        file = download_file(
+            url=_STATIONS_URL,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.METAINDEX,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            log.warning(f"Failed to fetch IPMA station catalogue: {file.content}")
+            return pl.LazyFrame()
+        stations = parse_ipma_stations(file.content.read())
+        if stations.is_empty():
+            return pl.LazyFrame()
+        # the catalogue is provider-wide; tag it with the single (resolution, dataset). Columns the
+        # catalogue omits (height, start_date, end_date, state) are null-filled by all().
+        resolution = self.metadata[0]
+        return stations.with_columns(
+            pl.lit(resolution.name, pl.String).alias("resolution"),
+            pl.lit(resolution.datasets[0].name, pl.String).alias("dataset"),
+        ).lazy()

--- a/src/wetterdienst/provider/ipma/observation/api.py
+++ b/src/wetterdienst/provider/ipma/observation/api.py
@@ -24,7 +24,11 @@ from wetterdienst.model.metadata import DatasetModel, ParameterModel
 from wetterdienst.model.request import TimeseriesRequest
 from wetterdienst.model.values import TimeseriesValues
 from wetterdienst.provider.ipma.observation.metadata import IpmaObservationMetadata
-from wetterdienst.provider.ipma.observation.parser import parse_ipma_observations, parse_ipma_stations
+from wetterdienst.provider.ipma.observation.parser import (
+    extract_ipma_station_observations,
+    parse_ipma_observations_feed,
+    parse_ipma_stations,
+)
 from wetterdienst.util.network import download_file
 
 if TYPE_CHECKING:
@@ -50,18 +54,17 @@ _EMPTY_VALUES_SCHEMA = {
 class IpmaObservationValues(TimeseriesValues):
     """Values class for IPMA observation data."""
 
-    def _collect_station_parameter_or_dataset(
-        self,
-        station_id: str,
-        parameter_or_dataset: ParameterModel | DatasetModel,
-    ) -> pl.DataFrame:
-        if isinstance(parameter_or_dataset, ParameterModel):
-            dataset = parameter_or_dataset.dataset
-        elif isinstance(parameter_or_dataset, DatasetModel):
-            dataset = parameter_or_dataset
-        else:
-            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    def _observations_feed(self) -> dict | None:
+        """Download and deserialise the all-stations feed once, memoised on the values instance.
 
+        A single ``observations.json`` holds every station, so parsing it per station (once per
+        ``_collect_station_parameter_or_dataset`` call in a rank loop) would re-run ``json.loads`` over
+        the whole payload N times. The parsed feed is cached here so it is deserialised exactly once
+        per query; ``None`` signals a fetch failure and is intentionally not cached so it is retried.
+        """
+        cached = getattr(self, "_feed_cache", None)
+        if cached is not None:
+            return cached
         settings = cast("Settings", self.sr.stations.settings)
         # one all-stations feed serves every station; a five-minute cache means the concurrent
         # per-station queries in a rank loop download it once.
@@ -76,8 +79,27 @@ class IpmaObservationValues(TimeseriesValues):
         if isinstance(file.content, Exception):
             if not file.is_no_internet_error:
                 log.warning(f"Failed to fetch IPMA observations: {file.content}")
+            return None
+        feed = parse_ipma_observations_feed(file.content.read())
+        self._feed_cache = feed
+        return feed
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        if isinstance(parameter_or_dataset, ParameterModel):
+            dataset = parameter_or_dataset.dataset
+        elif isinstance(parameter_or_dataset, DatasetModel):
+            dataset = parameter_or_dataset
+        else:
             return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
-        df = parse_ipma_observations(file.content.read(), station_id=station_id)
+
+        feed = self._observations_feed()
+        if feed is None:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        df = extract_ipma_station_observations(feed, station_id=station_id)
         if df.is_empty():
             return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
         return df.select(

--- a/src/wetterdienst/provider/ipma/observation/metadata.py
+++ b/src/wetterdienst/provider/ipma/observation/metadata.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""IPMA (Portugal) observation metadata.
+
+IPMA (Instituto Português do Mar e da Atmosfera) publishes near-real-time hourly observations from
+its automatic station network as a single key-less JSON feed
+(https://api.ipma.pt/open-data/observation/meteorology/stations/observations.json). The feed is a
+rolling window of roughly the last day, so only the ``recent`` period is available -- there is no
+historical archive here.
+
+Field semantics and units follow the IPMA open-data documentation (https://api.ipma.pt/): pressure
+is reduced to mean sea level, radiation is global solar radiation in kJ/m², and wind direction is
+published as an 8-point *code* (``idDireccVento``) that ``parser.py`` converts to degrees. The
+``intensidadeVentoKM`` field (the same wind speed in km/h) is intentionally not mapped -- it
+duplicates ``intensidadeVento`` (m/s). ``-99.0`` is the missing-value sentinel and becomes null.
+"""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, build_metadata_model
+
+IpmaObservationMetadata = {
+    "name_short": "IPMA",
+    "name_english": "Portuguese Institute for Sea and Atmosphere",
+    "name_local": "Instituto Português do Mar e da Atmosfera",
+    "country": "Portugal",
+    "copyright": "© IPMA (Instituto Português do Mar e da Atmosfera)",
+    "url": "https://api.ipma.pt/",
+    "kind": "observation",
+    "timezone": "Europe/Lisbon",
+    "timezone_data": "UTC",
+    "resolutions": [
+        {
+            "name": "hourly",
+            "name_original": "hourly",
+            "periods": ["recent"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": DATASET_NAME_DEFAULT,
+                    "name_original": DATASET_NAME_DEFAULT,
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "temperatura",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "humidity",
+                            "name_original": "humidade",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "pressure_air_sea_level",
+                            "name_original": "pressao",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "wind_speed",
+                            "name_original": "intensidadeVento",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_direction",
+                            "name_original": "idDireccVento",
+                            "unit_type": "angle",
+                            "unit": "degree",
+                        },
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "precAcumulada",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "radiation_global",
+                            "name_original": "radiacao",
+                            "unit_type": "energy_per_area",
+                            "unit": "kilojoule_per_square_meter",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+IpmaObservationMetadata = build_metadata_model(IpmaObservationMetadata, "IpmaObservationMetadata")

--- a/src/wetterdienst/provider/ipma/observation/parser.py
+++ b/src/wetterdienst/provider/ipma/observation/parser.py
@@ -40,13 +40,16 @@ _EMPTY_VALUES_SCHEMA = {
 
 
 def parse_ipma_stations(content: bytes) -> pl.DataFrame:
-    """Parse ``stations.json`` (a bare JSON array of GeoJSON Feature objects) into one row per station.
+    """Parse ``stations.json`` into one row per station.
 
-    Each feature carries ``properties.idEstacao`` (the numeric station id) and
+    IPMA serves the catalogue as a bare JSON array of GeoJSON ``Feature`` objects, but a standard
+    ``FeatureCollection`` wrapper (``{"type": "FeatureCollection", "features": [...]}``) is accepted
+    too. Each feature carries ``properties.idEstacao`` (the numeric station id) and
     ``properties.localEstacao`` (the name), plus a ``Point`` geometry as ``[longitude, latitude]``.
     The catalogue exposes no elevation, so ``height`` is left for the framework to null-fill.
     """
-    features = json.loads(content)
+    data = json.loads(content)
+    features = data.get("features") if isinstance(data, dict) else data
     if not isinstance(features, list) or not features:
         return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
     rows = [
@@ -70,17 +73,26 @@ def _value(field: str, raw: float | None) -> float | None:
     return float(raw)
 
 
-def parse_ipma_observations(content: bytes, station_id: str) -> pl.DataFrame:
-    """Parse the all-stations ``observations.json`` into long rows for a single station.
+def parse_ipma_observations_feed(content: bytes) -> dict:
+    """Deserialise the all-stations ``observations.json`` once into its nested dict.
 
     The feed is a nested object ``{timestamp: {station_id: {field: value}}}`` covering roughly the
-    last day. A station that reported nothing for a timestamp maps to ``null`` and is skipped. The
-    emitted ``parameter`` column keeps the raw IPMA field name (``name_original``); values are
-    normalised via :func:`_value`. Timestamps are UTC (``YYYY-MM-DDTHH:MM``).
+    last day and holding every station. Because a single feed serves all stations, callers parse it
+    once and hand the result to :func:`extract_ipma_station_observations` per station, rather than
+    re-running :func:`json.loads` over the whole payload for every station. A payload that is not a
+    JSON object yields an empty dict.
     """
     feed = json.loads(content)
-    if not isinstance(feed, dict):
-        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    return feed if isinstance(feed, dict) else {}
+
+
+def extract_ipma_station_observations(feed: dict, station_id: str) -> pl.DataFrame:
+    """Extract one station's long-form rows from an already-parsed observations ``feed``.
+
+    A station that reported nothing for a timestamp maps to ``null`` and is skipped. The emitted
+    ``parameter`` column keeps the raw IPMA field name (``name_original``); values are normalised via
+    :func:`_value`. Timestamps are UTC (``YYYY-MM-DDTHH:MM``).
+    """
     rows = []
     for timestamp, stations in feed.items():
         record = stations.get(station_id) if isinstance(stations, dict) else None
@@ -93,3 +105,14 @@ def parse_ipma_observations(content: bytes, station_id: str) -> pl.DataFrame:
     return pl.DataFrame(rows, schema={"date": pl.String, "parameter": pl.String, "value": pl.Float64}).with_columns(
         pl.col("date").str.to_datetime("%Y-%m-%dT%H:%M", time_unit="us").dt.replace_time_zone("UTC"),
     )
+
+
+def parse_ipma_observations(content: bytes, station_id: str) -> pl.DataFrame:
+    """Parse the all-stations ``observations.json`` into long rows for a single station.
+
+    Convenience wrapper that deserialises the feed and extracts one station in a single call. Callers
+    fetching many stations from the same feed should instead parse once via
+    :func:`parse_ipma_observations_feed` and reuse the result across
+    :func:`extract_ipma_station_observations` calls.
+    """
+    return extract_ipma_station_observations(parse_ipma_observations_feed(content), station_id)

--- a/src/wetterdienst/provider/ipma/observation/parser.py
+++ b/src/wetterdienst/provider/ipma/observation/parser.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Parsers for IPMA's open-data JSON feeds (station catalogue and hourly observations)."""
+
+from __future__ import annotations
+
+import json
+
+import polars as pl
+
+# IPMA's missing-value sentinel, used across every numeric observation field.
+_MISSING = -99.0
+
+# ``idDireccVento`` is an 8-point wind-direction code, not degrees. Per the IPMA docs: 0 = no
+# direction (calm) -> null; 1 and 9 both mean N; 2..8 step clockwise through NE, E, SE, S, SW, W, NW.
+_WIND_DIRECTION_DEGREES = {1: 0.0, 2: 45.0, 3: 90.0, 4: 135.0, 5: 180.0, 6: 225.0, 7: 270.0, 8: 315.0, 9: 0.0}
+
+# the raw observation fields mapped to parameters (i.e. every ``name_original`` in metadata.py).
+_VALUE_FIELDS = (
+    "temperatura",
+    "humidade",
+    "pressao",
+    "intensidadeVento",
+    "precAcumulada",
+    "radiacao",
+)
+
+_EMPTY_STATIONS_SCHEMA = {
+    "station_id": pl.String,
+    "name": pl.String,
+    "latitude": pl.Float64,
+    "longitude": pl.Float64,
+}
+
+_EMPTY_VALUES_SCHEMA = {
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "parameter": pl.String,
+    "value": pl.Float64,
+}
+
+
+def parse_ipma_stations(content: bytes) -> pl.DataFrame:
+    """Parse ``stations.json`` (a GeoJSON FeatureCollection) into one row per station.
+
+    Each feature carries ``properties.idEstacao`` (the numeric station id) and
+    ``properties.localEstacao`` (the name), plus a ``Point`` geometry as ``[longitude, latitude]``.
+    The catalogue exposes no elevation, so ``height`` is left for the framework to null-fill.
+    """
+    features = json.loads(content)
+    if not isinstance(features, list) or not features:
+        return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
+    rows = [
+        {
+            "station_id": str(feature["properties"]["idEstacao"]),
+            "name": feature["properties"]["localEstacao"],
+            "latitude": feature["geometry"]["coordinates"][1],
+            "longitude": feature["geometry"]["coordinates"][0],
+        }
+        for feature in features
+    ]
+    return pl.DataFrame(rows, schema=_EMPTY_STATIONS_SCHEMA)
+
+
+def _value(field: str, raw: float | None) -> float | None:
+    """Normalise one raw field value: sentinel/missing to null, wind-direction code to degrees."""
+    if raw is None or raw == _MISSING:
+        return None
+    if field == "idDireccVento":
+        return _WIND_DIRECTION_DEGREES.get(int(raw))  # code 0 (calm) and unknown codes -> null
+    return float(raw)
+
+
+def parse_ipma_observations(content: bytes, station_id: str) -> pl.DataFrame:
+    """Parse the all-stations ``observations.json`` into long rows for a single station.
+
+    The feed is a nested object ``{timestamp: {station_id: {field: value}}}`` covering roughly the
+    last day. A station that reported nothing for a timestamp maps to ``null`` and is skipped. The
+    emitted ``parameter`` column keeps the raw IPMA field name (``name_original``); values are
+    normalised via :func:`_value`. Timestamps are UTC (``YYYY-MM-DDTHH:MM``).
+    """
+    feed = json.loads(content)
+    if not isinstance(feed, dict):
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    rows = []
+    for timestamp, stations in feed.items():
+        record = stations.get(station_id) if isinstance(stations, dict) else None
+        if not record:
+            continue
+        for field in (*_VALUE_FIELDS, "idDireccVento"):
+            rows.append({"date": timestamp, "parameter": field, "value": _value(field, record.get(field))})
+    if not rows:
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    return pl.DataFrame(rows, schema={"date": pl.String, "parameter": pl.String, "value": pl.Float64}).with_columns(
+        pl.col("date").str.to_datetime("%Y-%m-%dT%H:%M", time_unit="us").dt.replace_time_zone("UTC"),
+    )

--- a/src/wetterdienst/provider/ipma/observation/parser.py
+++ b/src/wetterdienst/provider/ipma/observation/parser.py
@@ -40,7 +40,7 @@ _EMPTY_VALUES_SCHEMA = {
 
 
 def parse_ipma_stations(content: bytes) -> pl.DataFrame:
-    """Parse ``stations.json`` (a GeoJSON FeatureCollection) into one row per station.
+    """Parse ``stations.json`` (a bare JSON array of GeoJSON Feature objects) into one row per station.
 
     Each feature carries ``properties.idEstacao`` (the numeric station id) and
     ``properties.localEstacao`` (the name), plus a ``Point`` geometry as ``[longitude, latitude]``.

--- a/tests/provider/ipma/__init__.py
+++ b/tests/provider/ipma/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/ipma/observation/__init__.py
+++ b/tests/provider/ipma/observation/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/ipma/observation/test_api.py
+++ b/tests/provider/ipma/observation/test_api.py
@@ -10,7 +10,9 @@ import pytest
 
 from wetterdienst.provider.ipma.observation import IpmaObservationRequest
 from wetterdienst.provider.ipma.observation.parser import (
+    extract_ipma_station_observations,
     parse_ipma_observations,
+    parse_ipma_observations_feed,
     parse_ipma_stations,
 )
 
@@ -32,6 +34,35 @@ def test_parse_ipma_stations() -> None:
             "longitude": -9.1333,
         },
     ]
+
+
+def test_parse_ipma_stations_feature_collection() -> None:
+    """A standard GeoJSON FeatureCollection wrapper is accepted as well as the bare array."""
+    content = (
+        b'{"type": "FeatureCollection", "features": [{"geometry": {"type": "Point", '
+        b'"coordinates": [-9.1333, 38.7667]}, "type": "Feature", '
+        b'"properties": {"idEstacao": 1200579, "localEstacao": "Lisboa"}}]}'
+    )
+    df = parse_ipma_stations(content)
+    assert df.to_dicts() == [
+        {"station_id": "1200579", "name": "Lisboa", "latitude": 38.7667, "longitude": -9.1333},
+    ]
+
+
+def test_parse_ipma_observations_feed_extract_multiple_stations() -> None:
+    """The feed is deserialised once and reused to extract each station independently."""
+    content = b'{"2026-07-29T14:00": {"1200579": {"temperatura": 27.5}, "1210881": {"temperatura": 19.0}}}'
+    feed = parse_ipma_observations_feed(content)
+    assert set(feed["2026-07-29T14:00"]) == {"1200579", "1210881"}
+    first = extract_ipma_station_observations(feed, station_id="1200579")
+    second = extract_ipma_station_observations(feed, station_id="1210881")
+    assert first.filter(pl.col("parameter") == "temperatura")["value"].to_list() == [27.5]
+    assert second.filter(pl.col("parameter") == "temperatura")["value"].to_list() == [19.0]
+
+
+def test_parse_ipma_observations_feed_rejects_non_object() -> None:
+    """A payload that is not a JSON object yields an empty feed rather than raising."""
+    assert parse_ipma_observations_feed(b"[]") == {}
 
 
 def test_parse_ipma_observations_sentinel_and_wind_code() -> None:

--- a/tests/provider/ipma/observation/test_api.py
+++ b/tests/provider/ipma/observation/test_api.py
@@ -56,12 +56,27 @@ def test_parse_ipma_observations_sentinel_and_wind_code() -> None:
     assert df["date"].to_list() == [dt.datetime(2026, 7, 29, 14, 0, tzinfo=UTC)] * len(df)
 
 
-def test_parse_ipma_observations_calm_wind_is_null() -> None:
-    """Wind-direction code 0 (calm / no direction) maps to null, not 0 degrees."""
-    content = b'{"2026-07-29T14:00": {"1200579": {"idDireccVento": 0, "temperatura": 20.0}}}'
+@pytest.mark.parametrize(
+    ("code", "expected_degrees"),
+    [
+        (0, None),  # calm / no direction -> null (not 0°)
+        (1, 0.0),  # N
+        (2, 45.0),  # NE
+        (3, 90.0),  # E
+        (4, 135.0),  # SE
+        (5, 180.0),  # S
+        (6, 225.0),  # SW
+        (7, 270.0),  # W
+        (8, 315.0),  # NW
+        (9, 0.0),  # N (alias of 1)
+    ],
+)
+def test_parse_ipma_observations_wind_direction_codes(code: int, expected_degrees: float | None) -> None:
+    """Every IPMA wind-direction code 0-9 maps to the expected degrees (0/calm -> null, 9 aliases N)."""
+    content = f'{{"2026-07-29T14:00": {{"1200579": {{"idDireccVento": {code}}}}}}}'.encode()
     df = parse_ipma_observations(content, station_id="1200579")
     wind = df.filter(pl.col("parameter") == "idDireccVento")
-    assert wind["value"].to_list() == [None]
+    assert wind["value"].to_list() == [expected_degrees]
 
 
 def test_parse_ipma_observations_skips_absent_station() -> None:

--- a/tests/provider/ipma/observation/test_api.py
+++ b/tests/provider/ipma/observation/test_api.py
@@ -1,0 +1,121 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for IPMA (Portugal) observation provider."""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from wetterdienst.provider.ipma.observation import IpmaObservationRequest
+from wetterdienst.provider.ipma.observation.parser import (
+    parse_ipma_observations,
+    parse_ipma_stations,
+)
+
+UTC = ZoneInfo("UTC")
+
+
+def test_parse_ipma_stations() -> None:
+    """The GeoJSON catalogue maps to one row per station; coordinates come from the geometry."""
+    content = (
+        b'[{"geometry": {"type": "Point", "coordinates": [-9.1333, 38.7667]}, "type": "Feature", '
+        b'"properties": {"idEstacao": 1200579, "localEstacao": "Lisboa (Geof\xc3\xadsico)"}}]'
+    )
+    df = parse_ipma_stations(content)
+    assert df.to_dicts() == [
+        {
+            "station_id": "1200579",
+            "name": "Lisboa (Geofísico)",
+            "latitude": 38.7667,
+            "longitude": -9.1333,
+        },
+    ]
+
+
+def test_parse_ipma_observations_sentinel_and_wind_code() -> None:
+    """-99 sentinels become null and the wind-direction code is converted to degrees."""
+    content = (
+        b'{"2026-07-29T14:00": {"1200579": {'
+        b'"temperatura": 27.5, "humidade": 54.0, "pressao": 1018.6, '
+        b'"intensidadeVento": 3.1, "intensidadeVentoKM": 11.2, "idDireccVento": 4, '
+        b'"precAcumulada": -99.0, "radiacao": 3151.3}}}'
+    )
+    df = parse_ipma_observations(content, station_id="1200579")
+    by_param = {row["parameter"]: row["value"] for row in df.to_dicts()}
+    assert by_param["temperatura"] == 27.5
+    assert by_param["humidade"] == 54.0
+    assert by_param["pressao"] == 1018.6
+    assert by_param["intensidadeVento"] == 3.1
+    assert by_param["idDireccVento"] == 135.0  # code 4 == SE == 135°
+    assert by_param["precAcumulada"] is None  # -99 sentinel -> null
+    assert by_param["radiacao"] == 3151.3
+    # intensidadeVentoKM is not a mapped parameter -> not emitted
+    assert "intensidadeVentoKM" not in by_param
+    assert df["date"].to_list() == [dt.datetime(2026, 7, 29, 14, 0, tzinfo=UTC)] * len(df)
+
+
+def test_parse_ipma_observations_calm_wind_is_null() -> None:
+    """Wind-direction code 0 (calm / no direction) maps to null, not 0 degrees."""
+    content = b'{"2026-07-29T14:00": {"1200579": {"idDireccVento": 0, "temperatura": 20.0}}}'
+    df = parse_ipma_observations(content, station_id="1200579")
+    wind = df.filter(pl.col("parameter") == "idDireccVento")
+    assert wind["value"].to_list() == [None]
+
+
+def test_parse_ipma_observations_skips_absent_station() -> None:
+    """A station that reported nothing for a timestamp is skipped."""
+    content = b'{"2026-07-29T14:00": {"9999999": {"temperatura": 20.0}}}'
+    df = parse_ipma_observations(content, station_id="1200579")
+    assert df.is_empty()
+
+
+# ---------------------------------------------------------------------------
+# Remote tests -- hit the live (key-less) IPMA feed. It is a rolling ~1-day window, so values
+# are time-dependent; assert structure/ranges rather than exact numbers. xfail (not hard-fail) on an
+# outage keeps a transient blip from blocking CI, matching the CHMI/AEMET precedent.
+# ---------------------------------------------------------------------------
+
+xfail_if_ipma_unavailable = pytest.mark.xfail(strict=False, reason="IPMA API intermittently unavailable")
+
+
+@pytest.mark.remote
+@xfail_if_ipma_unavailable
+def test_ipma_observation_stations() -> None:
+    """The station catalogue resolves to a populated set of Portuguese stations."""
+    df = IpmaObservationRequest(parameters=[("hourly", "data")]).all().df
+    assert df.height > 100
+    assert df["resolution"].unique().to_list() == ["hourly"]
+    # mainland Portugal + Azores/Madeira: latitudes ~30-42 N, longitudes ~-32 to -6 E
+    assert df["latitude"].min() > 29.0
+    assert df["latitude"].max() < 43.0
+    assert df["longitude"].min() > -32.0
+    assert df["longitude"].max() < -5.0
+
+
+@pytest.mark.remote
+@xfail_if_ipma_unavailable
+def test_ipma_observation_values() -> None:
+    """A station returns recent hourly values with sane ranges and 45°-quantised wind direction."""
+    request = IpmaObservationRequest(
+        parameters=[("hourly", "data")],
+        start_date=dt.datetime.now(UTC) - dt.timedelta(hours=24),
+        end_date=dt.datetime.now(UTC),
+    )
+    station_id = request.all().df["station_id"][0]
+    df = request.filter_by_station_id(station_id).values.all().df
+    assert not df.is_empty()
+    assert df["resolution"].unique().to_list() == ["hourly"]
+    assert set(df["parameter"].unique().to_list()) <= {
+        "temperature_air_mean_2m",
+        "humidity",
+        "pressure_air_sea_level",
+        "wind_speed",
+        "wind_direction",
+        "precipitation_height",
+        "radiation_global",
+    }
+    # wind direction is emitted in degrees, quantised to the 8-point compass (multiples of 45)
+    wind = df.filter(pl.col("parameter") == "wind_direction").drop_nulls("value")
+    assert all(v % 45 == 0 for v in wind["value"].to_list())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,6 +28,7 @@ from wetterdienst.provider.fmi.observation import FmiObservationMetadata, FmiObs
 from wetterdienst.provider.geosphere.observation import GeosphereObservationMetadata, GeosphereObservationRequest
 from wetterdienst.provider.imgw.hydrology import ImgwHydrologyMetadata, ImgwHydrologyRequest
 from wetterdienst.provider.imgw.meteorology import ImgwMeteorologyMetadata, ImgwMeteorologyRequest
+from wetterdienst.provider.ipma.observation import IpmaObservationMetadata
 from wetterdienst.provider.knmi.observation import KnmiObservationMetadata, KnmiObservationRequest
 from wetterdienst.provider.meteofrance.observation import MeteoFranceObservationMetadata, MeteoFranceObservationRequest
 from wetterdienst.provider.meteofrance.synop import MeteoFranceSynopMetadata, MeteoFranceSynopRequest
@@ -118,6 +119,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
         HubeauMetadata,
         ImgwHydrologyMetadata,
         ImgwMeteorologyMetadata,
+        IpmaObservationMetadata,
         KnmiObservationMetadata,
         MeteoFranceObservationMetadata,
         MeteoFranceSynopMetadata,
@@ -156,6 +158,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
         HubeauMetadata,
         ImgwHydrologyMetadata,
         ImgwMeteorologyMetadata,
+        IpmaObservationMetadata,
         KnmiObservationMetadata,
         MeteoFranceObservationMetadata,
         MeteoFranceSynopMetadata,

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -71,6 +71,7 @@ def test_coverage(client: TestClient) -> None:
         "fmi",
         "geosphere",
         "imgw",
+        "ipma",
         "knmi",
         "meteofrance",
         "meteoswiss",


### PR DESCRIPTION
## Summary

Adds a Portugal meteorology provider backed by IPMA's key-less `api.ipma.pt` open-data JSON feeds (Instituto Português do Mar e da Atmosfera). Fills the Portugal / SW-Europe gap.

- ~222 automatic stations, near-real-time hourly observations (temperature, humidity, sea-level pressure, wind speed/direction, precipitation, global radiation)
- **Recent-only**: the feed is a rolling ~1-day window, so `periods=["recent"]` and a date range is required (NWS-style). A single all-stations `observations.json` serves every station's values.
- Registered as `ipma`/`observation`

## Notable handling (verified against the live API)

- `idDireccVento` is an 8-point wind-direction **code**, converted to degrees (0/calm → null; 1/9 → N).
- `-99.0` missing sentinel → null.
- `intensidadeVentoKM` (km/h duplicate of wind speed) left unmapped; pressure is mean-sea-level, radiation kJ/m².

## Tests

Offline parser tests (sentinel handling, wind-code→degrees, calm→null, absent-station skip) that always run, plus credential-free remote tests (structure/range assertions, xfail-on-outage). `IpmaObservationMetadata` added to the metadata name/unit test lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)