### PR TITLE
feat(lhmt): add LHMT (Lithuania) observation provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ Types of changes:
   stations. Recent-only (a rolling ~1-day window), so a date range within the last day is required.
   The `-99.0` missing sentinel becomes null and the 8-point wind-direction code is converted to
   degrees
+- Add an LHMT (Lithuania) observation provider (`lhmt`/`observation`) backed by the key-less
+  `api.meteo.lt` JSON REST API. Provides hourly observations (temperature, humidity, wind
+  speed/gust/direction, cloud cover, sea-level pressure, precipitation, snow depth) from ~52
+  stations, with historical data back to roughly 2016 fetched per station and day. Settled past days
+  are cached indefinitely while the current day uses a short cache
 
 ### Changed
 

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -86,6 +86,11 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
         - observations from the Dutch station network
         - 10-minute, hourly and daily resolution
         - requires a free API key from developer.dataplatform.knmi.nl (`WD_AUTH__KNMI`)
+- LHMT (Lietuvos hidrometeorologijos tarnyba / Lithuanian Hydrometeorological Service / Lithuania)
+    - Observation
+        - hourly observations from the Lithuanian automatic station network via the api.meteo.lt REST API
+        - ~52 stations; historical (back to ~2016)
+        - open data, no authentication required
 - Météo-France (French National Meteorological Service / France)
     - Synop
         - SYNOP observations at the native 3-hourly reporting interval

--- a/docs/data/provider/index.md
+++ b/docs/data/provider/index.md
@@ -15,6 +15,7 @@ geosphere/index.md
 imgw/index.md
 ipma/index.md
 knmi/index.md
+lhmt/index.md
 meteofrance/index.md
 meteoswiss/index.md
 metno/index.md

--- a/docs/data/provider/lhmt/index.md
+++ b/docs/data/provider/lhmt/index.md
@@ -1,0 +1,19 @@
+# LHMT
+
+Lietuvos hidrometeorologijos tarnyba (Lithuanian Hydrometeorological Service)
+
+## Overview
+
+LHMT publishes hourly observations from the Lithuanian station network through the key-less
+`api.meteo.lt` JSON REST API. No authentication is required.
+
+## License
+
+LHMT data is provided as open data through [api.meteo.lt](https://api.meteo.lt/). Check the portal
+for the applicable usage conditions and attribution requirements.
+
+```{toctree}
+:hidden:
+
+observation/index.md
+```

--- a/docs/data/provider/lhmt/observation/hourly.md
+++ b/docs/data/provider/lhmt/observation/hourly.md
@@ -1,0 +1,33 @@
+# hourly
+
+## metadata
+
+| property      | value  |
+|---------------|--------|
+| name          | hourly |
+| original name | hourly |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | data  |
+| original name | data  |
+
+#### parameters
+
+| name                    | original name    | unit type     | unit |
+|-------------------------|------------------|---------------|------|
+| temperature_air_mean_2m | airTemperature   | temperature   | °C   |
+| humidity                | relativeHumidity | fraction      | %    |
+| wind_speed              | windSpeed        | speed         | m/s  |
+| wind_gust_max           | windGust         | speed         | m/s  |
+| wind_direction          | windDirection    | angle         | °    |
+| cloud_cover_total       | cloudCover       | fraction      | %    |
+| pressure_air_sea_level  | seaLevelPressure | pressure      | hPa  |
+| precipitation_height    | precipitation    | precipitation | mm   |
+| snow_depth              | snowDepth        | length_short  | cm   |

--- a/docs/data/provider/lhmt/observation/index.md
+++ b/docs/data/provider/lhmt/observation/index.md
@@ -1,0 +1,30 @@
+# Observation
+
+## Overview
+
+LHMT's `api.meteo.lt` REST API provides hourly observations from the Lithuanian automatic weather
+station network (~52 stations). No API key or registration is required — the API is fully public.
+
+Two endpoints are used: a station list (`/v1/stations`, giving each station's code, name and
+coordinates) and per-station, per-day observation days
+(`/v1/stations/{code}/observations/{YYYY-MM-DD}`, one entry per hour). Unlike a rolling now-cast
+feed, the API serves historical data — reaching back to roughly 2016 — so a date range must be
+given and the provider fetches one day per station per day in the range.
+
+Values are already published in canonical units (temperature °C, wind m/s, direction in degrees,
+sea-level pressure hPa, humidity and cloud cover %, precipitation mm, snow depth cm) with `null` for
+missing data — there is no sentinel. The API also returns `feelsLikeTemperature` (apparent
+temperature) and a textual `conditionCode`, which are not exposed as they have no clean numeric
+canonical parameter. The catalogue carries no elevation, so `height` is always null, and — being a
+live API — there is no operational start/end date per station.
+
+## License
+
+Data is © LHMT (Lietuvos hidrometeorologijos tarnyba). See [api.meteo.lt](https://api.meteo.lt/) for
+further information and usage conditions.
+
+```{toctree}
+:hidden:
+
+hourly.md
+```

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -51,6 +51,9 @@ class Wetterdienst:
         "knmi": {
             "observation": "wetterdienst.provider.knmi.observation.KnmiObservationRequest",
         },
+        "lhmt": {
+            "observation": "wetterdienst.provider.lhmt.observation.LhmtObservationRequest",
+        },
         "noaa": {
             "ghcn": "wetterdienst.provider.noaa.ghcn.NoaaGhcnRequest",
         },

--- a/src/wetterdienst/provider/lhmt/__init__.py
+++ b/src/wetterdienst/provider/lhmt/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""LHMT (Lithuania) provider."""

--- a/src/wetterdienst/provider/lhmt/observation/__init__.py
+++ b/src/wetterdienst/provider/lhmt/observation/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""LHMT (Lithuania) observation provider."""
+
+from wetterdienst.provider.lhmt.observation.api import LhmtObservationRequest
+from wetterdienst.provider.lhmt.observation.metadata import LhmtObservationMetadata
+
+__all__ = ["LhmtObservationMetadata", "LhmtObservationRequest"]

--- a/src/wetterdienst/provider/lhmt/observation/api.py
+++ b/src/wetterdienst/provider/lhmt/observation/api.py
@@ -101,12 +101,14 @@ class LhmtObservationValues(TimeseriesValues):
 
     def _download_day(self, station_id: str, day: dt.date, settings: Settings) -> bytes | None:
         url = f"{_BASE_URL}/stations/{station_id}/observations/{day.isoformat()}"
+        # a settled past day is immutable, so it can be cached indefinitely; only the current (still
+        # filling) day needs a short cache. This keeps repeated historical queries off the network
+        # and well under the api.meteo.lt request-rate limit.
+        ttl = CacheExpiry.FIVE_MINUTES if day >= dt.datetime.now(dt.timezone.utc).date() else CacheExpiry.INFINITE
         file = download_file(
             url=url,
             cache_dir=settings.cache_dir,
-            # past days are immutable; the current day keeps filling, so a twelve-hour cache is a
-            # safe compromise that also stays well under the api.meteo.lt request-rate limit.
-            ttl=CacheExpiry.TWELVE_HOURS,
+            ttl=ttl,
             client_kwargs=settings.fsspec_client_kwargs,
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,

--- a/src/wetterdienst/provider/lhmt/observation/api.py
+++ b/src/wetterdienst/provider/lhmt/observation/api.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""LHMT (Lietuvos hidrometeorologijos tarnyba) observation provider.
+
+LHMT publishes hourly observations from its Lithuanian station network through the key-less
+``api.meteo.lt`` JSON REST API: a station list (``/v1/stations``) and per-station, per-day
+observation days (``/v1/stations/{code}/observations/{YYYY-MM-DD}``). History reaches back to
+roughly 2016.
+
+See ``metadata.py`` for the field/unit background and ``parser.py`` for the response shapes.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+import polars as pl
+
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.model.metadata import DatasetModel, ParameterModel
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.lhmt.observation.metadata import LhmtObservationMetadata
+from wetterdienst.provider.lhmt.observation.parser import parse_lhmt_observations, parse_lhmt_stations
+from wetterdienst.util.network import download_file
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from wetterdienst.settings import Settings
+
+log = logging.getLogger(__name__)
+
+_BASE_URL = "https://api.meteo.lt/v1"
+_STATIONS_URL = f"{_BASE_URL}/stations"
+
+_EMPTY_VALUES_SCHEMA = {
+    "resolution": pl.String,
+    "dataset": pl.String,
+    "parameter": pl.String,
+    "station_id": pl.String,
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "value": pl.Float64,
+    "quality": pl.Float64,
+}
+
+
+def _days(start: dt.datetime, end: dt.datetime) -> Iterator[dt.date]:
+    """Yield each UTC calendar date in ``[start, end]`` inclusive (observation days are UTC)."""
+    day = start.astimezone(dt.timezone.utc).date()
+    last = end.astimezone(dt.timezone.utc).date()
+    while day <= last:
+        yield day
+        day += dt.timedelta(days=1)
+
+
+class LhmtObservationValues(TimeseriesValues):
+    """Values class for LHMT observation data."""
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        if isinstance(parameter_or_dataset, ParameterModel):
+            dataset = parameter_or_dataset.dataset
+        elif isinstance(parameter_or_dataset, DatasetModel):
+            dataset = parameter_or_dataset
+        else:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        # the per-day endpoint requires a date range to address the days to fetch
+        if not self.sr.start_date or not self.sr.end_date:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        settings = cast("Settings", self.sr.stations.settings)
+        frames = []
+        for day in _days(self.sr.start_date, self.sr.end_date):
+            content = self._download_day(station_id, day, settings)
+            if content is None:
+                continue
+            df = parse_lhmt_observations(content)
+            if not df.is_empty():
+                frames.append(df)
+        if not frames:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        df = pl.concat(frames)
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            pl.col("parameter"),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            pl.col("date"),
+            pl.col("value"),
+            pl.lit(None, dtype=pl.Float64).alias("quality"),
+        )
+
+    def _download_day(self, station_id: str, day: dt.date, settings: Settings) -> bytes | None:
+        url = f"{_BASE_URL}/stations/{station_id}/observations/{day.isoformat()}"
+        file = download_file(
+            url=url,
+            cache_dir=settings.cache_dir,
+            # past days are immutable; the current day keeps filling, so a twelve-hour cache is a
+            # safe compromise that also stays well under the api.meteo.lt request-rate limit.
+            ttl=CacheExpiry.TWELVE_HOURS,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            # a day before the station's record (or an outage) simply contributes no rows
+            if not file.is_no_internet_error:
+                log.debug(f"No LHMT data for {station_id} on {day}: {file.content}")
+            return None
+        return file.content.read()
+
+
+@dataclass
+class LhmtObservationRequest(TimeseriesRequest):
+    """Request class for LHMT (Lietuvos hidrometeorologijos tarnyba) observation data."""
+
+    metadata = LhmtObservationMetadata
+    _values = LhmtObservationValues
+
+    def _all(self) -> pl.LazyFrame:
+        settings = cast("Settings", self.settings)
+        file = download_file(
+            url=_STATIONS_URL,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.METAINDEX,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            log.warning(f"Failed to fetch LHMT station catalogue: {file.content}")
+            return pl.LazyFrame()
+        stations = parse_lhmt_stations(file.content.read())
+        if stations.is_empty():
+            return pl.LazyFrame()
+        resolution = self.metadata[0]
+        return stations.with_columns(
+            pl.lit(resolution.name, pl.String).alias("resolution"),
+            pl.lit(resolution.datasets[0].name, pl.String).alias("dataset"),
+        ).lazy()

--- a/src/wetterdienst/provider/lhmt/observation/metadata.py
+++ b/src/wetterdienst/provider/lhmt/observation/metadata.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""LHMT (Lithuania) observation metadata.
+
+LHMT (Lietuvos hidrometeorologijos tarnyba) publishes hourly observations from its Lithuanian
+station network through a key-less JSON REST API (https://api.meteo.lt/). Unlike a rolling
+now-cast feed, the API serves historical data per station and day
+(``/v1/stations/{code}/observations/{YYYY-MM-DD}``), reaching back to roughly 2016, so the
+``historical`` period is exposed.
+
+Fields are already in canonical SI-ish units (temperature °C, wind m/s, direction degrees, pressure
+hPa, humidity/cloud %, precipitation mm, snow cm) and use ``null`` for missing values -- there is no
+sentinel to strip. The ``feelsLikeTemperature`` (apparent temperature, no clean canonical parameter)
+and ``conditionCode`` (a non-numeric text state) fields are intentionally not mapped.
+"""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, build_metadata_model
+
+LhmtObservationMetadata = {
+    "name_short": "LHMT",
+    "name_english": "Lithuanian Hydrometeorological Service",
+    "name_local": "Lietuvos hidrometeorologijos tarnyba",
+    "country": "Lithuania",
+    "copyright": "© LHMT (Lietuvos hidrometeorologijos tarnyba)",
+    "url": "https://api.meteo.lt/",
+    "kind": "observation",
+    "timezone": "Europe/Vilnius",
+    "timezone_data": "UTC",
+    "resolutions": [
+        {
+            "name": "hourly",
+            "name_original": "hourly",
+            "periods": ["historical"],
+            "date_required": True,
+            "datasets": [
+                {
+                    "name": DATASET_NAME_DEFAULT,
+                    "name_original": DATASET_NAME_DEFAULT,
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "airTemperature",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "humidity",
+                            "name_original": "relativeHumidity",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "wind_speed",
+                            "name_original": "windSpeed",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_gust_max",
+                            "name_original": "windGust",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {
+                            "name": "wind_direction",
+                            "name_original": "windDirection",
+                            "unit_type": "angle",
+                            "unit": "degree",
+                        },
+                        {
+                            "name": "cloud_cover_total",
+                            "name_original": "cloudCover",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "pressure_air_sea_level",
+                            "name_original": "seaLevelPressure",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "precipitation",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "snow_depth",
+                            "name_original": "snowDepth",
+                            "unit_type": "length_short",
+                            "unit": "centimeter",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+LhmtObservationMetadata = build_metadata_model(LhmtObservationMetadata, "LhmtObservationMetadata")

--- a/src/wetterdienst/provider/lhmt/observation/parser.py
+++ b/src/wetterdienst/provider/lhmt/observation/parser.py
@@ -48,15 +48,24 @@ def parse_lhmt_stations(content: bytes) -> pl.DataFrame:
         return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
     if not isinstance(stations, list) or not stations:
         return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
-    rows = [
-        {
-            "station_id": station["code"],
-            "name": station["name"],
-            "latitude": station["coordinates"]["latitude"],
-            "longitude": station["coordinates"]["longitude"],
-        }
-        for station in stations
-    ]
+    rows = []
+    for station in stations:
+        # skip a malformed entry rather than crash the whole listing: a station needs at least a
+        # code and coordinates to be usable
+        if not isinstance(station, dict):
+            continue
+        coordinates = station.get("coordinates")
+        coordinates = coordinates if isinstance(coordinates, dict) else {}
+        code = station.get("code")
+        latitude = coordinates.get("latitude")
+        longitude = coordinates.get("longitude")
+        if code is None or latitude is None or longitude is None:
+            continue
+        rows.append(
+            {"station_id": code, "name": station.get("name"), "latitude": latitude, "longitude": longitude},
+        )
+    if not rows:
+        return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
     return pl.DataFrame(rows, schema=_EMPTY_STATIONS_SCHEMA)
 
 
@@ -72,13 +81,17 @@ def parse_lhmt_observations(content: bytes) -> pl.DataFrame:
     except json.JSONDecodeError:
         return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
     observations = payload.get("observations") if isinstance(payload, dict) else None
-    if not observations:
+    if not isinstance(observations, list) or not observations:
         return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
     rows = [
-        {"date": observation["observationTimeUtc"], "parameter": field, "value": observation.get(field)}
+        {"date": timestamp, "parameter": field, "value": observation.get(field)}
         for observation in observations
+        # skip a malformed entry (non-dict, or one without a timestamp) rather than crash the day
+        if isinstance(observation, dict) and (timestamp := observation.get("observationTimeUtc")) is not None
         for field in _VALUE_FIELDS
     ]
+    if not rows:
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
     return pl.DataFrame(rows, schema={"date": pl.String, "parameter": pl.String, "value": pl.Float64}).with_columns(
         pl.col("date").str.to_datetime("%Y-%m-%d %H:%M:%S", time_unit="us").dt.replace_time_zone("UTC"),
     )

--- a/src/wetterdienst/provider/lhmt/observation/parser.py
+++ b/src/wetterdienst/provider/lhmt/observation/parser.py
@@ -42,7 +42,10 @@ def parse_lhmt_stations(content: bytes) -> pl.DataFrame:
     and ``coordinates`` (``latitude``/``longitude``). The API exposes no elevation, so ``height`` is
     left for the framework to null-fill.
     """
-    stations = json.loads(content)
+    try:
+        stations = json.loads(content)
+    except json.JSONDecodeError:
+        return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
     if not isinstance(stations, list) or not stations:
         return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
     rows = [
@@ -64,7 +67,10 @@ def parse_lhmt_observations(content: bytes) -> pl.DataFrame:
     with one entry per hour. Missing values are already ``null`` (no sentinel). Timestamps are UTC
     (``YYYY-MM-DD HH:MM:SS``).
     """
-    payload = json.loads(content)
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError:
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
     observations = payload.get("observations") if isinstance(payload, dict) else None
     if not observations:
         return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)

--- a/src/wetterdienst/provider/lhmt/observation/parser.py
+++ b/src/wetterdienst/provider/lhmt/observation/parser.py
@@ -92,6 +92,16 @@ def parse_lhmt_observations(content: bytes) -> pl.DataFrame:
     ]
     if not rows:
         return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
-    return pl.DataFrame(rows, schema={"date": pl.String, "parameter": pl.String, "value": pl.Float64}).with_columns(
-        pl.col("date").str.to_datetime("%Y-%m-%d %H:%M:%S", time_unit="us").dt.replace_time_zone("UTC"),
+    # parse non-strict so one malformed observationTimeUtc string yields null instead of raising and
+    # failing the whole day; drop those rows so only cleanly-timestamped observations remain
+    return (
+        pl.DataFrame(rows, schema={"date": pl.String, "parameter": pl.String, "value": pl.Float64})
+        .with_columns(
+            pl.col("date")
+            .str.to_datetime("%Y-%m-%d %H:%M:%S", time_unit="us", strict=False)
+            .dt.replace_time_zone(
+                "UTC",
+            ),
+        )
+        .drop_nulls("date")
     )

--- a/src/wetterdienst/provider/lhmt/observation/parser.py
+++ b/src/wetterdienst/provider/lhmt/observation/parser.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Parsers for LHMT's api.meteo.lt JSON responses (station list and per-day observations)."""
+
+from __future__ import annotations
+
+import json
+
+import polars as pl
+
+# the raw observation fields mapped to parameters (i.e. every ``name_original`` in metadata.py).
+_VALUE_FIELDS = (
+    "airTemperature",
+    "relativeHumidity",
+    "windSpeed",
+    "windGust",
+    "windDirection",
+    "cloudCover",
+    "seaLevelPressure",
+    "precipitation",
+    "snowDepth",
+)
+
+_EMPTY_STATIONS_SCHEMA = {
+    "station_id": pl.String,
+    "name": pl.String,
+    "latitude": pl.Float64,
+    "longitude": pl.Float64,
+}
+
+_EMPTY_VALUES_SCHEMA = {
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "parameter": pl.String,
+    "value": pl.Float64,
+}
+
+
+def parse_lhmt_stations(content: bytes) -> pl.DataFrame:
+    """Parse ``/v1/stations`` into one row per station.
+
+    Each entry carries ``code`` (a slug used as the station id and in observation URLs), ``name``
+    and ``coordinates`` (``latitude``/``longitude``). The API exposes no elevation, so ``height`` is
+    left for the framework to null-fill.
+    """
+    stations = json.loads(content)
+    if not isinstance(stations, list) or not stations:
+        return pl.DataFrame(schema=_EMPTY_STATIONS_SCHEMA)
+    rows = [
+        {
+            "station_id": station["code"],
+            "name": station["name"],
+            "latitude": station["coordinates"]["latitude"],
+            "longitude": station["coordinates"]["longitude"],
+        }
+        for station in stations
+    ]
+    return pl.DataFrame(rows, schema=_EMPTY_STATIONS_SCHEMA)
+
+
+def parse_lhmt_observations(content: bytes) -> pl.DataFrame:
+    """Parse a per-day ``/observations/{date}`` response into long ``(date, parameter, value)`` rows.
+
+    The response is ``{"station": {...}, "observations": [{"observationTimeUtc": ..., <field>: ...}]}``
+    with one entry per hour. Missing values are already ``null`` (no sentinel). Timestamps are UTC
+    (``YYYY-MM-DD HH:MM:SS``).
+    """
+    payload = json.loads(content)
+    observations = payload.get("observations") if isinstance(payload, dict) else None
+    if not observations:
+        return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+    rows = [
+        {"date": observation["observationTimeUtc"], "parameter": field, "value": observation.get(field)}
+        for observation in observations
+        for field in _VALUE_FIELDS
+    ]
+    return pl.DataFrame(rows, schema={"date": pl.String, "parameter": pl.String, "value": pl.Float64}).with_columns(
+        pl.col("date").str.to_datetime("%Y-%m-%d %H:%M:%S", time_unit="us").dt.replace_time_zone("UTC"),
+    )

--- a/tests/provider/lhmt/__init__.py
+++ b/tests/provider/lhmt/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/lhmt/observation/__init__.py
+++ b/tests/provider/lhmt/observation/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/lhmt/observation/test_api.py
+++ b/tests/provider/lhmt/observation/test_api.py
@@ -77,6 +77,29 @@ def test_parse_lhmt_malformed_json_yields_empty() -> None:
     assert parse_lhmt_stations(b"not json").is_empty()
 
 
+def test_parse_lhmt_skips_malformed_items() -> None:
+    """Valid JSON with malformed items degrades to the good rows rather than raising."""
+    # observations: a non-dict entry and one missing the timestamp are dropped; the good one stays
+    obs = (
+        b'{"station": {"code": "x"}, "observations": ['
+        b'"garbage", {"airTemperature": 1.0}, '
+        b'{"observationTimeUtc": "2020-07-01 12:00:00", "airTemperature": 22.3}]}'
+    )
+    df = parse_lhmt_observations(obs)
+    assert df["date"].unique().to_list() == [dt.datetime(2020, 7, 1, 12, 0, tzinfo=UTC)]
+    temp = df.filter(pl.col("parameter") == "airTemperature")
+    assert temp["value"].to_list() == [22.3]
+
+    # stations: entries missing a code or coordinates are skipped; the complete one survives
+    stations = (
+        b'[{"name": "no code"}, {"code": "y", "coordinates": {}}, '
+        b'{"code": "vilniaus-ams", "name": "Vilniaus AMS", '
+        b'"coordinates": {"latitude": 54.6, "longitude": 25.1}}]'
+    )
+    sdf = parse_lhmt_stations(stations)
+    assert sdf["station_id"].to_list() == ["vilniaus-ams"]
+
+
 @pytest.mark.parametrize(
     ("start", "end", "expected"),
     [
@@ -94,12 +117,13 @@ def test_parse_lhmt_malformed_json_yields_empty() -> None:
             dt.datetime(2020, 1, 1, tzinfo=UTC),
             [dt.date(2019, 12, 31), dt.date(2020, 1, 1)],
         ),
-        # a non-UTC start is converted to its UTC calendar date first: 23:30 in Vilnius (UTC+3) on
-        # 2020-07-01 is 20:30 UTC the same day, so the window still begins on 2020-07-01 UTC
+        # a non-UTC start is converted to its UTC calendar date first: 01:00 in Vilnius (UTC+3) on
+        # 2020-07-01 is 2020-06-30 22:00 UTC -- the PREVIOUS calendar day -- so the window must begin
+        # on 2020-06-30 (a naive .date() without the UTC conversion would wrongly start on 2020-07-01)
         (
-            dt.datetime(2020, 7, 1, 23, 30, tzinfo=ZoneInfo("Europe/Vilnius")),
-            dt.datetime(2020, 7, 2, 12, tzinfo=UTC),
-            [dt.date(2020, 7, 1), dt.date(2020, 7, 2)],
+            dt.datetime(2020, 7, 1, 1, 0, tzinfo=ZoneInfo("Europe/Vilnius")),
+            dt.datetime(2020, 7, 1, 12, tzinfo=UTC),
+            [dt.date(2020, 6, 30), dt.date(2020, 7, 1)],
         ),
     ],
 )

--- a/tests/provider/lhmt/observation/test_api.py
+++ b/tests/provider/lhmt/observation/test_api.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for LHMT (Lithuania) observation provider."""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from wetterdienst.provider.lhmt.observation import LhmtObservationRequest
+from wetterdienst.provider.lhmt.observation.parser import (
+    parse_lhmt_observations,
+    parse_lhmt_stations,
+)
+
+UTC = ZoneInfo("UTC")
+VILNIUS = "vilniaus-ams"
+
+
+def test_parse_lhmt_stations() -> None:
+    """The station list maps to one row per station with coordinates from the nested object."""
+    content = (
+        b'[{"code": "vilniaus-ams", "name": "Vilniaus AMS", '
+        b'"coordinates": {"latitude": 54.625992, "longitude": 25.107064}}]'
+    )
+    df = parse_lhmt_stations(content)
+    assert df.to_dicts() == [
+        {
+            "station_id": "vilniaus-ams",
+            "name": "Vilniaus AMS",
+            "latitude": 54.625992,
+            "longitude": 25.107064,
+        },
+    ]
+
+
+def test_parse_lhmt_observations() -> None:
+    """Observations become long rows; unmapped fields are dropped and missing values stay null."""
+    content = (
+        b'{"station": {"code": "vilniaus-ams"}, "observations": ['
+        b'{"observationTimeUtc": "2020-07-01 12:00:00", "airTemperature": 22.3, '
+        b'"feelsLikeTemperature": 22.3, "windSpeed": 4.7, "windGust": 12.3, "windDirection": 261, '
+        b'"cloudCover": 63, "seaLevelPressure": 1007.4, "relativeHumidity": 52, '
+        b'"precipitation": null, "snowDepth": 0, "conditionCode": "cloudy"}]}'
+    )
+    df = parse_lhmt_observations(content)
+    by_param = {row["parameter"]: row["value"] for row in df.to_dicts()}
+    assert by_param == {
+        "airTemperature": 22.3,
+        "windSpeed": 4.7,
+        "windGust": 12.3,
+        "windDirection": 261.0,
+        "cloudCover": 63.0,
+        "seaLevelPressure": 1007.4,
+        "relativeHumidity": 52.0,
+        "precipitation": None,  # null passes through as null (no sentinel)
+        "snowDepth": 0.0,
+    }
+    # feelsLikeTemperature and conditionCode are intentionally not mapped
+    assert "feelsLikeTemperature" not in by_param
+    assert "conditionCode" not in by_param
+    assert df["date"].to_list() == [dt.datetime(2020, 7, 1, 12, 0, tzinfo=UTC)] * len(df)
+
+
+def test_parse_lhmt_observations_empty() -> None:
+    """A day with no observations yields an empty frame with the expected schema."""
+    content = b'{"station": {"code": "vilniaus-ams"}, "observations": []}'
+    df = parse_lhmt_observations(content)
+    assert df.is_empty()
+    assert df.columns == ["date", "parameter", "value"]
+
+
+# ---------------------------------------------------------------------------
+# Remote tests -- hit the live (key-less) api.meteo.lt. Historical data is stable, so exact values
+# can be asserted. xfail (not hard-fail) on an outage matches the CHMI/AEMET precedent.
+# ---------------------------------------------------------------------------
+
+xfail_if_lhmt_unavailable = pytest.mark.xfail(strict=False, reason="LHMT API intermittently unavailable")
+
+
+@pytest.mark.remote
+@xfail_if_lhmt_unavailable
+def test_lhmt_observation_stations() -> None:
+    """The station catalogue resolves to Lithuanian stations, including Vilnius."""
+    df = LhmtObservationRequest(parameters=[("hourly", "data")]).all().df
+    assert df.height > 40
+    assert df["resolution"].unique().to_list() == ["hourly"]
+    assert VILNIUS in df["station_id"].to_list()
+    # Lithuania: latitudes ~53.9-56.4 N, longitudes ~21-26.8 E
+    assert df["latitude"].min() > 53.0
+    assert df["latitude"].max() < 57.0
+    assert df["longitude"].min() > 20.0
+    assert df["longitude"].max() < 27.0
+
+
+@pytest.mark.remote
+@xfail_if_lhmt_unavailable
+def test_lhmt_observation_values() -> None:
+    """Historical hourly values at Vilnius for 2020-07-01 match the api.meteo.lt reference values."""
+    df = (
+        LhmtObservationRequest(
+            parameters=[("hourly", "data")],
+            start_date=dt.datetime(2020, 7, 1, tzinfo=UTC),
+            end_date=dt.datetime(2020, 7, 1, 23, tzinfo=UTC),
+        )
+        .filter_by_station_id(VILNIUS)
+        .values.all()
+        .df
+    )
+    assert not df.is_empty()
+    assert df["resolution"].unique().to_list() == ["hourly"]
+
+    def value_at(parameter: str, hour: int) -> float:
+        return df.filter(
+            pl.col("parameter") == parameter,
+            pl.col("date") == dt.datetime(2020, 7, 1, hour, tzinfo=UTC),
+        )["value"].item()
+
+    assert value_at("temperature_air_mean_2m", 12) == pytest.approx(22.3)
+    assert value_at("wind_speed", 12) == pytest.approx(4.7)
+    assert value_at("wind_direction", 12) == pytest.approx(261.0)
+    assert value_at("pressure_air_sea_level", 12) == pytest.approx(1007.4)
+    # humidity is converted from percent to the default decimal target (52 % -> 0.52)
+    assert value_at("humidity", 12) == pytest.approx(0.52)

--- a/tests/provider/lhmt/observation/test_api.py
+++ b/tests/provider/lhmt/observation/test_api.py
@@ -71,6 +71,45 @@ def test_parse_lhmt_observations_empty() -> None:
     assert df.columns == ["date", "parameter", "value"]
 
 
+def test_parse_lhmt_malformed_json_yields_empty() -> None:
+    """A malformed 200 body (e.g. an HTML error page) yields an empty frame, not an exception."""
+    assert parse_lhmt_observations(b"<html>rate limited</html>").is_empty()
+    assert parse_lhmt_stations(b"not json").is_empty()
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    [
+        # single UTC day (start == end date) -> one day
+        (dt.datetime(2020, 7, 1, tzinfo=UTC), dt.datetime(2020, 7, 1, 23, tzinfo=UTC), [dt.date(2020, 7, 1)]),
+        # inclusive multi-day span -> every day incl. both ends
+        (
+            dt.datetime(2020, 7, 1, tzinfo=UTC),
+            dt.datetime(2020, 7, 3, tzinfo=UTC),
+            [dt.date(2020, 7, 1), dt.date(2020, 7, 2), dt.date(2020, 7, 3)],
+        ),
+        # month/year rollover
+        (
+            dt.datetime(2019, 12, 31, tzinfo=UTC),
+            dt.datetime(2020, 1, 1, tzinfo=UTC),
+            [dt.date(2019, 12, 31), dt.date(2020, 1, 1)],
+        ),
+        # a non-UTC start is converted to its UTC calendar date first: 23:30 in Vilnius (UTC+3) on
+        # 2020-07-01 is 20:30 UTC the same day, so the window still begins on 2020-07-01 UTC
+        (
+            dt.datetime(2020, 7, 1, 23, 30, tzinfo=ZoneInfo("Europe/Vilnius")),
+            dt.datetime(2020, 7, 2, 12, tzinfo=UTC),
+            [dt.date(2020, 7, 1), dt.date(2020, 7, 2)],
+        ),
+    ],
+)
+def test_days_covers_range_inclusive(start: dt.datetime, end: dt.datetime, expected: list[dt.date]) -> None:
+    """`_days` yields every UTC calendar date in [start, end] inclusive, handling non-UTC inputs."""
+    from wetterdienst.provider.lhmt.observation.api import _days  # noqa: PLC0415
+
+    assert list(_days(start, end)) == expected
+
+
 # ---------------------------------------------------------------------------
 # Remote tests -- hit the live (key-less) api.meteo.lt. Historical data is stable, so exact values
 # can be asserted. xfail (not hard-fail) on an outage matches the CHMI/AEMET precedent.

--- a/tests/provider/lhmt/observation/test_api.py
+++ b/tests/provider/lhmt/observation/test_api.py
@@ -79,10 +79,12 @@ def test_parse_lhmt_malformed_json_yields_empty() -> None:
 
 def test_parse_lhmt_skips_malformed_items() -> None:
     """Valid JSON with malformed items degrades to the good rows rather than raising."""
-    # observations: a non-dict entry and one missing the timestamp are dropped; the good one stays
+    # observations: a non-dict entry, one missing the timestamp, and one whose timestamp string is
+    # malformed are all dropped; the cleanly-timestamped one stays (no exception for the bad string)
     obs = (
         b'{"station": {"code": "x"}, "observations": ['
         b'"garbage", {"airTemperature": 1.0}, '
+        b'{"observationTimeUtc": "not-a-timestamp", "airTemperature": 9.9}, '
         b'{"observationTimeUtc": "2020-07-01 12:00:00", "airTemperature": 22.3}]}'
     )
     df = parse_lhmt_observations(obs)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -30,6 +30,7 @@ from wetterdienst.provider.imgw.hydrology import ImgwHydrologyMetadata, ImgwHydr
 from wetterdienst.provider.imgw.meteorology import ImgwMeteorologyMetadata, ImgwMeteorologyRequest
 from wetterdienst.provider.ipma.observation import IpmaObservationMetadata
 from wetterdienst.provider.knmi.observation import KnmiObservationMetadata, KnmiObservationRequest
+from wetterdienst.provider.lhmt.observation import LhmtObservationMetadata
 from wetterdienst.provider.meteofrance.observation import MeteoFranceObservationMetadata, MeteoFranceObservationRequest
 from wetterdienst.provider.meteofrance.synop import MeteoFranceSynopMetadata, MeteoFranceSynopRequest
 from wetterdienst.provider.meteoswiss.observation import MeteoswissObservationMetadata, MeteoswissObservationRequest
@@ -121,6 +122,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
         ImgwMeteorologyMetadata,
         IpmaObservationMetadata,
         KnmiObservationMetadata,
+        LhmtObservationMetadata,
         MeteoFranceObservationMetadata,
         MeteoFranceSynopMetadata,
         MeteoswissObservationMetadata,
@@ -160,6 +162,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
         ImgwMeteorologyMetadata,
         IpmaObservationMetadata,
         KnmiObservationMetadata,
+        LhmtObservationMetadata,
         MeteoFranceObservationMetadata,
         MeteoFranceSynopMetadata,
         MeteoswissObservationMetadata,

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -73,6 +73,7 @@ def test_coverage(client: TestClient) -> None:
         "imgw",
         "ipma",
         "knmi",
+        "lhmt",
         "meteofrance",
         "meteoswiss",
         "metno",


### PR DESCRIPTION
## Summary

Adds a Lithuania meteorology provider backed by LHMT's key-less `api.meteo.lt` JSON REST API (Lietuvos hidrometeorologijos tarnyba). Fills the Baltic gap.

- ~52 automatic stations, hourly observations (temperature, humidity, wind speed/gust/direction, cloud cover, sea-level pressure, precipitation, snow depth)
- **Historical**: the API serves per-station, per-day observation days reaching back to ~2016, so `periods=["historical"]` and a date range is required; the provider fetches one day per station per day in the range.
- Registered as `lhmt`/`observation`

## Notable handling

The format is already canonical (SI-ish units, wind direction in degrees, `null` for missing with no sentinel), so parsing is a straight field map. `feelsLikeTemperature` (no clean canonical) and the textual `conditionCode` are intentionally not mapped.

## Tests

Offline parser tests that always run, plus credential-free remote tests. Because historical data is stable, the remote tests assert **exact reference values** (e.g. Vilnius 2020-07-01 12:00 = 22.3 °C, humidity 0.52 after %→decimal). `LhmtObservationMetadata` added to the metadata name/unit test lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)