### PR TITLE
feat(dwd): add SWSMOS road weather forecast network (dwd/swsmos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Types of changes:
 
 ## [Unreleased]
 
+### Added
+
+- Add a DWD SWSMOS network (`dwd`/`swsmos`) exposing the road weather forecast (Straßenwetter-MOS)
+  for DWD's ~1800 road weather stations. Each model run provides an hourly forecast out to +167 hours
+  (selectable via `issue`, default: the latest run): air, dew-point and road surface temperature,
+  liquid precipitation, precipitation probabilities and the road surface condition. This is the
+  forecast counterpart to the DWD `road` observation network
+
 ### Changed
 
 - Sharpen the `interpolate`/`summarize` endpoint descriptions (which become the MCP tool

--- a/docs/data/overview.md
+++ b/docs/data/overview.md
@@ -25,6 +25,9 @@ Here's a quick overview of the data sources currently supported by `wetterdienst
         - Up to 115 parameters
     - Road
         - Historical weather observations of German highway stations
+    - SWSMOS
+        - road weather forecast (Straßenwetter-MOS) for ~1800 German road weather stations
+        - hourly, out to +167 hours; air/dew/road-surface temperature, precipitation, road condition
     - Radar
         - 16 locations in Germany
         - All of Composite, Radolan, Radvor, Sites and Radolan_CDC

--- a/docs/data/provider/dwd/index.md
+++ b/docs/data/provider/dwd/index.md
@@ -48,6 +48,7 @@ dmo/index.md
 mosmix/index.md
 observation/index.md
 road/index.md
+swsmos/index.md
 radar/index.md
 derived/index.md
 alerts/index.md

--- a/docs/data/provider/dwd/swsmos/hourly.md
+++ b/docs/data/provider/dwd/swsmos/hourly.md
@@ -1,0 +1,32 @@
+# hourly
+
+## metadata
+
+| property      | value  |
+|---------------|--------|
+| name          | hourly |
+| original name | hourly |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value |
+|---------------|-------|
+| name          | data  |
+| original name | data  |
+
+#### parameters
+
+| name                                     | original name | unit type     | unit |
+|------------------------------------------|---------------|---------------|------|
+| temperature_air_mean_2m                  | TL            | temperature   | °C   |
+| error_absolute_temperature_air_mean_2m   | TLSTA         | temperature   | °C   |
+| temperature_dew_point_mean_2m            | TD            | temperature   | °C   |
+| temperature_surface_mean                 | TS            | temperature   | °C   |
+| precipitation_height_liquid              | RRL1c         | precipitation | mm   |
+| precipitation_height_last_6h             | RR6           | precipitation | mm   |
+| probability_precipitation_liquid_last_6h | WWL6          | fraction      | %    |
+| road_surface_condition                   | RC            | dimensionless | -    |

--- a/docs/data/provider/dwd/swsmos/hourly.md
+++ b/docs/data/provider/dwd/swsmos/hourly.md
@@ -20,13 +20,13 @@
 
 #### parameters
 
-| name                                     | original name | unit type     | unit |
-|------------------------------------------|---------------|---------------|------|
-| temperature_air_mean_2m                  | TL            | temperature   | °C   |
-| error_absolute_temperature_air_mean_2m   | TLSTA         | temperature   | °C   |
-| temperature_dew_point_mean_2m            | TD            | temperature   | °C   |
-| temperature_surface_mean                 | TS            | temperature   | °C   |
-| precipitation_height_liquid              | RRL1c         | precipitation | mm   |
-| precipitation_height_last_6h             | RR6           | precipitation | mm   |
-| probability_precipitation_liquid_last_6h | WWL6          | fraction      | %    |
-| road_surface_condition                   | RC            | dimensionless | -    |
+| name                                            | original name | unit type     | unit |
+|-------------------------------------------------|---------------|---------------|------|
+| temperature_air_mean_2m                         | TL            | temperature   | °C   |
+| temperature_dew_point_mean_2m                   | TD            | temperature   | °C   |
+| temperature_surface_mean                        | TS            | temperature   | °C   |
+| precipitation_height_liquid                     | RRL1c         | precipitation | mm   |
+| precipitation_height_last_6h                    | RR6           | precipitation | mm   |
+| probability_precipitation_liquid_last_6h        | WWL6          | fraction      | %    |
+| probability_precipitation_height_gt_5mm_last_6h | R650          | fraction      | %    |
+| road_surface_condition                          | RC            | dimensionless | -    |

--- a/docs/data/provider/dwd/swsmos/index.md
+++ b/docs/data/provider/dwd/swsmos/index.md
@@ -1,0 +1,26 @@
+# SWSMOS
+
+## Overview
+
+SWSMOS (Straßenwetter-MOS) is the DWD's **road weather forecast** for its network of ~1800 road
+weather stations ("Straßenwetterstationen"). For each model run it provides an hourly forecast out
+to +167 hours (roughly seven days) of air temperature (with its forecast standard deviation),
+dew point, road surface temperature, liquid precipitation and its probability, and the road surface
+condition. Most variables come from a Model Output Statistics (MOS) post-processing; the road
+surface temperature and road condition come from the METRo road-weather model.
+
+The data is published as one CSV file per model run under
+[local_forecasts/swsmos](https://opendata.dwd.de/weather/local_forecasts/swsmos/)
+(`swsmos_<YYYYMMDDHH0000>_opendata.csv.bz2`), with the station catalogue in `swsKatalog.csv.bz2`.
+The `issue` argument selects the model run (default: the latest available). No authentication is
+required.
+
+This is the forecast counterpart to the DWD `road` **observation** network, sharing the road surface
+temperature and road condition variables. See
+[SWSMOS at the DWD](https://www.dwd.de/DE/leistungen/swis_swsmos/swis_swsmos.html).
+
+```{toctree}
+:hidden:
+
+hourly.md
+```

--- a/docs/data/provider/dwd/swsmos/index.md
+++ b/docs/data/provider/dwd/swsmos/index.md
@@ -4,10 +4,10 @@
 
 SWSMOS (Straßenwetter-MOS) is the DWD's **road weather forecast** for its network of ~1800 road
 weather stations ("Straßenwetterstationen"). For each model run it provides an hourly forecast out
-to +167 hours (roughly seven days) of air temperature (with its forecast standard deviation),
-dew point, road surface temperature, liquid precipitation and its probability, and the road surface
-condition. Most variables come from a Model Output Statistics (MOS) post-processing; the road
-surface temperature and road condition come from the METRo road-weather model.
+to +167 hours (roughly seven days) of air temperature, dew point, road surface temperature, liquid
+precipitation and precipitation probabilities, and the road surface condition. Most variables come
+from a Model Output Statistics (MOS) post-processing; the road surface temperature and road
+condition come from the METRo road-weather model.
 
 The data is published as one CSV file per model run under
 [local_forecasts/swsmos](https://opendata.dwd.de/weather/local_forecasts/swsmos/)

--- a/src/wetterdienst/api.py
+++ b/src/wetterdienst/api.py
@@ -30,6 +30,7 @@ class Wetterdienst:
             "mosmix": "wetterdienst.provider.dwd.mosmix.DwdMosmixRequest",
             "dmo": "wetterdienst.provider.dwd.dmo.DwdDmoRequest",
             "road": "wetterdienst.provider.dwd.road.DwdRoadRequest",
+            "swsmos": "wetterdienst.provider.dwd.swsmos.DwdSwsmosRequest",
             "radar": "wetterdienst.provider.dwd.radar.DwdRadarValues",
             "alerts": "wetterdienst.provider.dwd.alerts.DwdWeatherAlertRequest",
             "derived": "wetterdienst.provider.dwd.derived.DwdDerivedRequest",

--- a/src/wetterdienst/provider/dwd/swsmos/__init__.py
+++ b/src/wetterdienst/provider/dwd/swsmos/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""DWD SWSMOS (road weather forecast) provider."""
+
+from wetterdienst.provider.dwd.swsmos.api import DwdSwsmosRequest
+from wetterdienst.provider.dwd.swsmos.metadata import DwdSwsmosMetadata
+
+__all__ = ["DwdSwsmosMetadata", "DwdSwsmosRequest"]

--- a/src/wetterdienst/provider/dwd/swsmos/api.py
+++ b/src/wetterdienst/provider/dwd/swsmos/api.py
@@ -1,0 +1,202 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""DWD SWSMOS (Straßenwetter-MOS) road weather forecast provider.
+
+DWD publishes one CSV file per model run under
+https://opendata.dwd.de/weather/local_forecasts/swsmos/ (``swsmos_<YYYYMMDDHH0000>_opendata.csv.bz2``),
+each holding an hourly forecast to +167 h for every road weather station. The station catalogue is
+``swsKatalog.csv.bz2``. See ``metadata.py`` for the field/unit mapping.
+
+Each run file is a small deviation from a plain CSV: line 1 is the header, line 2 is the run
+timestamp, and the remaining lines are ``ID;Lat;Lon;YYYYMMDDHHmm;<values...>`` rows (one per station
+per forecast hour). Values use ``.`` decimals; the catalogue uses ``,`` decimals.
+"""
+
+from __future__ import annotations
+
+import bz2
+import contextlib
+import datetime as dt
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, cast
+from zoneinfo import ZoneInfo
+
+import polars as pl
+
+from wetterdienst.exceptions import InvalidEnumerationError
+from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.model.metadata import DatasetModel, ParameterModel
+from wetterdienst.model.request import TimeseriesRequest
+from wetterdienst.model.values import TimeseriesValues
+from wetterdienst.provider.dwd.swsmos.metadata import DwdSwsmosMetadata
+from wetterdienst.util.enumeration import parse_enumeration_from_template
+from wetterdienst.util.network import download_file, list_remote_files_fsspec
+
+if TYPE_CHECKING:
+    from wetterdienst.settings import Settings
+
+log = logging.getLogger(__name__)
+
+_UTC = ZoneInfo("UTC")
+_BASE_URL = "https://opendata.dwd.de/weather/local_forecasts/swsmos"
+_CATALOG_URL = f"{_BASE_URL}/swsKatalog.csv.bz2"
+_LATEST_FILE = "swsmos_LATEST_opendata.csv.bz2"
+
+_EMPTY_VALUES_SCHEMA = {
+    "resolution": pl.String,
+    "dataset": pl.String,
+    "parameter": pl.String,
+    "station_id": pl.String,
+    "date": pl.Datetime(time_unit="us", time_zone="UTC"),
+    "value": pl.Float64,
+    "quality": pl.Float64,
+}
+
+
+class DwdForecastDate(Enum):
+    """Sentinel selecting the latest available model run."""
+
+    LATEST = "latest"
+
+
+def _run_url(issue: dt.datetime) -> str:
+    return f"{_BASE_URL}/swsmos_{issue:%Y%m%d%H}0000_opendata.csv.bz2"
+
+
+def _read_run_csv(content: bytes) -> pl.DataFrame:
+    """Decompress and parse a run file, dropping the run-timestamp line between header and data."""
+    lines = bz2.decompress(content).decode("latin-1").splitlines()
+    if len(lines) < 3:
+        return pl.DataFrame()
+    csv = ("\n".join([lines[0], *lines[2:]])).encode()
+    return pl.read_csv(csv, separator=";", infer_schema_length=0)
+
+
+class DwdSwsmosValues(TimeseriesValues):
+    """Values class for DWD SWSMOS road weather forecast data."""
+
+    def _run_content(self, settings: Settings) -> bytes | None:
+        issue = cast("DwdSwsmosRequest", self.sr.stations).issue
+        if issue is DwdForecastDate.LATEST:
+            files = list_remote_files_fsspec(f"{_BASE_URL}/", settings, CacheExpiry.NO_CACHE)
+            names = {f.rsplit("/", 1)[-1]: f for f in files}
+            # DWD maintains a ``swsmos_LATEST_opendata.csv.bz2`` alias pointing at the newest run;
+            # fall back to the newest timestamped file if the alias is ever missing
+            if _LATEST_FILE in names:
+                url = names[_LATEST_FILE]
+            else:
+                timestamped = sorted(n for n in names if n.startswith("swsmos_") and n != _LATEST_FILE)
+                if not timestamped:
+                    return None
+                url = names[timestamped[-1]]
+        else:
+            url = _run_url(cast("dt.datetime", issue))
+        file = download_file(
+            url=url,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.TWELVE_HOURS,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            if not file.is_no_internet_error:
+                log.warning(f"Failed to fetch SWSMOS run {url}: {file.content}")
+            return None
+        return file.content.read()
+
+    def _collect_station_parameter_or_dataset(
+        self,
+        station_id: str,
+        parameter_or_dataset: ParameterModel | DatasetModel,
+    ) -> pl.DataFrame:
+        if isinstance(parameter_or_dataset, ParameterModel):
+            dataset = parameter_or_dataset.dataset
+        elif isinstance(parameter_or_dataset, DatasetModel):
+            dataset = parameter_or_dataset
+        else:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+
+        settings = cast("Settings", self.sr.stations.settings)
+        content = self._run_content(settings)
+        if content is None:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        df = _read_run_csv(content)
+        if df.is_empty() or "ID" not in df.columns:
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        df = df.filter(pl.col("ID") == station_id)
+        if df.is_empty():
+            return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
+        columns = [p.name_original for p in dataset.parameters if p.name_original in df.columns]
+        df = df.select(
+            pl.col("YYYYMMDDHHmm")
+            .str.to_datetime("%Y%m%d%H%M", time_unit="us")
+            .dt.replace_time_zone("UTC")
+            .alias("date"),
+            *[pl.col(c).cast(pl.Float64, strict=False) for c in columns],
+        )
+        df = df.unpivot(index=["date"], variable_name="parameter", value_name="value")
+        return df.select(
+            pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
+            pl.col("parameter"),
+            pl.lit(station_id, dtype=pl.String).alias("station_id"),
+            pl.col("date"),
+            pl.col("value"),
+            pl.lit(None, dtype=pl.Float64).alias("quality"),
+        )
+
+
+@dataclass
+class DwdSwsmosRequest(TimeseriesRequest):
+    """Request class for DWD SWSMOS road weather forecast data."""
+
+    metadata = DwdSwsmosMetadata
+    _values = DwdSwsmosValues
+
+    issue: str | dt.datetime | DwdForecastDate = DwdForecastDate.LATEST
+
+    def __post_init__(self) -> None:
+        """Resolve the ``issue`` (model run) to LATEST or a UTC hour."""
+        super().__post_init__()
+        issue: str | dt.datetime | DwdForecastDate = self.issue
+        with contextlib.suppress(InvalidEnumerationError):
+            issue = parse_enumeration_from_template(issue, DwdForecastDate)  # ty: ignore[no-matching-overload]
+        if issue is not DwdForecastDate.LATEST:
+            if isinstance(issue, str):
+                issue = dt.datetime.fromisoformat(issue)
+            issue = dt.datetime(issue.year, issue.month, issue.day, issue.hour, tzinfo=_UTC)
+        self.issue = issue
+
+    def _all(self) -> pl.LazyFrame:
+        settings = cast("Settings", self.settings)
+        file = download_file(
+            url=_CATALOG_URL,
+            cache_dir=settings.cache_dir,
+            ttl=CacheExpiry.METAINDEX,
+            client_kwargs=settings.fsspec_client_kwargs,
+            cache_disable=settings.cache_disable,
+            use_certifi=settings.use_certifi,
+        )
+        if isinstance(file.content, Exception):
+            log.warning(f"Failed to fetch SWSMOS station catalogue: {file.content}")
+            return pl.LazyFrame()
+        # the catalogue is latin-1 encoded (German station names carry umlauts)
+        catalogue = bz2.decompress(file.content.read()).decode("latin-1").encode("utf-8")
+        df = pl.read_csv(catalogue, separator=";", infer_schema_length=0)
+        if df.is_empty():
+            return pl.LazyFrame()
+        resolution = self.metadata[0]
+        # catalogue columns: Kennung;Name;Streckentyp;Streckenbelag;Breite;Laenge;Hoehe;Flughafen;Inaktiv
+        # (Breite/Laenge/Hoehe use a comma decimal separator, unlike the run files)
+        return df.select(
+            pl.col("Kennung").alias("station_id"),
+            pl.col("Name").alias("name"),
+            pl.col("Breite").str.replace(",", ".").cast(pl.Float64, strict=False).alias("latitude"),
+            pl.col("Laenge").str.replace(",", ".").cast(pl.Float64, strict=False).alias("longitude"),
+            pl.col("Hoehe").str.replace(",", ".").cast(pl.Float64, strict=False).alias("height"),
+            pl.lit(resolution.name, pl.String).alias("resolution"),
+            pl.lit(resolution.datasets[0].name, pl.String).alias("dataset"),
+        ).lazy()

--- a/src/wetterdienst/provider/dwd/swsmos/api.py
+++ b/src/wetterdienst/provider/dwd/swsmos/api.py
@@ -191,6 +191,9 @@ class DwdSwsmosRequest(TimeseriesRequest):
         resolution = self.metadata[0]
         # catalogue columns: Kennung;Name;Streckentyp;Streckenbelag;Breite;Laenge;Hoehe;Flughafen;Inaktiv
         # (Breite/Laenge/Hoehe use a comma decimal separator, unlike the run files)
+        # drop stations flagged inactive (the ``Inaktiv`` column is empty for active stations)
+        if "Inaktiv" in df.columns:
+            df = df.filter(pl.col("Inaktiv").is_null() | (pl.col("Inaktiv").str.strip_chars() == ""))
         return df.select(
             pl.col("Kennung").alias("station_id"),
             pl.col("Name").alias("name"),

--- a/src/wetterdienst/provider/dwd/swsmos/metadata.py
+++ b/src/wetterdienst/provider/dwd/swsmos/metadata.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""DWD SWSMOS (Straßenwetter-MOS) road weather forecast metadata.
+
+SWSMOS is DWD's road weather forecast for its ~1800 road weather stations (SWS). One CSV file is
+published per model run (``swsmos_<YYYYMMDDHH0000>_opendata.csv.bz2``) under
+https://opendata.dwd.de/weather/local_forecasts/swsmos/, holding an hourly forecast out to +167 h
+for every station. Most variables come from a MOS post-processing; road surface temperature and road
+condition come from the METRo road model. See
+https://www.dwd.de/DE/leistungen/swis_swsmos/swis_swsmos.html.
+
+Only the variables with a clean canonical parameter are mapped. The solid-precipitation *amounts*
+(``RRS1c``/``RRS3c``), the 3-hour solid-precipitation *probability* (``WWS3`` -- the enum has 1/6/12
+hour windows but no 3 hour one) and the undocumented ``R650`` are intentionally left unmapped.
+"""
+
+from __future__ import annotations
+
+from wetterdienst.model.metadata import DATASET_NAME_DEFAULT, build_metadata_model
+
+_TEMPERATURE = {"unit_type": "temperature", "unit": "degree_celsius"}
+_PRECIPITATION = {"unit_type": "precipitation", "unit": "millimeter"}
+
+DwdSwsmosMetadata = {
+    "name_short": "DWD",
+    "name_english": "German Weather Service",
+    "name_local": "Deutscher Wetterdienst",
+    "country": "Germany",
+    "copyright": "© Deutscher Wetterdienst (DWD), SWSMOS road weather forecast",
+    "url": "https://opendata.dwd.de/weather/local_forecasts/swsmos/",
+    "kind": "forecast",
+    "timezone": "Europe/Berlin",
+    "timezone_data": "UTC",
+    "resolutions": [
+        {
+            "name": "hourly",
+            "name_original": "hourly",
+            "periods": ["future"],
+            "date_required": False,
+            "datasets": [
+                {
+                    "name": DATASET_NAME_DEFAULT,
+                    "name_original": DATASET_NAME_DEFAULT,
+                    "grouped": True,
+                    "parameters": [
+                        {"name": "temperature_air_mean_2m", "name_original": "TL", **_TEMPERATURE},
+                        {"name": "error_absolute_temperature_air_mean_2m", "name_original": "TLSTA", **_TEMPERATURE},
+                        {"name": "temperature_dew_point_mean_2m", "name_original": "TD", **_TEMPERATURE},
+                        {"name": "temperature_surface_mean", "name_original": "TS", **_TEMPERATURE},
+                        {"name": "precipitation_height_liquid", "name_original": "RRL1c", **_PRECIPITATION},
+                        {"name": "precipitation_height_last_6h", "name_original": "RR6", **_PRECIPITATION},
+                        {
+                            "name": "probability_precipitation_liquid_last_6h",
+                            "name_original": "WWL6",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            "name": "road_surface_condition",
+                            "name_original": "RC",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+DwdSwsmosMetadata = build_metadata_model(DwdSwsmosMetadata, "DwdSwsmosMetadata")

--- a/src/wetterdienst/provider/dwd/swsmos/metadata.py
+++ b/src/wetterdienst/provider/dwd/swsmos/metadata.py
@@ -9,9 +9,13 @@ for every station. Most variables come from a MOS post-processing; road surface 
 condition come from the METRo road model. See
 https://www.dwd.de/DE/leistungen/swis_swsmos/swis_swsmos.html.
 
-Only the variables with a clean canonical parameter are mapped. The solid-precipitation *amounts*
-(``RRS1c``/``RRS3c``), the 3-hour solid-precipitation *probability* (``WWS3`` -- the enum has 1/6/12
-hour windows but no 3 hour one) and the undocumented ``R650`` are intentionally left unmapped.
+Only the variables with a clean canonical parameter are mapped. Left unmapped: the
+solid-precipitation *amounts* (``RRS1c``/``RRS3c`` -- no solid-precipitation-height parameter), the
+3-hour solid-precipitation *probability* (``WWS3`` -- the enum has 1/6/12 hour windows but no 3 hour
+one), and ``TLSTA`` (the air-temperature forecast *standard deviation*; the sibling
+``error_absolute_temperature_air_mean_2m`` used by dwd/mosmix and dwd/dmo is a different statistic --
+DWD's expected absolute error -- so reusing it would be misleading, and there is no standard-deviation
+parameter).
 """
 
 from __future__ import annotations
@@ -44,14 +48,22 @@ DwdSwsmosMetadata = {
                     "grouped": True,
                     "parameters": [
                         {"name": "temperature_air_mean_2m", "name_original": "TL", **_TEMPERATURE},
-                        {"name": "error_absolute_temperature_air_mean_2m", "name_original": "TLSTA", **_TEMPERATURE},
                         {"name": "temperature_dew_point_mean_2m", "name_original": "TD", **_TEMPERATURE},
                         {"name": "temperature_surface_mean", "name_original": "TS", **_TEMPERATURE},
+                        # RR6 is a 6-hour liquid precipitation total; there is no ``*_liquid_last_6h``
+                        # parameter, so the (window-bearing) generic 6-hour height is the closest fit
                         {"name": "precipitation_height_liquid", "name_original": "RRL1c", **_PRECIPITATION},
                         {"name": "precipitation_height_last_6h", "name_original": "RR6", **_PRECIPITATION},
                         {
                             "name": "probability_precipitation_liquid_last_6h",
                             "name_original": "WWL6",
+                            "unit_type": "fraction",
+                            "unit": "percent",
+                        },
+                        {
+                            # R650: probability of > 5 mm liquid+solid precipitation in the last 6 h
+                            "name": "probability_precipitation_height_gt_5mm_last_6h",
+                            "name_original": "R650",
                             "unit_type": "fraction",
                             "unit": "percent",
                         },

--- a/tests/provider/dwd/swsmos/__init__.py
+++ b/tests/provider/dwd/swsmos/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.

--- a/tests/provider/dwd/swsmos/test_api.py
+++ b/tests/provider/dwd/swsmos/test_api.py
@@ -85,12 +85,12 @@ def test_swsmos_values() -> None:
     assert df["resolution"].unique().to_list() == ["hourly"]
     assert set(df["parameter"].unique().to_list()) <= {
         "temperature_air_mean_2m",
-        "error_absolute_temperature_air_mean_2m",
         "temperature_dew_point_mean_2m",
         "temperature_surface_mean",
         "precipitation_height_liquid",
         "precipitation_height_last_6h",
         "probability_precipitation_liquid_last_6h",
+        "probability_precipitation_height_gt_5mm_last_6h",
         "road_surface_condition",
     }
     # the forecast is hourly and lies in the future of the run

--- a/tests/provider/dwd/swsmos/test_api.py
+++ b/tests/provider/dwd/swsmos/test_api.py
@@ -1,0 +1,104 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for DWD SWSMOS (road weather forecast) provider."""
+
+import bz2
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import polars as pl
+import pytest
+
+from wetterdienst.provider.dwd.swsmos import DwdSwsmosRequest
+from wetterdienst.provider.dwd.swsmos.api import DwdForecastDate, _read_run_csv, _run_url
+
+UTC = ZoneInfo("UTC")
+
+
+def test_read_run_csv_drops_run_timestamp_line() -> None:
+    """A run file's line-2 run timestamp is dropped so the header aligns with the data rows."""
+    raw = (
+        b"ID;Lat;Lon;YYYYMMDDHHmm;TL;RC;TS\n"
+        b"202607310700\n"  # the run-timestamp line between header and data
+        b"A006;54.889156;8.908735;202607310800;17.9;1;24.2\n"
+        b"A006;54.889156;8.908735;202607310900;17.6;2;25.1\n"
+    )
+    df = _read_run_csv(bz2.compress(raw))
+    assert df.columns == ["ID", "Lat", "Lon", "YYYYMMDDHHmm", "TL", "RC", "TS"]
+    assert df.height == 2  # only the two data rows, not the run-timestamp line
+    assert df["TL"].to_list() == ["17.9", "17.6"]
+
+
+def test_read_run_csv_too_short() -> None:
+    """A file without any data rows yields an empty frame rather than raising."""
+    assert _read_run_csv(bz2.compress(b"ID;TL\n202607310700\n")).is_empty()
+
+
+def test_run_url() -> None:
+    """The run URL is built from the issue hour (minutes/seconds are always zero)."""
+    url = _run_url(dt.datetime(2026, 7, 31, 7, 0, tzinfo=UTC))
+    assert url.endswith("/swsmos_20260731070000_opendata.csv.bz2")
+
+
+def test_issue_defaults_to_latest() -> None:
+    """Without an explicit issue, the request targets the latest model run."""
+    request = DwdSwsmosRequest(parameters=[("hourly", "data")])
+    assert request.issue is DwdForecastDate.LATEST
+
+
+def test_issue_string_parsed_to_utc_hour() -> None:
+    """An ISO issue string is floored to a UTC hour."""
+    request = DwdSwsmosRequest(parameters=[("hourly", "data")], issue="2026-07-31T07:34")
+    assert request.issue == dt.datetime(2026, 7, 31, 7, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Remote tests -- hit the live DWD opendata server. SWSMOS is a rolling forecast, so values are
+# time-dependent; assert structure/ranges. xfail on outage matches the DWD/CHMI precedent.
+# ---------------------------------------------------------------------------
+
+xfail_if_dwd_unavailable = pytest.mark.xfail(strict=False, reason="DWD opendata intermittently unavailable")
+
+
+@pytest.mark.remote
+@xfail_if_dwd_unavailable
+def test_swsmos_stations() -> None:
+    """The road-station catalogue resolves to a populated set of German stations."""
+    df = DwdSwsmosRequest(parameters=[("hourly", "data")]).all().df
+    assert df.height > 1000
+    assert df["resolution"].unique().to_list() == ["hourly"]
+    # Germany: latitudes ~47-55 N, longitudes ~6-15 E
+    assert df["latitude"].min() > 47.0
+    assert df["latitude"].max() < 56.0
+    assert df["longitude"].min() > 5.0
+    assert df["longitude"].max() < 16.0
+
+
+@pytest.mark.remote
+@xfail_if_dwd_unavailable
+def test_swsmos_values() -> None:
+    """The latest run returns an hourly forecast with the expected parameters and sane ranges."""
+    request = DwdSwsmosRequest(parameters=[("hourly", "data")])
+    station_id = request.all().df["station_id"][0]
+    df = request.filter_by_station_id(station_id).values.all().df
+    assert not df.is_empty()
+    assert df["resolution"].unique().to_list() == ["hourly"]
+    assert set(df["parameter"].unique().to_list()) <= {
+        "temperature_air_mean_2m",
+        "error_absolute_temperature_air_mean_2m",
+        "temperature_dew_point_mean_2m",
+        "temperature_surface_mean",
+        "precipitation_height_liquid",
+        "precipitation_height_last_6h",
+        "probability_precipitation_liquid_last_6h",
+        "road_surface_condition",
+    }
+    # the forecast is hourly and lies in the future of the run
+    dates = df["date"].unique().sort()
+    assert len(dates) > 24  # multi-day hourly horizon
+    deltas = dates.diff().drop_nulls().unique().to_list()
+    assert deltas == [dt.timedelta(hours=1)]
+    # air temperature in a physically plausible range
+    air = df.filter(pl.col("parameter") == "temperature_air_mean_2m")["value"].drop_nulls()
+    assert air.min() > -40.0
+    assert air.max() < 55.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,7 @@ from wetterdienst.provider.dwd.dmo import DwdDmoMetadata, DwdDmoRequest
 from wetterdienst.provider.dwd.mosmix import DwdMosmixMetadata, DwdMosmixRequest
 from wetterdienst.provider.dwd.observation import DwdObservationMetadata, DwdObservationRequest
 from wetterdienst.provider.dwd.road import DwdRoadMetadata, DwdRoadRequest
+from wetterdienst.provider.dwd.swsmos import DwdSwsmosMetadata
 from wetterdienst.provider.ea.hydrology import EAHydrologyMetadata, EAHydrologyRequest
 from wetterdienst.provider.eaufrance.hubeau import HubeauMetadata, HubeauRequest
 from wetterdienst.provider.eccc.observation import EcccObservationMetadata, EcccObservationRequest
@@ -109,6 +110,7 @@ def test_wetterdienst_api(provider: str, network: str) -> None:
         DwdMosmixMetadata,
         DwdObservationMetadata,
         DwdRoadMetadata,
+        DwdSwsmosMetadata,
         EAHydrologyMetadata,
         EcccObservationMetadata,
         FmiObservationMetadata,
@@ -146,6 +148,7 @@ def test_metadata_parameter_names(parameter_names: list[str], metadata: dict) ->
         DwdMosmixMetadata,
         DwdObservationMetadata,
         DwdRoadMetadata,
+        DwdSwsmosMetadata,
         EAHydrologyMetadata,
         EcccObservationMetadata,
         FmiObservationMetadata,

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -82,7 +82,7 @@ def test_coverage(client: TestClient) -> None:
         "wsv",
     }
     dwd = data["dwd"]
-    assert list(dwd.keys()) == ["observation", "mosmix", "dmo", "road", "radar", "alerts", "derived"]
+    assert list(dwd.keys()) == ["observation", "mosmix", "dmo", "road", "swsmos", "radar", "alerts", "derived"]
     for network_info in dwd.values():
         assert network_info["auth"] is False
         assert network_info["configured"] is True


### PR DESCRIPTION
## Summary

Adds a new DWD **forecast** network, `dwd/swsmos`, exposing **SWSMOS** (Straßenwetter-MOS) — DWD's road weather forecast for its ~1,800 road weather stations. For each model run it provides an hourly forecast out to **+167 h** (≈7 days) per station. It's the forecast counterpart to the existing DWD `road` **observation** network (shared road-surface-temperature and road-condition variables).

Modelled on the existing `dmo`/`mosmix` forecast networks: `kind="forecast"`, `periods=["future"]`, an `issue` (model-run) selector defaulting to the latest run (via DWD's `swsmos_LATEST` alias).

## Data & mapping

One bz2 CSV per run (`swsmos_<YYYYMMDDHH0000>_opendata.csv.bz2`) holding all stations × forecast hours; station catalogue in `swsKatalog.csv.bz2`. Both are latin-1; the catalogue uses comma decimals, and each run file carries a run-timestamp line between the header and data that is dropped on parse.

Fields mapped to canonical parameters (per DWD's SWSMOS description PDF):

| SWSMOS | → parameter |
|---|---|
| `TL` | temperature_air_mean_2m |
| `TD` | temperature_dew_point_mean_2m |
| `TS` (road surface) | temperature_surface_mean |
| `RRL1c` | precipitation_height_liquid |
| `RR6` | precipitation_height_last_6h |
| `WWL6` | probability_precipitation_liquid_last_6h |
| `R650` (>5 mm liquid+solid, 6 h) | probability_precipitation_height_gt_5mm_last_6h |
| `RC` | road_surface_condition |

Left unmapped (no clean canonical, documented): the solid-precipitation amounts `RRS1c`/`RRS3c`, the 3-hour solid-precip probability `WWS3`, and `TLSTA` (air-temp forecast *standard deviation* — distinct from the sibling providers' `error_absolute_temperature_air_mean_2m`, which is DWD's expected absolute error).

## Tests / docs

Registered as `dwd/swsmos` with docs, offline parser/issue-handling tests and credential-free remote tests. `DwdSwsmosMetadata` added to the metadata name/unit test lists and `swsmos` to the `/api/coverage` dwd-network test. Verified end-to-end against the live server (road surface 36 °C vs air 24.7 °C in sun; forecast horizon 167 hourly steps).

Two rounds of review (initial + a Fable code review, whose findings — mapping R650, dropping the mis-mapped TLSTA, filtering inactive stations — are in the second commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)