### PR TITLE
feat(dwd): add climate_urban 10-minute observation datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Types of changes:
   (selectable via `issue`, default: the latest run): air, dew-point and road surface temperature,
   liquid precipitation, precipitation probabilities and the road surface condition. This is the
   forecast counterpart to the DWD `road` observation network
+- Add the DWD `10_minutes` urban climate (Stadtklima) datasets to the `dwd`/`observation` network,
+  served from DWD's `climate_urban/` path (recent period only): `urban_precipitation`,
+  `urban_pressure`, `urban_solar`, `urban_temperature_air` (incl. the new
+  `temperature_radiant_mean_2m` parameter), `urban_temperature_extreme`, `urban_temperature_soil`,
+  `urban_wind` and `urban_wind_extreme`. These complement the existing hourly urban datasets. The
+  urban station-description lists are parsed by content because they frequently leave the optional
+  date and Bundesland fields blank
 
 ### Changed
 

--- a/docs/data/provider/dwd/observation/10_minutes.md
+++ b/docs/data/provider/dwd/observation/10_minutes.md
@@ -135,3 +135,151 @@ Codes (precipitation_indicator_wr):
 | wind_speed_min              | fnx_10        | minimum 10-minute mean wind velocity. The 10-minutes interval is moved in 10s steps over the last 20 minutes                                                                                                                                                   | speed     | m/s           | >=0         |
 | wind_speed_rolling_mean_max | fmx_10        | maximum 10-minute mean wind velocity. The 10-minutes interval is moved in 10s steps over the last 20 minutes                                                                                                                                                   | speed     | m/s           | >=0         |
 | wind_direction_gust_max     | dx_10         | wind direction of highest wind gust                                                                                                                                                                                                                            | angle     | °             | >=0,<=360   |
+
+### urban_precipitation
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                    |
+|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | urban_precipitation                                                                                                                                                                                                      |
+| original name | precipitation (climate_urban)                                                                                                                                                                                            |
+| description   | Recent 10-minute precipitation, observed at urban stations for selected urban areas in Germany ([details](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/precipitation/)) |
+| access        | [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/precipitation/)                                                                                                     |
+
+#### parameters
+
+| name                 | original name | description                                 | unit type     | unit | constraints |
+|----------------------|---------------|---------------------------------------------|---------------|------|-------------|
+| precipitation_height | rr_st_10      | precipitation height of the last 10 minutes | precipitation | mm   | >=0         |
+
+### urban_pressure
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                          |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | urban_pressure                                                                                                                                                                                                 |
+| original name | pressure (climate_urban)                                                                                                                                                                                       |
+| description   | Recent 10-minute pressure, observed at urban stations for selected urban areas in Germany ([details](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/pressure/)) |
+| access        | [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/pressure/)                                                                                                |
+
+#### parameters
+
+| name                   | original name | description                   | unit type | unit | constraints |
+|------------------------|---------------|-------------------------------|-----------|------|-------------|
+| pressure_air_sea_level | pp_st_10      | pressure reduced to sea level | pressure  | hPa  | >=0         |
+| pressure_air_site      | p0_st_10      | pressure at station height    | pressure  | hPa  | >=0         |
+
+### urban_solar
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                           |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | urban_solar                                                                                                                                                                                                                     |
+| original name | solar (climate_urban)                                                                                                                                                                                                           |
+| description   | Recent 10-minute solar radiation and sunshine, observed at urban stations for selected urban areas in Germany ([details](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/solar/)) |
+| access        | [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/solar/)                                                                                                                    |
+
+#### parameters
+
+| name              | original name | description                              | unit type       | unit  | constraints |
+|-------------------|---------------|------------------------------------------|-----------------|-------|-------------|
+| radiation_global  | fg_st_10      | 10min-sum of global (incoming) radiation | energy_per_area | J/cm² | >=0         |
+| sunshine_duration | sd_st_10      | 10min-sum of sunshine duration           | time            | min   | >=0         |
+
+### urban_temperature_air
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                                     |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | urban_temperature_air                                                                                                                                                                                                                     |
+| original name | air_temperature (climate_urban)                                                                                                                                                                                                           |
+| description   | Recent 10-minute air temperature and humidity, observed at urban stations for selected urban areas in Germany ([details](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/air_temperature/)) |
+| access        | [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/air_temperature/)                                                                                                                    |
+
+#### parameters
+
+| name                        | original name | description                      | unit type   | unit | constraints |
+|-----------------------------|---------------|----------------------------------|-------------|------|-------------|
+| temperature_air_mean_2m     | tt_st_10      | air temperature at 2m height     | temperature | °C   | -           |
+| humidity                    | rf_st_10      | relative humidity at 2m height   | fraction    | %    | >=0,<=100   |
+| temperature_radiant_mean_2m | strahl_st_10  | radiant temperature at 2m height | temperature | °C   | -           |
+| temperature_air_mean_0_05m  | tt5_st_10     | air temperature at 5cm height    | temperature | °C   | -           |
+
+### urban_temperature_extreme
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                                     |
+|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | urban_temperature_extreme                                                                                                                                                                                                                 |
+| original name | extreme_temperature (climate_urban)                                                                                                                                                                                                       |
+| description   | Recent 10-minute extreme air temperatures, observed at urban stations for selected urban areas in Germany ([details](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/extreme_temperature/)) |
+| access        | [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/extreme_temperature/)                                                                                                                |
+
+#### parameters
+
+| name                      | original name | description                           | unit type   | unit | constraints |
+|---------------------------|---------------|---------------------------------------|-------------|------|-------------|
+| temperature_air_max_2m    | tx_st_10      | maximum air temperature at 2m height  | temperature | °C   | -           |
+| temperature_air_min_2m    | tn_st_10      | minimum air temperature at 2m height  | temperature | °C   | -           |
+| temperature_air_min_0_05m | tn5_st_10     | minimum air temperature at 5cm height | temperature | °C   | -           |
+
+### urban_temperature_soil
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                          |
+|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | urban_temperature_soil                                                                                                                                                                                                         |
+| original name | soil_temperature (climate_urban)                                                                                                                                                                                               |
+| description   | Recent 10-minute soil temperature, observed at urban stations for selected urban areas in Germany ([details](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/soil_temperature/)) |
+| access        | [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/soil_temperature/)                                                                                                        |
+
+#### parameters
+
+| name                       | original name | description                      | unit type   | unit | constraints |
+|----------------------------|---------------|----------------------------------|-------------|------|-------------|
+| temperature_soil_mean_0_1m | te_st_01m_10  | soil temperature in 10 cm depth  | temperature | °C   | -           |
+| temperature_soil_mean_0_2m | te_st_02m_10  | soil temperature in 20 cm depth  | temperature | °C   | -           |
+| temperature_soil_mean_0_5m | te_st_05m_10  | soil temperature in 50 cm depth  | temperature | °C   | -           |
+| temperature_soil_mean_1m   | te_st_10m_10  | soil temperature in 100 cm depth | temperature | °C   | -           |
+
+### urban_wind
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                      |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | urban_wind                                                                                                                                                                                                                 |
+| original name | wind (climate_urban)                                                                                                                                                                                                       |
+| description   | Recent 10-minute wind speed and direction, observed at urban stations for selected urban areas in Germany ([details](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/wind/)) |
+| access        | [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/wind/)                                                                                                                |
+
+#### parameters
+
+| name           | original name | description                                    | unit type | unit | constraints |
+|----------------|---------------|------------------------------------------------|-----------|------|-------------|
+| wind_speed     | ff_st_10      | mean wind speed during the last 10 minutes     | speed     | m/s  | >=0         |
+| wind_direction | dd_st_10      | mean wind direction during the last 10 minutes | angle     | °    | >=0,<=360   |
+
+### urban_wind_extreme
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                  |
+|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | urban_wind_extreme                                                                                                                                                                                                     |
+| original name | extreme_wind (climate_urban)                                                                                                                                                                                           |
+| description   | Recent 10-minute extreme wind, observed at urban stations for selected urban areas in Germany ([details](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/extreme_wind/)) |
+| access        | [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate_urban/10_minutes/extreme_wind/)                                                                                                    |
+
+#### parameters
+
+| name          | original name | description                              | unit type | unit | constraints |
+|---------------|---------------|------------------------------------------|-----------|------|-------------|
+| wind_gust_max | fx_st_10      | maximum wind gust of the last 10 minutes | speed     | m/s  | >=0         |
+

--- a/docs/data/provider/dwd/observation/index.md
+++ b/docs/data/provider/dwd/observation/index.md
@@ -41,33 +41,36 @@ in the "now" period, although this may change in the future.
 The two dataset strings reflect on how we call a dataset e.g. "PRECIPITATION" and
 how the DWD calls the dataset e.g. "precipitation".
 
-| Dataset \ Granularity                               | 1_minute | 5_minutes | 10_minutes | hourly | subdaily | daily | monthly | annual |
-|-----------------------------------------------------|----------|-----------|------------|--------|----------|-------|---------|--------|
-| `PRECIPITATION = "precipitation"`                   | ✅        | ✅         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
-| `TEMPERATURE_AIR = "air_temperature"`               | ❌        | ❌         | ✅          | ✅      | ✅        | ❌     | ❌       | ❌      |
-| `TEMPERATURE_EXTREME = "extreme_temperature"`       | ❌        | ❌         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
-| `WIND_EXTREME = "extreme_wind"`                     | ❌        | ❌         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
-| `SOLAR = "solar"`                                   | ❌        | ❌         | ✅          | ✅      | ❌        | ✅     | ❌       | ❌      |
-| `WIND = "wind"`                                     | ❌        | ❌         | ✅          | ✅      | ✅        | ❌     | ❌       | ❌      |
-| `CLOUD_TYPE = "cloud_type"`                         | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `CLOUDINESS = "cloudiness"`                         | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
-| `DEW_POINT = "dew_point"`                           | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `PRESSURE = "pressure"`                             | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
-| `TEMPERATURE_SOIL = "soil_temperature"`             | ❌        | ❌         | ❌          | ✅      | ❌        | ✅     | ❌       | ❌      |
-| `SUNSHINE_DURATION = "sun"`                         | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `VISIBILITY = "visibility"`                         | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
-| `WIND_SYNOPTIC = "wind_synop"`                      | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `MOISTURE = "moisture"`                             | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
-| `CLIMATE_SUMMARY = "kl"`                            | ❌        | ❌         | ❌          | ❌      | ✅        | ✅     | ✅       | ✅      |
-| `PRECIPITATION_MORE = "more_precip"`                | ❌        | ❌         | ❌          | ❌      | ❌        | ✅     | ✅       | ✅      |
-| `WATER_EQUIVALENT = "water_equiv"`                  | ❌        | ❌         | ❌          | ❌      | ❌        | ✅     | ❌       | ❌      |
-| `WEATHER_PHENOMENA = "weather_phenomena"`           | ❌        | ❌         | ❌          | ❌      | ❌        | ✅     | ✅       | ✅      |
-| `URBAN_TEMPERATURE_AIR = "urban_temperature_air"`   | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `URBAN_PRECIPITATION = "urban_precipitation"`       | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `URBAN_PRESSURE = "urban_pressure"`                 | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `URBAN_TEMPERATURE_SOIL = "urban_temperature_soil"` | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `URBAN_SUN = "urban_sun"`                           | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
-| `URBAN_WIND = "urban_wind"`                         | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| Dataset \ Granularity                                     | 1_minute | 5_minutes | 10_minutes | hourly | subdaily | daily | monthly | annual |
+|-----------------------------------------------------------|----------|-----------|------------|--------|----------|-------|---------|--------|
+| `PRECIPITATION = "precipitation"`                         | ✅        | ✅         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
+| `TEMPERATURE_AIR = "air_temperature"`                     | ❌        | ❌         | ✅          | ✅      | ✅        | ❌     | ❌       | ❌      |
+| `TEMPERATURE_EXTREME = "extreme_temperature"`             | ❌        | ❌         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
+| `WIND_EXTREME = "extreme_wind"`                           | ❌        | ❌         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
+| `SOLAR = "solar"`                                         | ❌        | ❌         | ✅          | ✅      | ❌        | ✅     | ❌       | ❌      |
+| `WIND = "wind"`                                           | ❌        | ❌         | ✅          | ✅      | ✅        | ❌     | ❌       | ❌      |
+| `CLOUD_TYPE = "cloud_type"`                               | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `CLOUDINESS = "cloudiness"`                               | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
+| `DEW_POINT = "dew_point"`                                 | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `PRESSURE = "pressure"`                                   | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
+| `TEMPERATURE_SOIL = "soil_temperature"`                   | ❌        | ❌         | ❌          | ✅      | ❌        | ✅     | ❌       | ❌      |
+| `SUNSHINE_DURATION = "sun"`                               | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `VISIBILITY = "visibility"`                               | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
+| `WIND_SYNOPTIC = "wind_synop"`                            | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `MOISTURE = "moisture"`                                   | ❌        | ❌         | ❌          | ✅      | ✅        | ❌     | ❌       | ❌      |
+| `CLIMATE_SUMMARY = "kl"`                                  | ❌        | ❌         | ❌          | ❌      | ✅        | ✅     | ✅       | ✅      |
+| `PRECIPITATION_MORE = "more_precip"`                      | ❌        | ❌         | ❌          | ❌      | ❌        | ✅     | ✅       | ✅      |
+| `WATER_EQUIVALENT = "water_equiv"`                        | ❌        | ❌         | ❌          | ❌      | ❌        | ✅     | ❌       | ❌      |
+| `WEATHER_PHENOMENA = "weather_phenomena"`                 | ❌        | ❌         | ❌          | ❌      | ❌        | ✅     | ✅       | ✅      |
+| `URBAN_TEMPERATURE_AIR = "urban_temperature_air"`         | ❌        | ❌         | ✅          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `URBAN_PRECIPITATION = "urban_precipitation"`             | ❌        | ❌         | ✅          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `URBAN_PRESSURE = "urban_pressure"`                       | ❌        | ❌         | ✅          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `URBAN_TEMPERATURE_SOIL = "urban_temperature_soil"`       | ❌        | ❌         | ✅          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `URBAN_SUN = "urban_sun"`                                 | ❌        | ❌         | ❌          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `URBAN_WIND = "urban_wind"`                               | ❌        | ❌         | ✅          | ✅      | ❌        | ❌     | ❌       | ❌      |
+| `URBAN_SOLAR = "urban_solar"`                             | ❌        | ❌         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
+| `URBAN_TEMPERATURE_EXTREME = "urban_temperature_extreme"` | ❌        | ❌         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
+| `URBAN_WIND_EXTREME = "urban_wind_extreme"`               | ❌        | ❌         | ✅          | ❌      | ❌        | ❌     | ❌       | ❌      |
 
 This table and subsets of it can be printed with a function call of
 ``.discover()`` as described in the API section. Furthermore, individual

--- a/src/wetterdienst/exceptions.py
+++ b/src/wetterdienst/exceptions.py
@@ -15,6 +15,10 @@ class MetaFileNotFoundError(FileNotFoundError):
     """Raised when a meta file is not found."""
 
 
+class MetaFileFormatError(ValueError):
+    """Raised when a meta file does not match the expected format."""
+
+
 class ProductFileNotFoundError(FileNotFoundError):
     """Raised when a product file is not found."""
 

--- a/src/wetterdienst/metadata/parameter.py
+++ b/src/wetterdienst/metadata/parameter.py
@@ -541,6 +541,7 @@ class Parameter(Enum):
     TEMPERATURE_SOIL_MAX_BARE_MUCK_1_8M = "TEMPERATURE_SOIL_MAX_BARE_MUCK_1_8M"
 
     TEMPERATURE_SURFACE_MEAN = "TEMPERATURE_SURFACE_MEAN"
+    TEMPERATURE_RADIANT_MEAN_2M = "TEMPERATURE_RADIANT_MEAN_2M"  # radiant temperature ("Strahlungstemperatur")
 
     HEATING_DEGREE_DAY = "HEATING_DEGREE_DAY"  # This may be renamed/moved to the aggregated section
     COOLING_DEGREE_HOUR = "COOLING_DEGREE_HOUR"  # This may be renamed/moved to the aggregated section

--- a/src/wetterdienst/provider/dwd/observation/metadata.py
+++ b/src/wetterdienst/provider/dwd/observation/metadata.py
@@ -313,6 +313,218 @@ DwdObservationMetadata = {
                         },
                     ],
                 },
+                # urban (Stadtklima) 10-minute datasets -- served from climate_urban/ (recent only);
+                # column codes carry the ``_st_`` (Stadt) infix.
+                {
+                    "name": "urban_temperature_air",
+                    "name_original": "urban_air_temperature",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "quality",
+                            "name_original": "qn",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "tt_st_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {"name": "humidity", "name_original": "rf_st_10", "unit_type": "fraction", "unit": "percent"},
+                        {
+                            # "Strahlungstemperatur" -- radiant temperature at 2 m
+                            "name": "temperature_radiant_mean_2m",
+                            "name_original": "strahl_st_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_mean_0_05m",
+                            "name_original": "tt5_st_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                    ],
+                },
+                {
+                    "name": "urban_temperature_extreme",
+                    "name_original": "urban_extreme_temperature",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "quality",
+                            "name_original": "qn",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "temperature_air_max_2m",
+                            "name_original": "tx_st_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_min_2m",
+                            "name_original": "tn_st_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_air_min_0_05m",
+                            "name_original": "tn5_st_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                    ],
+                },
+                {
+                    "name": "urban_wind_extreme",
+                    "name_original": "urban_extreme_wind",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "quality",
+                            "name_original": "qn",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "wind_gust_max",
+                            "name_original": "fx_st_10",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                    ],
+                },
+                {
+                    "name": "urban_precipitation",
+                    "name_original": "urban_precipitation",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "quality",
+                            "name_original": "qn",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "precipitation_height",
+                            "name_original": "rr_st_10",
+                            "unit_type": "precipitation",
+                            "unit": "millimeter",
+                        },
+                    ],
+                },
+                {
+                    "name": "urban_pressure",
+                    "name_original": "urban_pressure",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "quality",
+                            "name_original": "qn",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "pressure_air_sea_level",
+                            "name_original": "pp_st_10",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                        {
+                            "name": "pressure_air_site",
+                            "name_original": "p0_st_10",
+                            "unit_type": "pressure",
+                            "unit": "hectopascal",
+                        },
+                    ],
+                },
+                {
+                    "name": "urban_temperature_soil",
+                    "name_original": "urban_soil_temperature",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "quality",
+                            "name_original": "qn",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "temperature_soil_mean_0_1m",
+                            "name_original": "te_st_01m_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_soil_mean_0_2m",
+                            "name_original": "te_st_02m_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_soil_mean_0_5m",
+                            "name_original": "te_st_05m_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "temperature_soil_mean_1m",
+                            "name_original": "te_st_10m_10",
+                            "unit_type": "temperature",
+                            "unit": "degree_celsius",
+                        },
+                    ],
+                },
+                {
+                    "name": "urban_solar",
+                    "name_original": "urban_solar",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "quality",
+                            "name_original": "qn",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "radiation_global",
+                            "name_original": "fg_st_10",
+                            "unit_type": "energy_per_area",
+                            "unit": "joule_per_square_centimeter",
+                        },
+                        # urban sunshine duration is reported in minutes (the non-urban solar sd_10 is hours)
+                        {
+                            "name": "sunshine_duration",
+                            "name_original": "sd_st_10",
+                            "unit_type": "time",
+                            "unit": "minute",
+                        },
+                    ],
+                },
+                {
+                    "name": "urban_wind",
+                    "name_original": "urban_wind",
+                    "grouped": True,
+                    "parameters": [
+                        {
+                            "name": "quality",
+                            "name_original": "qn",
+                            "unit_type": "dimensionless",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "wind_speed",
+                            "name_original": "ff_st_10",
+                            "unit_type": "speed",
+                            "unit": "meter_per_second",
+                        },
+                        {"name": "wind_direction", "name_original": "dd_st_10", "unit_type": "angle", "unit": "degree"},
+                    ],
+                },
             ],
         },
         {
@@ -1964,6 +2176,14 @@ DwdObservationMetadata = {
 DwdObservationMetadata = build_metadata_model(DwdObservationMetadata, "DwdObservationMetadata")
 
 DWD_URBAN_DATASETS = [
+    DwdObservationMetadata.minute_10.urban_temperature_air,
+    DwdObservationMetadata.minute_10.urban_temperature_extreme,
+    DwdObservationMetadata.minute_10.urban_wind_extreme,
+    DwdObservationMetadata.minute_10.urban_precipitation,
+    DwdObservationMetadata.minute_10.urban_pressure,
+    DwdObservationMetadata.minute_10.urban_temperature_soil,
+    DwdObservationMetadata.minute_10.urban_solar,
+    DwdObservationMetadata.minute_10.urban_wind,
     DwdObservationMetadata.hourly.urban_precipitation,
     DwdObservationMetadata.hourly.urban_pressure,
     DwdObservationMetadata.hourly.urban_sun,

--- a/src/wetterdienst/provider/dwd/observation/metaindex.py
+++ b/src/wetterdienst/provider/dwd/observation/metaindex.py
@@ -55,7 +55,10 @@ def create_meta_index_for_climate_observations(
     elif cond2:
         meta_index = _create_meta_index_for_subdaily_extreme_wind(period, settings)
     elif cond3:
-        meta_index = _create_meta_index_for_climate_observations(dataset, Period.RECENT, settings)
+        # The climate_urban station lists frequently leave optional fields (von_datum, bis_datum,
+        # Bundesland, Abgabe) blank, so whitespace-splitting misaligns the columns -- the urban path
+        # locates fields by their content instead (see _read_meta_df_urban). Urban data is recent-only.
+        meta_index = _create_meta_index_for_climate_observations(dataset, Period.RECENT, settings, urban=True)
     else:
         meta_index = _create_meta_index_for_climate_observations(dataset, period, settings)
     # If no state column available, take state information from daily historical
@@ -76,8 +79,10 @@ def create_meta_index_for_climate_observations(
         pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
         pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
         "station_id",
-        pl.col("start_date").str.to_datetime("%Y%m%d", time_zone="UTC"),
-        pl.col("end_date").str.to_datetime("%Y%m%d", time_zone="UTC"),
+        # strict=False keeps blank optional dates (present in the climate_urban lists) as null
+        # instead of raising; the well-formed non-urban lists are unaffected.
+        pl.col("start_date").str.to_datetime("%Y%m%d", time_zone="UTC", strict=False),
+        pl.col("end_date").str.to_datetime("%Y%m%d", time_zone="UTC", strict=False),
         pl.col("height").cast(pl.Float64),
         pl.col("latitude").cast(pl.Float64),
         pl.col("longitude").cast(pl.Float64),
@@ -90,6 +95,8 @@ def _create_meta_index_for_climate_observations(
     dataset: DatasetModel,
     period: Period,
     settings: Settings,
+    *,
+    urban: bool = False,
 ) -> pl.LazyFrame:
     """Create metadata DataFrame for climate observations."""
     url = _build_url_from_dataset_and_period(dataset, period)
@@ -116,13 +123,15 @@ def _create_meta_index_for_climate_observations(
         use_certifi=settings.use_certifi,
     )
     file.raise_if_exception()
-    return _read_meta_df(file)
+    return _read_meta_df(file, urban=urban)
 
 
-def _read_meta_df(file: File) -> pl.LazyFrame:
+def _read_meta_df(file: File, *, urban: bool = False) -> pl.LazyFrame:
     """Read meta file into DataFrame."""
     if isinstance(file.content, Exception):
         return pl.LazyFrame()
+    if urban:
+        return _read_meta_df_urban(file.content.readlines())
     lines = file.content.readlines()[2:]
     first = lines[0].decode("latin-1")
     if first.startswith("SP"):
@@ -157,6 +166,48 @@ def _create_csv_line(columns: list[str]) -> str:
     if "," in station_name:
         columns[-2] = f'"{station_name}"'
     return ",".join(columns)
+
+
+def _read_meta_df_urban(raw_lines: list[bytes]) -> pl.LazyFrame:
+    """Read a climate_urban station-description file into a DataFrame.
+
+    These lists carry the standard header (Stations_id, von_datum, bis_datum, Stationshoehe,
+    geoBreite, geoLaenge, Stationsname, Bundesland[, Abgabe]) but frequently leave the optional
+    von_datum/bis_datum (and, for the 10-minute lists, the trailing Bundesland/Abgabe) fields
+    blank. Whitespace-splitting then yields a varying number of tokens, so the fields are located
+    by their content instead: latitude and longitude are the first two decimal tokens, the height
+    is the token before them, and any 8-digit tokens ahead of the height are the dates. Station and
+    Bundesland names in these lists are single hyphenated tokens (e.g. "Freiburg-Mitte",
+    "Baden-Wuerttemberg"), so the token right after longitude is the name and the remainder (if
+    present, and after dropping a trailing "Frei" Abgabe marker) is the state.
+    """
+    records = []
+    for raw in raw_lines[2:]:
+        line = raw.decode("latin-1")
+        if not line.strip():
+            continue
+        tokens = line.split()
+        decimals = [i for i, token in enumerate(tokens) if "." in token]
+        lat_idx, lon_idx = decimals[0], decimals[1]
+        height_idx = lat_idx - 1
+        dates = [token for token in tokens[1:height_idx] if len(token) == 8 and token.isdigit()]
+        trailing = tokens[lon_idx + 1 :]
+        if trailing and trailing[-1] == "Frei":
+            trailing = trailing[:-1]
+        records.append(
+            {
+                "station_id": tokens[0],
+                "start_date": dates[0] if dates else "",
+                "end_date": dates[1] if len(dates) > 1 else "",
+                "height": tokens[height_idx],
+                "latitude": tokens[lat_idx],
+                "longitude": tokens[lon_idx],
+                "name": trailing[0] if trailing else "",
+                "state": " ".join(trailing[1:]),
+            }
+        )
+    columns = ("station_id", "start_date", "end_date", "height", "latitude", "longitude", "name", "state")
+    return pl.DataFrame(records, schema=dict.fromkeys(columns, pl.String)).lazy()
 
 
 def _create_meta_index_for_subdaily_extreme_wind(period: Period, settings: Settings) -> pl.LazyFrame:

--- a/src/wetterdienst/provider/dwd/observation/metaindex.py
+++ b/src/wetterdienst/provider/dwd/observation/metaindex.py
@@ -13,7 +13,7 @@ from zoneinfo import ZoneInfo
 import polars as pl
 from fsspec.implementations.zip import ZipFileSystem
 
-from wetterdienst.exceptions import MetaFileNotFoundError
+from wetterdienst.exceptions import MetaFileFormatError, MetaFileNotFoundError
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.period import Period
 from wetterdienst.provider.dwd.observation.fileindex import (
@@ -75,14 +75,16 @@ def create_meta_index_for_climate_observations(
             how="left",
         )
     meta_index = meta_index.sort(by=["station_id"])
+    # The climate_urban lists frequently leave von_datum/bis_datum blank; parse those leniently so
+    # blanks become null instead of raising. The well-formed non-urban lists keep strict parsing so a
+    # malformed date still fails loudly.
+    strict_dates = not cond3
     return meta_index.select(
         pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),
         pl.lit(dataset.name, dtype=pl.String).alias("dataset"),
         "station_id",
-        # strict=False keeps blank optional dates (present in the climate_urban lists) as null
-        # instead of raising; the well-formed non-urban lists are unaffected.
-        pl.col("start_date").str.to_datetime("%Y%m%d", time_zone="UTC", strict=False),
-        pl.col("end_date").str.to_datetime("%Y%m%d", time_zone="UTC", strict=False),
+        pl.col("start_date").str.to_datetime("%Y%m%d", time_zone="UTC", strict=strict_dates),
+        pl.col("end_date").str.to_datetime("%Y%m%d", time_zone="UTC", strict=strict_dates),
         pl.col("height").cast(pl.Float64),
         pl.col("latitude").cast(pl.Float64),
         pl.col("longitude").cast(pl.Float64),
@@ -180,6 +182,10 @@ def _read_meta_df_urban(raw_lines: list[bytes]) -> pl.LazyFrame:
     Bundesland names in these lists are single hyphenated tokens (e.g. "Freiburg-Mitte",
     "Baden-Wuerttemberg"), so the token right after longitude is the name and the remainder (if
     present, and after dropping a trailing "Frei" Abgabe marker) is the state.
+
+    Raises MetaFileFormatError if a row does not match these content assumptions (fewer than two
+    decimal tokens, or a decimal-valued height) so a changed DWD layout fails loudly instead of
+    silently shifting every field.
     """
     records = []
     for raw in raw_lines[2:]:
@@ -188,8 +194,14 @@ def _read_meta_df_urban(raw_lines: list[bytes]) -> pl.LazyFrame:
             continue
         tokens = line.split()
         decimals = [i for i, token in enumerate(tokens) if "." in token]
+        if len(decimals) < 2:
+            msg = f"Expected latitude and longitude as decimal tokens in climate_urban station row: {line!r}"
+            raise MetaFileFormatError(msg)
         lat_idx, lon_idx = decimals[0], decimals[1]
         height_idx = lat_idx - 1
+        if height_idx < 1 or "." in tokens[height_idx]:
+            msg = f"Expected an integer height before the coordinates in climate_urban station row: {line!r}"
+            raise MetaFileFormatError(msg)
         dates = [token for token in tokens[1:height_idx] if len(token) == 8 and token.isdigit()]
         trailing = tokens[lon_idx + 1 :]
         if trailing and trailing[-1] == "Frei":

--- a/tests/provider/dwd/observation/test_metaindex.py
+++ b/tests/provider/dwd/observation/test_metaindex.py
@@ -10,7 +10,7 @@ import polars as pl
 import pytest
 
 from wetterdienst import Settings
-from wetterdienst.exceptions import MetaFileNotFoundError
+from wetterdienst.exceptions import MetaFileFormatError, MetaFileNotFoundError
 from wetterdienst.metadata.period import Period
 from wetterdienst.provider.dwd.observation.api import DwdObservationRequest
 from wetterdienst.provider.dwd.observation.metadata import DwdObservationMetadata
@@ -124,6 +124,20 @@ def test_read_meta_df_urban() -> None:
         ("00399", "20040701", "20260724", "100", "52.5447", "13.4046", "Berlin-Alexanderplatz", ""),
         ("13667", "20080101", "20260724", "269", "48.0006", "7.8342", "Freiburg-Mitte", "Baden-Wuerttemberg"),
     ]
+
+
+def test_read_meta_df_urban_rejects_malformed_rows() -> None:
+    """A row that breaks the content assumptions fails loudly instead of shifting every field."""
+    header = [
+        b"Stations_id von_datum bis_datum Stationshoehe geoBreite geoLaenge Stationsname Bundesland\n",
+        b"----------- --------- --------- ------------- --------- --------- ----------- ----------\n",
+    ]
+    # fewer than two decimal tokens (truncated coordinates)
+    with pytest.raises(MetaFileFormatError):
+        _read_meta_df_urban([*header, b"13667 269 48.0006 Freiburg-Mitte\n"]).collect()
+    # a decimal-valued height would otherwise be mis-read as latitude
+    with pytest.raises(MetaFileFormatError):
+        _read_meta_df_urban([*header, b"13667 269.5 48.0006 7.8342 Freiburg-Mitte\n"]).collect()
 
 
 def test_missing_meta_file_skipped(default_settings: Settings) -> None:

--- a/tests/provider/dwd/observation/test_metaindex.py
+++ b/tests/provider/dwd/observation/test_metaindex.py
@@ -16,6 +16,7 @@ from wetterdienst.provider.dwd.observation.api import DwdObservationRequest
 from wetterdienst.provider.dwd.observation.metadata import DwdObservationMetadata
 from wetterdienst.provider.dwd.observation.metaindex import (
     _create_csv_line,
+    _read_meta_df_urban,
     create_meta_index_for_climate_observations,
 )
 
@@ -96,6 +97,33 @@ def test_create_csv_line() -> None:
         )
         == """01332,19660701,20240514,471,48.4832,12.7241,"Falkenberg,Kr.Rottal-Inn",Bayern"""
     )
+
+
+def test_read_meta_df_urban() -> None:
+    """climate_urban station lists are parsed by content, tolerating blank date/state fields.
+
+    The two leading lines are the header and its dashes ruler and are dropped. Data rows vary in
+    token count because von_datum/bis_datum and (for the 10-minute lists) the trailing
+    Bundesland/Abgabe fields are frequently left blank.
+    """
+    raw_lines = [
+        b"Stations_id von_datum bis_datum Stationshoehe geoBreite geoLaenge Stationsname Bundesland Abgabe\n",
+        b"----------- --------- --------- ------------- --------- --------- ----------- ---------- ------\n",
+        # 10-minute row: blank dates and blank state
+        b"13667 269 48.0006 7.8342 Freiburg-Mitte\n",
+        # dates present, state still blank
+        b"00399 20040701 20260724 100 52.5447 13.4046 Berlin-Alexanderplatz\n",
+        # full hourly row: dates, state and a trailing "Frei" Abgabe marker
+        b"13667 20080101 20260724 269 48.0006 7.8342 Freiburg-Mitte Baden-Wuerttemberg Frei\n",
+        # blank line is skipped
+        b"\n",
+    ]
+    df = _read_meta_df_urban(raw_lines).collect()
+    assert df.rows() == [
+        ("13667", "", "", "269", "48.0006", "7.8342", "Freiburg-Mitte", ""),
+        ("00399", "20040701", "20260724", "100", "52.5447", "13.4046", "Berlin-Alexanderplatz", ""),
+        ("13667", "20080101", "20260724", "269", "48.0006", "7.8342", "Freiburg-Mitte", "Baden-Wuerttemberg"),
+    ]
 
 
 def test_missing_meta_file_skipped(default_settings: Settings) -> None:


### PR DESCRIPTION
## Summary

Adds DWD's **climate_urban (Stadtklima) 10-minute** datasets to the `dwd`/`observation` network, complementing the existing hourly urban datasets. Served from DWD's `climate_urban/` path (recent period only):

- `urban_precipitation`
- `urban_pressure`
- `urban_solar`
- `urban_temperature_air` (incl. the new `temperature_radiant_mean_2m` parameter)
- `urban_temperature_extreme`
- `urban_temperature_soil`
- `urban_wind`
- `urban_wind_extreme`

Introduces the canonical parameter `temperature_radiant_mean_2m` ("Strahlungstemperatur"), mapped from `strahl_st_10`.

## Parsing note

The urban station-description lists frequently leave optional fields (`von_datum`, `bis_datum`, `Bundesland`, `Abgabe`) blank, which misaligns the whitespace split used for the regular lists (e.g. it produced `str -> datetime` crashes on `urban_pressure`). This PR adds a dedicated content-based parser (`_read_meta_df_urban`) routed **only** through the urban path — locating fields by content (decimal lat/lon, height, 8-digit dates) — and parses dates with `strict=False` so blank optional dates become null. The existing split parser is unchanged for all non-urban files.

## Tests

- New unit test `test_read_meta_df_urban` covering blank-date/blank-state 10-min rows, dated rows, and full hourly rows with a trailing "Frei" marker.
- All 8 datasets verified end-to-end against live DWD data (stations + values).
- Green: ruff, `ty` typecheck, `test_metadata_parameter_names`/`test_metadata_units`, `test_metaindex.py`, `test_data_coverage`, restapi `test_coverage`.

Docs (`10_minutes.md`) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)