### PR TITLE
ci: install the mcp extra in the testing job so fastmcp tests run

### DIFF
--- a/.github/workflows/install.sh
+++ b/.github/workflows/install.sh
@@ -13,7 +13,7 @@ set -e
 set -x
 
 if [ "${flavor}" = "testing" ]; then
-  uv sync --active --extra bufr --extra export --extra influxdb --extra interpolation --extra knmi --extra pdf --extra plotting --extra radar --extra radarplus --extra restapi --extra sql
+  uv sync --active --extra bufr --extra export --extra influxdb --extra interpolation --extra knmi --extra mcp --extra pdf --extra plotting --extra radar --extra radarplus --extra restapi --extra sql
 
 elif [ "${flavor}" = "docs" ]; then
   uv sync --active --extra interpolation --extra radar --extra radarplus --group docs


### PR DESCRIPTION
## Problem

The fastmcp-guarded tests in `tests/ui/test_restapi.py` — the `/mcp` endpoint mount, initialize handshake, agent-friendliness check, and the MCP output-schema validation tests — never actually run in CI. They all guard with `pytest.importorskip("fastmcp")` / `pytest.skip("fastmcp not installed")`, and `fastmcp` only ships in the optional **`mcp`** extra (`pyproject.toml`).

The Tests job installs dependencies via `.github/workflows/install.sh testing`, whose extras list omitted `mcp`:

```
--extra bufr --extra export --extra influxdb --extra interpolation --extra knmi
--extra pdf --extra plotting --extra radar --extra radarplus --extra restapi --extra sql
```

So `fastmcp` was never installed and every MCP test silently self-skipped — despite recent MCP work (the values/interpolate/summarize output-schema fixes in the last releases).

## Fix

Add `--extra mcp` to the `testing` flavor of `install.sh` so the MCP tests execute in CI.

## Verification

Installed the `mcp` extra locally and confirmed the previously-skipped tests pass:

```
tests/ui/test_restapi.py::test_mcp_endpoint_mounted PASSED
tests/ui/test_restapi.py::test_mcp_index_link PASSED
tests/ui/test_restapi.py::test_mcp_initialize_handshake PASSED
tests/ui/test_restapi.py::test_mcp_server_is_agent_friendly PASSED
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)