### PR TITLE
ci: pass WD_AUTH__CEDA into tests and coverage workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,7 @@ env:
   WD_AUTH__METNO_FROST: ${{ secrets.WD_AUTH__METNO_FROST }}
   WD_AUTH__AEMET: ${{ secrets.WD_AUTH__AEMET }}
   WD_AUTH__KNMI: ${{ secrets.WD_AUTH__KNMI }}
+  WD_AUTH__CEDA: ${{ secrets.WD_AUTH__CEDA }}
 
 permissions: {}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,6 +43,7 @@ jobs:
       WD_AUTH__METNO_FROST: ${{ secrets.WD_AUTH__METNO_FROST }}
       WD_AUTH__AEMET: ${{ secrets.WD_AUTH__AEMET }}
       WD_AUTH__KNMI: ${{ secrets.WD_AUTH__KNMI }}
+      WD_AUTH__CEDA: ${{ secrets.WD_AUTH__CEDA }}
 
     defaults:
       run:


### PR DESCRIPTION
## Summary

Wires the new `WD_AUTH__CEDA` repository secret into the `tests.yml` and `coverage.yml` workflow `env` blocks, alongside the existing `WD_AUTH__{METNO_FROST,AEMET,KNMI}` credentials.

This lets the credential-gated **Met Office (MIDAS Open / CEDA)** remote tests authenticate and run in CI — they currently `skipif` when `WD_AUTH__CEDA` is unset.

The `WD_AUTH__CEDA` secret has already been created in the repository settings (value not shown here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)