### PR TITLE
ci: remove duplicate macOS runner from test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,6 @@ jobs:
         include:
           - os: "windows-latest"
             python-version: "3.14"
-          - os: "macos-latest" # arm64 (Apple Silicon, macOS 15)
-            python-version: "3.14"
           - os: "macos-15-intel" # x86_64 (Intel, macOS 15)
             python-version: "3.14"
           - os: "macos-26" # arm64 (Apple Silicon, macOS 26 Tahoe)


### PR DESCRIPTION
## Summary

`macos-latest` now resolves to **macos-26 (arm64)** on GitHub-hosted runners, which makes it an exact duplicate of the explicit `macos-26` entry already in the test matrix — the same arm64/macOS-26 job was being run twice. This removes the redundant `macos-latest` entry.

The matrix keeps distinct macOS coverage:
- `macos-15-intel` — x86_64 (Intel, macOS 15)
- `macos-26` — arm64 (Apple Silicon, macOS 26 Tahoe)
- `macos-26-intel` — x86_64 (Intel, macOS 26 Tahoe)

The stale `# arm64 (Apple Silicon, macOS 15)` comment on the old `macos-latest` line (inaccurate since the runner migrated to macOS 26) is removed along with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)