### PR TITLE
fix: return irradiance in W/m² rather than W/cm²

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ Types of changes:
 
 ### Changed
 
+- **Breaking**: irradiance (`power_per_area`) is now returned in W/m² rather than W/cm², so
+  affected values are 10⁴ times larger. W/m² is what WMO specifies and what every source in this
+  library actually publishes — MeteoSwiss global radiation now reads 0–1344 W/m² where it used to
+  read 0–0.1344 W/cm². Affects the 17 declarations using `power_per_area`: KNMI (10 minutes),
+  MeteoSwiss, met.no Frost and RMI. Set `ts_unit_targets={"power_per_area":
+  "watt_per_square_centimeter"}` to keep the old output. Irradiation (`energy_per_area`) is
+  unchanged and still returned in J/cm², which is the conventional unit for it
 - Raise several dependency floors that were declared lower than what the code actually needs:
   `aiohttp>=3.14.0` (`encode_basic_auth`), `stamina>=25.1.0` (`set_testing` as a context manager),
   `pandas>=2.2.2`, `shapely>=2.0.4` and `h5py>=3.11` (NumPy 2 support),

--- a/src/wetterdienst/model/unit.py
+++ b/src/wetterdienst/model/unit.py
@@ -131,7 +131,8 @@ class UnitConverter:
             "conductivity": self.units["conductivity"][3],
             "dimensionless": self.units["dimensionless"][0],
             "energy_per_area": self.units["energy_per_area"][0],
-            "power_per_area": self.units["power_per_area"][0],
+            # W/m² is what every source publishes irradiance in, and what WMO specifies
+            "power_per_area": self.units["power_per_area"][1],
             "length_short": self.units["length_short"][1],
             "length_medium": self.units["length_medium"][2],
             "length_long": self.units["length_long"][3],

--- a/tests/model/test_unit.py
+++ b/tests/model/test_unit.py
@@ -27,7 +27,7 @@ def test_unit_converter_targets_defaults(unit_converter: UnitConverter) -> None:
         "length_medium": "meter",
         "length_long": "kilometer",
         "magnetic_field_intensity": "magnetic_field_strength",
-        "power_per_area": "watt_per_square_centimeter",
+        "power_per_area": "watt_per_square_meter",
         "precipitation": "millimeter",
         "precipitation_intensity": "millimeter_per_hour",
         "pressure": "hectopascal",


### PR DESCRIPTION
## What

`UnitConverter.targets["power_per_area"]` was `watt_per_square_centimeter`:

```python
"power_per_area": self.units["power_per_area"][0],
```

Nothing chose W/cm² — it is simply what index `0` happened to be in the list. Every other target in that dict picks a deliberate index (`length_medium` takes `[2]`, `pressure` takes `[1]`, `conductivity` takes `[3]`); this one inherited the default and nobody noticed.

W/m² is what WMO specifies for irradiance and what **every source in this library actually publishes** (KNMI `qg`, MeteoSwiss `gre000z0`, Geosphere `cglo`, met.no, RMI — all W/m²). So the default made every affected value read 10⁴ too small.

Verified against live data — MeteoSwiss Bern, 10-minute global radiation, 1.18M non-null readings:

| | min | max | mean |
| --- | --- | --- | --- |
| before (W/cm²) | 0.0 | 0.1344 | 0.015 |
| after (W/m²) | 0.0 | 1344.0 | 150.2 |

0–1344 W/m² is the physically expected range for global irradiance (clear-sky peak ~1000–1200, higher under cloud enhancement). The old numbers were correct but unreadable.

## ⚠️ Breaking

Irradiance values are **10⁴ times larger**. This affects the 17 `power_per_area` declarations across **KNMI (10 minutes), MeteoSwiss, met.no Frost and RMI**.

Anyone depending on the old output can restore it per-request:

```python
Settings(ts_unit_targets={"power_per_area": "watt_per_square_centimeter"})
```

(verified working — the unit is still in the list, only the default target moved)

Irradiation (`energy_per_area`) is **untouched** and still returns J/cm², which is the conventional unit for it and what DWD publishes. The two are different quantities; only the irradiance default was wrong.

## Scope

One line of behaviour plus its test. No provider metadata changes: the sources' own declared units were already correct, and this only changes what they are converted *to*.

## Testing

- `tests/model` + `tests/test_api.py` — 239 passed
- No provider test asserts on radiation values for the four affected providers (checked)
- `lint`, `typecheck` clean
- End-to-end fetch against live MeteoSwiss, as above

## Context

Split out of #1800 deliberately. That PR renames irradiance parameters to `radiation_*_intensity`; this one fixes what unit they come back in. They are independent — the affected declarations already used `power_per_area` before #1800 — and keeping the unit change separate makes both reviewable.

It is also a prerequisite for removing Geosphere's in-parser W/m² → J/cm² conversion (`provider/geosphere/observation/api.py:119`, the only in-parser unit conversion in the tree). Removing that *before* this fix would have briefly shipped Geosphere radiation in W/cm², which is worse than either end state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
