### PR TITLE
fix(geosphere): return sub-daily radiation as published, in W/m²

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Types of changes:
   `radiation_global` and `radiation_sky_short_wave_diffuse` names. That conversion is removed and
   the three declarations moved to `radiation_global_intensity` and
   `radiation_sky_short_wave_diffuse_intensity` in W/m². Values are correspondingly 16.67× (10
-  minutes) and 2.78× (hourly) larger; divide by 0.06 and 0.36 respectively to recover the old
+  minutes) and 2.78× (hourly) larger; multiply by 0.06 and 0.36 respectively to recover the old
   numbers. Daily and monthly are unaffected — they use `cglo_j`, a distinct upstream parameter
   genuinely accumulated over the interval, and keep `radiation_global` in J/cm². This was the only
   in-parser unit conversion left in the library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ Types of changes:
   hourly and daily `Q` is J/cm², so one name was covering two quantities that no unit conversion
   relates without the accumulation interval. Queries using the old names against these providers
   need to switch to the `_intensity` names; DWD and every other provider are unaffected
+- **Breaking**: Geosphere 10-minute and hourly radiation is now returned as published rather than
+  silently rescaled. `cglo` and `chim` are irradiance in W/m², but the parser multiplied them by
+  the interval length (600/10000 and 3600/10000) to present them as irradiation in J/cm² under the
+  `radiation_global` and `radiation_sky_short_wave_diffuse` names. That conversion is removed and
+  the three declarations moved to `radiation_global_intensity` and
+  `radiation_sky_short_wave_diffuse_intensity` in W/m². Values are correspondingly 16.67× (10
+  minutes) and 2.78× (hourly) larger; divide by 0.06 and 0.36 respectively to recover the old
+  numbers. Daily and monthly are unaffected — they use `cglo_j`, a distinct upstream parameter
+  genuinely accumulated over the interval, and keep `radiation_global` in J/cm². This was the only
+  in-parser unit conversion left in the library
 - **Breaking**: Météo-France synop `visibility_range` was the only declaration of that parameter
   using `length_long`, so it was returned in km while all 15 other declarations return m. It now
   uses `length_medium` and returns m

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -21,8 +21,8 @@ Types of changes:
 - `[All pages]` Glossary labels for the new `radiation_global_intensity`,
   `radiation_sky_long_wave_intensity` and `radiation_sky_short_wave_diffuse_intensity` parameters,
   which the backend introduced for sources reporting irradiance (W/m²) rather than irradiation
-  accumulated over the interval (J/cm²). Affects KNMI (10 minutes), MeteoSwiss, met.no and RMI,
-  whose radiation parameters are served under the new names.
+  accumulated over the interval (J/cm²). Affects KNMI (10 minutes), MeteoSwiss, met.no, RMI and
+  Geosphere (10 minutes and hourly), whose radiation parameters are served under the new names.
 
 ## [0.12.1] - 2026-08-02
 

--- a/docs/data/provider/geosphere/observation/10_minutes.md
+++ b/docs/data/provider/geosphere/observation/10_minutes.md
@@ -23,28 +23,28 @@
 
 #### parameters
 
-| name                                     | original name | description                      | unit  | constraints |
-|------------------------------------------|---------------|----------------------------------|-------|-------------|
-| {term}`humidity`                         | rf            | relative humidity                | %     | >=0,<=100   |
-| {term}`precipitation_duration`           | rrm           | precipitation duration           | min   | >=0         |
-| {term}`precipitation_height`             | rr            | precipitation height             | mm    | >=0         |
-| {term}`pressure_air_site`                | p             | air pressure at site             | hPa   | >=0         |
-| {term}`pressure_air_sea_level`           | pred          | air pressure at sea level        | hPa   | >=0         |
-| {term}`radiation_global`                 | cglo          | global radiation                 | J/cm² | >=0         |
-| {term}`radiation_sky_short_wave_diffuse` | chim          | sky short wave diffuse radiation | J/cm² | >=0         |
-| {term}`snow_depth`                       | sh            | snow depth                       | cm    | >=0         |
-| {term}`sunshine_duration`                | so            | sunshine duration                | s     | >=0         |
-| {term}`temperature_air_max_0_05m`        | tsmax         | air temperature max at 0.05m     | °C    | -           |
-| {term}`temperature_air_max_2m`           | tlmax         | air temperature max at 2m        | °C    | -           |
-| {term}`temperature_air_mean_0_05m`       | ts            | air temperature mean at 0.05m    | °C    | -           |
-| {term}`temperature_air_mean_2m`          | tl            | air temperature mean at 2m       | °C    | -           |
-| {term}`temperature_air_min_0_05m`        | tsmin         | air temperature min at 0.05m     | °C    | -           |
-| {term}`temperature_air_min_2m`           | tlmin         | air temperature min at 2m        | °C    | -           |
-| {term}`temperature_soil_mean_0_1m`       | tb10          | soil temperature mean at 0.1m    | °C    | -           |
-| {term}`temperature_soil_mean_0_2m`       | tb20          | soil temperature mean at 0.2m    | °C    | -           |
-| {term}`temperature_soil_mean_0_5m`       | tb50          | soil temperature mean at 0.5m    | °C    | -           |
-| {term}`wind_direction`                   | dd            | wind direction                   | °     | >=0,<=360   |
-| {term}`wind_direction_gust_max`          | ddx           | wind direction gust max          | °     | >=0,<=360   |
-| {term}`wind_gust_max`                    | ffx           | wind gust max                    | m/s   | >=0         |
-| {term}`wind_speed`                       | ff            | wind speed                       | m/s   | >=0         |
-| {term}`wind_speed_arithmetic`            | ffam          | arithmetic mean of wind speed    | m/s   | >=0         |
+| name                                               | original name | description                      | unit | constraints |
+|----------------------------------------------------|---------------|----------------------------------|------|-------------|
+| {term}`humidity`                                   | rf            | relative humidity                | %    | >=0,<=100   |
+| {term}`precipitation_duration`                     | rrm           | precipitation duration           | min  | >=0         |
+| {term}`precipitation_height`                       | rr            | precipitation height             | mm   | >=0         |
+| {term}`pressure_air_site`                          | p             | air pressure at site             | hPa  | >=0         |
+| {term}`pressure_air_sea_level`                     | pred          | air pressure at sea level        | hPa  | >=0         |
+| {term}`radiation_global_intensity`                 | cglo          | global radiation                 | W/m² | >=0         |
+| {term}`radiation_sky_short_wave_diffuse_intensity` | chim          | sky short wave diffuse radiation | W/m² | >=0         |
+| {term}`snow_depth`                                 | sh            | snow depth                       | cm   | >=0         |
+| {term}`sunshine_duration`                          | so            | sunshine duration                | s    | >=0         |
+| {term}`temperature_air_max_0_05m`                  | tsmax         | air temperature max at 0.05m     | °C   | -           |
+| {term}`temperature_air_max_2m`                     | tlmax         | air temperature max at 2m        | °C   | -           |
+| {term}`temperature_air_mean_0_05m`                 | ts            | air temperature mean at 0.05m    | °C   | -           |
+| {term}`temperature_air_mean_2m`                    | tl            | air temperature mean at 2m       | °C   | -           |
+| {term}`temperature_air_min_0_05m`                  | tsmin         | air temperature min at 0.05m     | °C   | -           |
+| {term}`temperature_air_min_2m`                     | tlmin         | air temperature min at 2m        | °C   | -           |
+| {term}`temperature_soil_mean_0_1m`                 | tb10          | soil temperature mean at 0.1m    | °C   | -           |
+| {term}`temperature_soil_mean_0_2m`                 | tb20          | soil temperature mean at 0.2m    | °C   | -           |
+| {term}`temperature_soil_mean_0_5m`                 | tb50          | soil temperature mean at 0.5m    | °C   | -           |
+| {term}`wind_direction`                             | dd            | wind direction                   | °    | >=0,<=360   |
+| {term}`wind_direction_gust_max`                    | ddx           | wind direction gust max          | °    | >=0,<=360   |
+| {term}`wind_gust_max`                              | ffx           | wind gust max                    | m/s  | >=0         |
+| {term}`wind_speed`                                 | ff            | wind speed                       | m/s  | >=0         |
+| {term}`wind_speed_arithmetic`                      | ffam          | arithmetic mean of wind speed    | m/s  | >=0         |

--- a/docs/data/provider/geosphere/observation/hourly.md
+++ b/docs/data/provider/geosphere/observation/hourly.md
@@ -23,24 +23,24 @@
 
 #### parameters
 
-| name                               | original name | description                   | unit  | constraints |
-|------------------------------------|---------------|-------------------------------|-------|-------------|
-| {term}`humidity`                   | rf            | relative humidity             | %     | >=0,<=100   |
-| {term}`precipitation_duration`     | rrm           | precipitation duration        | min   | >=0         |
-| {term}`precipitation_height`       | rr            | precipitation height          | mm    | >=0         |
-| {term}`pressure_air_site`          | p             | air pressure at site          | hPa   | >=0         |
-| {term}`pressure_air_sea_level`     | pred          | air pressure at sea level     | hPa   | >=0         |
-| {term}`radiation_global`           | cglo          | global radiation              | J/cm² | >=0         |
-| {term}`snow_depth`                 | sh            | snow depth                    | cm    | >=0         |
-| {term}`sunshine_duration`          | so_h          | sunshine duration             | h     | >=0         |
-| {term}`temperature_air_mean_2m`    | tl            | air temperature mean at 2m    | °C    | -           |
-| {term}`temperature_air_min_0_05m`  | tsmin         | air temperature min at 0.05m  | °C    | -           |
-| {term}`temperature_soil_mean_0_1m` | tb10          | soil temperature mean at 0.1m | °C    | -           |
-| {term}`temperature_soil_mean_0_2m` | tb20          | soil temperature mean at 0.2m | °C    | -           |
-| {term}`temperature_soil_mean_0_5m` | tb50          | soil temperature mean at 0.5m | °C    | -           |
-| {term}`temperature_soil_mean_1m`   | tb100         | soil temperature mean at 1m   | °C    | -           |
-| {term}`temperature_soil_mean_2m`   | tb200         | soil temperature mean at 2m   | °C    | -           |
-| {term}`wind_direction`             | dd            | wind direction                | °     | >=0,<=360   |
-| {term}`wind_direction_gust_max`    | ddx           | wind direction gust max       | °     | >=0,<=360   |
-| {term}`wind_gust_max`              | ffx           | wind gust max                 | m/s   | >=0         |
-| {term}`wind_speed`                 | ff            | wind speed                    | m/s   | >=0         |
+| name                               | original name | description                   | unit | constraints |
+|------------------------------------|---------------|-------------------------------|------|-------------|
+| {term}`humidity`                   | rf            | relative humidity             | %    | >=0,<=100   |
+| {term}`precipitation_duration`     | rrm           | precipitation duration        | min  | >=0         |
+| {term}`precipitation_height`       | rr            | precipitation height          | mm   | >=0         |
+| {term}`pressure_air_site`          | p             | air pressure at site          | hPa  | >=0         |
+| {term}`pressure_air_sea_level`     | pred          | air pressure at sea level     | hPa  | >=0         |
+| {term}`radiation_global_intensity` | cglo          | global radiation              | W/m² | >=0         |
+| {term}`snow_depth`                 | sh            | snow depth                    | cm   | >=0         |
+| {term}`sunshine_duration`          | so_h          | sunshine duration             | h    | >=0         |
+| {term}`temperature_air_mean_2m`    | tl            | air temperature mean at 2m    | °C   | -           |
+| {term}`temperature_air_min_0_05m`  | tsmin         | air temperature min at 0.05m  | °C   | -           |
+| {term}`temperature_soil_mean_0_1m` | tb10          | soil temperature mean at 0.1m | °C   | -           |
+| {term}`temperature_soil_mean_0_2m` | tb20          | soil temperature mean at 0.2m | °C   | -           |
+| {term}`temperature_soil_mean_0_5m` | tb50          | soil temperature mean at 0.5m | °C   | -           |
+| {term}`temperature_soil_mean_1m`   | tb100         | soil temperature mean at 1m   | °C   | -           |
+| {term}`temperature_soil_mean_2m`   | tb200         | soil temperature mean at 2m   | °C   | -           |
+| {term}`wind_direction`             | dd            | wind direction                | °    | >=0,<=360   |
+| {term}`wind_direction_gust_max`    | ddx           | wind direction gust max       | °    | >=0,<=360   |
+| {term}`wind_gust_max`              | ffx           | wind gust max                 | m/s  | >=0         |
+| {term}`wind_speed`                 | ff            | wind speed                    | m/s  | >=0         |

--- a/src/wetterdienst/provider/geosphere/observation/api.py
+++ b/src/wetterdienst/provider/geosphere/observation/api.py
@@ -116,21 +116,6 @@ class GeosphereObservationValues(TimeseriesValues):
             pl.col("value").struct.field("data").alias("value"),
         )
         df = df.explode("value", empty_as_null=True)
-        # adjust units for radiation parameters of 10 minute/hourly resolution from W / m² to J / cm²
-        if parameter_or_dataset.dataset.resolution.value == Resolution.MINUTE_10:
-            df = df.with_columns(
-                pl.when(pl.col("parameter").is_in(["cglo", "chim"]))
-                .then(pl.col("value") * 600 / 10000)
-                .otherwise(pl.col("value"))
-                .alias("value"),
-            )
-        elif parameter_or_dataset.dataset.resolution.value == Resolution.HOURLY:
-            df = df.with_columns(
-                pl.when(pl.col("parameter").eq("cglo"))
-                .then(pl.col("value") * 3600 / 10000)
-                .otherwise(pl.col("value"))
-                .alias("value"),
-            )
         return df.select(
             pl.lit(parameter_or_dataset.dataset.resolution.name, dtype=pl.String).alias("resolution"),
             pl.lit(parameter_or_dataset.dataset.name, dtype=pl.String).alias("dataset"),

--- a/src/wetterdienst/provider/geosphere/observation/metadata.py
+++ b/src/wetterdienst/provider/geosphere/observation/metadata.py
@@ -59,16 +59,16 @@ GeosphereObservationMetadata = {
                             "unit": "hectopascal",
                         },
                         {
-                            "name": "radiation_global",
+                            "name": "radiation_global_intensity",
                             "name_original": "cglo",
-                            "unit_type": "energy_per_area",
-                            "unit": "joule_per_square_centimeter",
+                            "unit_type": "power_per_area",
+                            "unit": "watt_per_square_meter",
                         },
                         {
-                            "name": "radiation_sky_short_wave_diffuse",
+                            "name": "radiation_sky_short_wave_diffuse_intensity",
                             "name_original": "chim",
-                            "unit_type": "energy_per_area",
-                            "unit": "joule_per_square_centimeter",
+                            "unit_type": "power_per_area",
+                            "unit": "watt_per_square_meter",
                         },
                         {
                             "name": "snow_depth",
@@ -212,10 +212,10 @@ GeosphereObservationMetadata = {
                             "unit": "hectopascal",
                         },
                         {
-                            "name": "radiation_global",
+                            "name": "radiation_global_intensity",
                             "name_original": "cglo",
-                            "unit_type": "energy_per_area",
-                            "unit": "joule_per_square_centimeter",
+                            "unit_type": "power_per_area",
+                            "unit": "watt_per_square_meter",
                         },
                         {
                             "name": "snow_depth",

--- a/tests/provider/geosphere/observation/test_api.py
+++ b/tests/provider/geosphere/observation/test_api.py
@@ -29,24 +29,30 @@ def test_geopshere_observation_api() -> None:
 
 @pytest.mark.remote
 @pytest.mark.parametrize(
-    "resolution",
+    ("resolution", "parameter", "expected"),
     [
-        "minute_10",
-        "hourly",
-        "daily",
+        # cglo, served as irradiance in W / m² and passed through unconverted
+        ("minute_10", "radiation_global_intensity", IsNumeric(ge=82770.0, le=82870.0)),
+        ("hourly", "radiation_global_intensity", IsNumeric(ge=13790.0, le=13815.0)),
+        # cglo_j, a distinct upstream parameter already accumulated over the day in J / cm²
+        ("daily", "radiation_global", IsNumeric(ge=4966.2000, le=4972.0000)),
     ],
 )
-def test_geopshere_observation_api_radiation(resolution: str) -> None:
-    """Test correct radiation conversion (W / m² -> J / cm²).
+def test_geopshere_observation_api_radiation(resolution: str, parameter: str, expected: IsNumeric) -> None:
+    """Test that radiation is reported in the unit the source publishes it in.
 
-    The factor should be 0.06.
+    Geosphere serves ``cglo`` as irradiance (W / m²) at 10 minutes and hourly, and ``cglo_j`` as
+    irradiation accumulated over the interval (J / cm²) at daily and monthly. The sub-daily values used
+    to be multiplied by the interval length in the parser to make them look like the daily ones; they
+    now keep their own unit and canonical name instead. The expected sums are equivalent to the former
+    J / cm² ones scaled by that interval: 82851 * 0.06 and 13795 * 0.36 both land in the daily range.
     """
     stations_at = GeosphereObservationRequest(
-        parameters=[(resolution, "data", "radiation_global")],
+        parameters=[(resolution, "data", parameter)],
         start_date=datetime(2022, 6, 1, tzinfo=ZoneInfo("UTC")),
         end_date=datetime(2022, 6, 2, hour=23, minute=50, tzinfo=ZoneInfo("UTC")),
     )
     station_at = stations_at.filter_by_station_id("4821")
     df = station_at.values.all().df
     # the result is slightly different for each resolution
-    assert df.get_column("value").sum() == IsNumeric(ge=4966.2000, le=4972.0000)
+    assert df.get_column("value").sum() == expected

--- a/tests/provider/geosphere/observation/test_api.py
+++ b/tests/provider/geosphere/observation/test_api.py
@@ -12,7 +12,7 @@ from wetterdienst.provider.geosphere.observation import GeosphereObservationRequ
 
 
 @pytest.mark.remote
-def test_geopshere_observation_api() -> None:
+def test_geosphere_observation_api() -> None:
     """Test the correct parsing of data, especially the dates.
 
     Thanks, @mhuber89, for the discovery and fix!
@@ -29,16 +29,21 @@ def test_geopshere_observation_api() -> None:
 
 @pytest.mark.remote
 @pytest.mark.parametrize(
-    ("resolution", "parameter", "expected"),
+    ("resolution", "parameter", "expected_rows", "expected_sum"),
     [
         # cglo, served as irradiance in W / m² and passed through unconverted
-        ("minute_10", "radiation_global_intensity", IsNumeric(ge=82770.0, le=82870.0)),
-        ("hourly", "radiation_global_intensity", IsNumeric(ge=13790.0, le=13815.0)),
+        ("minute_10", "radiation_global_intensity", 288, IsNumeric(ge=82770.0, le=82870.0)),
+        ("hourly", "radiation_global_intensity", 48, IsNumeric(ge=13790.0, le=13815.0)),
         # cglo_j, a distinct upstream parameter already accumulated over the day in J / cm²
-        ("daily", "radiation_global", IsNumeric(ge=4966.2000, le=4972.0000)),
+        ("daily", "radiation_global", 2, IsNumeric(ge=4966.2000, le=4972.0000)),
     ],
 )
-def test_geopshere_observation_api_radiation(resolution: str, parameter: str, expected: IsNumeric) -> None:
+def test_geosphere_observation_api_radiation(
+    resolution: str,
+    parameter: str,
+    expected_rows: int,
+    expected_sum: IsNumeric,
+) -> None:
     """Test that radiation is reported in the unit the source publishes it in.
 
     Geosphere serves ``cglo`` as irradiance (W / m²) at 10 minutes and hourly, and ``cglo_j`` as
@@ -46,6 +51,10 @@ def test_geopshere_observation_api_radiation(resolution: str, parameter: str, ex
     to be multiplied by the interval length in the parser to make them look like the daily ones; they
     now keep their own unit and canonical name instead. The expected sums are equivalent to the former
     J / cm² ones scaled by that interval: 82851 * 0.06 and 13795 * 0.36 both land in the daily range.
+
+    The row count is asserted alongside the sum because the window is a fixed and complete stretch of
+    archive, so a sum that drifts because rows went missing should say so rather than read as the unit
+    having changed.
     """
     stations_at = GeosphereObservationRequest(
         parameters=[(resolution, "data", parameter)],
@@ -54,5 +63,6 @@ def test_geopshere_observation_api_radiation(resolution: str, parameter: str, ex
     )
     station_at = stations_at.filter_by_station_id("4821")
     df = station_at.values.all().df
+    assert df.get_column("value").is_not_null().sum() == expected_rows
     # the result is slightly different for each resolution
-    assert df.get_column("value").sum() == expected
+    assert df.get_column("value").sum() == expected_sum


### PR DESCRIPTION
Removes the last in-parser unit conversion in the library.

## The problem

Geosphere serves `cglo` (global radiation) and `chim` (diffuse sky radiation) as **irradiance in W/m²**. The parser multiplied them by the interval length — `600/10000` at 10 minutes, `3600/10000` hourly — so they could be declared as **irradiation in J/cm²** under `radiation_global` and `radiation_sky_short_wave_diffuse`.

That made one canonical name cover two different quantities. Irradiance and irradiation are not inter-convertible without the accumulation interval, which is exactly why #1800 introduced the `_intensity` names.

## The change

- Delete the conversion block in `provider/geosphere/observation/api.py`
- Move three declarations onto `radiation_global_intensity` / `radiation_sky_short_wave_diffuse_intensity` with `watt_per_square_meter` (10 minutes: `cglo` + `chim`; hourly: `cglo`)
- Update the two affected docs tables
- Rewrite `test_geopshere_observation_api_radiation`, whose premise was the conversion being removed

**Daily and monthly are deliberately untouched.** They read `cglo_j` — a distinct upstream parameter genuinely accumulated over the interval — and keep `radiation_global` in J/cm².

## Verification

Measured against station 4821 for 2022-06-01..02, confirming the removal is behaviour-preserving on the underlying data:

| resolution | parameter | sum | × interval | old range |
|---|---|---|---|---|
| `minute_10` | `radiation_global_intensity` | 82851 W/m² | × 0.06 = 4971.06 | ✅ 4966.2–4972.0 |
| `hourly` | `radiation_global_intensity` | 13795 W/m² | × 0.36 = 4966.20 | ✅ 4966.2–4972.0 |
| `daily` | `radiation_global` | 4972 J/cm² | unchanged | ✅ |

The parser was doing precisely what the metadata now declares.

Local: `poe lint`, `poe typecheck`, and 149 tests across `tests/provider/geosphere`, `tests/test_docs.py`, `tests/test_api.py` all pass.

## Breaking

Values are 16.67× (10 minutes) and 2.78× (hourly) larger; multiply by 0.06 and 0.36 to recover the old numbers. Queries using the old names at those two resolutions need to switch to the `_intensity` names.

Follows #1800 and #1801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)