### PR TITLE
refactor(metadata): type unit_type as a literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ Types of changes:
 - Docs: a parameter glossary on the Parameters page, built from the canonical parameter table at
   build time by the local Sphinx extension `docs/_ext/parameter_glossary.py`. Every parameter in
   every provider's metadata table now links to its glossary entry
+- `wetterdienst.metadata.unit_type.UnitType`, a literal of the 23 unit types the unit converter
+  knows. `CanonicalParameter.unit_type` is typed with it, so a mistyped unit type in the parameter
+  table is a type error rather than something only a test can catch. A test pins the literal to
+  `UnitConverter` in both directions, since the converter builds its unit types as a runtime dict
+  that no static type can be derived from
 - A one-sentence description for all 504 canonical parameters, so the glossary now says what each
   quantity *is* rather than only which unit it comes back in — that soil temperatures are at a
   stated depth under a stated cover, that `wind_movement_24h` is wind run, that

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -31,6 +31,10 @@ exposed parameter names with no explanation of what they measure.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from wetterdienst.metadata.unit_type import UnitType
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,7 +42,7 @@ class CanonicalParameter:
     """Properties of a measured quantity, shared by every provider that reports it."""
 
     name: str
-    unit_type: str
+    unit_type: UnitType
     description: str | None = None
 
 

--- a/src/wetterdienst/metadata/unit_type.py
+++ b/src/wetterdienst/metadata/unit_type.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Unit types, the quantities the unit converter knows how to convert within.
+
+A unit type names a physical quantity -- ``temperature``, ``pressure``, ``speed`` -- and selects
+which unit values are returned in, via ``UnitConverter.targets``. Every canonical parameter has
+exactly one, so this is the closed vocabulary that ``CanonicalParameter.unit_type`` draws from.
+
+``UnitType`` restates the keys of ``UnitConverter.units``, which are built as a dict literal at
+runtime and so cannot be turned into a static type. That makes this a second place the same
+vocabulary is written down, which is worth it only because it is pinned:
+``tests/test_api.py::test_unit_type_matches_unit_converter`` asserts the two agree exactly, in
+both directions. Adding a unit type to one and not the other fails that test rather than drifting.
+
+Being a ``Literal`` it is checked by ``ty``, not at runtime, so a typo in a parameter table entry
+is caught by the type checker rather than only by a test.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+UnitType = Literal[
+    "angle",
+    "concentration",
+    "conductivity",
+    "degree_day",
+    "dimensionless",
+    "energy_per_area",
+    "fraction",
+    "length_long",
+    "length_medium",
+    "length_short",
+    "magnetic_field_intensity",
+    "power_per_area",
+    "precipitation",
+    "precipitation_intensity",
+    "pressure",
+    "significant_weather",
+    "speed",
+    "temperature",
+    "time",
+    "turbidity",
+    "volume_per_time",
+    "wave_period",
+    "wind_scale",
+]

--- a/src/wetterdienst/model/metadata.py
+++ b/src/wetterdienst/model/metadata.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
     from pydantic_core.core_schema import ValidationInfo
 
+    from wetterdienst.metadata.unit_type import UnitType
     from wetterdienst.model.request import _PARAMETER_TYPE
 
 log = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ class ParameterModel(BaseModel):  # noqa: PLW1641
     dataset: SkipValidation[DatasetModel] = Field(default=None, exclude=True, repr=False)  # ty: ignore[invalid-assignment]
 
     @property
-    def unit_type(self) -> str:
+    def unit_type(self) -> UnitType:
         """The unit type of the measured quantity, from the canonical parameter table.
 
         Resolved on access rather than at import, so an unknown name is caught by

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,7 @@
 import collections
 import zoneinfo
 from datetime import datetime
+from typing import get_args
 
 import polars as pl
 import pytest
@@ -15,6 +16,7 @@ from tests.conftest import IS_CI, IS_WINDOWS
 from wetterdienst import Parameter, Settings
 from wetterdienst.api import Wetterdienst
 from wetterdienst.metadata.parameter_table import PARAMETER_TABLE, PARAMETERS
+from wetterdienst.metadata.unit_type import UnitType
 from wetterdienst.model.metadata import ParameterModel
 from wetterdienst.model.unit import UnitConverter
 from wetterdienst.provider.aemet.observation import AemetObservationMetadata, AemetObservationRequest
@@ -166,8 +168,26 @@ def test_metadata_units(unit_converter: UnitConverter, unit_converter_unit_type_
                 assert parameter.unit in unit_converter_unit_type_units[parameter.unit_type]
 
 
+def test_unit_type_matches_unit_converter(unit_converter: UnitConverter) -> None:
+    """Test that the `UnitType` literal and the unit converter describe the same vocabulary.
+
+    `UnitType` has to restate the keys of `UnitConverter.units`, which are built as a dict literal
+    at runtime and so cannot be turned into a static type. That makes it a second place the same
+    vocabulary is written down, which is only safe while the two are pinned together. Checked in
+    both directions: a unit type added to the converter but not the literal cannot be named by a
+    parameter, and one added to the literal but not the converter has no target unit to convert to.
+    """
+    assert set(get_args(UnitType)) == set(unit_converter.units)
+    assert set(get_args(UnitType)) == set(unit_converter.targets)
+
+
 def test_parameter_table_unit_types(unit_converter: UnitConverter) -> None:
-    """Test that every canonical unit type is one the unit converter can convert to."""
+    """Test that every canonical unit type is one the unit converter can convert to.
+
+    `UnitType` makes this a type error too, but only for code the type checker sees. The table is
+    data, and a wrong-but-valid unit type -- `pressure` where `temperature` was meant -- is not a
+    typo the literal can catch.
+    """
     for parameter in PARAMETER_TABLE:
         assert parameter.unit_type in unit_converter.targets, parameter.name
 


### PR DESCRIPTION
Follow-up to #1803/#1804: `unit_type` is named 504 times in the canonical table as a bare `str`, so a typo was only ever caught by a test asserting membership of `UnitConverter.targets`. Typing it as a literal makes `ty` reject it at the point of the mistake.

## The tradeoff

`UnitType` has to **restate** the keys of `UnitConverter.units`, which are built as a dict literal at runtime and so cannot be turned into a static type. That makes it a second place the same vocabulary is written down — the exact duplication this migration has spent four PRs removing.

It is worth it only because the two are pinned. `test_unit_type_matches_unit_converter` asserts they agree exactly, **in both directions**, which is strictly stronger than the check it replaces (that one only looked table → targets, so a unit type present in the converter but unusable by any parameter went unnoticed).

If that test is ever deleted, the literal becomes a liability rather than a guard.

## Verified, not assumed

I injected `"frcation"` into the table and confirmed `ty` reports it:

```
296 |         "frcation",
    |         ^^^^^^^^^^ Expected `Literal["angle", "concentration", ... omitted 18 literals]`,
                         found `Literal["frcation"]`
```

Worth recording that **the first attempt at this check silently passed**: ruff had reflowed the table entries across multiple lines after #1804 added descriptions, so the string replacement never matched and `ty` was re-checking an unmodified file. The literal worked; the test of it did not. A verification that cannot fail proves nothing.

## Scope

`test_parameter_table_unit_types` stays. A wrong-but-valid unit type — `pressure` where `temperature` was meant — is not a typo any literal can catch, and that is the failure mode with actual consequences for users, since `unit_type` selects the output unit.

`UnitType` lives in `metadata/`, alongside `Parameter`, `Resolution` and `Period`, which is where the shared vocabulary already sits and keeps the existing `model/` → `metadata/` dependency direction. It is imported under `TYPE_CHECKING`, so it adds no import-time cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)