### PR TITLE
feat(ui): add glossary discovery to REST, MCP and CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ Types of changes:
   table is a type error rather than something only a test can catch. A test pins the literal to
   `UnitConverter` in both directions, since the converter builds its unit types as a runtime dict
   that no static type can be derived from
+- Parameter discovery across all three interfaces: `GET /api/glossary`, the `glossary` MCP tool and
+  `wetterdienst about glossary`. `coverage` answers which parameters a given provider offers; the
+  glossary answers what any of them measures and which unit it comes back in — neither of which
+  `coverage` reports. Filter with `parameter=` (substring match over the 504 names) or `unit_type=`
+  (exact). This is what puts the canonical descriptions in front of users rather than only in the
+  docs. A filter matching nothing is an empty list over HTTP and a non-zero exit on the CLI, the
+  latter following grep so a shell script can tell
 - A one-sentence description for all 504 canonical parameters, so the glossary now says what each
   quantity *is* rather than only which unit it comes back in — that soil temperatures are at a
   stated depth under a stated cover, that `wind_movement_24h` is wind run, that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,13 @@ Types of changes:
 - Parameter discovery across all three interfaces: `GET /api/glossary`, the `glossary` MCP tool and
   `wetterdienst about glossary`. `coverage` answers which parameters a given provider offers; the
   glossary answers what any of them measures and which unit it comes back in — neither of which
-  `coverage` reports. Filter with `parameter=` (substring match over the 504 names) or `unit_type=`
-  (exact). This is what puts the canonical descriptions in front of users rather than only in the
-  docs. A filter matching nothing is an empty list over HTTP and a non-zero exit on the CLI, the
-  latter following grep so a shell script can tell
+  `coverage` reports. Filter with `parameter=` (substring match over the 504 names), `unit_type=`
+  (a closed vocabulary, so an unknown one is a 422 or a CLI usage error rather than an empty
+  result) and `limit=` to cap the response. The unit reported is the one a values request would
+  actually return, including any `ts_unit_targets` override. This is what puts the canonical
+  descriptions in front of users rather than only in the docs. A filter matching nothing is an
+  empty list over HTTP and a non-zero exit on the CLI, the latter following grep so a shell script
+  can tell
 - A one-sentence description for all 504 canonical parameters, so the glossary now says what each
   quantity *is* rather than only which unit it comes back in — that soil temperatures are at a
   stated depth under a stated cover, that `wind_movement_24h` is wind run, that

--- a/docs/_ext/parameter_glossary.py
+++ b/docs/_ext/parameter_glossary.py
@@ -34,9 +34,8 @@ class ParameterGlossaryDirective(SphinxDirective):
         for parameter in PARAMETER_TABLE:
             target = unit_converter.targets[parameter.unit_type]
             lines.append(parameter.name)
-            if parameter.description:
-                lines.append(f"  {parameter.description}")
-                lines.append("")
+            lines.append(f"  {parameter.description}")
+            lines.append("")
             lines.append(f"  Unit type `{parameter.unit_type}`, returned in `{target.name}` ({target.symbol}).")
             lines.append("")
         lines.append("```")

--- a/docs/usage/restapi.md
+++ b/docs/usage/restapi.md
@@ -45,6 +45,22 @@ The following examples use [httpie](https://github.com/httpie/cli) to demonstrat
 http localhost:7890/api/coverage
 ```
 
+### Glossary
+
+Coverage says which parameters a provider offers; the glossary says what any of them means and
+which unit it comes back in.
+
+```bash
+# Look up every canonical parameter.
+http localhost:7890/api/glossary
+
+# Match names containing some text.
+http localhost:7890/api/glossary parameter==radiation
+
+# List every parameter of one quantity.
+http localhost:7890/api/glossary unit_type==temperature
+```
+
 ### Stations
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,9 @@ dependencies = [
     "stamina>=25.1.0,<27",
     "tabulate>=0.9,<1",
     "tqdm>=4.64,<5",
-    "typing-extensions>=4.15.0; python_version<'3.11'",
+    # imported unconditionally by model/result.py and ui/core.py, not just as a 3.10 backport:
+    # pydantic refuses typing.TypedDict as a response model below 3.12
+    "typing-extensions>=4.15.0",
     "tzdata>=2024.2",
     "tzfpy>=0.15.2,<2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ dependencies = [
     "tqdm>=4.64,<5",
     # imported unconditionally by model/result.py and ui/core.py, not just as a 3.10 backport:
     # pydantic refuses typing.TypedDict as a response model below 3.12
-    "typing-extensions>=4.15.0",
+    "typing-extensions>=4.15.0,<5",
     "tzdata>=2024.2",
     "tzfpy>=0.15.2,<2",
 ]

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -43,7 +43,9 @@ class CanonicalParameter:
 
     name: str
     unit_type: UnitType
-    description: str | None = None
+    # required rather than defaulted: every parameter has one, and a new entry without a
+    # description should not be constructible in the first place
+    description: str
 
 
 PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -28,6 +28,7 @@ from wetterdienst.ui.core import (
     ValuesRequest,
     _get_stripes_stations,
     _plot_stripes,
+    get_glossary,
     get_interpolate,
     get_issues,
     get_stations,
@@ -772,6 +773,43 @@ def coverage(
     )
 
     print(json.dumps(cov, indent=2))  # noqa: T201
+
+
+@about.command("glossary")
+@cloup.option_group(
+    "Parameter",
+    click.option(
+        "--parameter",
+        type=click.STRING,
+        help="Match canonical parameter names containing this text, e.g. radiation.",
+    ),
+)
+@cloup.option_group(
+    "Unit type",
+    click.option(
+        "--unit-type",
+        type=click.STRING,
+        help="Restrict to one quantity, e.g. temperature.",
+    ),
+)
+@debug_opt
+def glossary(
+    parameter: str,
+    unit_type: str,
+    debug: bool,  # noqa: FBT001
+) -> None:
+    """Look up what a parameter measures and which unit it is returned in."""
+    set_logging_level(debug=debug)
+
+    entries = get_glossary(parameter=parameter, unit_type=unit_type)
+
+    if not entries:
+        log.error("No canonical parameter matches the given filters.")
+        sys.exit(1)
+
+    # ensure_ascii=False so unit symbols print as °C and J/cm² rather than escapes; this command
+    # exists to show them
+    print(json.dumps(entries, indent=2, ensure_ascii=False))  # noqa: T201
 
 
 @about.command("fields")

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -804,7 +804,7 @@ def coverage(
 )
 @debug_opt
 def glossary(
-    parameter: str,
+    parameter: str | None,
     unit_type: UnitType | None,
     limit: int | None,
     debug: bool,  # noqa: FBT001

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -10,7 +10,7 @@ import logging
 import sys
 from pathlib import Path
 from pprint import pformat
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 import click
 import cloup
@@ -19,6 +19,7 @@ from cloup.constraints import AllSet, If, RequireExactly, accept_none
 
 from wetterdienst import Settings, Wetterdienst, __appname__, __version__
 from wetterdienst.exceptions import ApiNotFoundError
+from wetterdienst.metadata.unit_type import UnitType
 from wetterdienst.ui.core import (
     HistoryRequest,
     InterpolationRequest,
@@ -788,20 +789,34 @@ def coverage(
     "Unit type",
     click.option(
         "--unit-type",
-        type=click.STRING,
+        # a closed vocabulary, so an unknown one is a usage error rather than an empty result
+        type=click.Choice(get_args(UnitType)),
         help="Restrict to one quantity, e.g. temperature.",
+    ),
+)
+@cloup.option_group(
+    "Limit",
+    click.option(
+        "--limit",
+        type=click.IntRange(min=1),
+        help="Return at most this many entries; the full vocabulary is 504 parameters.",
     ),
 )
 @debug_opt
 def glossary(
     parameter: str,
-    unit_type: str,
+    unit_type: UnitType | None,
+    limit: int | None,
     debug: bool,  # noqa: FBT001
 ) -> None:
-    """Look up what a parameter measures and which unit it is returned in."""
+    """Look up what a parameter measures and which unit it is returned in.
+
+    The unit shown is the one a values request would return, including any WD_TS_UNIT_TARGETS
+    override.
+    """
     set_logging_level(debug=debug)
 
-    entries = get_glossary(parameter=parameter, unit_type=unit_type)
+    entries = get_glossary(parameter=parameter, unit_type=unit_type, limit=limit)
 
     if not entries:
         log.error("No canonical parameter matches the given filters.")

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -19,6 +19,7 @@ from typing_extensions import TypedDict
 
 from wetterdienst.exceptions import InvalidTimeIntervalError, StartDateEndDateError
 from wetterdienst.metadata.period import Period
+from wetterdienst.metadata.unit_type import UnitType  # noqa: TC001, needed at runtime by FastAPI
 from wetterdienst.model.metadata import parse_parameters
 from wetterdienst.provider.dwd.observation import DwdObservationRequest
 from wetterdienst.util.datetime import parse_date
@@ -683,35 +684,46 @@ class GlossaryEntry(TypedDict):
     """One canonical parameter: what it measures and which unit it is returned in."""
 
     name: str
-    unit_type: str
+    unit_type: UnitType
     unit: str
     unit_symbol: str
     description: str | None
 
 
-def get_glossary(parameter: str | None = None, unit_type: str | None = None) -> list[GlossaryEntry]:
+def get_glossary(
+    parameter: str | None = None,
+    unit_type: UnitType | None = None,
+    limit: int | None = None,
+    settings: Settings | None = None,
+) -> list[GlossaryEntry]:
     """Return the canonical parameter vocabulary, optionally filtered.
 
     `coverage` answers which parameters a given provider offers; this answers what any of them
-    means and which unit it comes back in, neither of which coverage reports. The unit is the
-    default target of the unit converter, so it is what a request returns unless `ts_unit_targets`
-    overrides it.
+    means and which unit it comes back in, neither of which coverage reports.
 
     `parameter` matches as a substring, since the useful question over 504 names is usually
-    "everything about radiation" rather than one exact name. `unit_type` matches exactly, because
-    it is a closed vocabulary a caller can enumerate from the results.
+    "everything about radiation" rather than one exact name. An exact name deliberately does *not*
+    short-circuit to a single entry: `humidity` is both a parameter and the prefix of
+    `humidity_max`, `humidity_min` and `humidity_absolute`, and hiding those would be the more
+    surprising behaviour. Use `limit` to bound the result instead.
+
+    The unit reported is the one a values request would actually return, so `ts_unit_targets` is
+    honoured -- reporting the built-in default while `values` hands back Fahrenheit would make this
+    worse than saying nothing.
     """
     from wetterdienst.metadata.parameter_table import PARAMETER_TABLE  # noqa: PLC0415
     from wetterdienst.model.unit import UnitConverter  # noqa: PLC0415
+    from wetterdienst.settings import Settings as _Settings  # noqa: PLC0415
 
+    settings = settings or _Settings()
     unit_converter = UnitConverter()
+    unit_converter.update_targets(settings.ts_unit_targets)
     needle = parameter.strip().lower() if parameter else None
-    wanted_unit_type = unit_type.strip().lower() if unit_type else None
     entries: list[GlossaryEntry] = []
     for canonical in PARAMETER_TABLE:
         if needle and needle not in canonical.name:
             continue
-        if wanted_unit_type and canonical.unit_type != wanted_unit_type:
+        if unit_type and canonical.unit_type != unit_type:
             continue
         target = unit_converter.targets[canonical.unit_type]
         entries.append(
@@ -723,6 +735,8 @@ def get_glossary(parameter: str | None = None, unit_type: str | None = None) -> 
                 description=canonical.description,
             ),
         )
+        if limit is not None and len(entries) >= limit:
+            break
     return entries
 
 

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -8,10 +8,14 @@ import json
 import logging
 import sys
 from collections.abc import Mapping  # noqa: TC003
-from typing import TYPE_CHECKING, Annotated, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 import polars as pl
 from pydantic import BaseModel, Field, field_validator
+
+# pydantic refuses typing.TypedDict as a response model on Python below 3.12, and GlossaryEntry
+# is one; model/result.py imports it from here for the same reason
+from typing_extensions import TypedDict
 
 from wetterdienst.exceptions import InvalidTimeIntervalError, StartDateEndDateError
 from wetterdienst.metadata.period import Period
@@ -673,6 +677,53 @@ class IssuesRequest(BaseModel):
     network: _NetworkField
     station: _StationIdField
     debug: _DebugField = False
+
+
+class GlossaryEntry(TypedDict):
+    """One canonical parameter: what it measures and which unit it is returned in."""
+
+    name: str
+    unit_type: str
+    unit: str
+    unit_symbol: str
+    description: str | None
+
+
+def get_glossary(parameter: str | None = None, unit_type: str | None = None) -> list[GlossaryEntry]:
+    """Return the canonical parameter vocabulary, optionally filtered.
+
+    `coverage` answers which parameters a given provider offers; this answers what any of them
+    means and which unit it comes back in, neither of which coverage reports. The unit is the
+    default target of the unit converter, so it is what a request returns unless `ts_unit_targets`
+    overrides it.
+
+    `parameter` matches as a substring, since the useful question over 504 names is usually
+    "everything about radiation" rather than one exact name. `unit_type` matches exactly, because
+    it is a closed vocabulary a caller can enumerate from the results.
+    """
+    from wetterdienst.metadata.parameter_table import PARAMETER_TABLE  # noqa: PLC0415
+    from wetterdienst.model.unit import UnitConverter  # noqa: PLC0415
+
+    unit_converter = UnitConverter()
+    needle = parameter.strip().lower() if parameter else None
+    wanted_unit_type = unit_type.strip().lower() if unit_type else None
+    entries: list[GlossaryEntry] = []
+    for canonical in PARAMETER_TABLE:
+        if needle and needle not in canonical.name:
+            continue
+        if wanted_unit_type and canonical.unit_type != wanted_unit_type:
+            continue
+        target = unit_converter.targets[canonical.unit_type]
+        entries.append(
+            GlossaryEntry(
+                name=canonical.name,
+                unit_type=canonical.unit_type,
+                unit=target.name,
+                unit_symbol=target.symbol,
+                description=canonical.description,
+            ),
+        )
+    return entries
 
 
 def get_issues(

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -687,7 +687,7 @@ class GlossaryEntry(TypedDict):
     unit_type: UnitType
     unit: str
     unit_symbol: str
-    description: str | None
+    description: str
 
 
 def get_glossary(

--- a/src/wetterdienst/ui/mcp.py
+++ b/src/wetterdienst/ui/mcp.py
@@ -55,6 +55,11 @@ ONLY when the user explicitly asks for an interpolated / between-stations estima
 plain-language "summary". `history` is different again: it returns a station's *metadata* history \
 (name/location/sensor changes), not weather.
 
+`glossary` answers what a parameter *means* and which unit its values come back in -- use it when \
+the user asks what something is, or what unit a number is in. It is not a way to find data: it \
+knows nothing about providers or stations, so `coverage` remains the tool for "which parameters \
+does this provider have".
+
 ## Conventions
 - provider/network: use "dwd"/"observation" for German ground observations (the common case). Call \
 `coverage` with no arguments to list every provider/network.
@@ -89,6 +94,7 @@ _EXCLUDE_PATTERNS = (r"^/$", r"^/robots\.txt$", r"^/health$", r"^/api/version$",
 # Clean, agent-friendly names for the auto-generated tools (auto name -> friendly name).
 _TOOL_NAMES = {
     "coverage_api_coverage_get": "coverage",
+    "glossary_api_glossary_get": "glossary",
     "stations_api_stations_get": "stations",
     "values_api_values_get": "values",
     "interpolate_api_interpolate_get": "interpolate",

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -14,7 +14,9 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Res
 
 from wetterdienst import Author, Info, Settings, Wetterdienst, __version__
 from wetterdienst.exceptions import ApiNotFoundError, StartDateEndDateError
-from wetterdienst.metadata.unit_type import UnitType
+
+# needed at runtime: FastAPI resolves this annotation to build the query parameter's enum
+from wetterdienst.metadata.unit_type import UnitType  # noqa: TC001
 from wetterdienst.model.result import (
     _InterpolatedValuesDict,
     _InterpolatedValuesOgcFeatureCollection,

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -25,6 +25,7 @@ from wetterdienst.model.result import (
     _ValuesOgcFeatureCollection,
 )
 from wetterdienst.ui.core import (
+    GlossaryEntry,
     HistoryRequest,
     InterpolationRequest,
     IssuesRequest,
@@ -34,6 +35,7 @@ from wetterdienst.ui.core import (
     _get_stripes_data,
     _get_stripes_stations,
     _plot_stripes,
+    get_glossary,
     get_interpolate,
     get_issues,
     get_stations,
@@ -164,6 +166,7 @@ def index() -> HTMLResponse:
                 <h2>Endpoints</h2>
                 <ul>
                     <li><a href="api/coverage" target="_blank" rel="noopener">coverage</a></li>
+                    <li><a href="api/glossary" target="_blank" rel="noopener">glossary</a></li>
                     <li><a href="api/stations" target="_blank" rel="noopener">stations</a></li>
                     <li><a href="api/values" target="_blank" rel="noopener">values</a></li>
                     <li><a href="api/interpolate" target="_blank" rel="noopener">interpolation</a></li>
@@ -348,6 +351,27 @@ def coverage(
     )
 
     return Response(content=json.dumps(cov, indent=4 if pretty else None), media_type="application/json")
+
+
+@app.get("/api/glossary", response_model=list[GlossaryEntry])
+def glossary(
+    parameter: str | None = None,
+    unit_type: str | None = None,
+    *,
+    debug: bool = False,
+) -> list[GlossaryEntry]:
+    """Look up what a parameter measures and which unit it is returned in.
+
+    Call with no arguments to list every canonical parameter. Pass parameter="radiation" to match
+    names containing that text, or unit_type="temperature" to list every parameter of one quantity.
+
+    This complements coverage: coverage says which parameters a given provider offers, this says
+    what any of them means. The unit reported here is what a values request returns unless the
+    ts_unit_targets setting overrides it.
+    """
+    set_logging_level(debug=debug)
+
+    return get_glossary(parameter=parameter, unit_type=unit_type)
 
 
 # response models for the different formats are

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -14,6 +14,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Res
 
 from wetterdienst import Author, Info, Settings, Wetterdienst, __version__
 from wetterdienst.exceptions import ApiNotFoundError, StartDateEndDateError
+from wetterdienst.metadata.unit_type import UnitType
 from wetterdienst.model.result import (
     _InterpolatedValuesDict,
     _InterpolatedValuesOgcFeatureCollection,
@@ -356,22 +357,25 @@ def coverage(
 @app.get("/api/glossary", response_model=list[GlossaryEntry])
 def glossary(
     parameter: str | None = None,
-    unit_type: str | None = None,
+    unit_type: UnitType | None = None,
+    limit: int | None = None,
     *,
     debug: bool = False,
 ) -> list[GlossaryEntry]:
     """Look up what a parameter measures and which unit it is returned in.
 
-    Call with no arguments to list every canonical parameter. Pass parameter="radiation" to match
-    names containing that text, or unit_type="temperature" to list every parameter of one quantity.
+    Filter with parameter="radiation" to match names containing that text, or
+    unit_type="temperature" for every parameter of one quantity. Both can be combined. Use limit to
+    cap the number of entries: the vocabulary is 504 parameters, so an unfiltered call is a large
+    response and a broad filter can still be a wide one (parameter="temperature" matches 184).
 
     This complements coverage: coverage says which parameters a given provider offers, this says
-    what any of them means. The unit reported here is what a values request returns unless the
-    ts_unit_targets setting overrides it.
+    what any of them means. The unit reported is the one a values request would actually return,
+    including any ts_unit_targets override.
     """
     set_logging_level(debug=debug)
 
-    return get_glossary(parameter=parameter, unit_type=unit_type)
+    return get_glossary(parameter=parameter, unit_type=unit_type, limit=limit)
 
 
 # response models for the different formats are

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -196,12 +196,13 @@ def test_parameter_table_descriptions() -> None:
     """Test that every canonical parameter says what it is, in one well-formed sentence.
 
     The description is what the docs glossary, the REST API and the MCP tools show a user who does
-    not already know what a parameter measures, so an entry added without one silently reintroduces
-    the gap this filled. Distinctness is checked too: a description repeated across two parameters
-    means at least one of them is not actually describing itself.
+    not already know what a parameter measures. `CanonicalParameter.description` is a required
+    field, so omitting one is a type error; what remains for this test is that it is not empty,
+    that it reads as a sentence, and that it is distinct. That last check is the one with teeth: a
+    description repeated across two parameters means at least one is not describing itself.
     """
     missing = sorted(p.name for p in PARAMETER_TABLE if not p.description)
-    assert not missing, f"canonical parameters without a description: {missing}"
+    assert not missing, f"canonical parameters with an empty description: {missing}"
     malformed = sorted(
         p.name for p in PARAMETER_TABLE if not p.description[0].isupper() or not p.description.endswith(".")
     )

--- a/tests/ui/cli/test_cli.py
+++ b/tests/ui/cli/test_cli.py
@@ -236,3 +236,24 @@ def test_cli_glossary_no_match() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["about", "glossary", "--parameter=not_a_parameter"])
     assert result.exit_code == 1
+
+
+def test_cli_glossary_unknown_unit_type() -> None:
+    """Test that an unknown unit type is a usage error listing the valid ones.
+
+    click.Choice turns the closed vocabulary into a message naming every option, so a typo tells
+    the user what to type instead of returning nothing.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["about", "glossary", "--unit-type=celsius"])
+    assert result.exit_code == 2
+    assert "'celsius' is not one of" in result.output
+    assert "temperature" in result.output
+
+
+def test_cli_glossary_limit() -> None:
+    """Test that --limit bounds the output."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["about", "glossary", "--limit=3"])
+    assert result.exit_code == 0
+    assert len(json.loads(result.stdout)) == 3

--- a/tests/ui/cli/test_cli.py
+++ b/tests/ui/cli/test_cli.py
@@ -199,3 +199,40 @@ def test_issues_unsupported_provider() -> None:
     runner = CliRunner()
     result = runner.invoke(cli, ["issues", "--provider=dwd", "--network=observation", "--station=00011"])
     assert result.exit_code == 1
+
+
+def test_cli_glossary() -> None:
+    """Test that the glossary reports what a parameter measures and its returned unit."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["about", "glossary", "--parameter=radiation_global_intensity"])
+    assert result.exit_code == 0
+    entries = json.loads(result.stdout)
+    assert entries == [
+        {
+            "name": "radiation_global_intensity",
+            "unit_type": "power_per_area",
+            "unit": "watt_per_square_meter",
+            "unit_symbol": "W/m²",
+            "description": "Global irradiance on a horizontal surface, reported as power rather than energy.",
+        },
+    ]
+
+
+def test_cli_glossary_unit_type() -> None:
+    """Test that filtering by unit type returns only parameters of that quantity."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["about", "glossary", "--unit-type=turbidity"])
+    assert result.exit_code == 0
+    entries = json.loads(result.stdout)
+    assert [entry["name"] for entry in entries] == ["turbidity"]
+
+
+def test_cli_glossary_no_match() -> None:
+    """Test that a filter matching nothing exits non-zero, as grep does.
+
+    The REST endpoint answers the same query with 200 and an empty list, because an empty result is
+    not an HTTP error. The exit code is what makes the difference visible to a shell script.
+    """
+    runner = CliRunner()
+    result = runner.invoke(cli, ["about", "glossary", "--parameter=not_a_parameter"])
+    assert result.exit_code == 1

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -8,6 +8,7 @@ import pytest
 from dirty_equals import IsApprox, IsNumber, IsStr
 from starlette.testclient import TestClient
 
+from wetterdienst.metadata.parameter_table import PARAMETER_TABLE
 from wetterdienst.ui.restapi import REQUEST_EXAMPLES
 
 
@@ -93,6 +94,50 @@ def test_coverage(client: TestClient) -> None:
     # `road` requires a date range for value queries, other DWD networks don't
     assert dwd["observation"]["date_required"] is False
     assert dwd["road"]["date_required"] is True
+
+
+def test_glossary(client: TestClient) -> None:
+    """Test that the glossary reports what a parameter measures and its returned unit."""
+    response = client.get("/api/glossary", params={"parameter": "radiation_global_intensity"})
+    assert response.status_code == 200
+    assert response.json() == [
+        {
+            "name": "radiation_global_intensity",
+            "unit_type": "power_per_area",
+            "unit": "watt_per_square_meter",
+            "unit_symbol": "W/m\u00b2",
+            "description": "Global irradiance on a horizontal surface, reported as power rather than energy.",
+        },
+    ]
+
+
+def test_glossary_all(client: TestClient) -> None:
+    """Test that the unfiltered glossary covers the whole canonical vocabulary."""
+    response = client.get("/api/glossary")
+    assert response.status_code == 200
+    entries = response.json()
+    assert len(entries) == len(PARAMETER_TABLE)
+    # every entry says what it is and which unit it comes back in; that is the point of the endpoint
+    assert all(entry["description"] for entry in entries)
+    assert all(entry["unit"] for entry in entries)
+
+
+def test_glossary_unit_type(client: TestClient) -> None:
+    """Test that filtering by unit type returns only parameters of that quantity."""
+    response = client.get("/api/glossary", params={"unit_type": "turbidity"})
+    assert response.status_code == 200
+    assert [entry["name"] for entry in response.json()] == ["turbidity"]
+
+
+def test_glossary_no_match(client: TestClient) -> None:
+    """Test that a filter matching nothing is an empty list, not an error.
+
+    The CLI exits 1 on the same query, following grep, but over HTTP a filter that matches nothing
+    is a successful request with no results.
+    """
+    response = client.get("/api/glossary", params={"parameter": "not_a_parameter"})
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 @pytest.mark.parametrize("network", ["alerts", "radar"])

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -8,7 +8,9 @@ import pytest
 from dirty_equals import IsApprox, IsNumber, IsStr
 from starlette.testclient import TestClient
 
+from wetterdienst import Settings
 from wetterdienst.metadata.parameter_table import PARAMETER_TABLE
+from wetterdienst.ui.core import get_glossary
 from wetterdienst.ui.restapi import REQUEST_EXAMPLES
 
 
@@ -127,6 +129,43 @@ def test_glossary_unit_type(client: TestClient) -> None:
     response = client.get("/api/glossary", params={"unit_type": "turbidity"})
     assert response.status_code == 200
     assert [entry["name"] for entry in response.json()] == ["turbidity"]
+
+
+def test_glossary_unknown_unit_type(client: TestClient) -> None:
+    """Test that an unknown unit type is rejected rather than answered with an empty list.
+
+    `unit_type` is a closed vocabulary, so a typo is a caller error. Returning 200 and [] would be
+    indistinguishable from a quantity that legitimately has no parameters, and the enum in the
+    OpenAPI schema is also how an agent learns the valid values without downloading all 504 entries.
+    """
+    response = client.get("/api/glossary", params={"unit_type": "celsius"})
+    assert response.status_code == 422
+
+
+def test_glossary_limit(client: TestClient) -> None:
+    """Test that limit bounds the response.
+
+    The full vocabulary is a large payload for a tool-driving agent, and even a broad filter can be
+    wide, so callers need a way to cap it explicitly. There is no default limit: silently truncating
+    would be worse than a big answer.
+    """
+    response = client.get("/api/glossary", params={"limit": 3})
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+
+
+def test_glossary_reports_unit_target_override(client: TestClient) -> None:
+    """Test that the reported unit follows ts_unit_targets rather than the built-in default.
+
+    Reporting degree_celsius while a values request hands back Fahrenheit would make the glossary
+    actively misleading, which is worse than it not existing.
+    """
+    entries = get_glossary(
+        parameter="temperature_air_mean_2m",
+        settings=Settings(ts_unit_targets={"temperature": "degree_fahrenheit"}),
+    )
+    assert entries
+    assert {entry["unit"] for entry in entries if entry["unit_type"] == "temperature"} == {"degree_fahrenheit"}
 
 
 def test_glossary_no_match(client: TestClient) -> None:
@@ -1909,7 +1948,7 @@ def test_mcp_server_is_agent_friendly() -> None:
 
     tools, instructions = asyncio.run(_introspect())
     # data endpoints exposed under clean, agent-friendly names
-    assert {"coverage", "stations", "values", "alerts"} <= tools
+    assert {"coverage", "glossary", "stations", "values", "alerts"} <= tools
     # the ugly auto-generated names are gone
     assert "values_api_values_get" not in tools
     # non-data/noise endpoints are excluded

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -154,7 +154,7 @@ def test_glossary_limit(client: TestClient) -> None:
     assert len(response.json()) == 3
 
 
-def test_glossary_reports_unit_target_override(client: TestClient) -> None:
+def test_glossary_reports_unit_target_override() -> None:
     """Test that the reported unit follows ts_unit_targets rather than the built-in default.
 
     Reporting degree_celsius while a values request hands back Fahrenheit would make the glossary

--- a/uv.lock
+++ b/uv.lock
@@ -7309,7 +7309,7 @@ dependencies = [
     { name = "stamina" },
     { name = "tabulate" },
     { name = "tqdm" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
     { name = "tzdata" },
     { name = "tzfpy" },
 ]
@@ -7488,7 +7488,7 @@ requires-dist = [
     { name = "tabula", marker = "extra == 'radar'", specifier = ">=1.0.5" },
     { name = "tabulate", specifier = ">=0.9,<1" },
     { name = "tqdm", specifier = ">=4.64,<5" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.15.0" },
+    { name = "typing-extensions", specifier = ">=4.15.0,<5" },
     { name = "tzdata", specifier = ">=2024.2" },
     { name = "tzfpy", specifier = ">=0.15.2,<2" },
     { name = "utm", marker = "extra == 'interpolation'", specifier = ">=0.7,<1" },


### PR DESCRIPTION
Step 8 of the canonical parameter migration, and the one that makes #1804 useful outside the docs.

## Why

The 504 canonical descriptions added in #1804 were visible only in the built documentation. Nothing in the library could answer *"what is this parameter"* or *"what unit will this number be in"* — `coverage` reports which parameters a provider offers and what they are called, not what they mean.

## What

One `get_glossary()` in `ui/core.py`, exposed on all three surfaces so they cannot drift:

| surface | how |
| --- | --- |
| REST | `GET /api/glossary` |
| MCP | `glossary` tool |
| CLI | `wetterdienst about glossary` |

Each entry carries the canonical name, its unit type, **the unit values are actually returned in**, that unit's symbol, and the description:

```console
$ wetterdienst about glossary --parameter radiation_global_intensity
[
  {
    "name": "radiation_global_intensity",
    "unit_type": "power_per_area",
    "unit": "watt_per_square_meter",
    "unit_symbol": "W/m²",
    "description": "Global irradiance on a horizontal surface, reported as power rather than energy."
  }
]
```

Filter by `parameter` (substring — over 504 names the useful question is usually "everything about radiation") or `unit_type` (exact, being a closed vocabulary).

## A bug worth flagging

The first version used `typing.TypedDict` for the response model. Pydantic refuses that below Python 3.12, and this project supports 3.10+ — so it raised at **import**, taking down the entire REST API rather than just this endpoint. `model/result.py` already imports `TypedDict` from `typing_extensions` for exactly this reason; the fix matches it.

It surfaced only because I exercised the endpoint rather than trusting that lint and `ty` passing meant it worked. Both did pass.

## Deliberate asymmetry

A filter matching nothing is **200 with an empty list** over HTTP — no error occurred — but the CLI **exits 1**, following grep, because that is what lets a shell script tell the difference. Both are tested, and each test says why it differs from the other.

## MCP

The instructions gain a line separating `glossary` from `coverage` — *"what does this mean"* versus *"what data exists"*. Agents driving this server have been misled by ambiguous tool descriptions before, so that distinction is worth stating rather than implying. Verified the tool is generated, named cleanly, and returns structured content via a real client call.

## Verification

- 4 REST tests, 3 CLI tests, all passing; 11 passed across the wider restapi selection
- lint, format and `ty` clean
- all three surfaces exercised end to end, including an actual MCP `call_tool`

CLI docs need no change — they render `wetterdienst_help` at build time, so the new command appears automatically. REST docs gain a Glossary section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)