### PR TITLE
fix!: raise on failed downloads instead of reporting them as no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,20 @@ Types of changes:
 
 ### Fixed
 
+- **Breaking**: a failed download is no longer reported as "there is no data". AEMET, CHMI, FMI,
+  IPMA, KNMI, LHMT, SMHI and DWD SWSMOS all logged a warning and returned an empty frame when a
+  request timed out, hit a rate limit or got a 5xx, which is indistinguishable from a station that
+  genuinely has nothing — a whole-provider outage came back as an empty result rather than an
+  error. Those failures now raise. A 404 stays routine, because providers use it to mean "this
+  station does not report this parameter", and a missing internet connection stays soft; the
+  distinction is `File.raise_unless_absent` for data requests against `File.raise_if_exception`
+  for a station catalogue, where an empty answer is never correct either. Code that relied on an
+  empty frame during an outage now sees the exception instead
+- The eight remaining `xfail` markers for live third-party services name the exceptions they
+  tolerate rather than tolerating everything. That only became possible with the change above:
+  while an outage arrived as an empty frame, the test failed with an `AssertionError` that no
+  marker could tell apart from a real regression
+
 - **Breaking**: WSV Pegelonline values are now scaled to the unit the metadata declares. The service
   publishes the unit per *timeseries*, not per parameter, and its stations disagree, so a single
   declaration was silently wrong wherever a station differed. Water level is `cm` at most gauges but

--- a/src/wetterdienst/provider/aemet/observation/api.py
+++ b/src/wetterdienst/provider/aemet/observation/api.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo
 import polars as pl
 import stamina
 
+from wetterdienst.exceptions import NoInternetError
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.model.metadata import DatasetModel, ParameterModel
@@ -274,7 +275,11 @@ class AemetObservationValues(TimeseriesValues):
         url = self._endpoint_realtime.format(station_id=station_id)
         payload = _fetch_datos(url, settings, CacheExpiry.FIVE_MINUTES)
         if isinstance(payload, Exception):
-            log.warning(f"Failed to acquire AEMET data for station {station_id}, chunk {url}: {payload}")
+            # a 404 means this station has nothing for the window, which is routine; a timeout or
+            # an exhausted rate limit does not, and an empty frame there reports an outage as data
+            if not isinstance(payload, (FileNotFoundError, NoInternetError)):
+                raise payload
+            log.debug(f"No AEMET data for station {station_id}, chunk {url}: {payload}")
             return pl.DataFrame(schema=_EMPTY_VALUES_SCHEMA)
         records = json.loads(payload.decode("latin-1"))
         if not records:
@@ -320,9 +325,12 @@ class AemetObservationValues(TimeseriesValues):
             )
             payload = _fetch_datos(url, settings, CacheExpiry.FIVE_MINUTES)
             if isinstance(payload, Exception):
-                # rate-limit retries (if applicable) are already exhausted at this point,
-                # so this chunk's data is genuinely missing from the result.
-                log.warning(f"Failed to acquire AEMET data for station {station_id}, chunk {url}: {payload}")
+                # rate-limit retries are already exhausted here, so a non-404 failure means this
+                # chunk is missing from a result that will otherwise look complete -- raise rather
+                # than return a partial series nobody can tell from a short one
+                if not isinstance(payload, (FileNotFoundError, NoInternetError)):
+                    raise payload
+                log.debug(f"No AEMET data for station {station_id}, chunk {url}: {payload}")
                 continue
             records.extend(json.loads(payload.decode("latin-1")))
         if not records:
@@ -386,7 +394,9 @@ class AemetObservationValues(TimeseriesValues):
             )
             payload = _fetch_datos(url, settings, CacheExpiry.FIVE_MINUTES)
             if isinstance(payload, Exception):
-                log.warning(f"Failed to acquire AEMET data for station {station_id}, chunk {url}: {payload}")
+                if not isinstance(payload, (FileNotFoundError, NoInternetError)):
+                    raise payload
+                log.debug(f"No AEMET data for station {station_id}, chunk {url}: {payload}")
                 continue
             records.extend(json.loads(payload.decode("latin-1")))
         if not records:
@@ -466,7 +476,10 @@ class AemetObservationRequest(TimeseriesRequest):
         settings = cast("Settings", self.settings)
         payload = _fetch_datos(self._endpoint, settings, CacheExpiry.METAINDEX)
         if isinstance(payload, Exception):
-            log.warning(f"Failed to fetch AEMET stations: {payload}")
+            # an empty station list is never a correct answer, so only a missing connection is soft
+            if not isinstance(payload, NoInternetError):
+                raise payload
+            log.warning("No internet connection while fetching AEMET stations")
             return pl.LazyFrame()
 
         df = pl.DataFrame(json.loads(payload.decode("latin-1")))

--- a/src/wetterdienst/provider/chmi/observation/api.py
+++ b/src/wetterdienst/provider/chmi/observation/api.py
@@ -146,8 +146,11 @@ class ChmiObservationValues(TimeseriesValues):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a station that does not measure an element (or has no data for a month) has no file,
+        # which is a 404 and routine; a timeout or a 5xx is not, and must not be reported as
+        # "this station has nothing"
+        file.raise_unless_absent()
         if isinstance(file.content, Exception):
-            # a station that does not measure an element (or has no data for a month) has no file
             if not file.is_no_internet_error:
                 log.debug(f"No CHMI file {url} for station {station_id}: {file.content}")
             return None
@@ -256,8 +259,12 @@ class ChmiObservationRequest(TimeseriesRequest):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a catalogue that failed to download is not an empty catalogue -- returning one
+        # turns an outage into "this provider has no stations", which no caller can tell
+        # apart from the real thing. Only a missing connection stays soft.
+        file.raise_if_exception()
         if isinstance(file.content, Exception):
-            log.warning(f"Failed to fetch CHMI station catalogue: {file.content}")
+            log.warning("No internet connection while fetching the CHMI station catalogue")
             return pl.LazyFrame()
         stations = parse_chmi_stations(file.content.read())
         if stations.is_empty():

--- a/src/wetterdienst/provider/dwd/swsmos/api.py
+++ b/src/wetterdienst/provider/dwd/swsmos/api.py
@@ -101,9 +101,12 @@ class DwdSwsmosValues(TimeseriesValues):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a run that has not been published yet has no file, which is a 404 and routine; a
+        # timeout or a 5xx is not, and must not be reported as "no forecast for this run"
+        file.raise_unless_absent()
         if isinstance(file.content, Exception):
             if not file.is_no_internet_error:
-                log.warning(f"Failed to fetch SWSMOS run {url}: {file.content}")
+                log.debug(f"No SWSMOS run {url}: {file.content}")
             return None
         return file.content.read()
 
@@ -180,8 +183,11 @@ class DwdSwsmosRequest(TimeseriesRequest):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a catalogue that failed to download is not an empty catalogue -- only a missing
+        # connection stays soft
+        file.raise_if_exception()
         if isinstance(file.content, Exception):
-            log.warning(f"Failed to fetch SWSMOS station catalogue: {file.content}")
+            log.warning("No internet connection while fetching the SWSMOS station catalogue")
             return pl.LazyFrame()
         # the catalogue is latin-1 encoded (German station names carry umlauts)
         catalogue = bz2.decompress(file.content.read()).decode("latin-1").encode("utf-8")

--- a/src/wetterdienst/provider/fmi/observation/api.py
+++ b/src/wetterdienst/provider/fmi/observation/api.py
@@ -191,12 +191,12 @@ class FmiObservationValues(TimeseriesValues):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a station reporting no data for a window yields an empty (200) response, so any exception
+        # here is a real transport/HTTP failure rather than an absence -- raise it instead of
+        # returning the same empty frame a genuinely quiet station would produce
+        file.raise_if_exception()
         if isinstance(file.content, Exception):
-            # a station reporting no data for a window yields an empty (200) response, so any
-            # exception here is a real transport/HTTP failure; NoInternetError is already logged
-            # at debug upstream.
-            if not file.is_no_internet_error:
-                log.warning(f"Failed to fetch FMI data for station {station_id}: {file.content}")
+            log.warning(f"No internet connection while fetching FMI data for station {station_id}")
             return pl.DataFrame(
                 schema={
                     "date": pl.Datetime(time_unit="us", time_zone="UTC"),
@@ -239,8 +239,12 @@ class FmiObservationRequest(TimeseriesRequest):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a catalogue that failed to download is not an empty catalogue -- returning one
+        # turns an outage into "this provider has no stations", which no caller can tell
+        # apart from the real thing. Only a missing connection stays soft.
+        file.raise_if_exception()
         if isinstance(file.content, Exception):
-            log.warning(f"Failed to fetch FMI station catalogue: {file.content}")
+            log.warning("No internet connection while fetching the FMI station catalogue")
             return pl.LazyFrame()
         stations = parse_fmi_stations(file.content.read())
         if stations.is_empty():

--- a/src/wetterdienst/provider/ipma/observation/api.py
+++ b/src/wetterdienst/provider/ipma/observation/api.py
@@ -76,9 +76,12 @@ class IpmaObservationValues(TimeseriesValues):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # this is the single all-stations feed rather than a per-station file, so a failure is
+        # never "that station has no data" -- an empty result here would misreport an outage as a
+        # provider with nothing to offer
+        file.raise_if_exception()
         if isinstance(file.content, Exception):
-            if not file.is_no_internet_error:
-                log.warning(f"Failed to fetch IPMA observations: {file.content}")
+            log.warning("No internet connection while fetching IPMA observations")
             return None
         feed = parse_ipma_observations_feed(file.content.read())
         self._feed_cache = feed
@@ -130,8 +133,12 @@ class IpmaObservationRequest(TimeseriesRequest):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a catalogue that failed to download is not an empty catalogue -- returning one
+        # turns an outage into "this provider has no stations", which no caller can tell
+        # apart from the real thing. Only a missing connection stays soft.
+        file.raise_if_exception()
         if isinstance(file.content, Exception):
-            log.warning(f"Failed to fetch IPMA station catalogue: {file.content}")
+            log.warning("No internet connection while fetching the IPMA station catalogue")
             return pl.LazyFrame()
         stations = parse_ipma_stations(file.content.read())
         if stations.is_empty():

--- a/src/wetterdienst/provider/knmi/observation/api.py
+++ b/src/wetterdienst/provider/knmi/observation/api.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, cast
 import polars as pl
 import stamina
 
+from wetterdienst.exceptions import NoInternetError
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.model.metadata import DatasetModel, ParameterModel
@@ -228,9 +229,12 @@ class KnmiObservationValues(TimeseriesValues):
             filename = _filename_for(resolution, moment)
             payload = _fetch_netcdf(dataset_name, version, filename, settings)
             if isinstance(payload, Exception):
-                # a single missing/failed timestamp shouldn't sink the whole range --
-                # rate-limit/transient retries (if applicable) are already exhausted here.
-                log.warning(f"Failed to acquire KNMI data for station {station_id}, file {filename}: {payload}")
+                # a missing timestamp is routine and shouldn't sink the whole range, but a timeout
+                # or a rate limit is not the same thing as "that moment has no data" -- returning
+                # rows for some moments and silently none for others is worse than failing
+                if not isinstance(payload, (FileNotFoundError, NoInternetError)):
+                    raise payload
+                log.debug(f"No KNMI data for station {station_id}, file {filename}: {payload}")
                 continue
             df = parse_knmi_netcdf(payload, station_id, parameter_names, moment)
             if not df.is_empty():
@@ -353,11 +357,18 @@ class KnmiObservationRequest(TimeseriesRequest):
         dataset_name, version = _DATASET_BY_RESOLUTION[resolution]
         filename = _latest_filename(dataset_name, version, settings)
         if isinstance(filename, Exception):
-            log.warning(f"Failed to look up latest KNMI {resolution.value} file: {filename}")
+            # without the listing there is no station inventory at all, so this is fatal for the
+            # same reason the catalogue below is; only a missing connection stays soft
+            if not isinstance(filename, NoInternetError):
+                raise filename
+            log.warning(f"No internet connection while looking up the latest KNMI {resolution.value} file")
             return None
         payload = _fetch_netcdf(dataset_name, version, filename, settings)
         if isinstance(payload, Exception):
-            log.warning(f"Failed to fetch KNMI {resolution.value} stations: {payload}")
+            # an empty station list is never a correct answer, so only a missing connection is soft
+            if not isinstance(payload, NoInternetError):
+                raise payload
+            log.warning(f"No internet connection while fetching KNMI {resolution.value} stations")
             return None
 
         import h5netcdf  # noqa: PLC0415

--- a/src/wetterdienst/provider/lhmt/observation/api.py
+++ b/src/wetterdienst/provider/lhmt/observation/api.py
@@ -113,8 +113,10 @@ class LhmtObservationValues(TimeseriesValues):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a day before the station's record has no file, which is a 404 and routine; an outage
+        # is not, and used to contribute no rows in exactly the same way
+        file.raise_unless_absent()
         if isinstance(file.content, Exception):
-            # a day before the station's record (or an outage) simply contributes no rows
             if not file.is_no_internet_error:
                 log.debug(f"No LHMT data for {station_id} on {day}: {file.content}")
             return None
@@ -138,8 +140,12 @@ class LhmtObservationRequest(TimeseriesRequest):
             cache_disable=settings.cache_disable,
             use_certifi=settings.use_certifi,
         )
+        # a catalogue that failed to download is not an empty catalogue -- returning one
+        # turns an outage into "this provider has no stations", which no caller can tell
+        # apart from the real thing. Only a missing connection stays soft.
+        file.raise_if_exception()
         if isinstance(file.content, Exception):
-            log.warning(f"Failed to fetch LHMT station catalogue: {file.content}")
+            log.warning("No internet connection while fetching the LHMT station catalogue")
             return pl.LazyFrame()
         stations = parse_lhmt_stations(file.content.read())
         if stations.is_empty():

--- a/src/wetterdienst/provider/smhi/observation/api.py
+++ b/src/wetterdienst/provider/smhi/observation/api.py
@@ -107,14 +107,12 @@ class SmhiObservationValues(TimeseriesValues):
             url = f"{_BASE_URL}/parameter/{parameter.name_original}/station/{station_id}/period/{period}/data.csv"
             payload = _fetch(url, settings)
             if isinstance(payload, Exception):
-                # a 404 (FileNotFoundError) just means this station doesn't report this
-                # parameter -- routine, since not every SMHI station measures everything -- and
-                # a NoInternetError is already logged at debug upstream. Anything else is an
-                # unexpected failure worth surfacing rather than silently dropping the data.
+                # a 404 just means this station doesn't report this parameter -- routine, since
+                # not every SMHI station measures everything -- and a NoInternetError is already
+                # logged at debug upstream. Anything else means the data may well exist and we
+                # simply did not get it, so it is raised rather than passed off as "no data".
                 if not isinstance(payload, (FileNotFoundError, NoInternetError)):
-                    log.warning(
-                        f"Failed to fetch SMHI parameter {parameter.name_original} for station {station_id}: {payload}",
-                    )
+                    raise payload
                 continue
             try:
                 df = parse_smhi_csv(payload.decode("utf-8-sig"))
@@ -177,8 +175,12 @@ class SmhiObservationRequest(TimeseriesRequest):
         )
         frames_by_group: defaultdict[tuple[str, str], list[pl.DataFrame]] = defaultdict(list)
         for parameter, file in zip(parameters, files, strict=True):
+            # a catalogue that failed to download is not an empty catalogue -- skipping it here
+            # turns an outage into "this parameter has no stations", which no caller can tell apart
+            # from the real thing. Only a missing connection stays soft.
+            file.raise_if_exception()
             if isinstance(file.content, Exception):
-                log.warning(f"Failed to fetch SMHI stations for parameter {parameter.name_original}: {file.content}")
+                log.warning(f"No internet connection while fetching SMHI stations for {parameter.name_original}")
                 continue
             stations = json.loads(file.content.read().decode("utf-8-sig")).get("station", [])
             if not stations:

--- a/src/wetterdienst/util/network.py
+++ b/src/wetterdienst/util/network.py
@@ -80,6 +80,24 @@ class File:
         if isinstance(self.content, Exception):
             raise self.content
 
+    def raise_unless_absent(self) -> None:
+        """Raise unless the download failed in a way the caller may treat as "there is no data".
+
+        A 404 is a legitimate answer for a per-station or per-parameter request -- not every station
+        reports every parameter -- and a missing internet connection is handled softly everywhere.
+        Anything else (a timeout, a rate limit, a 5xx) means the data may well exist and we simply
+        did not get it. Returning an empty frame there is what makes a server outage indistinguishable
+        from "this station has nothing", which hides the outage from the caller and, in the test
+        suite, from anyone reading a red build.
+
+        Use this for data requests. Use ``raise_if_exception`` for a station catalogue, where a 404
+        is not routine either: an empty station list is never a correct answer.
+        """
+        if isinstance(self.content, (NoInternetError, FileNotFoundError)):
+            return
+        if isinstance(self.content, Exception):
+            raise self.content
+
     @property
     def is_no_internet_error(self) -> bool:
         """Check if the content is a NoInternetError."""

--- a/tests/provider/aemet/observation/test_api.py
+++ b/tests/provider/aemet/observation/test_api.py
@@ -11,6 +11,8 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
+from fsspec.exceptions import FSTimeoutError
 
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.provider.aemet.observation.api import (
@@ -35,7 +37,13 @@ requires_aemet_credentials = pytest.mark.skipif(
 # provider's own (deliberately modest) retry budget -- see api.py. Same treatment as ECCC
 # elsewhere in this test suite: xfail rather than skip, so a pass is still recorded when
 # AEMET is up, but a failure here doesn't block CI/merges on AEMET's own availability.
-xfail_if_aemet_unavailable = pytest.mark.xfail(strict=False, reason="AEMET server intermittently unavailable")
+# scoped to the ways an upstream failure now reaches us: the providers raise transport errors
+# instead of returning an empty frame, so an AssertionError here is our bug, not theirs
+xfail_if_aemet_unavailable = pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="AEMET server intermittently unavailable",
+)
 
 
 @pytest.mark.remote
@@ -302,14 +310,16 @@ def test_aemet_observation_daily_normalizes_non_utc_start_end_date_to_utc(monkey
         if "todasestaciones" in url:
             return station_payload
         captured_urls.append(url)
-        return Exception("stop after capturing the request URL")
+        # a routine absence rather than a bare Exception: a transport failure is now raised
+        # instead of swallowed, and only the URL matters here
+        return FileNotFoundError("stop after capturing the request URL")
 
     monkeypatch.setattr("wetterdienst.provider.aemet.observation.api._fetch_datos", fake_fetch_datos)
 
     madrid = ZoneInfo("Europe/Madrid")
     with contextlib.suppress(ValueError):
         # ValueError("cannot concat empty list"): expected, since the daily fetch above
-        # deliberately fails after capturing the URL -- only the URL matters here.
+        # deliberately reports no data after capturing the URL -- only the URL matters here.
         AemetObservationRequest(
             parameters=[("daily", "data")],
             start_date=dt.datetime(2020, 1, 1, 0, 30, tzinfo=madrid),

--- a/tests/provider/chmi/observation/test_api.py
+++ b/tests/provider/chmi/observation/test_api.py
@@ -7,6 +7,8 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
+from fsspec.exceptions import FSTimeoutError
 
 from wetterdienst.provider.chmi.observation import ChmiObservationRequest
 from wetterdienst.provider.chmi.observation.parser import (
@@ -105,7 +107,13 @@ def test_parse_chmi_values_aggregate_annual_has_no_month() -> None:
 
 # CHMI's open-data portal is a live third-party service; xfail rather than a hard failure keeps a
 # transient blip from blocking CI/merges, matching the AEMET/FMI precedent.
-xfail_if_chmi_unavailable = pytest.mark.xfail(strict=False, reason="CHMI server intermittently unavailable")
+# scoped to the ways an upstream failure now reaches us: the providers raise transport errors
+# instead of returning an empty frame, so an AssertionError here is our bug, not theirs
+xfail_if_chmi_unavailable = pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="CHMI server intermittently unavailable",
+)
 
 
 def _values(resolution: str, start: dt.datetime, end: dt.datetime) -> pl.DataFrame:

--- a/tests/provider/dwd/swsmos/test_api.py
+++ b/tests/provider/dwd/swsmos/test_api.py
@@ -8,6 +8,8 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
+from fsspec.exceptions import FSTimeoutError
 
 from wetterdienst.provider.dwd.swsmos import DwdSwsmosRequest
 from wetterdienst.provider.dwd.swsmos.api import DwdForecastDate, _read_run_csv, _run_url
@@ -57,7 +59,13 @@ def test_issue_string_parsed_to_utc_hour() -> None:
 # time-dependent; assert structure/ranges. xfail on outage matches the DWD/CHMI precedent.
 # ---------------------------------------------------------------------------
 
-xfail_if_dwd_unavailable = pytest.mark.xfail(strict=False, reason="DWD opendata intermittently unavailable")
+# scoped to the ways an upstream failure now reaches us: the providers raise transport errors
+# instead of returning an empty frame, so an AssertionError here is our bug, not theirs
+xfail_if_dwd_unavailable = pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="DWD opendata intermittently unavailable",
+)
 
 
 @pytest.mark.remote

--- a/tests/provider/fmi/observation/test_api.py
+++ b/tests/provider/fmi/observation/test_api.py
@@ -7,6 +7,8 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
+from fsspec.exceptions import FSTimeoutError
 
 from wetterdienst.provider.fmi.observation import FmiObservationRequest
 from wetterdienst.provider.fmi.observation.parser import (
@@ -20,7 +22,13 @@ UTC = ZoneInfo("UTC")
 
 # FMI's open-data WFS is a live third-party service; xfail rather than a hard failure keeps a
 # transient blip from blocking CI/merges, matching the AEMET/SMHI precedent.
-xfail_if_fmi_unavailable = pytest.mark.xfail(strict=False, reason="FMI server intermittently unavailable")
+# scoped to the ways an upstream failure now reaches us: the providers raise transport errors
+# instead of returning an empty frame, so an AssertionError here is our bug, not theirs
+xfail_if_fmi_unavailable = pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="FMI server intermittently unavailable",
+)
 
 
 def test_parse_fmi_observations_trace_sentinel() -> None:

--- a/tests/provider/ipma/observation/test_api.py
+++ b/tests/provider/ipma/observation/test_api.py
@@ -7,6 +7,8 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
+from fsspec.exceptions import FSTimeoutError
 
 from wetterdienst.provider.ipma.observation import IpmaObservationRequest
 from wetterdienst.provider.ipma.observation.parser import (
@@ -123,7 +125,13 @@ def test_parse_ipma_observations_skips_absent_station() -> None:
 # outage keeps a transient blip from blocking CI, matching the CHMI/AEMET precedent.
 # ---------------------------------------------------------------------------
 
-xfail_if_ipma_unavailable = pytest.mark.xfail(strict=False, reason="IPMA API intermittently unavailable")
+# scoped to the ways an upstream failure now reaches us: the providers raise transport errors
+# instead of returning an empty frame, so an AssertionError here is our bug, not theirs
+xfail_if_ipma_unavailable = pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="IPMA API intermittently unavailable",
+)
 
 
 @pytest.mark.remote

--- a/tests/provider/knmi/observation/test_api.py
+++ b/tests/provider/knmi/observation/test_api.py
@@ -17,6 +17,8 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
+from fsspec.exceptions import FSTimeoutError
 
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.resolution import Resolution
@@ -49,7 +51,13 @@ requires_knmi_credentials = pytest.mark.skipif(
 )
 # Live third-party API; xfail rather than a hard failure keeps a transient blip (or KNMI's
 # per-key rate limit) from blocking CI/merges, matching the AEMET/SMHI/ECCC precedent.
-xfail_if_knmi_unavailable = pytest.mark.xfail(strict=False, reason="KNMI server intermittently unavailable")
+# scoped to the ways an upstream failure now reaches us: the providers raise transport errors
+# instead of returning an empty frame, so an AssertionError here is our bug, not theirs
+xfail_if_knmi_unavailable = pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="KNMI server intermittently unavailable",
+)
 
 
 def _write_netcdf(path: Path) -> bytes:

--- a/tests/provider/lhmt/observation/test_api.py
+++ b/tests/provider/lhmt/observation/test_api.py
@@ -7,6 +7,8 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
+from fsspec.exceptions import FSTimeoutError
 
 from wetterdienst.provider.lhmt.observation import LhmtObservationRequest
 from wetterdienst.provider.lhmt.observation.parser import (
@@ -141,7 +143,13 @@ def test_days_covers_range_inclusive(start: dt.datetime, end: dt.datetime, expec
 # can be asserted. xfail (not hard-fail) on an outage matches the CHMI/AEMET precedent.
 # ---------------------------------------------------------------------------
 
-xfail_if_lhmt_unavailable = pytest.mark.xfail(strict=False, reason="LHMT API intermittently unavailable")
+# scoped to the ways an upstream failure now reaches us: the providers raise transport errors
+# instead of returning an empty frame, so an AssertionError here is our bug, not theirs
+xfail_if_lhmt_unavailable = pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="LHMT API intermittently unavailable",
+)
 
 
 @pytest.mark.remote

--- a/tests/provider/smhi/observation/test_api.py
+++ b/tests/provider/smhi/observation/test_api.py
@@ -7,6 +7,8 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
+from fsspec.exceptions import FSTimeoutError
 
 from wetterdienst.provider.smhi.observation import SmhiObservationRequest
 
@@ -16,7 +18,13 @@ UTC = ZoneInfo("UTC")
 # SMHI's live service has not been observed to be chronically flaky the way AEMET/Frost
 # have been, but it's a live third-party API like any other -- xfail rather than a hard
 # failure keeps a transient blip from blocking CI/merges, matching the AEMET/ECCC precedent.
-xfail_if_smhi_unavailable = pytest.mark.xfail(strict=False, reason="SMHI server intermittently unavailable")
+# scoped to the ways an upstream failure now reaches us: the providers raise transport errors
+# instead of returning an empty frame, so an AssertionError here is our bug, not theirs
+xfail_if_smhi_unavailable = pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="SMHI server intermittently unavailable",
+)
 
 
 @pytest.mark.remote

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,6 +9,7 @@ from typing import get_args
 
 import polars as pl
 import pytest
+from aiohttp import ClientPayloadError, ClientResponseError
 from fsspec.exceptions import FSTimeoutError
 from pydantic import ValidationError
 
@@ -773,7 +774,11 @@ def test_api_meteoswiss_observation(default_settings: Settings) -> None:
     assert not values.drop_nulls(subset="value").is_empty()
 
 
-@pytest.mark.xfail(strict=False, reason="AEMET server intermittently unavailable")
+@pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="AEMET server intermittently unavailable",
+)
 @pytest.mark.remote
 @pytest.mark.skipif(
     not AemetObservationRequest.is_configured(),
@@ -801,7 +806,11 @@ def test_api_aemet_observation(default_settings: Settings) -> None:
     assert not values.drop_nulls(subset="value").is_empty()
 
 
-@pytest.mark.xfail(strict=False, reason="CHMI server intermittently unavailable")
+@pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="CHMI server intermittently unavailable",
+)
 @pytest.mark.remote
 def test_api_chmi_observation(default_settings: Settings) -> None:
     """Test CHMI observation API."""
@@ -825,7 +834,11 @@ def test_api_chmi_observation(default_settings: Settings) -> None:
     assert not values.drop_nulls(subset="value").is_empty()
 
 
-@pytest.mark.xfail(strict=False, reason="SMHI server intermittently unavailable")
+@pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="SMHI server intermittently unavailable",
+)
 @pytest.mark.remote
 def test_api_smhi_observation(default_settings: Settings) -> None:
     """Test SMHI observation API."""
@@ -848,7 +861,11 @@ def test_api_smhi_observation(default_settings: Settings) -> None:
     assert not values.drop_nulls(subset="value").is_empty()
 
 
-@pytest.mark.xfail(strict=False, reason="FMI server intermittently unavailable")
+@pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="FMI server intermittently unavailable",
+)
 @pytest.mark.remote
 def test_api_fmi_observation(default_settings: Settings) -> None:
     """Test FMI observation API."""
@@ -872,7 +889,11 @@ def test_api_fmi_observation(default_settings: Settings) -> None:
     assert not values.drop_nulls(subset="value").is_empty()
 
 
-@pytest.mark.xfail(strict=False, reason="KNMI server intermittently unavailable")
+@pytest.mark.xfail(
+    raises=(FSTimeoutError, FileNotFoundError, ClientResponseError, ClientPayloadError),
+    strict=False,
+    reason="KNMI server intermittently unavailable",
+)
 @pytest.mark.remote
 @pytest.mark.skipif(
     not KnmiObservationRequest.is_configured(),


### PR DESCRIPTION
Follow-up to #1812. Scoping the remaining `xfail` markers turned out to be impossible while the providers destroyed the information the scoping needs — so this fixes the cause first.

## The problem

Eight providers logged a warning and returned an empty frame when a download failed:

```python
if isinstance(file.content, Exception):
    log.warning(f"Failed to fetch X: {file.content}")
    return pl.LazyFrame()
```

So a whole-provider outage and a station that genuinely has no data are **the same result** to the caller — an empty frame, with the reason only in the logs. FMI's own comment said "any exception here is a real transport/HTTP failure" directly above the code that swallowed it.

## What changes

The distinction that matters is **absence versus failure**, not the transport:

| | behaviour |
|---|---|
| 404 on a data file | routine — providers use it for "this station does not report this parameter" |
| no internet | soft, as before |
| timeout, 429, 5xx, payload error | **raises** (new `File.raise_unless_absent`) |
| any failure on a **station catalogue** | **raises** — an empty station list is never correct |

## Verified in both directions

Not by reading the diff — by stubbing `download_file` and observing:

```
                       outage (FSTimeoutError)      404
aemet                  RAISES                        —
chmi                   RAISES                       ROUTINE, 0 rows
fmi                    RAISES                        —
ipma                   RAISES                        —
knmi                   RAISES                        —
lhmt                   RAISES                       ROUTINE, 0 rows
smhi                   RAISES                       ROUTINE, 0 rows
```

Before this change all seven returned **0 stations and no exception** under the outage. The 404 column is the half that would be easy to break: turning absence into a hard failure would be worse than the bug being fixed.

Two of them needed a second pass — AEMET and KNMI still swallowed in their `_all()` station paths after the first round, which the probe caught.

## Why the markers could not be scoped before

This is the actual point. While an outage arrived as an empty frame, the test failed with:

```
E   AssertionError: SMHI returned no stations
```

No `raises=(...)` can distinguish that from a real parsing regression, so the eight markers had to tolerate *everything*, including our own bugs. They now name the four exceptions an upstream failure produces, and a simulated outage yields `5 xfailed` rather than 5 failures.

Zero bare `xfail(strict=False)` markers remain in the suite.

## Note

One AEMET test used a bare `Exception` as a "stop after capturing the URL" sentinel and depended on it being swallowed. It returns `FileNotFoundError` now, which is what it always meant.

**Breaking**: code that relied on getting an empty frame during an outage now sees the exception.

670 non-remote tests pass; the eight provider suites pass against live services; lint and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
