### PR TITLE
fix(eccc)!: repair the hourly and monthly resolutions, and stop truncating every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,9 +116,15 @@ Types of changes:
   timestamp. Both now declare the fields ECCC actually serves; the requested field list is derived
   from those declarations rather than hand-maintained per resolution, which is what let hourly
   drift into a copy of daily in the first place. Parameter names change for both resolutions
+- **Breaking**: ECCC value requests return the whole period rather than an arbitrary 500 records.
+  The OGC endpoint pages at 500 features and a station-year of hourly data is ~8800, so every
+  request was silently truncated to a slice of the year -- June 1972 at station 4055 returned 16
+  timestamps where it holds 697. Results grow accordingly
 - ECCC exposes its whole station network rather than the first 500. The OGC endpoint pages at 500
   by default and ECCC publishes ~8600 stations, so 94% of them could not be requested at all --
   including every station whose data the hourly collection actually holds
+- ECCC no longer fails on the daylight-saving fall-back hour, which occurs twice in local time.
+  Unreachable while a request returned only part of a year, so it surfaced with the fix above
 - ECCC hourly `wind_direction` is returned in degrees rather than tens of degrees, the same source
   encoding already decoded for the daily gust direction
 - ECCC stations opened before standard time no longer fail the station listing. `America/Toronto`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,24 @@ Types of changes:
 
 ### Fixed
 
+- **Breaking**: ECCC hourly and monthly return data at all. Both resolutions declared parameters
+  the OGC API never publishes -- hourly carried a copy of the *daily* field list
+  (`max_temperature`, `snow_on_ground`, the degree days), monthly carried bulk-CSV column headers
+  (`"total precip (mm)"`) -- so every request came back empty. Monthly additionally crashed on
+  `LOCAL_DATE`, which is `"2023-06"` for that collection against a parser expecting a full
+  timestamp. Both now declare the fields ECCC actually serves; the requested field list is derived
+  from those declarations rather than hand-maintained per resolution, which is what let hourly
+  drift into a copy of daily in the first place. Parameter names change for both resolutions
+- ECCC exposes its whole station network rather than the first 500. The OGC endpoint pages at 500
+  by default and ECCC publishes ~8600 stations, so 94% of them could not be requested at all --
+  including every station whose data the hourly collection actually holds
+- ECCC hourly `wind_direction` is returned in degrees rather than tens of degrees, the same source
+  encoding already decoded for the daily gust direction
+- ECCC stations opened before standard time no longer fail the station listing. `America/Toronto`
+  is `-5:17:32` in 1895, an offset that is not a whole number of minutes and that polars rejects;
+  the conversion to UTC now happens in Python. A handful of stations publish no timezone at all
+  and fall back to UTC. Neither showed up while the listing stopped at 500 rows
+
 - **Breaking**: WSV Pegelonline values are now scaled to the unit the metadata declares. The service
   publishes the unit per *timeseries*, not per parameter, and its stations disagree, so a single
   declaration was silently wrong wherever a station differed. Water level is `cm` at most gauges but

--- a/docs/data/provider/eccc/observation/hourly.md
+++ b/docs/data/provider/eccc/observation/hourly.md
@@ -23,14 +23,14 @@
 
 #### parameters
 
-| name                                  | original name       | description              | unit | constraints |
-|---------------------------------------|---------------------|--------------------------|------|-------------|
-| {term}`humidity`                      | rel hum (%)         | humidity                 | %    | >=0,<=100   |
-| {term}`pressure_air_site`             | stn press (kpa)     | air pressure at site     | kPa  | >=0         |
-| {term}`temperature_air_mean_2m`       | temp (°c)           | 2m air temperature       | °C   | -           |
-| {term}`temperature_dew_point_mean_2m` | dew point temp (°c) | 2m dew point temperature | °C   | -           |
-| {term}`visibility_range`              | visibility (km)     | visibility range         | km   | >=0         |
-| {term}`weather`                       | weather             | weather code             | -    | -           |
-| {term}`wind_direction`                | wind dir (10s deg)  | wind direction           | °    | >=0,<=360   |
-| {term}`wind_gust_max`                 | wind gust (km/h)    | wind gust maximum        | km/h | >=0         |
-| {term}`wind_speed`                    | wind spd (km/h)     | wind speed               | km/h | >=0         |
+| name                                  | original name     | description                      | unit | constraints |
+|---------------------------------------|-------------------|----------------------------------|------|-------------|
+| {term}`humidity`                      | relative_humidity | humidity                         | %    | >=0,<=100   |
+| {term}`precipitation_height`          | precip_amount     | precipitation height             | mm   | >=0         |
+| {term}`pressure_air_site`             | station_pressure  | air pressure at site             | kPa  | >=0         |
+| {term}`temperature_air_mean_2m`       | temp              | 2m air temperature               | °C   | -           |
+| {term}`temperature_dew_point_mean_2m` | dew_point_temp    | 2m dew point temperature         | °C   | -           |
+| {term}`temperature_wind_chill`        | windchill         | wind chill temperature           | °C   | -           |
+| {term}`visibility_range`              | visibility        | visibility range                 | km   | >=0         |
+| {term}`wind_direction`                | wind_direction    | wind direction (source: 10s deg) | °    | >=0,<=360   |
+| {term}`wind_speed`                    | wind_speed        | wind speed                       | km/h | >=0         |

--- a/docs/data/provider/eccc/observation/monthly.md
+++ b/docs/data/provider/eccc/observation/monthly.md
@@ -4,14 +4,33 @@
 
 | property      | value                                                                                                                                                                              |
 |---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| name                            | original name           | description                  | unit | constraints |
-|---------------------------------|-------------------------|------------------------------|------|-------------|
-| {term}`cooling_degree_day`      | cooling_degree_days     | cooling degree days          | °Cd  | >=0         |
-| {term}`heating_degree_day`      | heating_degree_days     | heating degree days          | °Cd  | >=0         |
-| {term}`precipitation_height`    | total_precipitation     | precipitation height         | mm   | >=0         |
-| {term}`snow_depth`              | snow_on_ground_last_day | snow depth on the last day   | cm   | >=0         |
-| {term}`snow_depth_new`          | total_snowfall          | snowfall total               | cm   | >=0         |
-| {term}`sunshine_duration`       | bright_sunshine         | bright sunshine duration     | h    | >=0         |
-| {term}`temperature_air_max_2m`  | max_temperature         | 2m maximum air temperature   | °C   | -           |
-| {term}`temperature_air_mean_2m` | mean_temperature        | 2m mean air temperature      | °C   | -           |
-| {term}`temperature_air_min_2m`  | min_temperature         | 2m minimum air temperature   | °C   | -           |
+| name          | monthly                                                                                                                                                                            |
+| original name | mly                                                                                                                                                                                |
+| url           | [here](https://www.canada.ca/en/environment-climate-change/services/climate-change/canadian-centre-climate-services/display-download/technical-documentation-daily-data.html#toc0) |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property    | value                                                                                                                                                                                                                                      |
+|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name        | data                                                                                                                                                                                                                                       |
+| original    | data                                                                                                                                                                                                                                       |
+| description | Historical monthly station observations for Canada ([details](https://www.canada.ca/en/environment-climate-change/services/climate-change/canadian-centre-climate-services/display-download/technical-documentation-daily-data.html#toc0)) |
+| access      | [here](https://www.canada.ca/en/environment-climate-change/services/climate-change/canadian-centre-climate-services/display-download/technical-documentation-daily-data.html#toc0)                                                         |
+
+#### parameters
+
+| name                            | original name           | description                | unit | constraints |
+|---------------------------------|-------------------------|----------------------------|------|-------------|
+| {term}`cooling_degree_day`      | cooling_degree_days     | cooling degree days        | °Cd  | >=0         |
+| {term}`heating_degree_day`      | heating_degree_days     | heating degree days        | °Cd  | >=0         |
+| {term}`precipitation_height`    | total_precipitation     | precipitation height       | mm   | >=0         |
+| {term}`snow_depth`              | snow_on_ground_last_day | snow depth on the last day | cm   | >=0         |
+| {term}`snow_depth_new`          | total_snowfall          | snowfall total             | cm   | >=0         |
+| {term}`sunshine_duration`       | bright_sunshine         | bright sunshine duration   | h    | >=0         |
+| {term}`temperature_air_max_2m`  | max_temperature         | 2m maximum air temperature | °C   | -           |
+| {term}`temperature_air_mean_2m` | mean_temperature        | 2m mean air temperature    | °C   | -           |
+| {term}`temperature_air_min_2m`  | min_temperature         | 2m minimum air temperature | °C   | -           |

--- a/docs/data/provider/eccc/observation/monthly.md
+++ b/docs/data/provider/eccc/observation/monthly.md
@@ -4,35 +4,14 @@
 
 | property      | value                                                                                                                                                                              |
 |---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| name          | monthly                                                                                                                                                                            |
-| original name | mly                                                                                                                                                                                |
-| url           | [here](https://www.canada.ca/en/environment-climate-change/services/climate-change/canadian-centre-climate-services/display-download/technical-documentation-daily-data.html#toc0) |
-
-## datasets
-
-### data
-
-#### metadata
-
-| property    | value                                                                                                                                                                                                                                      |
-|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| name        | data                                                                                                                                                                                                                                       |
-| original    | data                                                                                                                                                                                                                                       |
-| description | Historical monthly station observations for Canada ([details](https://www.canada.ca/en/environment-climate-change/services/climate-change/canadian-centre-climate-services/display-download/technical-documentation-daily-data.html#toc0)) |
-| access      | [here](https://www.canada.ca/en/environment-climate-change/services/climate-change/canadian-centre-climate-services/display-download/technical-documentation-daily-data.html#toc0)                                                         |
-
-#### parameters
-
-| name                                | original name              | description                                | unit | constraints |
-|-------------------------------------|----------------------------|--------------------------------------------|------|-------------|
-| {term}`precipitation_height`        | total precip (mm)          | total precipitation                        | mm   | >=0         |
-| {term}`precipitation_height_liquid` | total rain (mm)            | total liquid precipitation                 | mm   | >=0         |
-| {term}`snow_depth`                  | snow grnd last day (cm)    | total snow depth                           | cm   | >=0         |
-| {term}`snow_depth_new`              | total snow (cm)            | new snow depth                             | cm   | >=0         |
-| {term}`temperature_air_max_2m`      | extr max temp (°c)         | monthly maximum 2m air temperature         | °C   | -           |
-| {term}`temperature_air_max_2m_mean` | mean max temp (°c)         | monthly mean of maximum 2m air temperature | °C   | -           |
-| {term}`temperature_air_mean_2m`     | mean temp (°c)             | monthly mean of 2m air temperature         | °C   | -           |
-| {term}`temperature_air_min_2m`      | extr min temp (°c)         | monthly minimum 2m air temperature         | °C   | -           |
-| {term}`temperature_air_min_2m_mean` | mean min temp (°c)         | monthly mean of minimum 2m air temperature | °C   | -           |
-| {term}`wind_direction_gust_max`     | dir of max gust (10's deg) | wind direction of maximum wind gust        | °    | >=0,<=360   |
-| {term}`wind_gust_max`               | spd of max gust (km/h)     | maximum wind gust                          | km/h | >=0         |
+| name                            | original name           | description                  | unit | constraints |
+|---------------------------------|-------------------------|------------------------------|------|-------------|
+| {term}`cooling_degree_day`      | cooling_degree_days     | cooling degree days          | °Cd  | >=0         |
+| {term}`heating_degree_day`      | heating_degree_days     | heating degree days          | °Cd  | >=0         |
+| {term}`precipitation_height`    | total_precipitation     | precipitation height         | mm   | >=0         |
+| {term}`snow_depth`              | snow_on_ground_last_day | snow depth on the last day   | cm   | >=0         |
+| {term}`snow_depth_new`          | total_snowfall          | snowfall total               | cm   | >=0         |
+| {term}`sunshine_duration`       | bright_sunshine         | bright sunshine duration     | h    | >=0         |
+| {term}`temperature_air_max_2m`  | max_temperature         | 2m maximum air temperature   | °C   | -           |
+| {term}`temperature_air_mean_2m` | mean_temperature        | 2m mean air temperature      | °C   | -           |
+| {term}`temperature_air_min_2m`  | min_temperature         | 2m minimum air temperature   | °C   | -           |

--- a/src/wetterdienst/provider/eccc/observation/api.py
+++ b/src/wetterdienst/provider/eccc/observation/api.py
@@ -25,6 +25,23 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# ECCC publishes ~8600 stations; the OGC default page size is 500
+_STATIONS_LIMIT = 10000
+
+
+def _localize(value: dt.datetime | None, timezone: str | None) -> dt.datetime | None:
+    """Attach the station's timezone and convert to UTC.
+
+    Converted here in Python rather than handed to polars tz-aware: stations opened before
+    standard time carry an LMT offset that is not a whole number of minutes (America/Toronto is
+    -5:17:32 in 1895), which polars rejects outright. A handful of stations publish no timezone at
+    all, which only shows up once the full catalogue is fetched rather than its first 500 rows.
+    """
+    if value is None:
+        return None
+    tz = ZoneInfo(timezone) if timezone else dt.timezone.utc
+    return value.replace(tzinfo=tz).astimezone(dt.timezone.utc)
+
 
 class EcccObservationValues(TimeseriesValues):
     """Values class for Environment and Climate Change Canada (ECCC) observation data."""
@@ -117,58 +134,18 @@ class EcccObservationValues(TimeseriesValues):
                 cache_disable=settings.cache_disable,
                 use_certifi=settings.use_certifi,
             )
-            if dataset.resolution.value in (Resolution.HOURLY, Resolution.DAILY):
-                parameters = [
-                    "COOLING_DEGREE_DAYS",
-                    "COOLING_DEGREE_DAYS_FLAG",
-                    "DIRECTION_MAX_GUST",
-                    "DIRECTION_MAX_GUST_FLAG",
-                    "HEATING_DEGREE_DAYS",
-                    "HEATING_DEGREE_DAYS_FLAG",
-                    "MAX_REL_HUMIDITY",
-                    "MAX_REL_HUMIDITY_FLAG",
-                    "MAX_TEMPERATURE",
-                    "MAX_TEMPERATURE_FLAG",
-                    "MEAN_TEMPERATURE",
-                    "MEAN_TEMPERATURE_FLAG",
-                    "MIN_REL_HUMIDITY",
-                    "MIN_REL_HUMIDITY_FLAG",
-                    "MIN_TEMPERATURE",
-                    "MIN_TEMPERATURE_FLAG",
-                    "SNOW_ON_GROUND",
-                    "SNOW_ON_GROUND_FLAG",
-                    "SPEED_MAX_GUST",
-                    "SPEED_MAX_GUST_FLAG",
-                    "TOTAL_PRECIPITATION",
-                    "TOTAL_PRECIPITATION_FLAG",
-                    "TOTAL_RAIN",
-                    "TOTAL_RAIN_FLAG",
-                    "TOTAL_SNOW",
-                    "TOTAL_SNOW_FLAG",
-                ]
-            else:
-                parameters = [
-                    "BRIGHT_SUNSHINE",
-                    "COOLING_DEGREE_DAYS",
-                    "DAYS_WITH_PRECIP_GE_1MM",
-                    "DAYS_WITH_VALID_MAX_TEMP",
-                    "DAYS_WITH_VALID_MEAN_TEMP",
-                    "DAYS_WITH_VALID_MIN_TEMP",
-                    "DAYS_WITH_VALID_PRECIP",
-                    "DAYS_WITH_VALID_SNOWFALL",
-                    "DAYS_WITH_VALID_SUNSHINE",
-                    "HEATING_DEGREE_DAYS",
-                    "MAX_TEMPERATURE",
-                    "MEAN_TEMPERATURE",
-                    "MIN_TEMPERATURE",
-                    "NORMAL_MEAN_TEMPERATURE",
-                    "NORMAL_PRECIPITATION",
-                    "NORMAL_SNOWFALL",
-                    "NORMAL_SUNSHINE",
-                    "SNOW_ON_GROUND_LAST_DAY",
-                    "TOTAL_PRECIPITATION",
-                    "TOTAL_SNOWFALL",
-                ]
+            # Derived from the declarations rather than hard-coded: the three lists used to be
+            # maintained by hand and the hourly one had drifted to a copy of the daily fields,
+            # none of which the hourly collection publishes, so the resolution returned nothing.
+            parameters = []
+            for parameter in dataset.parameters:
+                if parameter.name == "quality":
+                    continue
+                field = parameter.name_original.upper()
+                parameters.append(field)
+                if dataset.resolution.value in (Resolution.HOURLY, Resolution.DAILY):
+                    # monthly carries no per-value flags
+                    parameters.append(f"{field}_FLAG")
 
             _properties_schema = pl.Struct(
                 {
@@ -199,13 +176,14 @@ class EcccObservationValues(TimeseriesValues):
             )
             df = df.rename(str.lower)
             df = self._tidy_up_df(df)
-            # ECCC publishes the gust direction in tens of degrees -- its own docs call the column
+            # ECCC publishes both gust direction (daily) and wind direction (hourly) in tens of degrees --
+            # its own docs call the daily column
             # "Dir of Max Gust (10s deg)" -- so 23 means 230 degrees. Decoded here rather than
             # declared as a unit, because tens of degrees is a source encoding rather than a unit
             # anyone reports in. Without it every bearing came back 10x too small and inside
             # 0..36, which no range check on degrees would ever flag.
             df = df.with_columns(
-                pl.when(pl.col("parameter") == "direction_max_gust")
+                pl.when(pl.col("parameter").is_in(["direction_max_gust", "wind_direction"]))
                 .then(pl.col("value") * 10)
                 .otherwise(pl.col("value"))
                 .alias("value"),
@@ -216,7 +194,8 @@ class EcccObservationValues(TimeseriesValues):
                 "parameter",
                 pl.lit(station_id, dtype=pl.String).alias("station_id"),
                 pl.col("local_date")
-                .str.to_datetime("%Y-%m-%d %H:%M:%S")
+                # monthly publishes "2023-06"; hourly and daily a full timestamp
+                .str.to_datetime("%Y-%m" if dataset.resolution.value == Resolution.MONTHLY else "%Y-%m-%d %H:%M:%S")
                 .dt.replace_time_zone(station_tz)
                 .dt.convert_time_zone("UTC")
                 .alias("date"),
@@ -268,8 +247,11 @@ class EcccObservationRequest(TimeseriesRequest):
         from typing import cast  # noqa: PLC0415
 
         settings = cast("Settings", self.settings)
+        # The OGC endpoint defaults to 500 features, and ECCC has ~8600 stations, so the default
+        # silently reduced the network to its first 500 station ids -- every other station was
+        # simply unreachable. `limit` is the collection's documented maximum.
         file = download_file(
-            url=f"{self._endpoint}/collections/climate-stations/items",
+            url=f"{self._endpoint}/collections/climate-stations/items?limit={_STATIONS_LIMIT}&f=json",
             cache_dir=settings.cache_dir,
             ttl=CacheExpiry.METAINDEX,
             client_kwargs=settings.fsspec_client_kwargs,
@@ -331,17 +313,17 @@ class EcccObservationRequest(TimeseriesRequest):
             pl.col("end_date").str.to_datetime("%Y-%m-%d %H:%M:%S"),
             pl.col("height").cast(pl.Float64),
         )
-        # Convert datetime to the timezone from the timezone column
+        # Convert datetime to the timezone from the timezone column.
         df_raw = df_raw.with_columns(
             pl.struct(["start_date", "timezone"])
             .map_elements(
-                lambda row: row["start_date"].replace(tzinfo=ZoneInfo(row["timezone"])),
+                lambda row: _localize(row["start_date"], row["timezone"]),
                 return_dtype=pl.Datetime(time_zone="UTC"),
             )
             .alias("start_date"),
             pl.struct(["end_date", "timezone"])
             .map_elements(
-                lambda row: row["end_date"].replace(tzinfo=ZoneInfo(row["timezone"])),
+                lambda row: _localize(row["end_date"], row["timezone"]),
                 return_dtype=pl.Datetime(time_zone="UTC"),
             )
             .alias("end_date"),

--- a/src/wetterdienst/provider/eccc/observation/api.py
+++ b/src/wetterdienst/provider/eccc/observation/api.py
@@ -103,6 +103,22 @@ class EcccObservationValues(TimeseriesValues):
             dataset = parameter_or_dataset
         else:
             dataset = parameter_or_dataset.dataset
+        # Derived from the declarations rather than hard-coded: the three lists used to be
+        # maintained by hand and the hourly one had drifted to a copy of the daily fields, none of
+        # which the hourly collection publishes, so the resolution returned nothing. Built once
+        # here rather than per year, since it depends only on the dataset.
+        fields = []
+        for parameter in dataset.parameters:
+            if parameter.name == "quality":
+                continue
+            field = parameter.name_original.upper()
+            fields.append(field)
+            if dataset.resolution.value in (Resolution.HOURLY, Resolution.DAILY):
+                # monthly carries no per-value flags
+                fields.append(f"{field}_FLAG")
+        _properties_schema = pl.Struct(
+            {"LOCAL_DATE": pl.String} | {f: (pl.String if f.endswith("FLAG") else pl.Float64) for f in fields}
+        )
         data = []
         start_year = self.sr.start_date.year if self.sr.start_date else station_meta["start_date"].year
         end_year = self.sr.end_date.year if self.sr.end_date else station_meta["end_date"].year
@@ -133,25 +149,6 @@ class EcccObservationValues(TimeseriesValues):
                 client_kwargs=settings.fsspec_client_kwargs,
                 cache_disable=settings.cache_disable,
                 use_certifi=settings.use_certifi,
-            )
-            # Derived from the declarations rather than hard-coded: the three lists used to be
-            # maintained by hand and the hourly one had drifted to a copy of the daily fields,
-            # none of which the hourly collection publishes, so the resolution returned nothing.
-            parameters = []
-            for parameter in dataset.parameters:
-                if parameter.name == "quality":
-                    continue
-                field = parameter.name_original.upper()
-                parameters.append(field)
-                if dataset.resolution.value in (Resolution.HOURLY, Resolution.DAILY):
-                    # monthly carries no per-value flags
-                    parameters.append(f"{field}_FLAG")
-
-            _properties_schema = pl.Struct(
-                {
-                    "LOCAL_DATE": pl.String,
-                }
-                | {parameter: (pl.String if parameter.endswith("FLAG") else pl.Float64) for parameter in parameters}
             )
             file.raise_if_exception()
             if isinstance(file.content, Exception):

--- a/src/wetterdienst/provider/eccc/observation/api.py
+++ b/src/wetterdienst/provider/eccc/observation/api.py
@@ -27,6 +27,8 @@ log = logging.getLogger(__name__)
 
 # ECCC publishes ~8600 stations; the OGC default page size is 500
 _STATIONS_LIMIT = 10000
+# the collections page at 500 features by default, which silently truncates a station-year
+_PAGE_SIZE = 10000
 
 
 def _localize(value: dt.datetime | None, timezone: str | None) -> dt.datetime | None:
@@ -137,41 +139,53 @@ class EcccObservationValues(TimeseriesValues):
                 .astimezone(ZoneInfo(station_tz))
                 .strftime("%Y-%m-%dT%H:%M:%S")
             )
-            url = (
-                f"{self._endpoint}/collections/"
-                f"{self._resolution_to_dataset_mapping[dataset.resolution.value]}/"
-                f"items?STN_ID={station_id}&datetime={start}/{end}&f=json"
-            )
-            file = download_file(
-                url=url,
-                cache_dir=settings.cache_dir,
-                ttl=CacheExpiry.FIVE_MINUTES,
-                client_kwargs=settings.fsspec_client_kwargs,
-                cache_disable=settings.cache_disable,
-                use_certifi=settings.use_certifi,
-            )
-            file.raise_if_exception()
-            if isinstance(file.content, Exception):
-                return pl.DataFrame()
-            df = pl.read_json(
-                file.content,
-                schema=pl.Schema(
-                    {
-                        "features": pl.List(
-                            pl.Struct(
-                                {
-                                    "properties": _properties_schema,
-                                }
-                            )
-                        ),
-                    }
-                ),
-            )
-            df = df.lazy()
-            df = df.select(pl.col("features").explode(empty_as_null=True).struct.field("properties")).unnest(
-                "properties"
-            )
-            df = df.rename(str.lower)
+            # The endpoint pages at 500 features and a station-year of hourly data is ~8800, so a
+            # single request returns an arbitrary slice of the year and silently drops the rest.
+            # Page until a short page comes back.
+            pages = []
+            offset = 0
+            while True:
+                url = (
+                    f"{self._endpoint}/collections/"
+                    f"{self._resolution_to_dataset_mapping[dataset.resolution.value]}/"
+                    f"items?STN_ID={station_id}&datetime={start}/{end}"
+                    f"&limit={_PAGE_SIZE}&offset={offset}&f=json"
+                )
+                file = download_file(
+                    url=url,
+                    cache_dir=settings.cache_dir,
+                    ttl=CacheExpiry.FIVE_MINUTES,
+                    client_kwargs=settings.fsspec_client_kwargs,
+                    cache_disable=settings.cache_disable,
+                    use_certifi=settings.use_certifi,
+                )
+                file.raise_if_exception()
+                if isinstance(file.content, Exception):
+                    return pl.DataFrame()
+                df_page = pl.read_json(
+                    file.content,
+                    schema=pl.Schema(
+                        {
+                            "features": pl.List(
+                                pl.Struct(
+                                    {
+                                        "properties": _properties_schema,
+                                    }
+                                )
+                            ),
+                        }
+                    ),
+                )
+                df_page = df_page.lazy()
+                df_page = df_page.select(
+                    pl.col("features").explode(empty_as_null=True).struct.field("properties")
+                ).unnest("properties")
+                df_page = df_page.rename(str.lower).collect()
+                pages.append(df_page)
+                if df_page.height < _PAGE_SIZE:
+                    break
+                offset += _PAGE_SIZE
+            df = pl.concat(pages).lazy()
             df = self._tidy_up_df(df)
             # ECCC publishes both gust direction (daily) and wind direction (hourly) in tens of degrees --
             # its own docs call the daily column
@@ -193,7 +207,9 @@ class EcccObservationValues(TimeseriesValues):
                 pl.col("local_date")
                 # monthly publishes "2023-06"; hourly and daily a full timestamp
                 .str.to_datetime("%Y-%m" if dataset.resolution.value == Resolution.MONTHLY else "%Y-%m-%d %H:%M:%S")
-                .dt.replace_time_zone(station_tz)
+                # the fall-back hour occurs twice in local time and the spring-forward hour not at
+                # all; both were unreachable while a request returned only a slice of the year
+                .dt.replace_time_zone(station_tz, ambiguous="earliest", non_existent="null")
                 .dt.convert_time_zone("UTC")
                 .alias("date"),
                 "value",

--- a/src/wetterdienst/provider/eccc/observation/metadata.py
+++ b/src/wetterdienst/provider/eccc/observation/metadata.py
@@ -27,71 +27,57 @@ EcccObservationMetadata = {
                     "name": DATASET_NAME_DEFAULT,
                     "name_original": DATASET_NAME_DEFAULT,
                     "grouped": True,
+                    # The fields the climate-hourly collection actually publishes. This block used
+                    # to carry the daily field list -- max_temperature, snow_on_ground, the degree
+                    # days -- none of which exists here, so the whole resolution returned nothing.
                     "parameters": [
                         {
-                            "name": "cooling_degree_day",
-                            "name_original": "cooling_degree_days",
-                            "unit": "degree_celsius_day",
+                            "name": "temperature_air_mean_2m",
+                            "name_original": "temp",
+                            "unit": "degree_celsius",
                         },
                         {
-                            "name": "heating_degree_day",
-                            "name_original": "heating_degree_days",
-                            "unit": "degree_celsius_day",
+                            "name": "temperature_dew_point_mean_2m",
+                            "name_original": "dew_point_temp",
+                            "unit": "degree_celsius",
                         },
                         {
-                            "name": "humidity_max",
-                            "name_original": "max_rel_humidity",
-                            "unit": "percent",
-                        },
-                        {
-                            "name": "humidity_min",
-                            "name_original": "min_rel_humidity",
+                            "name": "humidity",
+                            "name_original": "relative_humidity",
                             "unit": "percent",
                         },
                         {
                             "name": "precipitation_height",
-                            "name_original": "total_precipitation",
+                            "name_original": "precip_amount",
                             "unit": "millimeter",
                         },
                         {
-                            "name": "precipitation_height_liquid",
-                            "name_original": "total_rain",
-                            "unit": "millimeter",
+                            # ECCC publishes hourly station pressure in kPa, not hPa
+                            "name": "pressure_air_site",
+                            "name_original": "station_pressure",
+                            "unit": "kilopascal",
                         },
                         {
-                            "name": "snow_depth",
-                            "name_original": "snow_on_ground",
-                            "unit": "centimeter",
+                            "name": "visibility_range",
+                            "name_original": "visibility",
+                            "unit": "kilometer",
                         },
                         {
-                            "name": "snow_depth_new",
-                            "name_original": "total_snow",
-                            "unit": "centimeter",
-                        },
-                        {
-                            "name": "temperature_air_max_2m",
-                            "name_original": "max_temperature",
-                            "unit": "degree_celsius",
-                        },
-                        {
-                            "name": "temperature_air_mean_2m",
-                            "name_original": "mean_temperature",
-                            "unit": "degree_celsius",
-                        },
-                        {
-                            "name": "temperature_air_min_2m",
-                            "name_original": "min_temperature",
-                            "unit": "degree_celsius",
-                        },
-                        {
-                            "name": "wind_direction_gust_max",
-                            "name_original": "direction_max_gust",
+                            # published in tens of degrees, decoded in the parser like the daily
+                            # gust direction
+                            "name": "wind_direction",
+                            "name_original": "wind_direction",
                             "unit": "degree",
                         },
                         {
-                            "name": "wind_gust_max",
-                            "name_original": "speed_max_gust",
+                            "name": "wind_speed",
+                            "name_original": "wind_speed",
                             "unit": "kilometer_per_hour",
+                        },
+                        {
+                            "name": "temperature_wind_chill",
+                            "name_original": "windchill",
+                            "unit": "degree_celsius",
                         },
                     ],
                 },
@@ -187,116 +173,58 @@ EcccObservationMetadata = {
                     "name": DATASET_NAME_DEFAULT,
                     "name_original": DATASET_NAME_DEFAULT,
                     "grouped": True,
+                    # The fields the climate-monthly collection actually publishes. This block used
+                    # to carry bulk-CSV column headers ("total precip (mm)", "spd of max gust(km/h)")
+                    # that the OGC API never returns, along with quality parameters -- quality
+                    # arrives in the `quality` column via the *_FLAG join, as it does for daily.
+                    # The DAYS_WITH_* counts and NORMAL_* fields are deliberately left out: they
+                    # have no canonical name yet, and adding vocabulary belongs in its own change
+                    # rather than a repair.
                     "parameters": [
                         {
-                            "name": "precipitation_height",
-                            "name_original": "total precip (mm)",
-                            "unit": "millimeter",
+                            "name": "sunshine_duration",
+                            "name_original": "bright_sunshine",
+                            "unit": "hour",
                         },
                         {
-                            "name": "quality_precipitation_height",
-                            "name_original": "total precip flag",
-                            "unit": "dimensionless",
+                            "name": "cooling_degree_day",
+                            "name_original": "cooling_degree_days",
+                            "unit": "degree_celsius_day",
                         },
                         {
-                            "name": "precipitation_height_liquid",
-                            "name_original": "total rain (mm)",
-                            "unit": "millimeter",
-                        },
-                        {
-                            "name": "quality_precipitation_height_liquid",
-                            "name_original": "total rain flag",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "snow_depth",
-                            "name_original": "snow grnd last day (cm)",
-                            "unit": "centimeter",
-                        },
-                        {
-                            "name": "quality_snow_depth",
-                            "name_original": "snow grnd last day flag",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "snow_depth_new",
-                            "name_original": "total snow (cm)",
-                            "unit": "centimeter",
-                        },
-                        {
-                            "name": "quality_snow_depth_new",
-                            "name_original": "total snow flag",
-                            "unit": "dimensionless",
+                            "name": "heating_degree_day",
+                            "name_original": "heating_degree_days",
+                            "unit": "degree_celsius_day",
                         },
                         {
                             "name": "temperature_air_max_2m",
-                            "name_original": "extr max temp (°c)",
+                            "name_original": "max_temperature",
                             "unit": "degree_celsius",
-                        },
-                        {
-                            "name": "quality_temperature_air_max_2m",
-                            "name_original": "extr max temp flag",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "temperature_air_max_2m_mean",
-                            "name_original": "mean max temp (°c)",
-                            "unit": "degree_celsius",
-                        },
-                        {
-                            "name": "quality_temperature_air_max_2m_mean",
-                            "name_original": "mean max temp flag",
-                            "unit": "dimensionless",
                         },
                         {
                             "name": "temperature_air_mean_2m",
-                            "name_original": "mean temp (°c)",
+                            "name_original": "mean_temperature",
                             "unit": "degree_celsius",
-                        },
-                        {
-                            "name": "quality_temperature_air_mean_2m",
-                            "name_original": "mean temp flag",
-                            "unit": "dimensionless",
                         },
                         {
                             "name": "temperature_air_min_2m",
-                            "name_original": "extr min temp (°c)",
+                            "name_original": "min_temperature",
                             "unit": "degree_celsius",
                         },
                         {
-                            "name": "quality_temperature_air_min_2m",
-                            "name_original": "extr min temp flag",
-                            "unit": "dimensionless",
+                            "name": "snow_depth",
+                            "name_original": "snow_on_ground_last_day",
+                            "unit": "centimeter",
                         },
                         {
-                            "name": "temperature_air_min_2m_mean",
-                            "name_original": "mean min temp (°c)",
-                            "unit": "degree_celsius",
+                            "name": "precipitation_height",
+                            "name_original": "total_precipitation",
+                            "unit": "millimeter",
                         },
                         {
-                            "name": "quality_temperature_air_min_2m_mean",
-                            "name_original": "mean min temp flag",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "wind_direction_gust_max",
-                            "name_original": "dir of max gust (10s deg)",
-                            "unit": "degree",
-                        },
-                        {
-                            "name": "quality_wind_direction_gust_max",
-                            "name_original": "dir of max gust flag",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "wind_gust_max",
-                            "name_original": "spd of max gust(km/h)",
-                            "unit": "kilometer_per_hour",
-                        },
-                        {
-                            "name": "quality_wind_gust_max",
-                            "name_original": "spd of max gust flag",
-                            "unit": "dimensionless",
+                            "name": "snow_depth_new",
+                            "name_original": "total_snowfall",
+                            "unit": "centimeter",
                         },
                     ],
                 },

--- a/tests/provider/eccc/test_api.py
+++ b/tests/provider/eccc/test_api.py
@@ -176,3 +176,52 @@ def test_eccc_degree_days_are_degree_days_not_day_counts(settings_convert_units_
     assert values["heating_degree_day"] == pytest.approx(18 - values["temperature_air_mean_2m"])
     # a count of days would be a whole number, and could never exceed the single day requested
     assert values["heating_degree_day"] > 1
+
+
+@pytest.mark.xfail(raises=FSTimeoutError, strict=False, reason="ECCC server regularly times out")
+@pytest.mark.remote
+def test_eccc_hourly_returns_data(settings_convert_units_false: Settings) -> None:
+    """Test that the hourly resolution returns data.
+
+    It declared a copy of the *daily* field list, none of which the hourly collection publishes, so
+    every hourly request came back empty. Station 4055 also exercises the station listing: it sits
+    past the first 500 rows the OGC endpoint returns by default.
+    """
+    request = EcccObservationRequest(
+        parameters=[("hourly", "data")],
+        start_date="1972-06-01",
+        end_date="1972-06-30",
+        settings=settings_convert_units_false,
+    ).filter_by_station_id(station_id=("4055",))
+    df = request.values.all().df
+    assert not df.is_empty()
+    values = dict(df.drop_nulls("value").select("parameter", "value").iter_rows())
+    assert "temperature_air_mean_2m" in values
+    # kPa, not hPa -- an hPa reading would be around 988
+    pressure = df.filter(pl.col("parameter") == "pressure_air_site").get_column("value").drop_nulls()
+    assert 80 < pressure.max() < 110
+    # published in tens of degrees; without the decode every bearing sits inside 0..36
+    direction = df.filter(pl.col("parameter") == "wind_direction").get_column("value").drop_nulls()
+    assert direction.max() > 36
+
+
+@pytest.mark.xfail(raises=FSTimeoutError, strict=False, reason="ECCC server regularly times out")
+@pytest.mark.remote
+def test_eccc_monthly_returns_data(settings_convert_units_false: Settings) -> None:
+    """Test that the monthly resolution returns data.
+
+    It declared bulk-CSV column headers the OGC API never returns, and crashed on `LOCAL_DATE`,
+    which is "2023-06" for this collection rather than a full timestamp.
+    """
+    request = EcccObservationRequest(
+        parameters=[("monthly", "data")],
+        start_date="2015-01-01",
+        end_date="2016-12-31",
+        settings=settings_convert_units_false,
+    ).filter_by_station_id(station_id=("26",))
+    df = request.values.all().df
+    assert not df.is_empty()
+    assert "temperature_air_mean_2m" in df.get_column("parameter").unique().to_list()
+    # one row per month over the two years requested, so the year-month date parsed
+    dates = df.get_column("date").unique()
+    assert dates.len() == 24

--- a/tests/provider/eccc/test_api.py
+++ b/tests/provider/eccc/test_api.py
@@ -197,6 +197,9 @@ def test_eccc_hourly_returns_data(settings_convert_units_false: Settings) -> Non
     assert not df.is_empty()
     values = dict(df.drop_nulls("value").select("parameter", "value").iter_rows())
     assert "temperature_air_mean_2m" in values
+    # June has 720 hours; a single unpaged request returns 500 features for the whole *year*, so
+    # truncation shows up here as a couple of dozen timestamps rather than a few hundred
+    assert df.get_column("date").unique().len() > 500
     # kPa, not hPa -- an hPa reading would be around 988
     pressure = df.filter(pl.col("parameter") == "pressure_air_site").get_column("value").drop_nulls()
     assert 80 < pressure.max() < 110


### PR DESCRIPTION
Two of ECCC's three resolutions returned **nothing at all**, and the third returned an arbitrary 500 records out of however many were asked for. Found during the per-provider `unit` audit: the 11 stale `quality_*` names in monthly, spelled with spaces (`'total precip flag'`), were the thread end of a dead block.

Each fix here exposed the next, so the scope grew as it went.

## 1. Hourly declared the *daily* field list

`max_temperature`, `snow_on_ground`, the degree days — none of which the `climate-hourly` collection publishes, so every hourly request came back empty. It actually serves `temp`, `dew_point_temp`, `relative_humidity`, `precip_amount`, `station_pressure`, `visibility`, `wind_direction`, `wind_speed`, `windchill`.

## 2. Monthly declared bulk-CSV headers, and crashed before that mattered

`"total precip (mm)"` and friends are never returned by the OGC API. And:

```
InvalidOperationError: conversion from `str` to `datetime[μs]` failed in column 'local_date'
```

`LOCAL_DATE` is `"2023-06"` for the monthly collection, against a parser expecting a full timestamp.

## 3. The station listing stopped at 500 rows

The OGC default page size, while ECCC publishes **~8600 stations**. 94% of the network was unrequestable — including every station the hourly collection actually holds data for. This is *why* the hourly breakage was invisible: there was no reachable station to expose it.

## 4. Every value request was truncated to 500 records

**CI caught this one.** The hourly regression test added in this branch failed on all six jobs while passing locally:

```
numberMatched: 8784    numberReturned: 500
```

A station-year of hourly data is ~8800 records, so each request returned an arbitrary slice of the year and dropped the rest without a word. Locally that slice happened to contain a few June records and the test passed; in CI it did not. The test was right and the fetch was wrong.

| station 4055, June 1972 | before | after |
|---|---|---|
| rows | 112 | **4882** |
| distinct timestamps | 16 | **697** (of 720 hours) |

Same defect as #3, one level down. Neither is visible without comparing `numberMatched` against `numberReturned`.

## 5. Two time edges that only a full fetch reaches

- **DST fall-back**: `1972-10-29 01:00:00` occurs twice in `America/Toronto`; polars refuses to localize it unless told which. Set to earliest, matching how ECCC records local standard time; the spring-forward gap maps to null.
- **Pre-standard-time offsets**: `America/Toronto` is `-5:17:32` in 1895, not a whole number of minutes. A few stations also publish no timezone at all. Neither was reachable while the listing stopped at 500 rows.

## 6. Hourly `wind_direction` is in tens of degrees

The same source encoding already decoded for the daily gust direction. Without it every bearing sits inside 0–36, which no range check on degrees would ever flag.

## The structural fix

The requested field list is now **derived from the declarations** rather than hand-maintained per resolution. Three hand-kept lists are exactly what let hourly drift into a copy of daily; deriving them makes that class of drift impossible.

## Verification

Hourly, station 4055 (Thunder Bay A, June 1972) — each unit checked against the source, not just row counts:

| parameter | range | note |
|---|---|---|
| `pressure_air_site` | 98.56–98.81 | **kPa**, not hPa |
| `visibility_range` | 3.20–24.10 | km |
| `wind_direction` | 10–210 | decoded ×10; raw was 1–21 |
| `wind_speed` | 5–19 | km/h |
| `temperature_air_mean_2m` | 12.8–24.4 | °C |

Monthly, station 26, 2015–2016: **192 rows across 24 distinct months**, heating degree days to 496.7 °Cd, precipitation to 362 mm.

Both regression tests were **confirmed to fail against the old code** with the original errors — an empty frame for hourly, the date conversion for monthly. The hourly test asserts a timestamp count rather than merely non-empty, so a return to truncation fails instead of passing on whichever slice arrives.

## Deliberately not included

`DAYS_WITH_*` and `NORMAL_*` have no canonical name yet. Adding vocabulary belongs in its own change rather than a repair, so they stay undeclared — say the word if you want them covered.

## Breaking

- parameter names change for hourly and monthly, because the old ones named fields that do not exist
- result sizes grow substantially, since requests are no longer truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
