### PR TITLE
fix!: correct six parameter declarations that disagreed with their source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,16 @@ Types of changes:
 
 ### Fixed
 
+- **Breaking**: Geosphere `cloud_cover_total` is returned as a fraction rather than a percentage
+  passed off as one. It was declared `decimal` while Geosphere documents `bewm_mittel` as `1/100`
+  and returns 0-100, so the raw percentage went straight through the `fraction` target unconverted
+  and every value was 100x its stated meaning. Geosphere's own `humidity` and
+  `sunshine_duration_relative` already declared `percent`, so this was the odd one out within the
+  provider. Values now read 0-1
+- **Breaking**: DWD road `visibility_range` is returned in metres rather than 1000x too large. It
+  was declared `kilometer`, but BUFR `0 20 001 horizontalVisibility` is metres, nothing in the
+  parser converts, and the provider's own docs page already said `m`
+
 - **Breaking**: ECCC hourly and monthly return data at all. Both resolutions declared parameters
   the OGC API never publishes -- hourly carried a copy of the *daily* field list
   (`max_temperature`, `snow_on_ground`, the degree days), monthly carried bulk-CSV column headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ Types of changes:
 
 ### Added
 
+- ECCC monthly and hourly expose the fields that were previously left undeclared, with twelve new
+  canonical parameters for them. Monthly gains the day counts
+  (`count_days_precipitation_height_ge_1mm` and the six `count_days_valid_*`) and the
+  climatological normals (`temperature_air_mean_2m_normal`, `precipitation_height_normal`,
+  `snow_depth_new_normal`, `sunshine_duration_normal`); hourly gains `temperature_humidex`. Units
+  were taken from the values rather than assumed: each normal matches the range of the quantity it
+  is a normal of in the same response, and humidex sits at or above the air temperature in all 233
+  paired observations sampled, which is what an apparent temperature does
+
 - CI: new `Minimum dependency versions` job that resolves every direct dependency to the lowest
   version its specifier allows (`UV_RESOLUTION=lowest-direct`) and runs the test suite against it,
   so that declared floors are actually exercised

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,26 @@ Types of changes:
 
 ### Fixed
 
+- **Breaking**: four DWD subdaily parameters named the wrong quantity, not merely the wrong unit.
+  DWD's own `Metadaten_Parameter_*.txt`, shipped inside every data ZIP, gives each field a
+  description and a unit, and for these four it disagreed with what wetterdienst declared:
+  - `e_tf_ter` is "Eisansatz bei der Messung der Feuchttemperatur", unit YES/NO -- whether ice had
+    formed on the wet bulb thermometer. It was declared `temperature_air_mean_0_05m` in °C, and
+    carries only 0 and 1 across 82901 values at station 00003. Now
+    `temperature_wet_ice_formation`, dimensionless
+  - `ek_ter` is "Terminwerte des Erdbodenzustand", unit CODE -- values 0-9, exactly 10 distinct. It
+    was declared `temperature_soil_mean_0_05m` in °C. Now `soil_state_index`, dimensionless
+  - `vk_ter` is "Terminwerte Sichtweite", unit CODE -- also 0-9. It was declared `visibility_range`
+    in metres, so a request for subdaily visibility returned "5 metres" for visibility class 5. Now
+    `visibility_range_class`, dimensionless
+  - `tf_ter` is the wet bulb temperature and was declared `temperature_air_mean_2m`. DWD's *hourly*
+    moisture dataset already maps the same quantity (`tf_std`) to `temperature_wet_mean_2m`, so the
+    two resolutions disagreed with each other. Confirmed against 83994 paired observations: it sits
+    a median 1.6 °C below the air temperature and never exceeds it, which is the wet bulb
+    signature. Now `temperature_wet_mean_2m`
+- Three new canonical parameters for the above: `temperature_wet_ice_formation`,
+  `soil_state_index` and `visibility_range_class`, all dimensionless
+
 - **Breaking**: Geosphere `cloud_cover_total` is returned as a fraction rather than a percentage
   passed off as one. It was declared `decimal` while Geosphere documents `bewm_mittel` as `1/100`
   and returns 0-100, so the raw percentage went straight through the `fraction` target unconverted

--- a/docs/data/provider/dwd/observation/subdaily.md
+++ b/docs/data/provider/dwd/observation/subdaily.md
@@ -45,8 +45,8 @@
 | name                               | original name | description         | unit | constraints |
 |------------------------------------|---------------|---------------------|------|-------------|
 | {term}`pressure_vapor`             | vp_ter        | vapor pressure      | hPa  | >=0         |
-| {term}`temperature_air_mean_0_05m` | e_tf_ter      | 5cm air temperature | °C   |             |
-| {term}`temperature_air_mean_2m`    | tf_ter        | 2m air temperature  | °C   |             |
+| {term}`temperature_wet_ice_formation` | e_tf_ter | ice on the wet bulb thermometer | -  |          |
+| {term}`temperature_wet_mean_2m`    | tf_ter        | 2m wet bulb temperature | °C |           |
 | {term}`humidity`                   | rf_ter        | humidity            | %    | >=0,<=100   |
 
 ### pressure
@@ -81,7 +81,7 @@
 
 | name                                | original name | description          | unit | constraints |
 |-------------------------------------|---------------|----------------------|------|-------------|
-| {term}`temperature_soil_mean_0_05m` | ek_ter        | soil temperature 5cm | °C   | -           |
+| {term}`soil_state_index` | ek_ter        | coded ground state              | -      | -           |
 
 ### temperature_air
 
@@ -116,7 +116,7 @@
 
 | name                     | original name | description      | unit | constraints |
 |--------------------------|---------------|------------------|------|-------------|
-| {term}`visibility_range` | vk_ter        | visibility range | m    | >=0         |
+| {term}`visibility_range_class` | vk_ter        | coded visibility class          | -      | >=0         |
 
 ### wind
 

--- a/docs/data/provider/eccc/observation/hourly.md
+++ b/docs/data/provider/eccc/observation/hourly.md
@@ -31,6 +31,7 @@
 | {term}`temperature_air_mean_2m`       | temp              | 2m air temperature               | °C   | -           |
 | {term}`temperature_dew_point_mean_2m` | dew_point_temp    | 2m dew point temperature         | °C   | -           |
 | {term}`temperature_wind_chill`        | windchill         | wind chill temperature           | °C   | -           |
+| {term}`temperature_humidex`           | humidex           | humidex apparent temperature     | °C   | -           |
 | {term}`visibility_range`              | visibility        | visibility range                 | km   | >=0         |
 | {term}`wind_direction`                | wind_direction    | wind direction (source: 10s deg) | °    | >=0,<=360   |
 | {term}`wind_speed`                    | wind_speed        | wind speed                       | km/h | >=0         |

--- a/docs/data/provider/eccc/observation/monthly.md
+++ b/docs/data/provider/eccc/observation/monthly.md
@@ -34,3 +34,14 @@
 | {term}`temperature_air_max_2m`  | max_temperature         | 2m maximum air temperature | °C   | -           |
 | {term}`temperature_air_mean_2m` | mean_temperature        | 2m mean air temperature    | °C   | -           |
 | {term}`temperature_air_min_2m`  | min_temperature         | 2m minimum air temperature | °C   | -           |
+| {term}`count_days_precipitation_height_ge_1mm` | days_with_precip_ge_1mm | days with >= 1 mm precipitation | - | >=0 |
+| {term}`count_days_valid_temperature_air_max_2m` | days_with_valid_max_temp | days with a valid maximum temperature | - | >=0 |
+| {term}`count_days_valid_temperature_air_mean_2m` | days_with_valid_mean_temp | days with a valid mean temperature | - | >=0 |
+| {term}`count_days_valid_temperature_air_min_2m` | days_with_valid_min_temp | days with a valid minimum temperature | - | >=0 |
+| {term}`count_days_valid_precipitation_height` | days_with_valid_precip | days with a valid precipitation observation | - | >=0 |
+| {term}`count_days_valid_snow_depth_new` | days_with_valid_snowfall | days with a valid snowfall observation | - | >=0 |
+| {term}`count_days_valid_sunshine_duration` | days_with_valid_sunshine | days with a valid sunshine observation | - | >=0 |
+| {term}`temperature_air_mean_2m_normal` | normal_mean_temperature | normal of the mean air temperature | °C | - |
+| {term}`precipitation_height_normal` | normal_precipitation | normal of the precipitation height | mm | >=0 |
+| {term}`snow_depth_new_normal` | normal_snowfall | normal of the snowfall total | cm | >=0 |
+| {term}`sunshine_duration_normal` | normal_sunshine | normal of the sunshine duration | h | >=0 |

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -180,6 +180,41 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "count_days_multiday_wind_movement", "dimensionless", "Number of days covered by a multi-day wind run total."
     ),
     CanonicalParameter(
+        "count_days_precipitation_height_ge_1mm",
+        "dimensionless",
+        "Number of days on which at least 1 mm of precipitation fell.",
+    ),
+    CanonicalParameter(
+        "count_days_valid_precipitation_height",
+        "dimensionless",
+        "Number of days in the period carrying a valid precipitation observation.",
+    ),
+    CanonicalParameter(
+        "count_days_valid_snow_depth_new",
+        "dimensionless",
+        "Number of days in the period carrying a valid fresh snow observation.",
+    ),
+    CanonicalParameter(
+        "count_days_valid_sunshine_duration",
+        "dimensionless",
+        "Number of days in the period carrying a valid sunshine duration observation.",
+    ),
+    CanonicalParameter(
+        "count_days_valid_temperature_air_max_2m",
+        "dimensionless",
+        "Number of days in the period carrying a valid maximum air temperature observation.",
+    ),
+    CanonicalParameter(
+        "count_days_valid_temperature_air_mean_2m",
+        "dimensionless",
+        "Number of days in the period carrying a valid mean air temperature observation.",
+    ),
+    CanonicalParameter(
+        "count_days_valid_temperature_air_min_2m",
+        "dimensionless",
+        "Number of days in the period carrying a valid minimum air temperature observation.",
+    ),
+    CanonicalParameter(
         "count_hours_cooling_degree", "dimensionless", "Number of hours during which cooling was required."
     ),
     CanonicalParameter("count_weather_type_dew", "dimensionless", "Number of days on which dew was observed."),
@@ -387,6 +422,11 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
     ),
     CanonicalParameter(
         "precipitation_height_night", "precipitation", "Depth of precipitation collected during the night hours."
+    ),
+    CanonicalParameter(
+        "precipitation_height_normal",
+        "precipitation",
+        "Climatological normal of the precipitation height for the period.",
     ),
     CanonicalParameter(
         "precipitation_height_rocker",
@@ -864,6 +904,11 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "snow_depth_new_multiday", "length_short", "Depth of fresh snow over several days, reported as one total."
     ),
     CanonicalParameter(
+        "snow_depth_new_normal",
+        "length_short",
+        "Climatological normal of the fresh snow total for the period.",
+    ),
+    CanonicalParameter(
         "soil_moisture_corn_loamysilt_00cm_60cm",
         "fraction",
         "Soil moisture in loamy silt under corn, between the surface and 60 cm.",
@@ -938,6 +983,11 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "sunshine_duration_last_3h", "time", "Length of time the sun shone unobstructed in the preceding 3 hours."
     ),
     CanonicalParameter(
+        "sunshine_duration_normal",
+        "time",
+        "Climatological normal of the sunshine duration for the period.",
+    ),
+    CanonicalParameter(
         "sunshine_duration_relative",
         "fraction",
         "Sunshine duration as a fraction of the longest possible for the location and date.",
@@ -979,6 +1029,11 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "temperature",
         "Mean air temperature at 2 m above ground over the preceding 24 hours.",
     ),
+    CanonicalParameter(
+        "temperature_air_mean_2m_normal",
+        "temperature",
+        "Climatological normal of the mean air temperature at 2 m above ground.",
+    ),
     CanonicalParameter("temperature_air_min_0_05m", "temperature", "Minimum air temperature at 0.05 m above ground."),
     CanonicalParameter(
         "temperature_air_min_0_05m_last_12h",
@@ -1014,6 +1069,11 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "temperature_dew_point_mean_2m",
         "temperature",
         "Dew point at 2 m above ground, the temperature at which the air would become saturated.",
+    ),
+    CanonicalParameter(
+        "temperature_humidex",
+        "temperature",
+        "Humidex, the apparent temperature combining air temperature and humidity.",
     ),
     CanonicalParameter(
         "temperature_radiant_mean_2m",

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -923,6 +923,11 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "fraction",
         "Soil moisture in sand under winter wheat, between the surface and 60 cm.",
     ),
+    CanonicalParameter(
+        "soil_state_index",
+        "dimensionless",
+        "Coded state of the ground surface, such as dry, moist, frozen or snow-covered.",
+    ),
     CanonicalParameter("stage", "length_short", "Water level at the gauge, measured against the gauge datum."),
     CanonicalParameter("stage_max", "length_short", "Highest water level at the gauge over the period."),
     CanonicalParameter("stage_mean", "length_short", "Mean water level at the gauge over the period."),
@@ -1615,6 +1620,11 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
     CanonicalParameter("temperature_water_max", "temperature", "Highest water temperature over the period."),
     CanonicalParameter("temperature_water_mean", "temperature", "Mean water temperature over the period."),
     CanonicalParameter("temperature_water_min", "temperature", "Lowest water temperature over the period."),
+    CanonicalParameter(
+        "temperature_wet_ice_formation",
+        "dimensionless",
+        "Whether ice had formed on the thermometer during the wet bulb measurement.",
+    ),
     CanonicalParameter("temperature_wet_mean_2m", "temperature", "Wet-bulb temperature at 2 m above ground."),
     CanonicalParameter(
         "temperature_wind_chill",
@@ -1641,6 +1651,11 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
     CanonicalParameter("turbidity", "turbidity", "Cloudiness of the water caused by suspended particles."),
     CanonicalParameter(
         "visibility_range", "length_medium", "Horizontal distance at which an object can still be made out."
+    ),
+    CanonicalParameter(
+        "visibility_range_class",
+        "dimensionless",
+        "Coded class the visibility range falls into, rather than a measured distance.",
     ),
     CanonicalParameter("visibility_range_index", "dimensionless", "Coded indicator of the visibility range."),
     CanonicalParameter(

--- a/src/wetterdienst/provider/dwd/observation/metadata.py
+++ b/src/wetterdienst/provider/dwd/observation/metadata.py
@@ -1114,12 +1114,18 @@ DwdObservationMetadata = {
                             "unit": "hectopascal",
                         },
                         {
-                            "name": "temperature_air_mean_0_05m",
+                            # "Eisansatz bei der Messung der Feuchttemperatur", unit YES/NO -- a
+                            # flag for ice on the wet bulb thermometer, not a temperature. Only
+                            # ever 0 or 1 across 82901 values at station 00003.
+                            "name": "temperature_wet_ice_formation",
                             "name_original": "e_tf_ter",
-                            "unit": "degree_celsius",
+                            "unit": "dimensionless",
                         },
                         {
-                            "name": "temperature_air_mean_2m",
+                            # Feuchttemperatur -- wet bulb, not air temperature. DWD's hourly
+                            # moisture dataset already maps the same quantity (tf_std) to
+                            # temperature_wet_mean_2m; subdaily disagreed with it.
+                            "name": "temperature_wet_mean_2m",
                             "name_original": "tf_ter",
                             "unit": "degree_celsius",
                         },
@@ -1154,9 +1160,11 @@ DwdObservationMetadata = {
                             "unit": "dimensionless",
                         },
                         {
-                            "name": "temperature_soil_mean_0_05m",
+                            # "Terminwerte des Erdbodenzustand", unit CODE -- a coded ground
+                            # state, not a soil temperature. Values run 0-9, exactly 10 distinct.
+                            "name": "soil_state_index",
                             "name_original": "ek_ter",
-                            "unit": "degree_celsius",
+                            "unit": "dimensionless",
                         },
                     ],
                 },
@@ -1189,9 +1197,11 @@ DwdObservationMetadata = {
                             "unit": "dimensionless",
                         },
                         {
-                            "name": "visibility_range",
+                            # "Terminwerte Sichtweite", unit CODE -- a visibility class, not a
+                            # distance. Declared as metres it read "5 metres" for class 5.
+                            "name": "visibility_range_class",
                             "name_original": "vk_ter",
-                            "unit": "meter",
+                            "unit": "dimensionless",
                         },
                     ],
                 },

--- a/src/wetterdienst/provider/dwd/road/api.py
+++ b/src/wetterdienst/provider/dwd/road/api.py
@@ -96,7 +96,9 @@ DwdRoadMetadata = {
                         {
                             "name": "visibility_range",
                             "name_original": "horizontalVisibility",
-                            "unit": "kilometer",
+                            # BUFR 0 20 001 horizontalVisibility is metres, and nothing in this
+                            # parser converts; the docs page already said m
+                            "unit": "meter",
                         },
                         {
                             "name": "water_film_thickness",

--- a/src/wetterdienst/provider/eccc/observation/metadata.py
+++ b/src/wetterdienst/provider/eccc/observation/metadata.py
@@ -79,6 +79,12 @@ EcccObservationMetadata = {
                             "name_original": "windchill",
                             "unit": "degree_celsius",
                         },
+                        {
+                            # apparent temperature, always at or above the air temperature
+                            "name": "temperature_humidex",
+                            "name_original": "humidex",
+                            "unit": "degree_celsius",
+                        },
                     ],
                 },
             ],
@@ -225,6 +231,62 @@ EcccObservationMetadata = {
                             "name": "snow_depth_new",
                             "name_original": "total_snowfall",
                             "unit": "centimeter",
+                        },
+                        {
+                            "name": "count_days_precipitation_height_ge_1mm",
+                            "name_original": "days_with_precip_ge_1mm",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "count_days_valid_temperature_air_max_2m",
+                            "name_original": "days_with_valid_max_temp",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "count_days_valid_temperature_air_mean_2m",
+                            "name_original": "days_with_valid_mean_temp",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "count_days_valid_temperature_air_min_2m",
+                            "name_original": "days_with_valid_min_temp",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "count_days_valid_precipitation_height",
+                            "name_original": "days_with_valid_precip",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "count_days_valid_snow_depth_new",
+                            "name_original": "days_with_valid_snowfall",
+                            "unit": "dimensionless",
+                        },
+                        {
+                            "name": "count_days_valid_sunshine_duration",
+                            "name_original": "days_with_valid_sunshine",
+                            "unit": "dimensionless",
+                        },
+                        # climatological normals, in the same units as the quantities above
+                        {
+                            "name": "temperature_air_mean_2m_normal",
+                            "name_original": "normal_mean_temperature",
+                            "unit": "degree_celsius",
+                        },
+                        {
+                            "name": "precipitation_height_normal",
+                            "name_original": "normal_precipitation",
+                            "unit": "millimeter",
+                        },
+                        {
+                            "name": "snow_depth_new_normal",
+                            "name_original": "normal_snowfall",
+                            "unit": "centimeter",
+                        },
+                        {
+                            "name": "sunshine_duration_normal",
+                            "name_original": "normal_sunshine",
+                            "unit": "hour",
                         },
                     ],
                 },

--- a/src/wetterdienst/provider/geosphere/observation/metadata.py
+++ b/src/wetterdienst/provider/geosphere/observation/metadata.py
@@ -271,7 +271,8 @@ GeosphereObservationMetadata = {
                         {
                             "name": "cloud_cover_total",
                             "name_original": "bewm_mittel",
-                            "unit": "decimal",
+                            # Geosphere documents bewm_mittel as "1/100", i.e. percent
+                            "unit": "percent",
                         },
                         {
                             "name": "humidity",
@@ -366,7 +367,8 @@ GeosphereObservationMetadata = {
                         {
                             "name": "cloud_cover_total",
                             "name_original": "bewm_mittel",
-                            "unit": "decimal",
+                            # Geosphere documents bewm_mittel as "1/100", i.e. percent
+                            "unit": "percent",
                         },
                         {
                             "name": "humidity",


### PR DESCRIPTION
Step 6 pass 2 of the parameter migration, finishing the audit. Six defects across two rounds.

## Round 1 — the four "minority of one" unit declarations

Where a provider disagrees with every other and so has nothing to cross-check against. **Two were wrong.**

**Geosphere `cloud_cover_total`** — declared `decimal`, but Geosphere documents `bewm_mittel` as `1/100` and returns 0–100, median 67. The `fraction` target *is* `decimal`, so nothing converted and a percentage was reported as a 0–1 fraction. All nine other declarations of the name land at 0.64–0.88 after conversion; Geosphere sat at 67. Its own `humidity` and `sunshine_duration_relative` already said `percent`. Now reads 0–1.

**DWD road `visibility_range`** — declared `kilometer`, so conversion to the metre target multiplied by 1000. BUFR `0 20 001` is metres, nothing in the parser converts, ten other providers say metres, and the provider's own docs page already said `m`.

The other two are correct and were verified, not assumed: **KNMI `precipitation_duration`** (the NetCDF this provider reads declares `units = h`, so the legacy 0.1-hour ASCII convention does not apply — answering from that convention would have broken a correct declaration), and the **Pa/kJ/knots/km-h group**, each landing alongside the majority on the shared target.

## Round 2 — four DWD subdaily parameters naming the wrong quantity

The 95 DWD declarations in datasets with no description PDF looked unauditable. They are not: **every data ZIP ships `Metadaten_Parameter_*.txt`**, a `Parameter;Parameterbeschreibung;Einheit` table — structured rather than prose, so the unit comes from a column instead of a regex over a sentence.

It disagreed with four declarations, and in three cases the disagreement was the **quantity**, not the unit — which is why no unit-level check could catch them, and why cross-provider comparison could not either, all four being DWD-only names.

| was | DWD says | live values | now |
|---|---|---|---|
| `temperature_air_mean_0_05m` °C ← `e_tf_ter` | "Eisansatz bei der Messung der Feuchttemperatur", **YES/NO** | only 0.0 and 1.0, n=82901 | `temperature_wet_ice_formation` |
| `temperature_soil_mean_0_05m` °C ← `ek_ter` | "Erdbodenzustand", **CODE** | 0–9, exactly 10 distinct | `soil_state_index` |
| `visibility_range` m ← `vk_ter` | "Sichtweite", **CODE** | 0–9, exactly 10 distinct | `visibility_range_class` |
| `temperature_air_mean_2m` ← `tf_ter` | wet bulb temperature | see below | `temperature_wet_mean_2m` |

Subdaily visibility answered **"5 metres" for visibility class 5**.

The fourth surfaced while checking the others: `tf_ter` is *Feuchttemperatur*, and DWD's **hourly** moisture dataset already maps the same quantity (`tf_std`) to `temperature_wet_mean_2m` — the two resolutions contradicted each other. Verified across **83,994 paired observations** against the real air temperature: a median **1.6 °C below** it, **never** exceeding it, zero breaches. That is the wet-bulb signature; a second air-temperature sensor would scatter symmetrically. No new name needed.

## On the three new names

They follow the table's existing convention for coded values: dimensionless, `_index` where the source publishes a code.

`visibility_range_index` was **not** reused for `vk_ter`, even though its description ("Coded indicator of the visibility range") fits perfectly. It is currently occupied by DWD's `v_vv_i`, which is a *measurement method* indicator (P = person, I = instrument). Putting both under one name is exactly the collision the table exists to prevent — the same shape as the irradiance/irradiation split. That mismatch between `visibility_range_index` and its own description, and the identical one for `cloud_cover_total_index`, is left as a separate cleanup.

## Audit status

All **95** previously-unauditable DWD declarations are now done: 84 via the ZIP metadata, 11 via the urban PDFs — which were never missing, just under `observations_germany/climate_urban/` rather than `.../climate/`. The hourly urban declarations are all correct.

132 tests pass; lint and `ty` clean.

**Breaking**: Geosphere cloud cover and DWD road visibility change value; four DWD subdaily parameters are renamed and three change unit type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
