### PR TITLE
fix!: name DWD's method indicators after what they hold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,17 @@ Types of changes:
 
 ### Fixed
 
+- **Breaking**: DWD's `v_n_i` and `v_vv_i` are named for what they hold. Both are *measurement
+  method* indicators -- P for a human observer, I for an instrument, which is why the parser lists
+  them among its string parameters -- while `cloud_cover_total_index` and `visibility_range_index`
+  both described a coded *value*. They are now `cloud_cover_total_measurement_method` and
+  `visibility_range_measurement_method`
+- **Breaking**: `visibility_range_class` is renamed `visibility_range_index`. It only existed
+  because `visibility_range_index` was occupied by the method indicator above, and its description
+  ("Coded indicator of the visibility range") always described DWD subdaily `vk_ter` rather than
+  what it was attached to. `cloud_cover_total_index` is removed; no provider declares a coded cloud
+  cover
+
 - **Breaking**: four DWD subdaily parameters named the wrong quantity, not merely the wrong unit.
   DWD's own `Metadaten_Parameter_*.txt`, shipped inside every data ZIP, gives each field a
   description and a unit, and for these four it disagreed with what wetterdienst declared:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Types of changes:
 
 ### Added
 
+- Dataset and resolution descriptions on the metadata models: 88 of 148 datasets and 2 resolutions,
+  lifted out of the provider docs metadata tables the same way the parameter descriptions were.
+  `DatasetModel.description` and `ResolutionModel.description` had been declared but never
+  populated, so `metadata["hourly"]["data"].description` returned `None` for every provider.
+  `tests/test_docs.py` checks the tables still agree with the model, ignoring the trailing
+  `([details](url))` pointer the pages add, which is page formatting rather than description
+
 - Source descriptions for 1057 parameters, in `metadata.source_descriptions` and reported by
   `discover()` -- so by `GET /api/coverage`, the `coverage` MCP tool and `wetterdienst about
   coverage`. These say what a given provider's field means, as against the canonical,

--- a/docs/data/provider/dwd/observation/hourly.md
+++ b/docs/data/provider/dwd/observation/hourly.md
@@ -70,7 +70,7 @@ Code (cloud_type_layer):
 
 | name                            | original name | description                    | unit | constraints                         |
 |---------------------------------|---------------|--------------------------------|------|-------------------------------------|
-| {term}`cloud_cover_total_index` | v_n_i | Index how measurement is taken, P = by human person,I = by instrument. | - | ∈ \[P, I\] |
+| {term}`cloud_cover_total_measurement_method` | v_n_i | Index how measurement is taken, P = by human person,I = by instrument. | - | ∈ \[P, I\] |
 | {term}`cloud_cover_total` | v_n | Total cloud cover. | 1/8 | ∈ \[0, 1, 2, 3, 4, 5, 6, 7, 8, -1\] |
 
 Code (cloud_cover_total_indicator):
@@ -379,7 +379,7 @@ Code (precipitation_form):
 
 | name                           | original name | description                    | unit | constraints |
 |--------------------------------|---------------|--------------------------------|------|-------------|
-| {term}`visibility_range_index` | v_vv_i | Visibility index, noting how the measurement is taken,P=by human person,I=by an instrument. | - | ∈ \[P, I\] |
+| {term}`visibility_range_measurement_method` | v_vv_i | Visibility index, noting how the measurement is taken,P=by human person,I=by an instrument. | - | ∈ \[P, I\] |
 | {term}`visibility_range` | v_vv | Visibility range. | m | >=0 |
 
 Code (visibility_range_indicator):

--- a/docs/data/provider/dwd/observation/subdaily.md
+++ b/docs/data/provider/dwd/observation/subdaily.md
@@ -116,7 +116,7 @@
 
 | name                     | original name | description      | unit | constraints |
 |--------------------------|---------------|------------------|------|-------------|
-| {term}`visibility_range_class` | vk_ter | Coded visibility class. | - | >=0 |
+| {term}`visibility_range_index` | vk_ter | Coded visibility class. | - | >=0 |
 
 ### wind
 

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -85,9 +85,9 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
     ),
     CanonicalParameter("cloud_cover_total", "fraction", "Fraction of the sky covered by cloud of any kind."),
     CanonicalParameter(
-        "cloud_cover_total_index",
+        "cloud_cover_total_measurement_method",
         "dimensionless",
-        "Coded index describing total cloud cover, as published by the source.",
+        "Coded indicator of how the total cloud cover was determined, such as by a person or an instrument.",
     ),
     CanonicalParameter(
         "cloud_cover_total_midnight_to_midnight",
@@ -1713,11 +1713,15 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "visibility_range", "length_medium", "Horizontal distance at which an object can still be made out."
     ),
     CanonicalParameter(
-        "visibility_range_class",
+        "visibility_range_index",
         "dimensionless",
         "Coded class the visibility range falls into, rather than a measured distance.",
     ),
-    CanonicalParameter("visibility_range_index", "dimensionless", "Coded indicator of the visibility range."),
+    CanonicalParameter(
+        "visibility_range_measurement_method",
+        "dimensionless",
+        "Coded indicator of how the visibility range was determined, such as by a person or an instrument.",
+    ),
     CanonicalParameter(
         "water_equivalent_snow_depth",
         "precipitation",

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -1278,3 +1278,256 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("hourly", "data", "windspeed"): "wind speed",
     },
 }
+
+
+# What a dataset holds, keyed by metadata model name then ``(resolution, dataset)``.
+# The docs tables carry a trailing "([details](url))" pointer; that is page formatting and
+# is not part of the description here.
+DATASET_DESCRIPTIONS: dict[str, dict[tuple[str, str], str]] = {
+    "DwdDerivedMetadata": {
+        ("daily", "soil"): (
+            "Daily soil data including temperature at various depths, soil moisture, and evapotranspiration estimates."
+        ),
+        ("hourly", "radiation_global"): "Hourly global radiation data with quality flags and uncertainty estimates.",
+        ("hourly", "sunshine_duration"): "Hourly sunshine duration data with quality flags and uncertainty estimates.",
+        ("monthly", "climate_correction_factor"): (
+            "Data on climate correction factors, comparing the degree days between a postal code and "
+            "a reference station."
+        ),
+        ("monthly", "heating_degreedays"): (
+            "Data on degree days, comparing the monthly temperatures to the reference temperature of 20 degree Celsius."
+        ),
+        ("monthly", "soil"): (
+            "Monthly aggregated soil data including temperature at various depths, soil moisture, and "
+            "evapotranspiration estimates."
+        ),
+    },
+    "DwdDmoMetadata": {
+        ("hourly", "icon"): (
+            "Local forecast of 115 parameters for worldwide stations, 4 times a day with a lead-time of 240 hours."
+        ),
+        ("hourly", "icon_eu"): (
+            "Local forecast of 40 parameters for worldwide stations, 24 times a day with a lead-time of 240 hours."
+        ),
+    },
+    "DwdObservationMetadata": {
+        ("10_minutes", "precipitation"): "10-minute station observations of precipitation for Germany.",
+        ("10_minutes", "solar"): "10-minute station observations of solar and sunshine for Germany.",
+        ("10_minutes", "temperature_air"): "10-minute station observations of air temperature for Germany.",
+        ("10_minutes", "temperature_extreme"): "10-minute station observations of extreme temperatures for Germany.",
+        ("10_minutes", "urban_precipitation"): (
+            "Recent 10-minute precipitation, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("10_minutes", "urban_pressure"): (
+            "Recent 10-minute pressure, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("10_minutes", "urban_solar"): (
+            "Recent 10-minute solar radiation and sunshine, observed at urban stations for selected "
+            "urban areas in Germany."
+        ),
+        ("10_minutes", "urban_temperature_air"): (
+            "Recent 10-minute air temperature and humidity, observed at urban stations for selected "
+            "urban areas in Germany."
+        ),
+        ("10_minutes", "urban_temperature_extreme"): (
+            "Recent 10-minute extreme air temperatures, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("10_minutes", "urban_temperature_soil"): (
+            "Recent 10-minute soil temperature, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("10_minutes", "urban_wind"): (
+            "Recent 10-minute wind speed and direction, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("10_minutes", "urban_wind_extreme"): (
+            "Recent 10-minute extreme wind, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("10_minutes", "wind"): "10-minute station observations of wind for Germany.",
+        ("10_minutes", "wind_extreme"): "10-minute station observations of extreme wind for Germany.",
+        ("1_minute", "precipitation"): "1-minute station observations of precipitation for Germany.",
+        ("5_minutes", "precipitation"): "5-minute station observations of precipitation for Germany.",
+        ("annual", "climate_summary"): (
+            "Historical annual station observations (temperature, pressure, precipitation, sunshine "
+            "duration, etc.) for Germany (details missing, parameter descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("annual", "precipitation_more"): (
+            "Historical annual precipitation observations for Germany (details missing, parameter "
+            "descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("annual", "weather_phenomena"): (
+            "Counts of weather phenomena fog, thunder, storm (strong wind), storm (stormier wind), "
+            "dew, glaze, ripe, sleet and hail for stations of Germany (details missing, parameter "
+            "descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("daily", "climate_summary"): (
+            "Daily station observations (temperature, pressure, precipitation, sunshine duration, etc.) for Germany."
+        ),
+        ("daily", "precipitation_more"): "Daily precipitation observations for Germany.",
+        ("daily", "solar"): (
+            "Daily station observations of solar incoming (total/diffuse) and longwave downward radiation for Germany."
+        ),
+        ("daily", "temperature_soil"): "Daily station observations of soil temperature station data for Germany.",
+        ("daily", "water_equivalent"): "Daily observations of snow height and water equivalent for Germany.",
+        ("daily", "weather_phenomena"): (
+            "Counts of weather phenomena fog, thunder, storm (strong wind), storm (stormier wind), "
+            "dew, glaze, ripe, sleet and hail for stations of Germany (details missing, parameter "
+            "descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("daily", "weather_phenomena_more"): (
+            "Counts of (additional) weather phenomena sleet, hail, fog and thunder for stations of "
+            "Germany (details missing, parameter descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("hourly", "cloud_type"): (
+            "Hourly station observations of cloud cover, cloud type and cloud height in up to 4 layers for Germany."
+        ),
+        ("hourly", "cloudiness"): "Hourly station observations of cloudiness for Germany.",
+        ("hourly", "dew_point"): "Hourly station observations of air and dew point temperature for Germany.",
+        ("hourly", "moisture"): "Hourly station observations of moisture parameters for Germany.",
+        ("hourly", "precipitation"): "Hourly station observations of precipitation for Germany.",
+        ("hourly", "pressure"): "Hourly station observations of pressure for Germany.",
+        ("hourly", "solar"): (
+            "Hourly station observations of solar incoming (total/diffuse) and longwave downward radiation for Germany."
+        ),
+        ("hourly", "sun"): "Hourly station observations of sunshine duration for Germany.",
+        ("hourly", "temperature_air"): "Hourly station observations of 2 m air temperature and humidity for Germany.",
+        ("hourly", "temperature_soil"): "Hourly station observations of of soil temperature for Germany.",
+        ("hourly", "urban_precipitation"): (
+            "Recent hourly precipitation, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("hourly", "urban_pressure"): (
+            "Recent hourly pressure, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("hourly", "urban_sun"): (
+            "Recent hourly sunshine duration, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("hourly", "urban_temperature_air"): (
+            "Recent hourly air temperature and humidity, observed at urban stations for selected "
+            "urban areas in Germany."
+        ),
+        ("hourly", "urban_temperature_soil"): (
+            "Recent hourly soil temperature, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("hourly", "urban_wind"): (
+            "Recent hourly wind speed and direction, observed at urban stations for selected urban areas in Germany."
+        ),
+        ("hourly", "visibility"): "Hourly station observations of visibility for Germany.",
+        ("hourly", "weather_phenomena"): "Hourly station observations of weather phenomena for Germany.",
+        ("hourly", "wind"): "Hourly mean value from station observations of wind speed and wind direction for Germany.",
+        ("hourly", "wind_extreme"): "Hourly maximum value from station observations of windspeed for Germany.",
+        ("hourly", "wind_synoptic"): "Hourly station observations of wind speed and wind direction for Germany.",
+        ("monthly", "climate_summary"): (
+            "Monthly station observations (temperature, precipitation, sunshine duration, wind and "
+            "cloud cover) for Germany."
+        ),
+        ("monthly", "precipitation_more"): "Monthly precipitation observations for Germany.",
+        ("monthly", "weather_phenomena"): (
+            "Counts of weather phenomena fog, thunder, storm (strong wind), storm (stormier wind), "
+            "dew, glaze, ripe, sleet and hail for stations of Germany (details missing, parameter "
+            "descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("subdaily", "cloudiness"): (
+            "Recent subdaily cloud cover and cloud density of stations in Germany (details missing, "
+            "parameter descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("subdaily", "moisture"): (
+            "Recent subdaily vapor pressure, mean temperature in 2m height, mean temperature in 5cm "
+            "height and humidity of stations in Germany (details missing, parameter descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("subdaily", "pressure"): (
+            "Recent air pressure at site of stations in Germany (details missing, parameter "
+            "descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("subdaily", "soil"): (
+            "Recent soil temperature in 5cm depth of stations in Germany (details missing, parameter "
+            "descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("subdaily", "temperature_air"): (
+            "Recent subdaily air temperature and humidity of stations in Germany (details missing, "
+            "parameter descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("subdaily", "visibility"): (
+            "Recent visibility range of stations in Germany (details missing, parameter descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("subdaily", "wind"): (
+            "Recent wind direction and wind force (beaufort) of stations in Germany (details missing, "
+            "parameter descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+        ("subdaily", "wind_extreme"): (
+            "Recent subdaily extreme wind of stations in Germany (details missing, parameter "
+            "descriptions "
+            "[here](https://opendata.dwd.de/climate_environment/CDC/help/Abkuerzung_neu_Spaltenname_CDC_20171128.xlsx))."
+        ),
+    },
+    "DwdRoadMetadata": {
+        ("15_minutes", "data"): "15-minute road weather data of German highway stations.",
+    },
+    "EAHydrologyMetadata": {
+        ("15_minutes", "data"): "Historical 15 minute station observations of flow and groundwater level for the UK.",
+        ("daily", "data"): "Historical daily station observations of flow and groundwater level for the UK.",
+    },
+    "EcccObservationMetadata": {
+        ("daily", "data"): "Historical daily station observations for Canada.",
+        ("hourly", "data"): (
+            "Historical hourly station observations of 2m air temperature, humidity, wind direction, "
+            "wind speed, visibility range, air pressure, wind gust and weather for Canada."
+        ),
+        ("monthly", "data"): "Historical monthly station observations for Canada.",
+    },
+    "GeosphereObservationMetadata": {
+        ("10_minutes", "data"): "historical 10 minute data.",
+        ("daily", "data"): "Historical daily station observations of 2m air temperature and humidity for Germany.",
+        ("hourly", "data"): "Historical hourly station observations of 2m air temperature and humidity for Germany.",
+        ("monthly", "data"): "Historical monthly station observations of 2m air temperature and humidity for Germany.",
+    },
+    "HubeauMetadata": {
+        ("dynamic", "data"): "Flow and stage for France.",
+    },
+    "ImgwHydrologyMetadata": {
+        ("daily", "hydrology"): "historical daily hydrology data.",
+        ("monthly", "hydrology"): "historical daily climate data.",
+    },
+    "ImgwMeteorologyMetadata": {
+        ("daily", "climate"): "historical daily climate data.",
+        ("daily", "precipitation"): "historical daily precipitation data.",
+        ("daily", "synop"): "historical daily synop data.",
+        ("monthly", "precipitation"): "historical monthly precipitation data.",
+        ("monthly", "synop"): "historical monthly synop data.",
+    },
+    "NoaaGhcnMetadata": {
+        ("daily", "data"): "Historical daily weather data from the Global Historical Climatology Network (GHCN).",
+        ("hourly", "data"): "Historical hourly weather data from the Global Historical Climatology Network (GHCN).",
+    },
+    "NwsObservationMetadata": {
+        ("hourly", "data"): (
+            "Historical hourly station observations (temperature, pressure, precipitation, etc.) for the US."
+        ),
+    },
+    "WsvPegelMetadata": {
+        ("dynamic", "data"): (
+            "Recent data (last 30 days) of German waterways including water level and discharge for "
+            "most stations but may also include chemical, meteorologic and other types of values."
+        ),
+    },
+}
+
+# What a resolution holds, keyed by metadata model name then resolution name.
+RESOLUTION_DESCRIPTIONS: dict[str, dict[str, str]] = {
+    "DwdObservationMetadata": {
+        "subdaily": "measurements at 7am, 2pm, 9pm.",
+    },
+    "EAHydrologyMetadata": {
+        "15_minutes": "no specific dataset is provided but parameters can be queried individually.",
+    },
+}

--- a/src/wetterdienst/model/metadata.py
+++ b/src/wetterdienst/model/metadata.py
@@ -299,23 +299,36 @@ class MetadataModel(BaseModel):
 def build_metadata_model(metadata: dict, name: str) -> MetadataModel:
     """Build a MetadataModel from a dictionary.
 
-    Attaches the source descriptions kept in ``metadata.source_descriptions``. Those are the
-    curated descriptions the provider docs tables have always carried. A description a provider
-    module already declares wins, since that is a transcription of the source's own wording and is
-    only kept where it says at least as much as the curated text.
+    Attaches the descriptions kept in ``metadata.source_descriptions`` -- for parameters, datasets
+    and resolutions alike. Those are the curated descriptions the provider docs tables have always
+    carried. A description a provider module already declares wins, since that is a transcription of
+    the source's own wording and is only kept where it says at least as much as the curated text.
     """
-    from wetterdienst.metadata.source_descriptions import SOURCE_DESCRIPTIONS  # noqa: PLC0415
+    from wetterdienst.metadata.source_descriptions import (  # noqa: PLC0415
+        DATASET_DESCRIPTIONS,
+        RESOLUTION_DESCRIPTIONS,
+        SOURCE_DESCRIPTIONS,
+    )
 
-    descriptions = SOURCE_DESCRIPTIONS.get(name, {})
-    if descriptions:
-        for resolution in metadata["resolutions"]:
-            for dataset in resolution["datasets"]:
-                for parameter in dataset["parameters"]:
-                    if parameter.get("description"):
-                        continue
-                    description = descriptions.get((resolution["name"], dataset["name"], parameter["name_original"]))
-                    if description:
-                        parameter["description"] = description
+    parameters = SOURCE_DESCRIPTIONS.get(name, {})
+    datasets = DATASET_DESCRIPTIONS.get(name, {})
+    resolutions = RESOLUTION_DESCRIPTIONS.get(name, {})
+    for resolution in metadata["resolutions"]:
+        if not resolution.get("description"):
+            description = resolutions.get(resolution["name"])
+            if description:
+                resolution["description"] = description
+        for dataset in resolution["datasets"]:
+            if not dataset.get("description"):
+                description = datasets.get((resolution["name"], dataset["name"]))
+                if description:
+                    dataset["description"] = description
+            for parameter in dataset["parameters"]:
+                if parameter.get("description"):
+                    continue
+                description = parameters.get((resolution["name"], dataset["name"], parameter["name_original"]))
+                if description:
+                    parameter["description"] = description
     validated = MetadataModel.model_validate(metadata)
     validated.__name__ = name  # ty: ignore[unresolved-attribute]
     return validated

--- a/src/wetterdienst/provider/dwd/observation/api.py
+++ b/src/wetterdienst/provider/dwd/observation/api.py
@@ -71,12 +71,12 @@ DROPPABLE_COLUMNS = [
     DwdObservationMetadata.hourly.cloud_type.cloud_type_layer3_abbreviation.name_original,
     DwdObservationMetadata.hourly.cloud_type.cloud_type_layer4_abbreviation.name_original,
     # Cloudiness
-    DwdObservationMetadata.hourly.cloudiness.cloud_cover_total_index.name_original,
+    DwdObservationMetadata.hourly.cloudiness.cloud_cover_total_measurement_method.name_original,
     # Solar
     DwdObservationMetadata.hourly.solar.end_of_interval.name_original,
     DwdObservationMetadata.hourly.solar.true_local_time.name_original,
     # Visibility
-    DwdObservationMetadata.hourly.visibility.visibility_range_index.name_original,
+    DwdObservationMetadata.hourly.visibility.visibility_range_measurement_method.name_original,
     # Weather
     DwdObservationMetadata.hourly.weather_phenomena.weather_text.name_original,
 ]

--- a/src/wetterdienst/provider/dwd/observation/metadata.py
+++ b/src/wetterdienst/provider/dwd/observation/metadata.py
@@ -487,7 +487,9 @@ DwdObservationMetadata = {
                             "unit": "one_eighth",
                         },
                         {
-                            "name": "cloud_cover_total_index",
+                            # v_n_i says how the cover was determined (P = person, I = instrument),
+                            # not what the cover was
+                            "name": "cloud_cover_total_measurement_method",
                             "name_original": "v_n_i",
                             "unit": "dimensionless",
                         },
@@ -584,7 +586,9 @@ DwdObservationMetadata = {
                             "unit": "dimensionless",
                         },
                         {
-                            "name": "cloud_cover_total_index",
+                            # v_n_i says how the cover was determined (P = person, I = instrument),
+                            # not what the cover was
+                            "name": "cloud_cover_total_measurement_method",
                             "name_original": "v_n_i",
                             "unit": "dimensionless",
                         },
@@ -844,7 +848,9 @@ DwdObservationMetadata = {
                             "unit": "dimensionless",
                         },
                         {
-                            "name": "visibility_range_index",
+                            # v_vv_i is DWD's "visibility index, noting how the measurement is
+                            # taken", a method indicator rather than a coded visibility
+                            "name": "visibility_range_measurement_method",
                             "name_original": "v_vv_i",
                             "unit": "dimensionless",
                         },
@@ -1199,7 +1205,7 @@ DwdObservationMetadata = {
                         {
                             # "Terminwerte Sichtweite", unit CODE -- a visibility class, not a
                             # distance. Declared as metres it read "5 metres" for class 5.
-                            "name": "visibility_range_class",
+                            "name": "visibility_range_index",
                             "name_original": "vk_ter",
                             "unit": "dimensionless",
                         },

--- a/src/wetterdienst/provider/dwd/observation/parser.py
+++ b/src/wetterdienst/provider/dwd/observation/parser.py
@@ -34,15 +34,15 @@ DROPPABLE_PARAMETERS = {
     # STRING_PARAMETERS
     # hourly
     # cloud_type
-    DwdObservationMetadata.hourly.cloud_type.cloud_cover_total_index.name_original,
+    DwdObservationMetadata.hourly.cloud_type.cloud_cover_total_measurement_method.name_original,
     DwdObservationMetadata.hourly.cloud_type.cloud_type_layer1_abbreviation.name_original,
     DwdObservationMetadata.hourly.cloud_type.cloud_type_layer2_abbreviation.name_original,
     DwdObservationMetadata.hourly.cloud_type.cloud_type_layer3_abbreviation.name_original,
     DwdObservationMetadata.hourly.cloud_type.cloud_type_layer4_abbreviation.name_original,
     # cloudiness
-    DwdObservationMetadata.hourly.cloudiness.cloud_cover_total_index.name_original,
+    DwdObservationMetadata.hourly.cloudiness.cloud_cover_total_measurement_method.name_original,
     # visibility
-    DwdObservationMetadata.hourly.visibility.visibility_range_index.name_original,
+    DwdObservationMetadata.hourly.visibility.visibility_range_measurement_method.name_original,
     # DATE_PARAMETERS_IRREGULAR
     DwdObservationMetadata.hourly.solar.true_local_time.name_original,
     DwdObservationMetadata.hourly.solar.end_of_interval.name_original,

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -179,3 +179,51 @@ def test_docs_parameter_descriptions_match_the_model() -> None:
                         f"docs {shown!r} != model {parameter.description!r}",
                     )
     assert not mismatches, "\n".join(mismatches[:10])
+
+
+def _documented_dataset_descriptions(path: Path) -> dict[str, str]:
+    """Return {dataset: description} from the '#### metadata' tables of one docs page."""
+    documented = {}
+    dataset = None
+    in_table = False
+    prop = {}
+    for line in path.read_text(encoding="utf8").splitlines():
+        if line.startswith("### ") and not line.startswith("#### "):
+            dataset = line[4:].strip()
+        if line.startswith("|"):
+            cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+            if cells[:1] == ["property"]:
+                in_table, prop = True, {}
+                continue
+            if in_table and not all(set(cell) <= {"-", ":"} for cell in cells) and len(cells) >= 2:
+                prop[cells[0]] = cells[1]
+        elif in_table:
+            if dataset and prop.get("description"):
+                documented[dataset] = prop["description"]
+            in_table, prop = False, {}
+    if in_table and dataset and prop.get("description"):
+        documented[dataset] = prop["description"]
+    return documented
+
+
+def test_docs_dataset_descriptions_match_the_model() -> None:
+    """Test that the docs dataset metadata tables agree with the model.
+
+    Same reason as the parameter descriptions: the text used to live only in markdown. The docs
+    append a "([details](url))" pointer that is page formatting rather than part of the
+    description, so it is ignored here.
+    """
+    mismatches = []
+    for provider, network, resolution, path in _documented_resolutions():
+        documented = _documented_dataset_descriptions(path)
+        for dataset in resolution:
+            shown = documented.get(dataset.name)
+            if not shown or not dataset.description:
+                continue
+            shown = re.sub(r"\s*\(\[[^\]]+\]\([^)]*\)\)\s*$", "", shown).strip().rstrip(".")
+            if shown != dataset.description.rstrip("."):
+                mismatches.append(
+                    f"{provider}/{network}/{resolution.name}/{dataset.name}: "
+                    f"docs {shown!r} != model {dataset.description!r}",
+                )
+    assert not mismatches, "\n".join(mismatches[:10])


### PR DESCRIPTION
The last naming defect the audit turned up: one name meaning two quantities, which is the collision the canonical table exists to prevent. This instance predates the table.

## What was wrong

`cloud_cover_total_index` and `visibility_range_index` were attached to DWD's `v_n_i` and `v_vv_i`. DWD's own sheet says what those are:

> *"index how measurement is taken, P = by human person, I = by instrument"*

They are **measurement method** indicators. Both canonical descriptions said a coded *value*:

| name | description | actually held |
|---|---|---|
| `cloud_cover_total_index` | "Coded index describing total cloud cover" | how it was observed |
| `visibility_range_index` | "Coded indicator of the visibility range" | how it was observed |

The clearest evidence was already in the code: **the parser lists both among its string parameters**, because they hold the letters `P` and `I` rather than numbers. A cloud cover is not a letter.

## What changes

- `cloud_cover_total_index` → **`cloud_cover_total_measurement_method`**
- `visibility_range_index` (on `v_vv_i`) → **`visibility_range_measurement_method`**
- `visibility_range_class` → **`visibility_range_index`**
- `cloud_cover_total_index` is **removed**

The third one closes a loop from #1815. `visibility_range_class` existed for one release-in-progress only because `visibility_range_index` was occupied: DWD subdaily `vk_ter` is a genuine coded visibility class (values 0–9), and its natural name was taken by the method indicator. Now that the collision is resolved, `vk_ter` takes the name whose description always described it.

`cloud_cover_total_index` is removed rather than left dangling — no provider declares a coded cloud cover, and an unused canonical name is vocabulary noise of exactly the kind this migration removed from the enum.

673 tests pass; lint and `ty` clean.

**Breaking**: three parameter names change and one is removed. Queries using the old names against DWD need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
