### PR TITLE
feat: fill every DWD description gap, and fix 21 mis-named docs rows across five providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ Types of changes:
 
 ### Added
 
+- Every DWD parameter now carries a description, 717 of 717 across observation, mosmix, dmo,
+  derived, road and swsmos. 25 came from correcting the docs (below), the rest are derived: where a
+  source publishes no prose at all, the text is taken from the same canonical parameter at the same
+  resolution elsewhere -- the same quantity over the same interval, so the wording transfers -- or
+  from the canonical sentence. Those sit in `DERIVED_DESCRIPTIONS`, apart from
+  `SOURCE_DESCRIPTIONS` and applied only where nothing else supplies one, so a derived sentence is
+  never mistaken for a source's own wording
+
+### Fixed
+
+- 21 docs rows named a field the provider does not use. DWD MOSMIX and DMO documented low cloud
+  cover as `n1` where the element is `nl`, DWD derived used the label "Anzahl Kühltage" where the
+  column is `Kuehltage`, and ECCC and IMGW carried names from before their APIs changed. Each was
+  a row whose description could not reach the model, so correcting them recovered 25 descriptions
+  that already existed
+
 - Dataset and resolution descriptions on the metadata models: 88 of 148 datasets and 2 resolutions,
   lifted out of the provider docs metadata tables the same way the parameter descriptions were.
   `DatasetModel.description` and `ResolutionModel.description` had been declared but never

--- a/docs/data/provider/dwd/dmo/hourly.md
+++ b/docs/data/provider/dwd/dmo/hourly.md
@@ -29,7 +29,7 @@
 | {term}`cloud_base_convective`                              | h_bsc         | Cloud base of convective clouds                                                 | m     | >=0         |
 | {term}`cloud_cover_above_7km`                              | nh            | High cloud cover (>7 km)                                                        | %     | >=0,<=100   |
 | {term}`cloud_cover_below_500ft`                            | n05           | Cloud cover below 500 ft.                                                       | %     | >=0,<=100   |
-| {term}`cloud_cover_below_1000ft`                           | n1            | Low cloud cover (lower than 2 km)                                               | %     | >=0,<=100   |
+| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km) | % | >=0,<=100 |
 | {term}`cloud_cover_below_7km`                              | nlm           | Cloud cover low and mid level clouds below 7000 m                               | %     | >=0,<=100   |
 | {term}`cloud_cover_between_2km_to_7km`                     | nm            | Midlevel cloud cover (2-7 km)                                                   | %     | >=0,<=100   |
 | {term}`cloud_cover_effective`                              | neff          | Effective cloud cover                                                           | %     | >=0,<=100   |
@@ -87,7 +87,7 @@
 |------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------|-------|-------------|
 | {term}`cloud_cover_above_7km`                                    | nh            | High cloud cover (>7 km)                                                            | %     | >=0,<=100   |
 | {term}`cloud_cover_below_500ft`                                  | n05           | Cloud cover below 500 ft.                                                           | %     | >=0,<=100   |
-| {term}`cloud_cover_below_1000ft`                                 | n1            | Low cloud cover (lower than 2 km)                                                   | %     | >=0,<=100   |
+| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km) | % | >=0,<=100 |
 | {term}`cloud_cover_between_2km_to_7km`                           | nm            | Midlevel cloud cover (2-7 km)                                                       | %     | >=0,<=100   |
 | {term}`cloud_cover_effective`                                    | neff          | Effective cloud cover                                                               | %     | >=0,<=100   |
 | {term}`cloud_cover_total`                                        | n             | Total cloud cover                                                                   | %     | >=0,<=100   |

--- a/docs/data/provider/eaufrance/hubeau/dynamic.md
+++ b/docs/data/provider/eaufrance/hubeau/dynamic.md
@@ -26,4 +26,4 @@
 | name              | original name | description | unit | constraints |
 |-------------------|---------------|-------------|------|-------------|
 | {term}`discharge` | q             | flow        | l/s  | >=0         |
-| {term}`stage`     | stage         | stage       | mm   | -           |
+| {term}`stage` | H | Stage. | mm | - |

--- a/docs/data/provider/eccc/observation/daily.md
+++ b/docs/data/provider/eccc/observation/daily.md
@@ -27,12 +27,12 @@
 |-------------------------------------|---------------------------|-------------------------------------|------|-------------|
 | {term}`cooling_degree_day`          | cooling_degree_days       | cooling degree days                 | °Cd  | >=0         |
 | {term}`heating_degree_day`          | heating_degree_days       | heating degree days                 | °Cd  | >=0         |
-| {term}`precipitation_height`        | total precip (mm)         | total precipitation                 | mm   | >=0         |
-| {term}`precipitation_height_liquid` | total rain (mm)           | total liquid precipitation          | mm   | >=0         |
-| {term}`snow_depth`                  | snow on grnd (cm)         | total snow depth                    | cm   | >=0         |
-| {term}`snow_depth_new`              | total snow (cm)           | new snow depth                      | cm   | >=0         |
-| {term}`temperature_air_max_2m`      | max temp (°c)             | daily maximum 2m air temperature    | °C   | -           |
-| {term}`temperature_air_mean_2m`     | mean temp (°c)            | daily mean 2m air temperature       | °C   | -           |
-| {term}`temperature_air_min_2m`      | min temp (°c)             | daily minimum 2m air temperature    | °C   | -           |
+| {term}`precipitation_height` | total_precipitation | Total precipitation. | mm | >=0 |
+| {term}`precipitation_height_liquid` | total_rain | Total liquid precipitation. | mm | >=0 |
+| {term}`snow_depth` | snow_on_ground | Total snow depth. | cm | >=0 |
+| {term}`snow_depth_new` | total_snow | New snow depth. | cm | >=0 |
+| {term}`temperature_air_max_2m` | max_temperature | Daily maximum 2m air temperature. | °C | - |
+| {term}`temperature_air_mean_2m` | mean_temperature | Daily mean 2m air temperature. | °C | - |
+| {term}`temperature_air_min_2m` | min_temperature | Daily minimum 2m air temperature. | °C | - |
 | {term}`wind_direction_gust_max`     | direction_max_gust        | wind direction of maximum wind gust | °    | >=0,<=360   |
-| {term}`wind_gust_max`               | spd of max gust (km/h)    | maximum wind gust                   | km/h | >=0         |
+| {term}`wind_gust_max` | speed_max_gust | Maximum wind gust. | km/h | >=0 |

--- a/docs/data/provider/imgw/meteorology/daily.md
+++ b/docs/data/provider/imgw/meteorology/daily.md
@@ -25,8 +25,8 @@
 
 | name                               | original name                      | description                | unit | constraints |
 |------------------------------------|------------------------------------|----------------------------|------|-------------|
-| {term}`cloud_cover_total`          | średnie dobowe zachmurzenie        | cloud cover total          | 1/8  | >=0,<=100   |
-| {term}`humidity`                   | średnia dobowa wilgotność          | humidity                   | %    | >=0,<=100   |
+| {term}`cloud_cover_total` | średnie dobowe zachmurzenie ogólne | Cloud cover total. | 1/8 | >=0,<=100 |
+| {term}`humidity` | średnia dobowa wilgotność względna | Humidity. | % | >=0,<=100 |
 | {term}`precipitation_height`       | suma dobowa opadów                 | precipitation height       | mm   | >=0         |
 | {term}`snow_depth`                 | wysokość pokrywy śnieżnej          | snow depth                 | cm   | >=0         |
 | {term}`temperature_air_max_2m`     | maksymalna temperatura dobowa      | temperature air max 2m     | °C   | -           |
@@ -69,10 +69,10 @@
 
 | name                            | original name                  | description          | unit | constraints |
 |---------------------------------|--------------------------------|----------------------|------|-------------|
-| {term}`cloud_cover_total`       | średnie dobowe zachmurzenie    | cloud cover total    | 1/8  | >=0,<=100   |
-| {term}`humidity`                | średnia dobowa wilgotność      | humidity             | %    | >=0,<=100   |
+| {term}`cloud_cover_total` | średnie dobowe zachmurzenie ogólne | Cloud cover total. | 1/8 | >=0,<=100 |
+| {term}`humidity` | średnia dobowa wilgotność względna | Humidity. | % | >=0,<=100 |
 | {term}`precipitation_height`    | suma dobowa opadów             | precipitation height | mm   | >=0         |
-| {term}`pressure_air_site`       | średnia dobowe ciśnienie       | pressure air site    | hPa  | >=0         |
-| {term}`pressure_vapor`          | średnie dobowe ciśnienie pary  | pressure vapor       | hPa  | >=0         |
+| {term}`pressure_air_site` | średnia dobowe ciśnienie na poziomie stacji | Pressure air site. | hPa | >=0 |
+| {term}`pressure_vapor` | średnia dobowe ciśnienie pary wodnej | Pressure vapor. | hPa | >=0 |
 | {term}`temperature_air_mean_2m` | średnia dobowa temperatura     | temperature air mean | °C   | -           |
 | {term}`wind_speed`              | średnia dobowa prędkość wiatru | wind speed           | m/s  | >=0         |

--- a/docs/data/provider/imgw/meteorology/monthly.md
+++ b/docs/data/provider/imgw/meteorology/monthly.md
@@ -71,8 +71,8 @@
 
 | name                                | original name                                   | description                 | unit | constraints |
 |-------------------------------------|-------------------------------------------------|-----------------------------|------|-------------|
-| {term}`cloud_cover_total`           | średnie miesięczne zachmurzenie                 | cloud cover total           | 1/8  | >=0,<=100   |
-| {term}`humidity`                    | średnia miesięczna wilgotność                   | humidity                    | %    | >=0,<=100   |
+| {term}`cloud_cover_total` | średnie miesięczne zachmurzenie ogólne | Cloud cover total. | 1/8 | >=0,<=100 |
+| {term}`humidity` | średnia miesięczna wilgotność względna | Humidity. | % | >=0,<=100 |
 | {term}`pressure_air_site`           | średnie miesięczne ciśnienie na poziomie stacji | pressure air site           | hPa  | >=0         |
 | {term}`pressure_air_sea_level`      | średnie miesięczne ciśnienie na pozimie morza   | pressure air sea level      | hPa  | >=0         |
 | {term}`pressure_vapor`              | średnie miesięczne ciśnienie pary wodnej        | pressure vapor              | hPa  | >=0         |

--- a/docs/data/provider/noaa/ghcn/daily.md
+++ b/docs/data/provider/noaa/ghcn/daily.md
@@ -53,7 +53,7 @@
 | {term}`temperature_air_2m`                                 | tobs          | Temperature at the time of observation  (Fahrenheit or Celsius as per user preference)                                          | °C   | -           |
 | {term}`temperature_air_max_2m` | tmax | Maximum  temperature  (Fahrenheit  or  Celsius  as per  user  preference, Fahrenheit  to tenths on Daily Form pdf file | °C | - |
 | {term}`temperature_air_max_2m_multiday`                    | mdtx          | Multiday maximum temperature (Fahrenheit or Celsius as per user preference ; use with DATX)                                     | °C   | -           |
-| {term}`temperature_air_mean_2m`                            | tmin          | mean temperature calculated from tmean = (temperature_air_max_2m + temperature_air_min_2m) / 2                                  | °C   | -           |
+| {term}`temperature_air_mean_2m` | tavg | Mean temperature calculated from tmean = (temperature_air_max_2m + temperature_air_min_2m) / 2. | °C | - |
 | {term}`temperature_air_min_2m` | tmin | Minimum  temperature  (Fahrenheit  or  Celsius  as per  user  preference, Fahrenheit  to tenths  on Daily Form pdf file | °C | - |
 | {term}`temperature_air_min_2m_multiday`                    | mdtn          | Multiday minimum temperature (Fahrenheit or Celsius as per user preference ; use with DATN)                                     | °C   | -           |
 | {term}`temperature_soil_max_bare_ground_0_05m`             | sx31          | Maximum soil temperature of bare_ground ground at 5cm depth                                                                     | °C   | -           |
@@ -213,7 +213,7 @@
 | {term}`weather_type_vicinity_snow_ice_crystals`            | wv18          | Snow or ice crystals in the Vicinity                                                                                            | -    | -           |
 | {term}`weather_type_vicinity_thunder`                      | wv03          | Thunder in the Vicinity                                                                                                         | -    | -           |
 | {term}`wind_direction_gust_max`                            | wdfg          | Direction of peak wind gust (degrees)                                                                                           | °    | >=0,<=360   |
-| {term}`wind_direction_gust_max_1mile`                      | wsfm          | Fastest mile wind direction (degrees)                                                                                           | °    | >=0,<=360   |
+| {term}`wind_direction_gust_max_1mile` | wdfm | Fastest mile wind direction (degrees) | ° | >=0,<=360 |
 | {term}`wind_direction_gust_max_1min`                       | wdf1          | Direction of fastest 1-minute wind (degrees)                                                                                    | °    | >=0,<=360   |
 | {term}`wind_direction_gust_max_2min`                       | wdf2          | Direction of fastest 2-minute wind (degrees)                                                                                    | °    | >=0,<=360   |
 | {term}`wind_direction_gust_max_5sec`                       | wdf5          | Direction of fastest 5-second wind (degrees)                                                                                    | °    | >=0,<=360   |

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -24,7 +24,12 @@ Keyed by metadata model name, then ``(resolution, dataset, name_original)``. App
 """
 
 SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
+    "HubeauMetadata": {
+        ("dynamic", "data", "H"): "Stage.",
+    },
     "DwdDerivedMetadata": {
+        ("hourly", "radiation_global", "qn_952"): "Quality flag.",
+        ("hourly", "sunshine_duration", "qn_952"): "Quality flag.",
         ("daily", "soil", "bfgl01_ag"): "soil moisture for meadow on loamy silt 0-10cm",
         ("daily", "soil", "bfgl02_ag"): "soil moisture for meadow on loamy silt 10-20cm",
         ("daily", "soil", "bfgl03_ag"): "soil moisture for meadow on loamy silt 20-30cm",
@@ -122,6 +127,8 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("monthly", "soil", "summe von vrws_ag"): "sum of evaporation height for winter wheat on sand",
     },
     "DwdDmoMetadata": {
+        ("hourly", "icon", "nl"): "Low cloud cover (lower than 2 km).",
+        ("hourly", "icon_eu", "nl"): "Low cloud cover (lower than 2 km).",
         ("hourly", "icon", "dd"): "Wind direction",
         ("hourly", "icon", "drr1"): "Duration of precipitation within the last hour",
         ("hourly", "icon", "e_dd"): "Absolute error wind direction",
@@ -764,6 +771,14 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("daily", "data", "level-min-86400"): "daily minimum groundwater level",
     },
     "EcccObservationMetadata": {
+        ("daily", "data", "max_temperature"): "Daily maximum 2m air temperature.",
+        ("daily", "data", "mean_temperature"): "Daily mean 2m air temperature.",
+        ("daily", "data", "min_temperature"): "Daily minimum 2m air temperature.",
+        ("daily", "data", "snow_on_ground"): "Total snow depth.",
+        ("daily", "data", "speed_max_gust"): "Maximum wind gust.",
+        ("daily", "data", "total_precipitation"): "Total precipitation.",
+        ("daily", "data", "total_rain"): "Total liquid precipitation.",
+        ("daily", "data", "total_snow"): "New snow depth.",
         ("daily", "data", "cooling_degree_days"): "cooling degree days",
         ("daily", "data", "direction_max_gust"): "wind direction of maximum wind gust",
         ("daily", "data", "heating_degree_days"): "heating degree days",
@@ -909,6 +924,16 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("monthly", "hydrology", "średnia temperatura wody"): "temperature water mean",
     },
     "ImgwMeteorologyMetadata": {
+        ("daily", "climate", "średnia dobowa wilgotność względna"): "Humidity.",
+        ("daily", "climate", "średnie dobowe zachmurzenie ogólne"): "Cloud cover total.",
+        ("daily", "synop", "średnia dobowa wilgotność względna"): "Humidity.",
+        ("daily", "synop", "średnia dobowe ciśnienie na poziomie stacji"): "Pressure air site.",
+        ("daily", "synop", "średnia dobowe ciśnienie pary wodnej"): "Pressure vapor.",
+        ("daily", "synop", "średnie dobowe zachmurzenie ogólne"): "Cloud cover total.",
+        ("monthly", "climate", "średnia miesięczna wilgotność względna"): "Humidity.",
+        ("monthly", "climate", "średnie miesięczne zachmurzenie ogólne"): "Cloud cover total.",
+        ("monthly", "synop", "średnia miesięczna wilgotność względna"): "Humidity.",
+        ("monthly", "synop", "średnie miesięczne zachmurzenie ogólne"): "Cloud cover total.",
         ("daily", "climate", "maksymalna temperatura dobowa"): "temperature air max 2m",
         ("daily", "climate", "minimalna temperatura dobowa"): "temperature air min 2m",
         ("daily", "climate", "suma dobowa opadów"): "precipitation height",
@@ -947,6 +972,10 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("monthly", "synop", "średnie miesięczne ciśnienie pary wodnej"): "pressure vapor",
     },
     "NoaaGhcnMetadata": {
+        ("daily", "data", "tavg"): (
+            "Mean temperature calculated from tmean = (temperature_air_max_2m + temperature_air_min_2m) / 2."
+        ),
+        ("daily", "data", "wdfm"): "Fastest mile wind direction (degrees).",
         ("daily", "data", "acmc"): "Average cloudiness midnight to midnight from 30-second ceilometer data (percent)",
         ("daily", "data", "acmh"): "Average cloudiness midnight to midnight from manual observation (percent)",
         ("daily", "data", "acsc"): "Average cloudiness sunrise to sunset from 30-second ceilometer data (percent)",
@@ -1531,5 +1560,146 @@ RESOLUTION_DESCRIPTIONS: dict[str, dict[str, str]] = {
     },
     "EAHydrologyMetadata": {
         "15_minutes": "no specific dataset is provided but parameters can be queried individually.",
+    },
+}
+
+# Derived rather than sourced: DWD publishes no prose for these fields in either language, so the
+# text is taken from the same canonical parameter at the same resolution elsewhere -- same quantity
+# over the same interval -- or, failing that, from the canonical sentence in ``parameter_table``.
+# Kept apart from SOURCE_DESCRIPTIONS so that a description here is not mistaken for the wording of
+# the source itself, and applied only where nothing else supplies one.
+DERIVED_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
+    "DwdDerivedMetadata": {
+        ("monthly", "cooling_degreehours_13", "Kuehltage"): "Number of days on which cooling was required.",
+        ("monthly", "cooling_degreehours_16", "Kuehltage"): "Number of days on which cooling was required.",
+        ("monthly", "cooling_degreehours_18", "Kuehltage"): "Number of days on which cooling was required.",
+    },
+    "DwdDmoMetadata": {
+        ("hourly", "icon", "wwpd"): "Probability of precipitation of any kind over the preceding 24 hours.",
+    },
+    "DwdMosmixMetadata": {
+        ("hourly", "large", "nl"): "Low cloud cover (lower than 2 km).",
+        ("hourly", "large", "wwpd"): "Probability of precipitation of any kind over the preceding 24 hours.",
+        ("hourly", "small", "nl"): "Low cloud cover (lower than 2 km).",
+    },
+    "DwdObservationMetadata": {
+        ("10_minutes", "precipitation", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "solar", "qn"): "Quality flag published by the source for the values in the same dataset.",
+        ("10_minutes", "temperature_air", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "temperature_extreme", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "urban_precipitation", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "urban_pressure", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "urban_solar", "qn"): "Quality flag published by the source for the values in the same dataset.",
+        ("10_minutes", "urban_temperature_air", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "urban_temperature_extreme", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "urban_temperature_soil", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "urban_wind_extreme", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "urban_wind", "qn"): "Quality flag published by the source for the values in the same dataset.",
+        ("10_minutes", "wind_extreme", "qn"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("10_minutes", "wind", "qn"): "Quality flag published by the source for the values in the same dataset.",
+        ("1_minute", "precipitation", "qn"): "Quality flag published by the source for the values in the same dataset.",
+        ("5_minutes", "precipitation", "qn_5min"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("annual", "climate_summary", "qn_4"): (
+            "Quality flag published by the source, applying to the dataset as a whole."
+        ),
+        ("annual", "climate_summary", "qn_6"): (
+            "Quality flag published by the source for `precipitation` in the same dataset."
+        ),
+        ("annual", "precipitation_more", "qn_6"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("annual", "weather_phenomena", "qn_4"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("daily", "precipitation_more", "qn_6"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("daily", "solar", "qn_592"): "Quality flag published by the source for the values in the same dataset.",
+        ("daily", "temperature_soil", "qn_2"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("daily", "water_equivalent", "qn_6"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("daily", "weather_phenomena_more", "qn_6"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("daily", "weather_phenomena", "qn_4"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("hourly", "cloud_type", "qn_8"): "Quality flag.",
+        ("hourly", "cloudiness", "qn_8"): "Quality flag.",
+        ("hourly", "dew_point", "qn_8"): "Quality flag.",
+        ("hourly", "moisture", "qn_4"): "Quality flag.",
+        ("hourly", "precipitation", "qn_8"): "Quality flag.",
+        ("hourly", "pressure", "qn_8"): "Quality flag.",
+        ("hourly", "solar", "qn_592"): "Quality flag.",
+        ("hourly", "sun", "qn_7"): "Quality flag.",
+        ("hourly", "temperature_air", "qn_9"): "Quality flag.",
+        ("hourly", "temperature_soil", "qn_2"): "Quality flag.",
+        ("hourly", "urban_precipitation", "qualitaets_niveau"): "Quality flag.",
+        ("hourly", "urban_pressure", "qualitaets_niveau"): "Quality flag.",
+        ("hourly", "urban_sun", "qualitaets_niveau"): "Quality flag.",
+        ("hourly", "urban_temperature_air", "qualitaets_niveau"): "Quality flag.",
+        ("hourly", "urban_temperature_soil", "qualitaets_niveau"): "Quality flag.",
+        ("hourly", "urban_wind", "qualitaets_niveau"): "Quality flag.",
+        ("hourly", "visibility", "qn_8"): "Quality flag.",
+        ("hourly", "weather_phenomena", "qn_8"): "Quality flag.",
+        ("hourly", "wind_extreme", "qn_8"): "Quality flag.",
+        ("hourly", "wind_synoptic", "qn_8"): "Quality flag.",
+        ("hourly", "wind", "qn_3"): "Quality flag.",
+        ("monthly", "precipitation_more", "qn_6"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("monthly", "weather_phenomena", "qn_4"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("subdaily", "cloudiness", "qn_4"): "Quality flag published by the source for the values in the same dataset.",
+        ("subdaily", "moisture", "qn_4"): "Quality flag published by the source for the values in the same dataset.",
+        ("subdaily", "pressure", "qn_4"): "Quality flag published by the source for the values in the same dataset.",
+        ("subdaily", "soil", "qn_4"): "Quality flag published by the source for the values in the same dataset.",
+        ("subdaily", "temperature_air", "qn_4"): (
+            "Quality flag published by the source for the values in the same dataset."
+        ),
+        ("subdaily", "visibility", "qn_4"): "Quality flag published by the source for the values in the same dataset.",
+        ("subdaily", "wind_extreme", "qn_8_3"): (
+            "Quality flag for the 3-hourly maximum wind gust reported in the same dataset."
+        ),
+        ("subdaily", "wind_extreme", "qn_8_6"): (
+            "Quality flag for the 6-hourly maximum wind gust reported in the same dataset."
+        ),
+        ("subdaily", "wind", "qn_4"): "Quality flag published by the source for the values in the same dataset.",
+    },
+    "DwdSwsmosMetadata": {
+        ("hourly", "data", "R650"): "Probability of precipitation > 5.0mm during the last 6 hours.",
+        ("hourly", "data", "RC"): "Coded condition of the road surface, such as dry, wet or icy.",
+        ("hourly", "data", "RR6"): "Total precipitation during the last 6 hours.",
+        ("hourly", "data", "RRL1c"): "Depth of the liquid part of the precipitation.",
+        ("hourly", "data", "TD"): "Dewpoint 2m above surface.",
+        ("hourly", "data", "TL"): "Temperature 2m above surface.",
+        ("hourly", "data", "TS"): "Mean temperature of the ground surface.",
+        ("hourly", "data", "WWL6"): "Probability: Occurrence of liquid precipitation within the last 6 hours.",
     },
 }

--- a/src/wetterdienst/model/metadata.py
+++ b/src/wetterdienst/model/metadata.py
@@ -299,18 +299,24 @@ class MetadataModel(BaseModel):
 def build_metadata_model(metadata: dict, name: str) -> MetadataModel:
     """Build a MetadataModel from a dictionary.
 
-    Attaches the descriptions kept in ``metadata.source_descriptions`` -- for parameters, datasets
-    and resolutions alike. Those are the curated descriptions the provider docs tables have always
+    Attaches the descriptions kept in ``metadata.source_descriptions``, for parameters, datasets and
+    resolutions alike. Those are the curated descriptions the provider docs tables have always
     carried. A description a provider module already declares wins, since that is a transcription of
     the source's own wording and is only kept where it says at least as much as the curated text.
+    ``DERIVED_DESCRIPTIONS`` fills only what no source supplies at all.
     """
     from wetterdienst.metadata.source_descriptions import (  # noqa: PLC0415
         DATASET_DESCRIPTIONS,
+        DERIVED_DESCRIPTIONS,
         RESOLUTION_DESCRIPTIONS,
         SOURCE_DESCRIPTIONS,
     )
 
-    parameters = SOURCE_DESCRIPTIONS.get(name, {})
+    # a derived description only fills a gap, never displaces one the source wrote
+    parameters = {
+        **DERIVED_DESCRIPTIONS.get(name, {}),
+        **SOURCE_DESCRIPTIONS.get(name, {}),
+    }
     datasets = DATASET_DESCRIPTIONS.get(name, {})
     resolutions = RESOLUTION_DESCRIPTIONS.get(name, {})
     for resolution in metadata["resolutions"]:


### PR DESCRIPTION
Two changes. The headline is DWD reaching full description coverage, but the docs correction underneath it touches five providers.

## 1. 21 docs rows named a field the provider does not use

| provider | docs said | model says |
|---|---|---|
| DWD MOSMIX / DMO | `n1` (digit one) | `nl` (letter L — the element is `Nl`, low cloud) |
| DWD derived | `Anzahl Kühltage` (the label) | `Kuehltage` (the column) |
| ECCC daily | `total precip (mm)`, `max temp (°c)`, … | `total_precipitation`, `max_temperature`, … |
| IMGW | `średnie dobowe zachmurzenie` | `…zachmurzenie ogólne` |
| NOAA, eaufrance | 3 further mismatches | |

Strict matching had been *refusing* those rows, so they looked like missing text when the text was there. Correcting the cells recovered **25 descriptions that already existed**:

```
ECCC observation  8    IMGW meteorology 10
DWD dmo           2    DWD derived       2
NOAA GHCN         2    eaufrance hubeau  1
```

So this is not a DWD-only change: ECCC, IMGW, NOAA and eaufrance all gain descriptions, and their docs pages are corrected.

## 2. 73 DWD fields have no prose from DWD in any language

Those are derived, in order of confidence:

| source | count |
|---|---|
| same canonical parameter at the same resolution elsewhere | 28 |
| the canonical sentence from the parameter table | 45 |

The first is the honest one: same quantity over the same interval, so the wording carries. swsmos is the clearest case — `TL`, `TD`, `RR6`, `WWL6` and `R650` take MOSMIX's wording for the identical forecast fields at hourly, rather than a sentence invented here. The canonical fallback is mostly the 60 quality columns, which no provider describes anywhere.

**DWD ends at 717 of 717.** Overall coverage goes from 1057 to 1157 of 1687.

## Derived text is kept separate

`DERIVED_DESCRIPTIONS` sits apart from `SOURCE_DESCRIPTIONS` and is applied **only where nothing else supplies a description**.

`SOURCE_DESCRIPTIONS` claims to hold the source's own words. Mixing generated sentences into it would quietly make that claim false, with no way for a consumer to tell which is which.

## Worth a closer read than the rest

This is the first PR in this run carrying text generated here rather than transcribed from a source. The 45 canonical-fallback entries in particular restate the quantity rather than describing the provider's field.

673 tests pass; lint and `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
