### PR TITLE
fix(eaufrance)!: keep the source's own case, and recover the 22 descriptions the mismatch hid

### DIFF
--- a/docs/data/provider/eaufrance/hubeau/dynamic.md
+++ b/docs/data/provider/eaufrance/hubeau/dynamic.md
@@ -25,5 +25,5 @@
 
 | name              | original name | description | unit | constraints |
 |-------------------|---------------|-------------|------|-------------|
-| {term}`discharge` | q             | flow        | l/s  | >=0         |
-| {term}`stage` | H | Stage. | mm | - |
+| {term}`discharge` | Q             | Flow.       | l/s  | >=0         |
+| {term}`stage`     | H             | Stage.      | mm   | -           |

--- a/docs/data/provider/wsv/pegel/dynamic.md
+++ b/docs/data/provider/wsv/pegel/dynamic.md
@@ -23,26 +23,26 @@
 
 #### parameters
 
-| name                            | original name           | description                                       | unit  | constraints |
-|---------------------------------|-------------------------|---------------------------------------------------|-------|-------------|
-| {term}`chlorid_concentration`   | cl                      | average chlorid concentration during time scale   | mg/l  | -           |
-| {term}`clearance_height`        | dfh                     | average clearance height during time scale        | cm    | -           |
-| {term}`discharge`               | q                       | average discharge during time scale               | m³/s  | >=0         |
-| {term}`electric_conductivity`   | lf                      | average electric conductivity during time scale   | μS/cm | -           |
-| {term}`flow_direction`          | r                       | direction of the water current                    | °     | >=0,<=360   |
-| {term}`flow_speed`              | va                      | average flow speed during time scale              | m/s   | -           |
-| {term}`groundwater_level`       | gru                     | average groundwater level during time scale       | m     | -           |
-| {term}`humidity`                | hl                      | average water level during time scale             | °     | >=0,<=100   |
-| {term}`oxygen_level`            | o2                      | average oxygen level during time scale            | mg/l  | >=0         |
-| {term}`ph_value`                | ph                      | average pH during time scale                      | -     | -           |
-| {term}`precipitation_height`    | niederschlag            | average precipitation height during time scale    | mm    | >=0         |
-| {term}`precipitation_intensity` | niederschlagsintensität | average precipitation intensity during time scale | mm/h  | >=0         |
-| {term}`stage`                   | w                       | average water level during time scale             | cm    | >=0         |
-| {term}`temperature_air_mean_2m` | lt                      | average air temperature during time scale         | °C    | -           |
-| {term}`temperature_water`       | wt                      | average water temperature during time scale       | °C    | -           |
-| {term}`turbidity`               | tr                      | average turbidity during time scale               | NTU   | -           |
-| {term}`wave_height_max`         | maxh                    | max wave height during time scale                 | cm    | -           |
-| {term}`wave_height_sign`        | sigh                    | average wave height sign during time scale        | cm    | -           |
-| {term}`wave_period`             | tp                      | average wave period during time scale             | s     | >=0         |
-| {term}`wind_direction`          | wr                      | average wind direction during time scale          | °     | >=0,<=360   |
-| {term}`wind_speed`              | wg                      | average wind speed during time scale              | m/s   | -           |
+| name                            | original name           | description                                            | unit  | constraints |
+|---------------------------------|-------------------------|--------------------------------------------------------|-------|-------------|
+| {term}`chlorid_concentration`   | CL                      | average chlorid concentration during time scale        | mg/l  | -           |
+| {term}`clearance_height`        | DFH                     | average clearance height during time scale             | cm    | -           |
+| {term}`discharge`               | Q                       | average discharge during time scale                    | m³/s  | >=0         |
+| {term}`electric_conductivity`   | LF                      | average electric conductivity during time scale        | μS/cm | -           |
+| {term}`flow_direction`          | R                       | direction of the water current                         | °     | >=0,<=360   |
+| {term}`flow_speed`              | VA                      | average flow speed during time scale                   | m/s   | -           |
+| {term}`groundwater_level`       | GRU                     | average groundwater level during time scale            | m     | -           |
+| {term}`humidity`                | HL                      | average relative humidity of the air during time scale | %     | >=0,<=100   |
+| {term}`oxygen_level`            | O2                      | average oxygen level during time scale                 | mg/l  | >=0         |
+| {term}`ph_value`                | PH                      | average pH during time scale                           | -     | -           |
+| {term}`precipitation_height`    | NIEDERSCHLAG            | average precipitation height during time scale         | mm    | >=0         |
+| {term}`precipitation_intensity` | NIEDERSCHLAGSINTENSITÄT | average precipitation intensity during time scale      | mm/h  | >=0         |
+| {term}`stage`                   | W                       | average water level during time scale                  | cm    | >=0         |
+| {term}`temperature_air_mean_2m` | LT                      | average air temperature during time scale              | °C    | -           |
+| {term}`temperature_water`       | WT                      | average water temperature during time scale            | °C    | -           |
+| {term}`turbidity`               | TR                      | average turbidity during time scale                    | NTU   | -           |
+| {term}`wave_height_max`         | MAXH                    | max wave height during time scale                      | cm    | -           |
+| {term}`wave_height_sign`        | SIGH                    | average significant wave height during time scale      | cm    | -           |
+| {term}`wave_period`             | TP                      | average wave period during time scale                  | s     | >=0         |
+| {term}`wind_direction`          | WR                      | average wind direction during time scale               | °     | >=0,<=360   |
+| {term}`wind_speed`              | WG                      | average wind speed during time scale                   | m/s   | -           |

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -26,6 +26,7 @@ Keyed by metadata model name, then ``(resolution, dataset, name_original)``. App
 SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
     "HubeauMetadata": {
         ("dynamic", "data", "H"): "Stage.",
+        ("dynamic", "data", "Q"): "Flow.",
     },
     "DwdDerivedMetadata": {
         ("hourly", "radiation_global", "qn_952"): "Quality flag.",
@@ -1307,6 +1308,31 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("hourly", "data", "winddirection"): "wind direction",
         ("hourly", "data", "windgust"): "maximum wind gust",
         ("hourly", "data", "windspeed"): "wind speed",
+    },
+    "WsvPegelMetadata": {
+        # Pegelonline names each timeseries in German; the meaning below is the API's own
+        # ``longname`` for that shortname, e.g. HL is LUFTFEUCHTE and SIGH SIGNIFIKANTEWELLENHÖHE.
+        ("dynamic", "data", "CL"): "average chlorid concentration during time scale",
+        ("dynamic", "data", "DFH"): "average clearance height during time scale",
+        ("dynamic", "data", "GRU"): "average groundwater level during time scale",
+        ("dynamic", "data", "HL"): "average relative humidity of the air during time scale",
+        ("dynamic", "data", "LF"): "average electric conductivity during time scale",
+        ("dynamic", "data", "LT"): "average air temperature during time scale",
+        ("dynamic", "data", "MAXH"): "max wave height during time scale",
+        ("dynamic", "data", "NIEDERSCHLAG"): "average precipitation height during time scale",
+        ("dynamic", "data", "NIEDERSCHLAGSINTENSITÄT"): "average precipitation intensity during time scale",
+        ("dynamic", "data", "O2"): "average oxygen level during time scale",
+        ("dynamic", "data", "PH"): "average pH during time scale",
+        ("dynamic", "data", "Q"): "average discharge during time scale",
+        ("dynamic", "data", "R"): "direction of the water current",
+        ("dynamic", "data", "SIGH"): "average significant wave height during time scale",
+        ("dynamic", "data", "TP"): "average wave period during time scale",
+        ("dynamic", "data", "TR"): "average turbidity during time scale",
+        ("dynamic", "data", "VA"): "average flow speed during time scale",
+        ("dynamic", "data", "W"): "average water level during time scale",
+        ("dynamic", "data", "WG"): "average wind speed during time scale",
+        ("dynamic", "data", "WR"): "average wind direction during time scale",
+        ("dynamic", "data", "WT"): "average water temperature during time scale",
     },
 }
 

--- a/src/wetterdienst/provider/eaufrance/hubeau/api.py
+++ b/src/wetterdienst/provider/eaufrance/hubeau/api.py
@@ -212,7 +212,10 @@ class HubeauValues(TimeseriesValues):
         return df.select(
             pl.lit(parameter_or_dataset.dataset.resolution.name, dtype=pl.String).alias("resolution"),
             pl.lit(parameter_or_dataset.dataset.name, dtype=pl.String).alias("dataset"),
-            pl.lit(parameter_or_dataset.name_original.lower()).alias("parameter"),
+            # not lowercased: `_create_humanized_parameters_mapping` and the skip-criteria check
+            # both key on `name_original` as declared, so a lowercased value never matched --
+            # Hubeau silently never humanized and every station counted as having no data
+            pl.lit(parameter_or_dataset.name_original).alias("parameter"),
             "station_id",
             pl.col("date").str.to_datetime(format="%Y-%m-%dT%H:%M:%SZ").dt.replace_time_zone("UTC"),
             "value",

--- a/src/wetterdienst/provider/wsv/pegel/api.py
+++ b/src/wetterdienst/provider/wsv/pegel/api.py
@@ -405,11 +405,11 @@ class WsvPegelRequest(TimeseriesRequest):
         df = df.rename(mapping={"number": "station_id", "shortname": "name", "km": "river_kilometer"})
         df = df.with_columns(
             pl.col("water").struct.field("shortname"),
-            pl.col("timeseries").list.eval(pl.element().struct.field("shortname").str.to_lowercase()).alias("ts"),
+            # matched as published: Pegelonline names every timeseries in upper case, the same case
+            # the parameters are declared in, so there is nothing to normalize away here
+            pl.col("timeseries").list.eval(pl.element().struct.field("shortname")).alias("ts"),
         )
-        parameters = {
-            parameter.name_original.lower() for parameter in self.parameters if isinstance(parameter, ParameterModel)
-        }
+        parameters = {parameter.name_original for parameter in self.parameters if isinstance(parameter, ParameterModel)}
         df = df.filter(pl.col("ts").list.set_intersection(list(parameters)).list.len() > 0)
         df = df.with_columns(
             pl.col("timeseries")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -659,6 +659,9 @@ def test_api_eaufrance_hubeau(default_settings: Settings) -> None:
     assert first_date.tzinfo
     assert set(values.columns).issuperset(DF_VALUES_MINIMUM_COLUMNS)
     assert not values.drop_nulls(subset="value").is_empty()
+    # humanizing keys on `name_original` as declared, so emitting a lowercased "q" left the values
+    # un-humanized and made the skip criteria count the station as having no data
+    assert values.get_column("parameter").unique().to_list() == ["discharge"]
 
 
 @pytest.mark.remote


### PR DESCRIPTION
Closes the case-sensitivity thread left open by #1809 and #1820.

## The bug

Hubeau declares its two fields as `Q` and `H` — the case the API itself uses — but the value parser emitted them lowercased. Everything downstream keys on `name_original` **as declared**, so nothing matched:

- `_create_humanized_parameters_mapping` never replaced anything, so values came back as `q` and `h` rather than `discharge` and `stage`, with `ts_humanize` on (the default)
- `_get_actual_percentage` counted both fields as absent, so with `ts_skip_empty` set every station scored 0% and was skipped no matter how much data it had

This is the same defect fixed for WSV in #1809, found the same way: the docs tables carried the lowercased names, i.e. what the parser produced rather than what the provider publishes.

WSV's remaining `.lower()` was in the station filter, where both sides were lowercased and the result never left the frame. Pegelonline names every timeseries in upper case — all 787 stations, all 23 shortnames — so the normalization had nothing to do. Dropped; station counts unchanged (738 for `W`, 22 for `CL`+`O2`).

## The descriptions

The lift that moved the docs descriptions into the model matched `original name` case-sensitively, so every WSV row and Hubeau's `q` row missed. A sweep over all providers finds **exactly these 22 rows** affected and no others.

Three of the recovered texts were wrong and are corrected against the API's own `longname` per shortname:

| field | was | is |
|---|---|---|
| `HL` | average water level during time scale | average relative humidity of the air during time scale |
| `SIGH` | average wave height **sign** during time scale | average **significant** wave height during time scale |
| `Q` (Hubeau) | flow | Flow. |

`HL` is LUFTFEUCHTE, relative humidity in percent — the docs unit cell said `°` for the same copy-paste reason and is fixed to `%`, which the model has always declared. `SIGH` is SIGNIFIKANTEWELLENHÖHE, misread as "sign".

## Breaking

Anyone reading Hubeau values with `ts_humanize=False` now gets `Q` and `H` rather than `q` and `h`.

## Verified

- live Hubeau request returns `['discharge']` humanized, `['Q']` raw
- live WSV station counts match the API's own shortname tally
- `tests/test_api.py` 118 passed, `tests/test_docs.py` 5 passed, `tests/provider/wsv` 8 passed
- lint and `ty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)