### PR TITLE
feat(dwd)!: stop declaring seven parameters that never returned a value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,27 +18,22 @@ Types of changes:
 
 ### Removed
 
-- **Breaking**: six DWD observation parameters that were declared but never returned a value are no
-  longer declared, so a request for one now says so instead of answering with an empty frame:
+- **Breaking**: seven DWD observation parameters that were declared but never returned a value are
+  no longer declared, so a request for one now says so instead of answering with an empty frame:
   `cloud_type_layer1..4_abbreviation` (`v_sN_csa`, hourly cloud_type), `weather_text` (`ww_text`,
-  hourly weather_phenomena) and `end_of_interval` (hourly solar). The first five are the letter
-  form of a numeric code declared beside them -- across 398,381 cloud_type records `v_sN_csa`
-  matches `v_sN_cs` exactly, and across 443,827 weather records every `ww` maps to one text while
-  two codes share a text, so the text says strictly less than the code. `end_of_interval` names a
-  column that does not exist in the solar files at all. Their canonical entries are dropped too,
-  since no provider can express text in a `Float64` value column
+  hourly weather_phenomena), `end_of_interval` and `true_local_time` (`mess_datum_woz`, hourly
+  solar). Each was checked against the archive rather than assumed: `v_sN_csa` is the letter form
+  of `v_sN_cs` and matches it exactly across 398,381 records; every `ww` maps to one text across
+  443,827 records while two codes share a text, so the text says strictly less than the code;
+  `end_of_interval` names a column that does not exist in the solar files at all; and
+  `mess_datum_woz` is published as a whole hour, leaving it a fixed one hour from the returned
+  timestamp at station 00183 once the solar timestamps are rounded, which is where the sub-hour
+  solar correction actually lives. Their canonical entries are dropped too, since no provider can
+  express text in a `Float64` value column
 - `DwdObservationValues.DROPPABLE_COLUMNS`, which duplicated the parser's drop list and had already
   drifted from it. Dropping happens once, in the parser
 
 ### Added
-
-- **Breaking**: DWD hourly solar `true_local_time` (`mess_datum_woz`) is returned rather than
-  dropped, the one of the seven declared-but-dropped parameters carrying something its neighbours
-  do not. DWD publishes it as a whole timestamp; what it adds over the record's own timestamp is
-  the offset -- 28 to 71 minutes across the stations sampled, moving with the season rather than
-  fixed per station. It is returned as the time of day it names, hours elapsed since local
-  midnight, and its canonical unit type changes from `dimensionless` to `time`, so it follows the
-  `time` target like any other duration and arrives in seconds by default
 
 - DWD's two measurement method indicators are returned instead of dropped:
   `cloud_cover_total_measurement_method` (`v_n_i`, hourly cloud_type and cloudiness) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,29 @@ Types of changes:
 
 ## [Unreleased]
 
+### Removed
+
+- **Breaking**: six DWD observation parameters that were declared but never returned a value are no
+  longer declared, so a request for one now says so instead of answering with an empty frame:
+  `cloud_type_layer1..4_abbreviation` (`v_sN_csa`, hourly cloud_type), `weather_text` (`ww_text`,
+  hourly weather_phenomena) and `end_of_interval` (hourly solar). The first five are the letter
+  form of a numeric code declared beside them -- across 398,381 cloud_type records `v_sN_csa`
+  matches `v_sN_cs` exactly, and across 443,827 weather records every `ww` maps to one text while
+  two codes share a text, so the text says strictly less than the code. `end_of_interval` names a
+  column that does not exist in the solar files at all. Their canonical entries are dropped too,
+  since no provider can express text in a `Float64` value column
+- `DwdObservationValues.DROPPABLE_COLUMNS`, which duplicated the parser's drop list and had already
+  drifted from it. Dropping happens once, in the parser
+
 ### Added
+
+- **Breaking**: DWD hourly solar `true_local_time` (`mess_datum_woz`) is returned rather than
+  dropped, the one of the seven declared-but-dropped parameters carrying something its neighbours
+  do not. DWD publishes it as a whole timestamp; what it adds over the record's own timestamp is
+  the offset -- 28 to 71 minutes across the stations sampled, moving with the season rather than
+  fixed per station. It is returned as the time of day it names, hours elapsed since local
+  midnight, and its canonical unit type changes from `dimensionless` to `time`, so it follows the
+  `time` target like any other duration and arrives in seconds by default
 
 - DWD's two measurement method indicators are returned instead of dropped:
   `cloud_cover_total_measurement_method` (`v_n_i`, hourly cloud_type and cloudiness) and

--- a/docs/data/provider/dwd/observation/hourly.md
+++ b/docs/data/provider/dwd/observation/hourly.md
@@ -199,6 +199,7 @@ Code (precipitation_form):
 | {term}`radiation_global` | fg_lberg | The solar incoming radiation includes the direct and the diffuse part of the solar radiation with respect to the horizontal plane. It is sometimes also referred to as shortwave, including the solar spectrum up to 2.8 micron, as opposed to longwave , which refers to the thermal radiation of the atmosphere. | J/cm² | >=0 |
 | {term}`sunshine_duration` | sd_lberg | Hourly sum of sunshine duration. | min | >=0 |
 | {term}`sun_zenith_angle` | zenit | Solar zenith angle at mid of interval. The solar zenith angle is between 0-180 and is defined as: ZENIT= 90 - solar_height. | ° | >=0,<=180 |
+| {term}`true_local_time` | mess_datum_woz | Local true solar time. Published as a whole timestamp, returned as the time of day it names: hours elapsed since local midnight. | h | >=0,<24 |
 
 ### sun
 
@@ -406,7 +407,6 @@ Code (visibility_range_measurement_method):
 | name                 | original name | description                       | unit | constraints |
 |----------------------|---------------|-----------------------------------|------|-------------|
 | {term}`weather` | ww | Weather code of current condition. | - | - |
-| {term}`weather_text` | ww_text | Weather description of the current condition. | - | - |
 
 weather codes and descriptions: [here](https://opendata.dwd.de/climate_environment/CDC/observations_germany/climate/hourly/weather_phenomena/historical/Wetter_Beschreibung.txt)
 

--- a/docs/data/provider/dwd/observation/hourly.md
+++ b/docs/data/provider/dwd/observation/hourly.md
@@ -199,7 +199,6 @@ Code (precipitation_form):
 | {term}`radiation_global` | fg_lberg | The solar incoming radiation includes the direct and the diffuse part of the solar radiation with respect to the horizontal plane. It is sometimes also referred to as shortwave, including the solar spectrum up to 2.8 micron, as opposed to longwave , which refers to the thermal radiation of the atmosphere. | J/cm² | >=0 |
 | {term}`sunshine_duration` | sd_lberg | Hourly sum of sunshine duration. | min | >=0 |
 | {term}`sun_zenith_angle` | zenit | Solar zenith angle at mid of interval. The solar zenith angle is between 0-180 and is defined as: ZENIT= 90 - solar_height. | ° | >=0,<=180 |
-| {term}`true_local_time` | mess_datum_woz | Local true solar time. Published as a whole timestamp, returned as the time of day it names: hours elapsed since local midnight. | h | >=0,<24 |
 
 ### sun
 

--- a/docs/data/provider/dwd/observation/index.md
+++ b/docs/data/provider/dwd/observation/index.md
@@ -127,17 +127,32 @@ is deliberately left unused so that "not measured" stays distinguishable from ei
 Before this decoding both parameters were declared but silently dropped, so a request for them
 returned nothing at all.
 
-### Excluded string parameters
+### True local time
 
-A few parameters are still left out, because their content cannot be expressed as a number without
-inventing a meaning for it, or because the same information is already available as a number:
+**hourly solar** publishes the true local solar time of each record as a whole timestamp
+(`1981010101:00` beside a record stamped `1981010100:09`). What it adds over the record's own
+timestamp is the offset -- 28 to 71 minutes across the stations sampled, moving with the season
+rather than fixed per station -- so it is kept, returned as the time of day it names: hours elapsed
+since local midnight. Being a time, it follows the `time` unit target like any other, so it arrives
+in seconds unless you ask for something else.
 
-- cloud type abbreviations (1 - 4) in the **hourly cloud_type** dataset -- the numeric
-  `cloud_type_layerN` (`v_sN_cs`) codes beside them carry the same information
-- true local time and end of interval in the **hourly solar** dataset -- timestamps rather than
-  measurements
-- weather text in the **hourly weather_phenomena** dataset -- free text, alongside the numeric
-  `weather` code
+### Columns that are not parameters
+
+Some columns in the files are not measurements and are not declared as parameters, so they never
+appear in a result and cannot be requested:
+
+- **cloud type abbreviations** (`v_s1_csa` - `v_s4_csa`) in **hourly cloud_type** -- the letter form
+  of the numeric `cloud_type_layerN` (`v_sN_cs`) code beside each one, matching it exactly across
+  the 398,381 records sampled (`0` = CI ... `9` = CB), so nothing would be recovered by decoding
+- **weather text** (`ww_text`) in **hourly weather_phenomena** -- German prose spelling out the
+  numeric `weather` (`ww`) code beside it. Across 443,827 records every code maps to exactly one
+  text, and two codes share a text, so the text says strictly less than the code
+- **record markers** (`eor`, `struktur_version`) and the radiation temperature diagnostic
+  (`strahlungstemperatur`) in **10 minute urban_temperature_air**
+
+`tests/provider/dwd/observation/test_api_metadata.py` keeps the two halves apart, so a parameter
+cannot be declared and dropped at the same time -- which is how several came to be advertised while
+never returning a value.
 
 ### Quality
 

--- a/docs/data/provider/dwd/observation/index.md
+++ b/docs/data/provider/dwd/observation/index.md
@@ -127,15 +127,6 @@ is deliberately left unused so that "not measured" stays distinguishable from ei
 Before this decoding both parameters were declared but silently dropped, so a request for them
 returned nothing at all.
 
-### True local time
-
-**hourly solar** publishes the true local solar time of each record as a whole timestamp
-(`1981010101:00` beside a record stamped `1981010100:09`). What it adds over the record's own
-timestamp is the offset -- 28 to 71 minutes across the stations sampled, moving with the season
-rather than fixed per station -- so it is kept, returned as the time of day it names: hours elapsed
-since local midnight. Being a time, it follows the `time` unit target like any other, so it arrives
-in seconds unless you ask for something else.
-
 ### Columns that are not parameters
 
 Some columns in the files are not measurements and are not declared as parameters, so they never
@@ -147,12 +138,30 @@ appear in a result and cannot be requested:
 - **weather text** (`ww_text`) in **hourly weather_phenomena** -- German prose spelling out the
   numeric `weather` (`ww`) code beside it. Across 443,827 records every code maps to exactly one
   text, and two codes share a text, so the text says strictly less than the code
-- **record markers** (`eor`, `struktur_version`) and the radiation temperature diagnostic
-  (`strahlungstemperatur`) in **10 minute urban_temperature_air**
+- **true local time** (`mess_datum_woz`) in **hourly solar** -- the true local solar time of the
+  record, published as a whole hour. What carries the solar correction is the minute of the
+  record's own timestamp beside it, which runs 0-20 and 49-59 over the year at station 00183 and
+  is rounded away when that timestamp is rounded to the hour (see below). What remains is the hour
+  label, a fixed one hour from the returned timestamp across all 387,120 of that station's records,
+  and 0 or 1 at stations further west
+- **record markers** (`eor`, `struktur_version`), which close every DWD observation record at every
+  resolution, and the radiation temperature diagnostic (`strahlungstemperatur`) in **10 minute
+  urban_temperature_air**
 
 `tests/provider/dwd/observation/test_api_metadata.py` keeps the two halves apart, so a parameter
 cannot be declared and dropped at the same time -- which is how several came to be advertised while
 never returning a value.
+
+### Solar timestamps
+
+**hourly solar** does not stamp its records on the hour. The timestamps follow the true solar hour,
+so they carry minutes that move with the season -- 0 to 20 and 49 to 59 over the year at station
+00183 -- and are occasionally off by ten minutes in either direction besides. wetterdienst rounds
+them to the nearest hour, so that a solar series lines up with every other hourly series.
+
+That rounding is what discards the sub-hour solar correction, and `mess_datum_woz` was the only
+other record of it. If you need the exact instant of a solar reading rather than the hour it
+belongs to, this is the thing to be aware of.
 
 ### Quality
 

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -1688,11 +1688,6 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "length_short",
         "Greatest depth to which ground under plant cover thawed in the month.",
     ),
-    CanonicalParameter(
-        "true_local_time",
-        "time",
-        "True local solar time at the station, as opposed to zone time, as elapsed time since local midnight.",
-    ),
     CanonicalParameter("turbidity", "turbidity", "Cloudiness of the water caused by suspended particles."),
     CanonicalParameter(
         "visibility_range", "length_medium", "Horizontal distance at which an object can still be made out."

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -123,21 +123,9 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "cloud_height_layer4", "length_medium", "Height above ground of the base of the fourth reported cloud layer."
     ),
     CanonicalParameter("cloud_type_layer1", "dimensionless", "Coded cloud genus of the lowest reported cloud layer."),
-    CanonicalParameter(
-        "cloud_type_layer1_abbreviation", "dimensionless", "Abbreviated cloud genus of the lowest reported cloud layer."
-    ),
     CanonicalParameter("cloud_type_layer2", "dimensionless", "Coded cloud genus of the second reported cloud layer."),
-    CanonicalParameter(
-        "cloud_type_layer2_abbreviation", "dimensionless", "Abbreviated cloud genus of the second reported cloud layer."
-    ),
     CanonicalParameter("cloud_type_layer3", "dimensionless", "Coded cloud genus of the third reported cloud layer."),
-    CanonicalParameter(
-        "cloud_type_layer3_abbreviation", "dimensionless", "Abbreviated cloud genus of the third reported cloud layer."
-    ),
     CanonicalParameter("cloud_type_layer4", "dimensionless", "Coded cloud genus of the fourth reported cloud layer."),
-    CanonicalParameter(
-        "cloud_type_layer4_abbreviation", "dimensionless", "Abbreviated cloud genus of the fourth reported cloud layer."
-    ),
     CanonicalParameter(
         "cooling_degree_day",
         "degree_day",
@@ -245,11 +233,6 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "electric_conductivity",
         "conductivity",
         "Electrical conductivity of the water, a proxy for its dissolved salt content.",
-    ),
-    CanonicalParameter(
-        "end_of_interval",
-        "dimensionless",
-        "Marker showing that the timestamp denotes the end of the measuring interval.",
     ),
     CanonicalParameter(
         "error_absolute_pressure_air_site", "pressure", "Absolute error attached to the reported air pressure."
@@ -1706,7 +1689,9 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "Greatest depth to which ground under plant cover thawed in the month.",
     ),
     CanonicalParameter(
-        "true_local_time", "dimensionless", "True local solar time at the station, as opposed to zone time."
+        "true_local_time",
+        "time",
+        "True local solar time at the station, as opposed to zone time, as elapsed time since local midnight.",
     ),
     CanonicalParameter("turbidity", "turbidity", "Cloudiness of the water caused by suspended particles."),
     CanonicalParameter(
@@ -1792,7 +1777,6 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "significant_weather",
         "Coded significant weather over the preceding 6 hours, where reported.",
     ),
-    CanonicalParameter("weather_text", "dimensionless", "Plain-language description of the present weather."),
     CanonicalParameter(
         "weather_type_blowing_drifting_snow", "dimensionless", "Whether blowing or drifting snow was observed."
     ),

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -459,7 +459,6 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
     },
     "DwdObservationMetadata": {
         ("hourly", "urban_pressure", "luftdruck_nn"): "Air pressure reduced to sea level.",
-        ("hourly", "solar", "end_of_interval"): "Timestamp marking the end of the measurement interval.",
         ("10_minutes", "precipitation", "rws_10"): "Sum of the precipitation height of the previous 10 minutes.",
         ("10_minutes", "precipitation", "rws_dau_10"): "Duration of precipitation during the previous 10 minutes.",
         ("10_minutes", "precipitation", "rws_ind_10"): (
@@ -624,19 +623,15 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
             "Index how measurement is taken, P = by human person,I = by instrument. Returned as 1 for P and 2 for I."
         ),
         ("hourly", "cloud_type", "v_s1_cs"): "Cloud type of 1. layer.",
-        ("hourly", "cloud_type", "v_s1_csa"): "Abbrev. cloud type 1.layer.",
         ("hourly", "cloud_type", "v_s1_hhs"): "Lower boundary height of 1.layer.",
         ("hourly", "cloud_type", "v_s1_ns"): "Cloud cover in the first layer.",
         ("hourly", "cloud_type", "v_s2_cs"): "Cloud type of 2. layer.",
-        ("hourly", "cloud_type", "v_s2_csa"): "Abbrev. cloud type 2.layer.",
         ("hourly", "cloud_type", "v_s2_hhs"): "Lower boundary height of 2.layer.",
         ("hourly", "cloud_type", "v_s2_ns"): "Cloud cover in the second layer.",
         ("hourly", "cloud_type", "v_s3_cs"): "Cloud type of 3. layer.",
-        ("hourly", "cloud_type", "v_s3_csa"): "Abbrev. cloud type 3.layer.",
         ("hourly", "cloud_type", "v_s3_hhs"): "Lower boundary height of 3.layer.",
         ("hourly", "cloud_type", "v_s3_ns"): "Cloud cover in the third layer.",
         ("hourly", "cloud_type", "v_s4_cs"): "Cloud type of 4. layer.",
-        ("hourly", "cloud_type", "v_s4_csa"): "Abbrev. cloud type 4.layer.",
         ("hourly", "cloud_type", "v_s4_hhs"): "Lower boundary height of 4.layer.",
         ("hourly", "cloud_type", "v_s4_ns"): "Cloud cover in the fourth layer.",
         ("hourly", "cloudiness", "v_n"): "Total cloud cover.",
@@ -665,7 +660,10 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
             "shortwave, including the solar spectrum up to 2.8 micron, as opposed to longwave , which "
             "refers to the thermal radiation of the atmosphere."
         ),
-        ("hourly", "solar", "mess_datum_woz"): "Local true solar time.",
+        ("hourly", "solar", "mess_datum_woz"): (
+            "Local true solar time. Published as a whole timestamp, returned as the time of day it "
+            "names: hours elapsed since local midnight."
+        ),
         ("hourly", "solar", "sd_lberg"): "Hourly sum of sunshine duration.",
         ("hourly", "solar", "zenit"): (
             "Solar zenith angle at mid of interval. The solar zenith angle is between 0-180 and is "
@@ -698,7 +696,6 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
             "Returned as 1 for P and 2 for I."
         ),
         ("hourly", "weather_phenomena", "ww"): "Weather code of current condition.",
-        ("hourly", "weather_phenomena", "ww_text"): "Weather description of the current condition.",
         ("hourly", "wind", "d"): "Mean wind direction.",
         ("hourly", "wind", "f"): "Mean wind speed.",
         ("hourly", "wind_extreme", "fx_911"): "Maximum wind gust 10 m above ground.",

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -660,10 +660,6 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
             "shortwave, including the solar spectrum up to 2.8 micron, as opposed to longwave , which "
             "refers to the thermal radiation of the atmosphere."
         ),
-        ("hourly", "solar", "mess_datum_woz"): (
-            "Local true solar time. Published as a whole timestamp, returned as the time of day it "
-            "names: hours elapsed since local midnight."
-        ),
         ("hourly", "solar", "sd_lberg"): "Hourly sum of sunshine duration.",
         ("hourly", "solar", "zenit"): (
             "Solar zenith angle at mid of interval. The solar zenith angle is between 0-180 and is "

--- a/src/wetterdienst/provider/dwd/observation/api.py
+++ b/src/wetterdienst/provider/dwd/observation/api.py
@@ -62,21 +62,6 @@ if TYPE_CHECKING:
     from wetterdienst.model.result import StationsResult
 log = logging.getLogger(__name__)
 
-# columns that can't be coerced to float are dropped
-DROPPABLE_COLUMNS = [
-    # Hourly
-    # Cloud type
-    DwdObservationMetadata.hourly.cloud_type.cloud_type_layer1_abbreviation.name_original,
-    DwdObservationMetadata.hourly.cloud_type.cloud_type_layer2_abbreviation.name_original,
-    DwdObservationMetadata.hourly.cloud_type.cloud_type_layer3_abbreviation.name_original,
-    DwdObservationMetadata.hourly.cloud_type.cloud_type_layer4_abbreviation.name_original,
-    # Solar
-    DwdObservationMetadata.hourly.solar.end_of_interval.name_original,
-    DwdObservationMetadata.hourly.solar.true_local_time.name_original,
-    # Weather
-    DwdObservationMetadata.hourly.weather_phenomena.weather_text.name_original,
-]
-
 
 class DwdObservationValues(TimeseriesValues):
     """Values class for DWD observation data."""
@@ -143,7 +128,6 @@ class DwdObservationValues(TimeseriesValues):
             msg = "Expected DataFrame from collect()"
             raise TypeError(msg)
         parameter_df = result
-        parameter_df = parameter_df.drop(*DROPPABLE_COLUMNS, strict=False)
         if dataset.resolution.value in (Resolution.MINUTE_1, Resolution.MINUTE_5, Resolution.MINUTE_10):
             parameter_df = self._fix_timestamps(parameter_df)
         df = self._tidy_up_df(parameter_df)

--- a/src/wetterdienst/provider/dwd/observation/metadata.py
+++ b/src/wetterdienst/provider/dwd/observation/metadata.py
@@ -728,13 +728,6 @@ DwdObservationMetadata = {
                             "name_original": "zenit",
                             "unit": "degree",
                         },
-                        {
-                            # published as a full timestamp, returned as the time of day it names:
-                            # hours elapsed since local midnight, true solar time
-                            "name": "true_local_time",
-                            "name_original": "mess_datum_woz",
-                            "unit": "hour",
-                        },
                     ],
                 },
                 {

--- a/src/wetterdienst/provider/dwd/observation/metadata.py
+++ b/src/wetterdienst/provider/dwd/observation/metadata.py
@@ -499,11 +499,6 @@ DwdObservationMetadata = {
                             "unit": "dimensionless",
                         },
                         {
-                            "name": "cloud_type_layer1_abbreviation",
-                            "name_original": "v_s1_csa",
-                            "unit": "dimensionless",
-                        },
-                        {
                             "name": "cloud_height_layer1",
                             "name_original": "v_s1_hhs",
                             "unit": "meter",
@@ -516,11 +511,6 @@ DwdObservationMetadata = {
                         {
                             "name": "cloud_type_layer2",
                             "name_original": "v_s2_cs",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "cloud_type_layer2_abbreviation",
-                            "name_original": "v_s2_csa",
                             "unit": "dimensionless",
                         },
                         {
@@ -539,11 +529,6 @@ DwdObservationMetadata = {
                             "unit": "dimensionless",
                         },
                         {
-                            "name": "cloud_type_layer3_abbreviation",
-                            "name_original": "v_s3_csa",
-                            "unit": "dimensionless",
-                        },
-                        {
                             "name": "cloud_height_layer3",
                             "name_original": "v_s3_hhs",
                             "unit": "meter",
@@ -556,11 +541,6 @@ DwdObservationMetadata = {
                         {
                             "name": "cloud_type_layer4",
                             "name_original": "v_s4_cs",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "cloud_type_layer4_abbreviation",
-                            "name_original": "v_s4_csa",
                             "unit": "dimensionless",
                         },
                         {
@@ -724,11 +704,6 @@ DwdObservationMetadata = {
                             "unit": "dimensionless",
                         },
                         {
-                            "name": "end_of_interval",
-                            "name_original": "end_of_interval",
-                            "unit": "dimensionless",
-                        },
-                        {
                             "name": "radiation_sky_long_wave",
                             "name_original": "atmo_lberg",
                             "unit": "joule_per_square_centimeter",
@@ -754,9 +729,11 @@ DwdObservationMetadata = {
                             "unit": "degree",
                         },
                         {
+                            # published as a full timestamp, returned as the time of day it names:
+                            # hours elapsed since local midnight, true solar time
                             "name": "true_local_time",
                             "name_original": "mess_datum_woz",
-                            "unit": "dimensionless",
+                            "unit": "hour",
                         },
                     ],
                 },
@@ -874,11 +851,6 @@ DwdObservationMetadata = {
                         {
                             "name": "weather",
                             "name_original": "ww",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "weather_text",
-                            "name_original": "ww_text",
                             "unit": "dimensionless",
                         },
                     ],

--- a/src/wetterdienst/provider/dwd/observation/parser.py
+++ b/src/wetterdienst/provider/dwd/observation/parser.py
@@ -43,6 +43,12 @@ DROPPABLE_PARAMETERS = {
     "v_s2_csa",
     "v_s3_csa",
     "v_s4_csa",
+    # hourly solar: the true local solar time, published as a whole hour. What carries the solar
+    # correction is the minute of `mess_datum` beside it (0-20 and 49-59, moving with the season),
+    # and that is rounded away when the record's own timestamp is rounded to the hour. What is left
+    # is the hour label, which then sits a fixed 1 hour from the returned timestamp at station
+    # 00183 over all 387,120 of its records, and 0 or 1 at stations further west.
+    "mess_datum_woz",
     # hourly weather_phenomena: German free text spelling out the numeric `ww` code beside it
     # ("Wetter wurde nicht gemeldet" for -1)
     "ww_text",
@@ -82,20 +88,6 @@ def _decode_measurement_method(series: pl.Series) -> pl.Series:
             f"expected one of {sorted(MEASUREMENT_METHOD_CODES)}. These values are returned as null.",
         )
     return series.replace_strict(MEASUREMENT_METHOD_CODES, default=None, return_dtype=pl.String)
-
-
-# hourly solar publishes the true local solar time as a whole timestamp (`1981010101:00` beside a
-# record stamped `1981010100:09`). What it adds over the record's own timestamp is the offset --
-# 28 to 71 minutes across the stations sampled, moving with the season, so not a per-station
-# constant -- and that is worth keeping. It is returned as the time of day it names: hours elapsed
-# since local midnight. Text, for the same reason the method codes are.
-TRUE_LOCAL_TIME = DwdObservationMetadata.hourly.solar.true_local_time.name_original
-
-
-def _encode_true_local_time() -> pl.Expr:
-    """Express the true local time timestamp as hours elapsed since local midnight."""
-    parsed = pl.col(TRUE_LOCAL_TIME).str.to_datetime("%Y%m%d%H:%M", strict=False)
-    return (parsed.dt.hour() + parsed.dt.minute() / 60).cast(pl.String).alias(TRUE_LOCAL_TIME)
 
 
 COLUMNS_MAPPING = {
@@ -175,8 +167,6 @@ def _parse_climate_observations_data(  # noqa: C901
         pl.col(parameter).map_batches(_decode_measurement_method, return_dtype=pl.String)
         for parameter in sorted(CODED_STRING_PARAMETERS & columns)
     )
-    if TRUE_LOCAL_TIME in columns:
-        df = df.with_columns(_encode_true_local_time())
     # Assign meaningful column names (baseline).
     df = df.rename(mapping=lambda col: COLUMNS_MAPPING.get(col, col))
     if dataset == DwdObservationMetadata.minute_1.precipitation:

--- a/src/wetterdienst/provider/dwd/observation/parser.py
+++ b/src/wetterdienst/provider/dwd/observation/parser.py
@@ -27,22 +27,26 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+# Columns that arrive in the files but are not parameters, and so are not declared in the metadata
+# either -- `tests/provider/dwd/observation/test_api_metadata.py` holds those two halves apart, so
+# that nothing can be declared and dropped at the same time.
+#
+# Named as literal strings rather than through `DwdObservationMetadata`, because the point is that
+# they have no declaration to refer to.
 DROPPABLE_PARAMETERS = {
-    # EOR
+    # record markers rather than data
     "eor",
     "struktur_version",
-    # the cloud type abbreviations are the same information as the numeric `v_sN_cs` codes
-    # declared beside them, in letters rather than digits, so there is nothing here to recover
-    # hourly
-    # cloud_type
-    DwdObservationMetadata.hourly.cloud_type.cloud_type_layer1_abbreviation.name_original,
-    DwdObservationMetadata.hourly.cloud_type.cloud_type_layer2_abbreviation.name_original,
-    DwdObservationMetadata.hourly.cloud_type.cloud_type_layer3_abbreviation.name_original,
-    DwdObservationMetadata.hourly.cloud_type.cloud_type_layer4_abbreviation.name_original,
-    # DATE_PARAMETERS_IRREGULAR
-    DwdObservationMetadata.hourly.solar.true_local_time.name_original,
-    DwdObservationMetadata.hourly.solar.end_of_interval.name_original,
-    # URBAN_TEMPERATURE_AIR
+    # hourly cloud_type: the letter form of the numeric `v_sN_cs` code beside it, one for one
+    # (0 = CI ... 9 = CB, -1 = -1), so it carries nothing the declared parameter does not
+    "v_s1_csa",
+    "v_s2_csa",
+    "v_s3_csa",
+    "v_s4_csa",
+    # hourly weather_phenomena: German free text spelling out the numeric `ww` code beside it
+    # ("Wetter wurde nicht gemeldet" for -1)
+    "ww_text",
+    # 10 minute urban_temperature_air: radiation temperature, an instrument diagnostic
     "strahlungstemperatur",
 }
 
@@ -78,6 +82,20 @@ def _decode_measurement_method(series: pl.Series) -> pl.Series:
             f"expected one of {sorted(MEASUREMENT_METHOD_CODES)}. These values are returned as null.",
         )
     return series.replace_strict(MEASUREMENT_METHOD_CODES, default=None, return_dtype=pl.String)
+
+
+# hourly solar publishes the true local solar time as a whole timestamp (`1981010101:00` beside a
+# record stamped `1981010100:09`). What it adds over the record's own timestamp is the offset --
+# 28 to 71 minutes across the stations sampled, moving with the season, so not a per-station
+# constant -- and that is worth keeping. It is returned as the time of day it names: hours elapsed
+# since local midnight. Text, for the same reason the method codes are.
+TRUE_LOCAL_TIME = DwdObservationMetadata.hourly.solar.true_local_time.name_original
+
+
+def _encode_true_local_time() -> pl.Expr:
+    """Express the true local time timestamp as hours elapsed since local midnight."""
+    parsed = pl.col(TRUE_LOCAL_TIME).str.to_datetime("%Y%m%d%H:%M", strict=False)
+    return (parsed.dt.hour() + parsed.dt.minute() / 60).cast(pl.String).alias(TRUE_LOCAL_TIME)
 
 
 COLUMNS_MAPPING = {
@@ -150,11 +168,15 @@ def _parse_climate_observations_data(  # noqa: C901
     df = df.rename(mapping=lambda col: col.strip().lower())
     # End of record (EOR) has no value, so drop it right away.
     df = df.drop(*DROPPABLE_PARAMETERS, strict=False)
-    # decode the letter-coded indicators before anything downstream expects a number
+    # turn what the file writes as text into the numbers the value column can hold, before anything
+    # downstream expects a number
+    columns = set(df.collect_schema().names())
     df = df.with_columns(
         pl.col(parameter).map_batches(_decode_measurement_method, return_dtype=pl.String)
-        for parameter in sorted(CODED_STRING_PARAMETERS & set(df.collect_schema().names()))
+        for parameter in sorted(CODED_STRING_PARAMETERS & columns)
     )
+    if TRUE_LOCAL_TIME in columns:
+        df = df.with_columns(_encode_true_local_time())
     # Assign meaningful column names (baseline).
     df = df.rename(mapping=lambda col: COLUMNS_MAPPING.get(col, col))
     if dataset == DwdObservationMetadata.minute_1.precipitation:

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -1443,31 +1443,6 @@ def test_dwd_observation_measurement_method_indicators(
 
 
 @pytest.mark.remote
-def test_dwd_observation_true_local_time(settings_convert_units_false: Settings) -> None:
-    """Test that the true local solar time is returned as the time of day it names.
-
-    DWD publishes it as a whole timestamp, which the Float64 value column cannot hold, so it was
-    declared but dropped. It is the offset against the record's own timestamp that makes it worth
-    keeping -- tens of minutes, moving with the season -- so that is what is checked here.
-    """
-    request = DwdObservationRequest(
-        parameters=[("hourly", "solar", "true_local_time")],
-        start_date=dt.datetime(2024, 6, 1, 0, 0, tzinfo=ZoneInfo("UTC")),
-        end_date=dt.datetime(2024, 6, 1, 6, 0, tzinfo=ZoneInfo("UTC")),
-        settings=settings_convert_units_false,
-    ).filter_by_station_id("00183")
-    values = request.values.all().df
-    assert not values.is_empty()
-    hours = values.get_column("value").to_list()
-    # hours of the day, so within a day and running with the clock
-    assert all(0 <= hour < 24 for hour in hours)
-    assert hours == sorted(hours)
-    # ahead of UTC at this station, by less than the hour that would make it just the timestamp
-    offsets = [hour - date.hour for hour, date in zip(hours, values.get_column("date").to_list(), strict=True)]
-    assert set(offsets) == {1}
-
-
-@pytest.mark.remote
 def test_dwd_observation_data_daily_climate_summary_custom_units() -> None:
     """Test for custom unit conversion."""
     unit_targets = {

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -1443,6 +1443,31 @@ def test_dwd_observation_measurement_method_indicators(
 
 
 @pytest.mark.remote
+def test_dwd_observation_true_local_time(settings_convert_units_false: Settings) -> None:
+    """Test that the true local solar time is returned as the time of day it names.
+
+    DWD publishes it as a whole timestamp, which the Float64 value column cannot hold, so it was
+    declared but dropped. It is the offset against the record's own timestamp that makes it worth
+    keeping -- tens of minutes, moving with the season -- so that is what is checked here.
+    """
+    request = DwdObservationRequest(
+        parameters=[("hourly", "solar", "true_local_time")],
+        start_date=dt.datetime(2024, 6, 1, 0, 0, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(2024, 6, 1, 6, 0, tzinfo=ZoneInfo("UTC")),
+        settings=settings_convert_units_false,
+    ).filter_by_station_id("00183")
+    values = request.values.all().df
+    assert not values.is_empty()
+    hours = values.get_column("value").to_list()
+    # hours of the day, so within a day and running with the clock
+    assert all(0 <= hour < 24 for hour in hours)
+    assert hours == sorted(hours)
+    # ahead of UTC at this station, by less than the hour that would make it just the timestamp
+    offsets = [hour - date.hour for hour, date in zip(hours, values.get_column("date").to_list(), strict=True)]
+    assert set(offsets) == {1}
+
+
+@pytest.mark.remote
 def test_dwd_observation_data_daily_climate_summary_custom_units() -> None:
     """Test for custom unit conversion."""
     unit_targets = {

--- a/tests/provider/dwd/observation/test_api_metadata.py
+++ b/tests/provider/dwd/observation/test_api_metadata.py
@@ -175,3 +175,24 @@ def test_dwd_observation_metadata_describe_fields_temperature_10minutes() -> Non
         "rf_10",
         "td_10",
     ]
+
+
+def test_dwd_observation_no_declared_parameter_is_dropped() -> None:
+    """Test that nothing is declared as a parameter and dropped from the data at the same time.
+
+    A parameter listed in the metadata is offered everywhere the metadata is read -- `discover()`,
+    the REST coverage endpoint, the MCP tools, the docs tables -- so dropping its column means
+    advertising a field that answers every request with an empty frame. Seven did exactly that
+    before this check existed.
+    """
+    from wetterdienst.provider.dwd.observation.metadata import DwdObservationMetadata  # noqa: PLC0415
+    from wetterdienst.provider.dwd.observation.parser import DROPPABLE_PARAMETERS  # noqa: PLC0415
+
+    declared = {
+        (resolution.name, dataset.name, parameter.name_original)
+        for resolution in DwdObservationMetadata
+        for dataset in resolution
+        for parameter in dataset.parameters
+    }
+    both = sorted(site for site in declared if site[2] in DROPPABLE_PARAMETERS)
+    assert not both, f"declared as parameters but dropped from the data: {both}"


### PR DESCRIPTION
Closes the last item from the #1822 review: seven DWD observation parameters were declared in the metadata but dropped from the data, so they appeared in `discover()`, `GET /api/coverage`, the MCP tools and the docs tables while answering every request with an empty frame.

Each was checked against the archive rather than assumed. None of them survives.

| parameter | why it carries nothing |
|---|---|
| `cloud_type_layer1..4_abbreviation` (`v_sN_csa`) | the letter form of the numeric `v_sN_cs` code declared beside them. Across **398,381** historical cloud_type records the two agree exactly (`0` = CI … `9` = CB, `-1` = `-1`), with **no row** where one is present and the other missing |
| `weather_text` (`ww_text`) | German prose spelling out the numeric `ww` code beside it. Across **443,827** records neither is ever present without the other, every code maps to exactly one text, and **two codes share a text** — so the text says strictly less than the code |
| `end_of_interval` | names a column that **does not exist in the solar files at all** |
| `true_local_time` (`mess_datum_woz`) | published as a **whole hour** — the minute field is `00` across all 387,120 records of station 00183. See below |

Removed, along with their canonical entries — no provider can ever use them, because a `Float64` value column cannot hold text.

## On `true_local_time`

An earlier revision of this PR kept it, on the grounds that it carries a 28–71 minute solar offset. That was wrong, and the review caught it.

That offset is the gap to the **unrounded** `mess_datum`, whose own minute runs 0–20 and 49–59 over the year — that is where the equation of time lives. Solar timestamps are rounded to the nearest hour a few lines later, so the seasonal minute is discarded and what reaches the caller is the hour label:

| station | gap between returned timestamp and WOZ hour |
|---|---|
| 00183 | `1` for all 387,120 records |
| 15000 (Aachen) | `0` Jan–Aug, `1` Oct–Nov |
| 05100 (Trier) | `0` or `1` |

A per-station constant, not the equation of time. So it belongs with the other six.

## What the rounding costs

Worth knowing, so the docs now say it: hourly solar records are **not** stamped on the hour. wetterdienst rounds them so a solar series lines up with every other hourly series, and `mess_datum_woz` was the only other record of the sub-hour correction. If you need the exact instant of a solar reading rather than the hour it belongs to, that is the thing to be aware of.

## The invariant

`tests/provider/dwd/observation/test_api_metadata.py` now holds the two halves apart — a parameter cannot be declared and dropped at the same time. That is the actual fix; the seven were only the symptom.

`DROPPABLE_PARAMETERS` names its columns as literal strings now, since the point is that they have no declaration to refer to.

`DwdObservationValues.DROPPABLE_COLUMNS` is gone. It duplicated the parser's list and had **already drifted from it** — the parser dropped `mess_datum_woz` while the API dropped `ww_text`, so each had to be found separately. Dropping happens once, in the parser.

## Verified

- `hourly/solar`, `hourly/cloud_type` and `hourly/weather_phenomena` still return everything they did, minus the phantoms
- new invariant test; `tests/provider/dwd/observation`, `tests/test_docs.py` and the DWD half of `tests/test_api.py` green; lint and `ty` clean

One note on local runs: hammering `opendata.dwd.de` gets you throttled and then refused outright. Three `test_dwd_observation_datasets_low_resolution` failures I saw reproduce identically on unmodified `main` and pass in isolation, so they are throttling rather than this diff.

## Breaking

Seven DWD observation parameters are no longer declared — a request naming one now fails instead of returning an empty frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)