### PR TITLE
feat(dwd): expose the solar time correction as true_local_time_offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ Types of changes:
 
 ### Added
 
+- DWD hourly solar `true_local_time_offset` (`mess_datum_woz`), a new canonical parameter holding
+  how far true local solar time runs ahead of a record's timestamp -- the longitude correction plus
+  the equation of time. Solar records are stamped with the UTC instant of a whole true-solar-time
+  hour, so the correction sits in the minutes of that timestamp, which wetterdienst rounds to the
+  hour so a solar series lines up with every other hourly series. The rounding discarded it and the
+  column that also held it was dropped, so it was not reachable at all. At station 00183 it runs 40
+  to 71 minutes, its monthly mean tracing the equation of time from 40.4 in February to 69.1 in
+  November about a 54.7 minute longitude term
+
 - DWD's two measurement method indicators are returned instead of dropped:
   `cloud_cover_total_measurement_method` (`v_n_i`, hourly cloud_type and cloudiness) and
   `visibility_range_measurement_method` (`v_vv_i`, hourly visibility). DWD writes them as letters

--- a/docs/data/provider/dwd/observation/hourly.md
+++ b/docs/data/provider/dwd/observation/hourly.md
@@ -199,6 +199,7 @@ Code (precipitation_form):
 | {term}`radiation_global` | fg_lberg | The solar incoming radiation includes the direct and the diffuse part of the solar radiation with respect to the horizontal plane. It is sometimes also referred to as shortwave, including the solar spectrum up to 2.8 micron, as opposed to longwave , which refers to the thermal radiation of the atmosphere. | J/cm² | >=0 |
 | {term}`sunshine_duration` | sd_lberg | Hourly sum of sunshine duration. | min | >=0 |
 | {term}`sun_zenith_angle` | zenit | Solar zenith angle at mid of interval. The solar zenith angle is between 0-180 and is defined as: ZENIT= 90 - solar_height. | ° | >=0,<=180 |
+| {term}`true_local_time_offset` | mess_datum_woz | Local true solar time, published as a whole timestamp and returned as its distance from the timestamp of the record: the longitude correction plus the equation of time. | min | - |
 
 ### sun
 

--- a/docs/data/provider/dwd/observation/index.md
+++ b/docs/data/provider/dwd/observation/index.md
@@ -138,12 +138,6 @@ appear in a result and cannot be requested:
 - **weather text** (`ww_text`) in **hourly weather_phenomena** -- German prose spelling out the
   numeric `weather` (`ww`) code beside it. Across 443,827 records every code maps to exactly one
   text, and two codes share a text, so the text says strictly less than the code
-- **true local time** (`mess_datum_woz`) in **hourly solar** -- the true local solar time of the
-  record, published as a whole hour. What carries the solar correction is the minute of the
-  record's own timestamp beside it, which runs 0-20 and 49-59 over the year at station 00183 and
-  is rounded away when that timestamp is rounded to the hour (see below). What remains is the hour
-  label, a fixed one hour from the returned timestamp across all 387,120 of that station's records,
-  and 0 or 1 at stations further west
 - **record markers** (`eor`, `struktur_version`), which close every DWD observation record at every
   resolution, and the radiation temperature diagnostic (`strahlungstemperatur`) in **10 minute
   urban_temperature_air**
@@ -152,16 +146,36 @@ appear in a result and cannot be requested:
 cannot be declared and dropped at the same time -- which is how several came to be advertised while
 never returning a value.
 
-### Solar timestamps
+### Solar timestamps and true local time
 
-**hourly solar** does not stamp its records on the hour. The timestamps follow the true solar hour,
-so they carry minutes that move with the season -- 0 to 20 and 49 to 59 over the year at station
-00183 -- and are occasionally off by ten minutes in either direction besides. wetterdienst rounds
-them to the nearest hour, so that a solar series lines up with every other hourly series.
+**hourly solar** does not stamp its records on the hour. Each one is stamped with the UTC instant
+of a whole hour of *true local solar time*, so the minutes move with the season -- 0 to 20 and 49
+to 59 over the year at station 00183. wetterdienst rounds those timestamps to the nearest hour, so
+that a solar series lines up with every other hourly series.
 
-That rounding is what discards the sub-hour solar correction, and `mess_datum_woz` was the only
-other record of it. If you need the exact instant of a solar reading rather than the hour it
-belongs to, this is the thing to be aware of.
+The rounding discards the solar correction, so it is offered as a parameter of its own,
+`true_local_time_offset`: how far true local solar time runs ahead of the record's timestamp. It is
+the longitude correction plus the equation of time, and at station 00183 it runs from 40 to 71
+minutes, its monthly mean tracing the equation of time about a 54.7 minute longitude term:
+
+| month | mean offset |
+|-------|-------------|
+| February | 40.4 min |
+| May | 57.6 min |
+| November | 69.1 min |
+
+Being a time, it follows the `time` unit target like any other duration, so it arrives in seconds
+unless you ask for something else.
+
+```python
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
+
+request = DwdObservationRequest(
+    parameters=[("hourly", "solar", "true_local_time_offset")],
+    start_date="2023-11-10",
+    end_date="2023-11-10 06:00",
+).filter_by_station_id("00183")
+```
 
 ### Quality
 

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -1688,6 +1688,12 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "length_short",
         "Greatest depth to which ground under plant cover thawed in the month.",
     ),
+    CanonicalParameter(
+        "true_local_time_offset",
+        "time",
+        "How far true local solar time runs ahead of the timestamp of the record, being the "
+        "longitude correction plus the equation of time.",
+    ),
     CanonicalParameter("turbidity", "turbidity", "Cloudiness of the water caused by suspended particles."),
     CanonicalParameter(
         "visibility_range", "length_medium", "Horizontal distance at which an object can still be made out."

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -654,6 +654,10 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("hourly", "pressure", "p0"): "Barometric pressure at station height.",
         ("hourly", "solar", "atmo_lberg"): "Hourly sum of longwave downward radiation.",
         ("hourly", "solar", "fd_lberg"): "Hourly sum of diffuse solar radiation.",
+        ("hourly", "solar", "mess_datum_woz"): (
+            "Local true solar time, published as a whole timestamp and returned as its distance from "
+            "the timestamp of the record: the longitude correction plus the equation of time."
+        ),
         ("hourly", "solar", "fg_lberg"): (
             "The solar incoming radiation includes the direct and the diffuse part of the solar "
             "radiation with respect to the horizontal plane. It is sometimes also referred to as "

--- a/src/wetterdienst/provider/dwd/observation/metadata.py
+++ b/src/wetterdienst/provider/dwd/observation/metadata.py
@@ -728,6 +728,14 @@ DwdObservationMetadata = {
                             "name_original": "zenit",
                             "unit": "degree",
                         },
+                        {
+                            # the column holds a whole-hour timestamp; what is returned is its
+                            # distance from the record's own timestamp, which is where the solar
+                            # correction actually sits
+                            "name": "true_local_time_offset",
+                            "name_original": "mess_datum_woz",
+                            "unit": "minute",
+                        },
                     ],
                 },
                 {

--- a/src/wetterdienst/provider/dwd/observation/parser.py
+++ b/src/wetterdienst/provider/dwd/observation/parser.py
@@ -43,12 +43,6 @@ DROPPABLE_PARAMETERS = {
     "v_s2_csa",
     "v_s3_csa",
     "v_s4_csa",
-    # hourly solar: the true local solar time, published as a whole hour. What carries the solar
-    # correction is the minute of `mess_datum` beside it (0-20 and 49-59, moving with the season),
-    # and that is rounded away when the record's own timestamp is rounded to the hour. What is left
-    # is the hour label, which then sits a fixed 1 hour from the returned timestamp at station
-    # 00183 over all 387,120 of its records, and 0 or 1 at stations further west.
-    "mess_datum_woz",
     # hourly weather_phenomena: German free text spelling out the numeric `ww` code beside it
     # ("Wetter wurde nicht gemeldet" for -1)
     "ww_text",
@@ -88,6 +82,36 @@ def _decode_measurement_method(series: pl.Series) -> pl.Series:
             f"expected one of {sorted(MEASUREMENT_METHOD_CODES)}. These values are returned as null.",
         )
     return series.replace_strict(MEASUREMENT_METHOD_CODES, default=None, return_dtype=pl.String)
+
+
+# hourly solar stamps each record with the UTC instant of a whole true-solar-time hour, so the two
+# timestamps sit apart by the solar correction: `1981010101:00` beside `1981010100:09`. That
+# distance is the parameter -- longitude correction plus the equation of time, 40 to 71 minutes at
+# station 00183, its monthly mean tracing the equation of time from 40.4 in February to 69.1 in
+# November about a 54.7 minute longitude term.
+#
+# It has to be taken here, from the two timestamps as published. `mess_datum` is rounded to the hour
+# a few lines further down so that a solar series lines up with every other hourly series, and that
+# rounding is what discards the correction.
+TIME_FORMAT_SOLAR = "%Y%m%d%H:%M"
+TRUE_LOCAL_TIME = DwdObservationMetadata.hourly.solar.true_local_time_offset.name_original
+
+
+def _encode_true_local_time_offset(series: pl.Series) -> pl.Series:
+    """Express the true local time as its distance in minutes from the record's own timestamp."""
+    frame = series.struct.unnest()
+    published = frame.get_column(TRUE_LOCAL_TIME)
+    true_local_time = published.str.to_datetime(TIME_FORMAT_SOLAR, strict=False)
+    stamp = frame.get_column("mess_datum").str.to_datetime(TIME_FORMAT_SOLAR, strict=False)
+    # a format change would otherwise turn every value null without a word, leaving a declared
+    # parameter that answers with nothing -- the failure this whole area exists to prevent
+    unparsed = published.filter(published.is_not_null() & true_local_time.is_null())
+    if not unparsed.is_empty():
+        log.warning(
+            f"{unparsed.len()} value(s) of {TRUE_LOCAL_TIME!r} do not parse as "
+            f"{TIME_FORMAT_SOLAR!r} and are returned as null, e.g. {unparsed.head(1).to_list()}.",
+        )
+    return (true_local_time - stamp).dt.total_minutes().cast(pl.String)
 
 
 COLUMNS_MAPPING = {
@@ -167,6 +191,12 @@ def _parse_climate_observations_data(  # noqa: C901
         pl.col(parameter).map_batches(_decode_measurement_method, return_dtype=pl.String)
         for parameter in sorted(CODED_STRING_PARAMETERS & columns)
     )
+    if TRUE_LOCAL_TIME in columns:
+        df = df.with_columns(
+            pl.struct("mess_datum", TRUE_LOCAL_TIME)
+            .map_batches(_encode_true_local_time_offset, return_dtype=pl.String)
+            .alias(TRUE_LOCAL_TIME),
+        )
     # Assign meaningful column names (baseline).
     df = df.rename(mapping=lambda col: COLUMNS_MAPPING.get(col, col))
     if dataset == DwdObservationMetadata.minute_1.precipitation:

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -1443,6 +1443,34 @@ def test_dwd_observation_measurement_method_indicators(
 
 
 @pytest.mark.remote
+def test_dwd_observation_true_local_time_offset(settings_convert_units_false: Settings) -> None:
+    """Test that the true local time offset carries the seasonal solar correction.
+
+    The offset is the longitude correction plus the equation of time, so it has to *move* over the
+    year -- a value that came out constant would mean the correction had been rounded away, which
+    is exactly what happens to it in the timestamp.
+    """
+
+    def offsets(month: int) -> list[float]:
+        request = DwdObservationRequest(
+            parameters=[("hourly", "solar", "true_local_time_offset")],
+            start_date=dt.datetime(2023, month, 10, 0, 0, tzinfo=ZoneInfo("UTC")),
+            end_date=dt.datetime(2023, month, 10, 6, 0, tzinfo=ZoneInfo("UTC")),
+            settings=settings_convert_units_false,
+        ).filter_by_station_id("00183")
+        return request.values.all().df.get_column("value").to_list()
+
+    february, november = offsets(2), offsets(11)
+    assert february
+    assert november
+    # the equation of time is near its minimum in February and its maximum in November, roughly
+    # half an hour apart, about this station's ~55 minute longitude term
+    assert max(february) < min(november)
+    assert min(november) - max(february) > 20
+    assert all(0 < offset < 120 for offset in february + november)
+
+
+@pytest.mark.remote
 def test_dwd_observation_data_daily_climate_summary_custom_units() -> None:
     """Test for custom unit conversion."""
     unit_targets = {

--- a/tests/provider/dwd/observation/test_parser.py
+++ b/tests/provider/dwd/observation/test_parser.py
@@ -136,6 +136,51 @@ def test_parse_dwd_data_decodes_measurement_method(dataset: DatasetModel, column
     assert df.schema[column] == pl.String
 
 
+def test_parse_dwd_data_encodes_true_local_time_offset() -> None:
+    """Test that true local time becomes its distance from the record's own timestamp.
+
+    Solar records are stamped with the UTC instant of a whole true-solar-time hour, so the two
+    timestamps sit apart by the solar correction. Taking that here is the whole point: `mess_datum`
+    is rounded to the hour later on, and the rounding is what would discard it.
+    """
+    payload = (
+        "STATIONS_ID;MESS_DATUM;QN_592;FG_LBERG;MESS_DATUM_WOZ;eor\n"
+        # February, near the equation of time's minimum
+        "  183;2023021005:20;    1;      0;2023021006:00;eor\n"
+        # November, near its maximum -- same station, half an hour further ahead
+        "  183;2023111004:50;    1;      0;2023111006:00;eor\n"
+    )
+    file = File(url="", content=BytesIO(payload.encode("utf8")), status=200)
+    df = parse_climate_observations_data(
+        files=[file],
+        dataset=DwdObservationMetadata.hourly.solar,
+        period=Period.HISTORICAL,
+    ).collect()
+    assert df.get_column("mess_datum_woz").to_list() == ["40", "70"]
+
+
+def test_parse_dwd_data_reports_unknown_true_local_time(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that a true local time that no longer parses is reported rather than quietly nulled.
+
+    A format change would otherwise turn every value null without a word, leaving a parameter that
+    is declared and answers with nothing -- the failure this area exists to prevent.
+    """
+    payload = (
+        "STATIONS_ID;MESS_DATUM;QN_592;FG_LBERG;MESS_DATUM_WOZ;eor\n"
+        "  183;2023021005:20;    1;      0;2023-02-10T06:00:00;eor\n"
+    )
+    file = File(url="", content=BytesIO(payload.encode("utf8")), status=200)
+    with caplog.at_level(logging.WARNING):
+        df = parse_climate_observations_data(
+            files=[file],
+            dataset=DwdObservationMetadata.hourly.solar,
+            period=Period.HISTORICAL,
+        ).collect()
+    assert df.get_column("mess_datum_woz").to_list() == [None]
+    assert "mess_datum_woz" in caplog.text
+    assert "2023-02-10T06:00:00" in caplog.text
+
+
 def test_parse_dwd_data_reports_unknown_measurement_method(caplog: pytest.LogCaptureFixture) -> None:
     """Test that an indicator outside the code table is reported rather than quietly nulled.
 


### PR DESCRIPTION
Follow-up to #1823, which removed `true_local_time` because what it returned was a per-station constant. The quantity underneath it is real; this exposes it properly.

## What was being thrown away

Hourly solar does **not** stamp records on the hour. Each one carries the UTC instant of a whole hour of true local solar time, so the two timestamps in the file sit apart by the solar correction:

```
MESS_DATUM         MESS_DATUM_WOZ
1981010100:09      1981010101:00     -> 51 minutes
```

wetterdienst rounds `mess_datum` to the hour so a solar series lines up with every other hourly series. That rounding discards the correction, and `mess_datum_woz` — the only other record of it — was dropped. The quantity was not reachable at all.

## The new parameter

`true_local_time_offset` (`mess_datum_woz`, hourly solar): how far true local solar time runs ahead of the record's timestamp — the longitude correction plus the equation of time. Taken from the two timestamps as published, **before** the rounding.

Checked over station 00183's full archive, 387,120 records:

| property | value |
|---|---|
| range | 40 – 71 minutes |
| within-day spread | 0 or 1 minute |
| day-to-day step | 0 or 1 minute |

and the monthly mean traces the equation of time about a ~54.7 minute longitude term:

| month | mean |
|---|---|
| February | 40.4 min |
| May | 57.6 min |
| November | 69.1 min |

That is the equation of time curve — minimum in February, maximum in November, a ±14.5 minute swing — recovered from data the library was discarding.

Unit type `time`, so it follows the `time` target like any other duration and arrives in seconds by default.

## Why this is not the parameter #1823 removed

`true_local_time` returned the whole-hour *label*, which after the timestamp rounding sat a fixed one hour from the returned timestamp at 00183 across its entire archive. This returns the *distance between the two published timestamps*, which is the part that moves.

The remote test asserts the February-to-November swing rather than the presence of a value, so a version that rounded the correction away again would fail — the test my first attempt lacked.

## Also

- a `mess_datum_woz` that stops parsing is now reported rather than silently nulled, so a format change cannot quietly turn the parameter back into one that answers with nothing
- the docs explain the solar timestamp rounding, what it costs, and how to get the correction back

## Verified

- live: `2023-02-10` returns `40.0`, `2023-11-10` returns `70.0` minutes at station 00183
- new parser tests for the encoding and the unparsable case; new remote test for the seasonal swing
- `tests/provider/dwd/observation`, `tests/test_docs.py`, parameter-table tests green; lint and `ty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)