### PR TITLE
fix(dwd)!: return obscured-sky cloud cover as null, not -0.125 of the sky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ Types of changes:
 
 ### Fixed
 
+- **Breaking**: DWD hourly cloud cover no longer reports -0.125 of the sky. `cloud_cover_total`
+  (`v_n`) and `cloud_cover_layer1` to `cloud_cover_layer4` (`v_sN_ns`) carry -1 where the sky could
+  not be seen at all, SYNOP's N = 9, and being declared in eighths that converted to -0.125 as a
+  fraction. It is returned as null now. DWD's description documents only -999 and says nothing
+  about -1, so the reading is from the data: -1 stands in 1.2% of station 00003's hourly
+  observations, and fog codes (`ww` 40-49) accompany 69.1% of those against 0.8% of the rest. The
+  cloud *type* codes beside them keep their -1, DWD's own value for an automated observation, which
+  is dimensionless and so passes through unscaled
+
 - Descriptions no longer leak between resolutions. `build_metadata_model` wrote them into the
   metadata dicts it was given, and providers commonly build one resolution's parameter list from
   another's by comprehension, which reuses the very same dicts: AEMET's annual parameters are its

--- a/docs/data/provider/dwd/observation/hourly.md
+++ b/docs/data/provider/dwd/observation/hourly.md
@@ -73,7 +73,7 @@ Code (cloud_type_layer):
 | name                            | original name | description                    | unit | constraints                         |
 |---------------------------------|---------------|--------------------------------|------|-------------------------------------|
 | {term}`cloud_cover_total_measurement_method` | v_n_i | Index how measurement is taken, P = by human person,I = by instrument. Returned as 1 for P and 2 for I. | - | ∈ \[1, 2\] |
-| {term}`cloud_cover_total` | v_n | Total cloud cover. | 1/8 | ∈ \[0, 1, 2, 3, 4, 5, 6, 7, 8, -1\] |
+| {term}`cloud_cover_total` | v_n | Total cloud cover. | 1/8 | >=0,<=8 |
 | {term}`quality` | qn_8 | Quality flag. | dimensionless | - |
 
 Code (cloud_cover_total_measurement_method):

--- a/docs/data/provider/dwd/observation/index.md
+++ b/docs/data/provider/dwd/observation/index.md
@@ -104,6 +104,28 @@ of which only `rs_05` and `rs_ind_05` are available in the `recent` and `now` pe
 | Cumulonimbus    | 9      |
 | Automated       | -1     |
 
+Note that `-1` means two different things in the hourly cloud datasets, depending on the column. In
+the cloud *type* codes above it is DWD's value for an automated observation, and it is returned as
+`-1`. In the cloud *cover* fields it is not a type but an absence, and it is not returned at all —
+see below.
+
+### Obscured sky
+
+The hourly cloud cover fields — `cloud_cover_total` (`v_n`) and `cloud_cover_layer1` to
+`cloud_cover_layer4` (`v_sN_ns`) — carry `-1` where the sky could not be seen at all, which is
+SYNOP's N = 9. It says that no amount could be given, rather than giving one, so wetterdienst
+returns it as null.
+
+Left as it stands it would be read as −1 eighths and converted like any other cloud cover, so a
+default request would report −0.125 of the sky covered.
+
+DWD's own dataset description documents only `-999` as a missing value and says nothing about `-1`,
+so the reading is from the data: across station 00003's hourly record `-1` stands in 1.2% of
+observations, and fog codes (`ww` 40 to 49) accompany 69.1% of those against 0.8% of the rest —
+`45` and `47`, "fog, sky invisible", most of all. If you need to tell an obscured sky from a plain
+gap in the record, the **hourly weather_phenomena** dataset still carries the weather code for that
+hour.
+
 ### Measurement method indicators
 
 Two DWD parameters say *how* a value was obtained rather than what was measured, and DWD writes

--- a/src/wetterdienst/provider/dwd/observation/parser.py
+++ b/src/wetterdienst/provider/dwd/observation/parser.py
@@ -61,6 +61,24 @@ DROPPABLE_PARAMETERS = {
 # Written as text because DWD pads its fields with spaces, so every data column is read as text and
 # cast to Float64 only at the very end; a numeric column here would not stack with its neighbours.
 MEASUREMENT_METHOD_CODES = {"P": "1", "I": "2"}
+
+# The hourly cloud fields carry -1 where the sky could not be seen at all, SYNOP's N = 9. DWD's own
+# sheet documents only -999 as a missing value, but -1 stands in 1.2% of station 00003's hourly
+# records, and fog codes (`ww` 40-49) accompany 69.1% of those against 0.8% of the rest -- 45 and
+# 47, "fog, sky invisible", most of all. It is a statement that no amount could be given, not an
+# amount: left alone it is read as -1 eighths and converts to -0.125 of the sky.
+#
+# Only the cover fields. `v_sN_cs` beside them is a cloud *type* code where -1 is DWD's own value
+# for an automated observation, and dimensionless, so nothing distorts it.
+SKY_OBSCURED = "-1"
+CLOUD_COVER_PARAMETERS = {
+    DwdObservationMetadata.hourly.cloudiness.cloud_cover_total.name_original,
+    DwdObservationMetadata.hourly.cloud_type.cloud_cover_total.name_original,
+    DwdObservationMetadata.hourly.cloud_type.cloud_cover_layer1.name_original,
+    DwdObservationMetadata.hourly.cloud_type.cloud_cover_layer2.name_original,
+    DwdObservationMetadata.hourly.cloud_type.cloud_cover_layer3.name_original,
+    DwdObservationMetadata.hourly.cloud_type.cloud_cover_layer4.name_original,
+}
 CODED_STRING_PARAMETERS = {
     DwdObservationMetadata.hourly.cloud_type.cloud_cover_total_measurement_method.name_original,
     DwdObservationMetadata.hourly.cloudiness.cloud_cover_total_measurement_method.name_original,
@@ -190,6 +208,9 @@ def _parse_climate_observations_data(  # noqa: C901
     df = df.with_columns(
         pl.col(parameter).map_batches(_decode_measurement_method, return_dtype=pl.String)
         for parameter in sorted(CODED_STRING_PARAMETERS & columns)
+    )
+    df = df.with_columns(
+        pl.col(parameter).replace(SKY_OBSCURED, None) for parameter in sorted(CLOUD_COVER_PARAMETERS & columns)
     )
     if TRUE_LOCAL_TIME in columns:
         df = df.with_columns(

--- a/tests/provider/dwd/observation/test_parser.py
+++ b/tests/provider/dwd/observation/test_parser.py
@@ -181,6 +181,31 @@ def test_parse_dwd_data_reports_unknown_true_local_time(caplog: pytest.LogCaptur
     assert "2023-02-10T06:00:00" in caplog.text
 
 
+def test_parse_dwd_data_drops_obscured_sky_cloud_cover() -> None:
+    """Test that -1 in the hourly cloud cover fields becomes null, while cloud type keeps its -1.
+
+    DWD writes -1 where the sky could not be seen at all, SYNOP's N = 9. It is a statement that no
+    amount could be given, not an amount: left alone it is read as -1 eighths and converts to
+    -0.125 of the sky. `v_sN_cs` beside it is a cloud *type* code where -1 is DWD's own value for
+    an automated observation, so that one has to survive.
+    """
+    payload = (
+        "STATIONS_ID;MESS_DATUM;QN_8;V_N_I;V_N;V_S1_CS;V_S1_CSA;V_S1_HHS;V_S1_NS;eor\n"
+        "    3;1994010100;    5;   I;  -1;      -1;      -1;    -999;      -1;eor\n"
+        "    3;1994010101;    5;   I;   7;       6;      SC;     600;       4;eor\n"
+    )
+    file = File(url="", content=BytesIO(payload.encode("utf8")), status=200)
+    df = parse_climate_observations_data(
+        files=[file],
+        dataset=DwdObservationMetadata.hourly.cloud_type,
+        period=Period.HISTORICAL,
+    ).collect()
+    assert df.get_column("v_n").to_list() == [None, "7"]
+    assert df.get_column("v_s1_ns").to_list() == [None, "4"]
+    # the cloud type code keeps it: -1 is what DWD writes for an automated observation
+    assert df.get_column("v_s1_cs").to_list() == ["-1", "6"]
+
+
 def test_parse_dwd_data_reports_unknown_measurement_method(caplog: pytest.LogCaptureFixture) -> None:
     """Test that an indicator outside the code table is reported rather than quietly nulled.
 


### PR DESCRIPTION
The hourly cloud cover fields carry `-1` where the sky could not be seen at all — SYNOP's N = 9. Declared in eighths, that went through unit conversion like any other number:

```
cloud_cover_total   12:00 UTC   0.875
cloud_cover_total   13:00 UTC  -0.125   <- "sky obscured", converted
cloud_cover_total   14:00 UTC   1.0
```

## What `-1` actually means

DWD's own dataset description documents only `-999` and says nothing about `-1`, so the reading is from the data. Joining station 00003's hourly cloud record against its hourly weather codes:

| | rows | fog (`ww` 40–49) |
|---|---|---|
| `v_n == -1` | 4,038 | **69.1%** |
| `v_n != -1` | 237,289 | 0.8% |

An 86-fold enrichment, topped by `45` and `47` — "fog, sky invisible". It is a statement that no amount could be given, not an amount. It stands in 1.2% of that station's 347,190 hourly observations.

## The fix

Returned as null, for `cloud_cover_total` (`v_n`) and `cloud_cover_layer1` … `cloud_cover_layer4` (`v_sN_ns`).

This is the treatment IPMA's `-99` and FMI's `-1` already get in this codebase: a sentinel is resolved where it is parsed, never carried through unit conversion.

**The cloud *type* codes beside them keep their `-1`**, which is DWD's own value for an automated observation. Nothing scales it because it is dimensionless — and that is the whole asymmetry. The same number survives in one column and cannot in the other, purely because one carries a unit. The parser test pins both halves.

Considered and rejected: exempting `-1` from conversion so it could be kept verbatim. It leaves a magic code in a column of converted physical values, so `mean()` and plots still break, exports carry it, and the generic converter gains a per-parameter special case.

## Scope

Checked the other resolutions — subdaily cloudiness, daily `kl` and monthly `kl` contain no `-1` at all. Confined to the hourly cloud datasets.

## Docs

- a new **Obscured sky** section explaining what `-1` is, what it would otherwise convert to, and how to recover the reason (the `ww` code in **hourly weather_phenomena** still carries it)
- a note on the **Cloud types** table that `-1` means two different things depending on the column — an automated observation in the type codes, an absence in the cover fields
- the `cloud_cover_total` constraints no longer advertise `-1` as a valid value

## Verified

- station 00003, 1994: 8,725 hourly values, min 0.0, max 8.0, **no negative values**, 44 nulls
- with default conversion the range is now 0.0–1.0
- new parser test covering both the nulled cover and the surviving type code; `tests/test_docs.py` and the DWD observation suite green; lint and `ty` clean

## Breaking

DWD hourly cloud cover returns null where it previously returned `-1` (or `-0.125` with the default unit conversion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)