### PR TITLE
feat!: nest discover() so dataset and resolution descriptions can be reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ Types of changes:
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking**: `discover()` nests its answer so that every level has a place for its description,
+  which had nowhere to go before: `{resolution: {"description": ..., "datasets": {dataset:
+  {"description": ..., "parameters": [...]}}}}`. The 88 dataset descriptions and 2 resolution
+  descriptions were on the model but unreachable over `GET /api/coverage`, the `coverage` MCP tool
+  and `wetterdienst about coverage`, which all pass this dict through as their response. Consumers
+  reading `data[resolution][dataset]` as a list of parameters now read
+  `data[resolution]["datasets"][dataset]["parameters"]`
+
 ### Fixed
 
 - **Breaking**: MET Norway's in-band codes are decoded rather than returned as measurements. Frost

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -22,8 +22,10 @@ Types of changes:
   listed with `Object.keys()` over the resolution, which answers `["description", "datasets"]`
   under the new shape, and the dataset was indexed as a list of parameters. Both now read through
   `datasets` and `parameters`, and the types gain `CoverageResolution` and `CoverageDataset` plus a
-  `description` on `CoverageParameter`. No visible change: the descriptions are carried but not yet
-  shown anywhere
+  `description` on `CoverageParameter`
+- `[Parameter selection]` Show what the shape change makes reachable: the resolution and dataset
+  selects carry the source's own description as help text, and each parameter in the menu shows its
+  description beneath the label
 
 ### Added
 

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -16,6 +16,15 @@ Types of changes:
 
 ## [Unreleased]
 
+### Changed
+
+- `[Parameter selection]` Follow the nested shape `GET /api/coverage` now returns. Datasets were
+  listed with `Object.keys()` over the resolution, which answers `["description", "datasets"]`
+  under the new shape, and the dataset was indexed as a list of parameters. Both now read through
+  `datasets` and `parameters`, and the types gain `CoverageResolution` and `CoverageDataset` plus a
+  `description` on `CoverageParameter`. No visible change: the descriptions are carried but not yet
+  shown anywhere
+
 ### Added
 
 - `[All pages]` Glossary labels for the new `radiation_global_intensity`,

--- a/frontend/app/components/ParameterSelection.vue
+++ b/frontend/app/components/ParameterSelection.vue
@@ -111,6 +111,13 @@ const datasets = computed((): string[] => {
   const resolutionData = providerNetworkCoverage.value[resolution.value as Resolution]
   return resolutionData ? Object.keys(resolutionData.datasets).sort() : []
 })
+const parameterDescriptions = computed<Record<string, string>>(() => {
+  if (!providerNetworkCoverage.value || !resolution.value || !dataset.value)
+    return {}
+  const resolutionData = providerNetworkCoverage.value[resolution.value as Resolution]
+  const entries = resolutionData?.datasets[dataset.value]?.parameters ?? []
+  return Object.fromEntries(entries.map((p: CoverageParameter) => [p.name, p.description ?? '']))
+})
 const params = computed<string[]>(() => {
   if (!providerNetworkCoverage.value || !resolution.value || !dataset.value)
     return []
@@ -124,6 +131,20 @@ const params = computed<string[]>(() => {
     .map((p: CoverageParameter) => p.name)
     .sort()
 })
+// the source's own words for the selected resolution and dataset, which `/api/coverage` carries
+// since the backend nested its answer; absent for most resolutions, so the hint just disappears
+const resolutionDescription = computed<string>(() => {
+  if (!providerNetworkCoverage.value || !resolution.value)
+    return ''
+  return providerNetworkCoverage.value[resolution.value as Resolution]?.description ?? ''
+})
+const datasetDescription = computed<string>(() => {
+  if (!providerNetworkCoverage.value || !resolution.value || !dataset.value)
+    return ''
+  const resolutionData = providerNetworkCoverage.value[resolution.value as Resolution]
+  return resolutionData?.datasets[dataset.value]?.description ?? ''
+})
+
 const dateRequired = computed<boolean>(() => {
   if (!coverage.value || !provider.value || !network.value)
     return false
@@ -133,7 +154,11 @@ const dateRequired = computed<boolean>(() => {
 // Friendly, locale-aware labels for the select menus (value stays the raw backend id).
 const resolutionItems = computed(() => resolutions.value.map(r => ({ label: resolutionLabel(r), value: r })))
 const datasetItems = computed(() => datasets.value.map(d => ({ label: datasetLabel(d), value: d })))
-const paramItems = computed(() => params.value.map(p => ({ label: parameterLabel(p), value: p })))
+const paramItems = computed(() => params.value.map(p => ({
+  label: parameterLabel(p),
+  value: p,
+  description: parameterDescriptions.value[p] ?? '',
+})))
 
 // Initialize from query params and validate step by step
 async function initializeFromProps() {
@@ -335,15 +360,22 @@ watch([provider, network, resolution, dataset, parameters, dateRequired], () => 
       <UFormField :label="t('parameterSelection.networkLabel')">
         <USelect v-model="network" :items="networkItems" :placeholder="t('parameterSelection.selectNetwork')" :disabled="!provider || !!restrictNetwork" class="w-full" :class="{ 'needs-input': activeField === 'network' }" />
       </UFormField>
-      <UFormField :label="t('parameterSelection.resolutionLabel')">
+      <UFormField :label="t('parameterSelection.resolutionLabel')" :help="resolutionDescription">
         <USelect v-model="resolution" :items="resolutionItems" :placeholder="t('parameterSelection.selectResolution')" :disabled="!network || networkCoveragePending" class="w-full" :class="{ 'needs-input': activeField === 'resolution' }" />
       </UFormField>
-      <UFormField :label="t('parameterSelection.datasetLabel')">
+      <UFormField :label="t('parameterSelection.datasetLabel')" :help="datasetDescription">
         <USelect v-model="dataset" :items="datasetItems" :placeholder="t('parameterSelection.selectDataset')" :disabled="!resolution || networkCoveragePending" class="w-full" :class="{ 'needs-input': activeField === 'dataset' }" />
       </UFormField>
       <UFormField v-if="props.showParameters !== false" :label="t('parameterSelection.parametersLabel')">
         <div class="flex gap-2 items-center min-w-0">
-          <USelectMenu v-model="parameters" :items="paramItems" value-key="value" multiple :placeholder="t('parameterSelection.selectParameters')" :disabled="!dataset" class="flex-1 min-w-0 overflow-hidden" :class="{ 'needs-input': activeField === 'parameters' }" />
+          <USelectMenu v-model="parameters" :items="paramItems" value-key="value" multiple :placeholder="t('parameterSelection.selectParameters')" :disabled="!dataset" class="flex-1 min-w-0 overflow-hidden" :class="{ 'needs-input': activeField === 'parameters' }">
+            <template #item-label="{ item }">
+              <span>{{ item.label }}</span>
+              <span v-if="item.description" class="block text-xs text-gray-500 dark:text-gray-400 whitespace-normal">
+                {{ item.description }}
+              </span>
+            </template>
+          </USelectMenu>
           <UButton
             v-if="dataset && !allSelected"
             size="xs"

--- a/frontend/app/components/ParameterSelection.vue
+++ b/frontend/app/components/ParameterSelection.vue
@@ -109,7 +109,7 @@ const datasets = computed((): string[] => {
   if (!providerNetworkCoverage.value || !resolution.value)
     return []
   const resolutionData = providerNetworkCoverage.value[resolution.value as Resolution]
-  return resolutionData ? Object.keys(resolutionData).sort() : []
+  return resolutionData ? Object.keys(resolutionData.datasets).sort() : []
 })
 const params = computed<string[]>(() => {
   if (!providerNetworkCoverage.value || !resolution.value || !dataset.value)
@@ -117,7 +117,7 @@ const params = computed<string[]>(() => {
   const resolutionData = providerNetworkCoverage.value[resolution.value as Resolution]
   if (!resolutionData)
     return []
-  const datasetParams = resolutionData[dataset.value]
+  const datasetParams = resolutionData.datasets[dataset.value]?.parameters
   if (!datasetParams)
     return []
   return datasetParams

--- a/frontend/shared/types/api.ts
+++ b/frontend/shared/types/api.ts
@@ -23,6 +23,19 @@ export interface CoverageParameter {
   name_original?: string
   unit?: string
   unit_original?: string
+  description?: string | null
+}
+
+/** A dataset in the coverage response, with the source's own description of it */
+export interface CoverageDataset {
+  description?: string | null
+  parameters: CoverageParameter[]
+}
+
+/** A resolution in the coverage response, with its datasets */
+export interface CoverageResolution {
+  description?: string | null
+  datasets: Record<string, CoverageDataset>
 }
 
 /** Per-network metadata in the coverage response */
@@ -48,7 +61,7 @@ export interface AuthResponse {
 /** Detailed coverage for a provider-network pair */
 export type ProviderNetworkCoverageResponse = Record<
   Resolution,
-  Record<string, CoverageParameter[]>
+  CoverageResolution
 >
 
 export interface CoverageQuery {

--- a/frontend/tests/nuxt/components/ParameterSelection.test.ts
+++ b/frontend/tests/nuxt/components/ParameterSelection.test.ts
@@ -243,7 +243,13 @@ describe('parameterSelection Component', () => {
         new Response(
           JSON.stringify({
             daily: {
-              climate_summary: [{ name: 'temperature_air_max_200' }],
+              description: null,
+              datasets: {
+                climate_summary: {
+                  description: null,
+                  parameters: [{ name: 'temperature_air_max_200' }],
+                },
+              },
             },
           }),
           { status: 200 },

--- a/frontend/tests/nuxt/pages/explorer.test.ts
+++ b/frontend/tests/nuxt/pages/explorer.test.ts
@@ -66,7 +66,7 @@ describe('explorer Page', () => {
     registerEndpoint('/api/coverage', (event) => {
       const q = getQuery(event)
       if (q.provider)
-        return { daily: { climate_summary: [{ name: 'temperature_air_max_200' }] } }
+        return { daily: { description: null, datasets: { climate_summary: { description: null, parameters: [{ name: 'temperature_air_max_200' }] } } } }
       return { dwd: { observation: {} } }
     })
     registerEndpoint('/api/stations', () => ({

--- a/frontend/tests/nuxt/pages/history.test.ts
+++ b/frontend/tests/nuxt/pages/history.test.ts
@@ -10,7 +10,7 @@ describe('history Page', () => {
     registerEndpoint('/api/coverage', (event) => {
       const q = getQuery(event)
       if (q.provider)
-        return { daily: { climate_summary: [{ name: 'temperature_air_max_200' }] } }
+        return { daily: { description: null, datasets: { climate_summary: { description: null, parameters: [{ name: 'temperature_air_max_200' }] } } } }
       return { dwd: { observation: {} } }
     })
   })

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -364,6 +364,12 @@ class TimeseriesRequest:
     ) -> dict:
         """Discover metadata for the given resolutions and datasets.
 
+        Each level carries its own description, so the shape has a place for one::
+
+            {resolution: {"description": ..., "datasets": {dataset: {"description": ...,
+             "parameters": [{"name": ..., "name_original": ..., "unit_type": ..., "unit": ...,
+             "description": ...}]}}}}
+
         Args:
             resolutions: Resolutions to discover metadata for.
             datasets: Datasets to discover metadata for.
@@ -397,7 +403,7 @@ class TimeseriesRequest:
                 and resolution.name_original not in resolution_strings
             ):
                 continue
-            data[resolution.name] = {}
+            described_datasets = {}
             for dataset in resolution:
                 if (
                     dataset_strings
@@ -405,9 +411,9 @@ class TimeseriesRequest:
                     and dataset.name_original not in dataset_strings
                 ):
                     continue
-                data[resolution.name][dataset.name] = []
-                for parameter in dataset:
-                    data[resolution.name][dataset.name].append(
+                described_datasets[dataset.name] = {
+                    "description": dataset.description,
+                    "parameters": [
                         {
                             "name": parameter.name,
                             "name_original": parameter.name_original,
@@ -416,10 +422,16 @@ class TimeseriesRequest:
                             # the source's own words for its own field, where we have them; the
                             # canonical, provider-independent sentence lives in the glossary
                             "description": parameter.description,
-                        },
-                    )
-            if not data[resolution.name]:
-                del data[resolution.name]
+                        }
+                        for parameter in dataset
+                    ],
+                }
+            if not described_datasets:
+                continue
+            data[resolution.name] = {
+                "description": resolution.description,
+                "datasets": described_datasets,
+            }
         return data
 
     @staticmethod

--- a/src/wetterdienst/ui/mcp.py
+++ b/src/wetterdienst/ui/mcp.py
@@ -66,7 +66,9 @@ does this provider have".
 - parameters: "resolution/dataset" (e.g. "daily/kl") for a whole dataset, or \
 "resolution/dataset/parameter" (e.g. "daily/climate_summary/temperature_air_mean_2m") for a single \
 measurement. Prefer the single-measurement form to keep responses small. Parameter names are \
-snake_case; `coverage(provider="dwd", network="observation", datasets="climate_summary")` lists them.
+snake_case; `coverage(provider="dwd", network="observation", datasets="climate_summary")` lists them. \
+Its answer is keyed by resolution, then `datasets`, then each dataset's `parameters`, and every one \
+of those three levels carries a `description` saying what the source means by it.
 - periods: "recent" (roughly the last 1.5 years) is the usual choice; "historical" for older data.
 - Handy DWD datasets: daily/kl (= climate_summary: temperature, precipitation, wind, sunshine), \
 hourly/air_temperature, hourly/precipitation.

--- a/tests/provider/dwd/observation/test_api_metadata.py
+++ b/tests/provider/dwd/observation/test_api_metadata.py
@@ -46,15 +46,20 @@ def test_dwd_observation_metadata_discover_parameters() -> None:
     # as discover() gained a key
     actual = {
         resolution: {
-            dataset: [{k: p[k] for k in ("name", "name_original", "unit_type", "unit")} for p in parameters]
-            for dataset, parameters in datasets.items()
+            dataset: [
+                {k: p[k] for k in ("name", "name_original", "unit_type", "unit")} for p in described["parameters"]
+            ]
+            for dataset, described in entry["datasets"].items()
         }
-        for resolution, datasets in metadata.items()
+        for resolution, entry in metadata.items()
         if resolution == "1_minute"
     }
     assert actual == expected
-    # descriptions come from the source sheets and are reported alongside
-    assert all(p["description"] for p in metadata["1_minute"]["precipitation"])
+    # descriptions come from the source sheets and are reported alongside, at every level
+    precipitation = metadata["1_minute"]["datasets"]["precipitation"]
+    assert all(p["description"] for p in precipitation["parameters"])
+    assert precipitation["description"]
+    assert metadata["subdaily"]["description"] == "measurements at 7am, 2pm, 9pm."
 
 
 @pytest.mark.remote

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -942,8 +942,11 @@ def test_source_descriptions_reach_the_metadata() -> None:
     assert DwdObservationRequest.metadata["daily"]["climate_summary"]["snow_depth"].description
 
     discovered = DwdObservationRequest.discover(resolutions="10_minutes", datasets="solar")
-    entry = next(p for p in discovered["10_minutes"]["solar"] if p["name"] == "radiation_global")
+    solar = discovered["10_minutes"]["datasets"]["solar"]
+    entry = next(p for p in solar["parameters"] if p["name"] == "radiation_global")
     assert entry["description"] == parameter.description
+    # the dataset's own description is reachable now too, which is why the shape has this level
+    assert solar["description"]
 
 
 def test_source_descriptions_reach_the_parameter_they_name() -> None:

--- a/tests/ui/cli/test_cli.py
+++ b/tests/ui/cli/test_cli.py
@@ -101,9 +101,9 @@ def test_coverage() -> None:
     assert result.exit_code == 0
     response = json.loads(result.stdout)
     assert "1_minute" in response
-    assert "precipitation" in response["1_minute"]
-    assert len(response["1_minute"]["precipitation"]) > 0
-    parameters = [p["name"] for p in response["1_minute"]["precipitation"]]
+    assert "precipitation" in response["1_minute"]["datasets"]
+    assert len(response["1_minute"]["datasets"]["precipitation"]["parameters"]) > 0
+    parameters = [p["name"] for p in response["1_minute"]["datasets"]["precipitation"]["parameters"]]
     assert parameters == [
         "precipitation_height",
         "precipitation_height_droplet",
@@ -143,9 +143,9 @@ def test_coverage_dataset_climate_summary() -> None:
     assert result.exit_code == 0
     response = json.loads(result.stdout)
     assert response.keys() == {"daily", "monthly", "annual"}
-    assert response["daily"].keys() == {"climate_summary"}
-    assert response["monthly"].keys() == {"climate_summary"}
-    assert response["annual"].keys() == {"climate_summary"}
+    assert response["daily"]["datasets"].keys() == {"climate_summary"}
+    assert response["monthly"]["datasets"].keys() == {"climate_summary"}
+    assert response["annual"]["datasets"].keys() == {"climate_summary"}
 
 
 def test_cli_radar_stations_opera() -> None:

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -214,9 +214,9 @@ def test_coverage_dwd_observation(client: TestClient) -> None:
     assert response.status_code == 200
     data = response.json()
     assert "1_minute" in data
-    assert "precipitation" in data["1_minute"]
-    assert len(data["1_minute"]["precipitation"]) > 0
-    parameters = [item["name"] for item in data["1_minute"]["precipitation"]]
+    assert "precipitation" in data["1_minute"]["datasets"]
+    assert len(data["1_minute"]["datasets"]["precipitation"]["parameters"]) > 0
+    parameters = [item["name"] for item in data["1_minute"]["datasets"]["precipitation"]["parameters"]]
     assert parameters == [
         "precipitation_height",
         "precipitation_height_droplet",
@@ -255,9 +255,9 @@ def test_coverage_dwd_observation_dataset_climate_summary(client: TestClient) ->
     assert response.status_code == 200
     data = response.json()
     assert data.keys() == {"daily", "monthly", "annual"}
-    assert data["daily"].keys() == {"climate_summary"}
-    assert data["monthly"].keys() == {"climate_summary"}
-    assert data["annual"].keys() == {"climate_summary"}
+    assert data["daily"]["datasets"].keys() == {"climate_summary"}
+    assert data["monthly"]["datasets"].keys() == {"climate_summary"}
+    assert data["annual"]["datasets"].keys() == {"climate_summary"}
 
 
 @pytest.mark.remote


### PR DESCRIPTION
`DatasetModel.description` and `ResolutionModel.description` were populated in #1818 and #1825, but no interface could read them. `discover()` answered `{resolution: {dataset: [parameters]}}` — a shape with nowhere to put either — and `GET /api/coverage`, the `coverage` MCP tool and `wetterdienst about coverage` all pass that dict straight through as their response. So 88 dataset descriptions and 2 resolution ones sat on the model, reachable only from Python.

## The shape

```json
{
  "hourly": {
    "description": null,
    "datasets": {
      "cloudiness": {
        "description": "Hourly station observations of cloudiness for Germany.",
        "parameters": [
          {"name": "cloud_cover_total", "name_original": "v_n", "unit_type": "fraction",
           "unit": "one_eighth", "description": "Total cloud cover."}
        ]
      }
    }
  }
}
```

## Why not an opt-in flag

That was the alternative considered. Against it:

- the consumers that most need these descriptions are **REST and MCP**, where the default response *is* the answer. Behind `details=true` they would stay invisible to exactly the caller they exist for
- it changes the **shape**, not the content, so every client has to branch on which it asked for — and it would have to be implemented three times: Python argument, REST query param, MCP tool argument
- two shapes then have to be kept working forever

The project is at `0.132.0` with ~30 breaking changes already in the changelog and no deprecation machinery, so one clean break is cheaper than a permanent fork in the response.

## The frontend would have broken

Worth calling out, since it is easy to miss: `ParameterSelection.vue` lists datasets with `Object.keys(resolutionData)` — which now answers `["description", "datasets"]` — and indexes `resolutionData[dataset]` as an array of parameters. Both updated, and the types gain `CoverageResolution` and `CoverageDataset` plus `description` on `CoverageParameter`. `pnpm typecheck` passes.

## Also updated

- five CLI, REST and metadata tests that asserted the old shape; the metadata test now also asserts a dataset and a resolution description arrive
- the `discover()` docstring, which now states the shape — it is a public contract
- the MCP tool guidance, so the model knows all three levels carry a description

The docs pages render `discover()` output live at build time, so they follow on their own.

## Verified

- `tests/ui`, `tests/test_api.py`, `tests/test_docs.py` and the DWD metadata tests: 197 passed
- `pnpm typecheck` clean; `ruff` and `ty` clean

## Breaking

Consumers reading `data[resolution][dataset]` as a list of parameters now read `data[resolution]["datasets"][dataset]["parameters"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)