### PR TITLE
feat: take 84 more descriptions from the sources that turned out to document them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ htmlcov
 /tmp
 /geckodriver.log
 /troubleshooting
+
+# working notes, not part of the distribution
+notes/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ Types of changes:
 
 ### Changed
 
+- 84 more descriptions come from the source rather than from the canonical sentence, after finding
+  that three providers document their fields after all. Météo-France publishes a
+  `*_descriptif_champs*.csv` beside each resolution (43 parameters, translated from French), the
+  Met Office's MIDAS tables are documented by CEDA in English (32), and LHMT lists its fields on
+  api.meteo.lt (9, translated from Lithuanian). They say what the canonical sentence cannot: that
+  Météo-France's daily precipitation runs 06h to 06h UTC and is attributed to the earlier day, that
+  Met Office pressure is uncorrected for altitude, that LHMT returns null for cloud cover it cannot
+  determine through fog. 224 derived descriptions remain, DMI (52) and RMI (42) the largest, neither
+  of which documents its fields anywhere reachable
+
+### Changed
+
 - **Breaking**: `discover()` nests its answer so that every level has a place for its description,
   which had nowhere to go before: `{resolution: {"description": ..., "datasets": {dataset:
   {"description": ..., "parameters": [...]}}}}`. The 88 dataset descriptions and 2 resolution

--- a/docs/data/provider/lhmt/observation/hourly.md
+++ b/docs/data/provider/lhmt/observation/hourly.md
@@ -22,12 +22,12 @@
 
 | name                            | original name    | description                                                                                   | unit |
 |---------------------------------|------------------|-----------------------------------------------------------------------------------------------|------|
-| {term}`temperature_air_mean_2m` | airTemperature   | Mean air temperature at 2 m above ground.                                                     | °C   |
-| {term}`humidity`                | relativeHumidity | Relative humidity of the air, the fraction of the moisture it could hold at that temperature. | %    |
-| {term}`wind_speed`              | windSpeed        | Mean speed of the wind over the period.                                                       | m/s  |
-| {term}`wind_gust_max`           | windGust         | Speed of the strongest gust of the period.                                                    | m/s  |
-| {term}`wind_direction`          | windDirection    | Direction the wind is blowing from, clockwise from true north.                                | °    |
-| {term}`cloud_cover_total`       | cloudCover       | Fraction of the sky covered by cloud of any kind.                                             | %    |
-| {term}`pressure_air_sea_level`  | seaLevelPressure | Air pressure reduced to mean sea level, so that stations at different heights compare.        | hPa  |
-| {term}`precipitation_height`    | precipitation    | Depth of precipitation collected over the period.                                             | mm   |
-| {term}`snow_depth`              | snowDepth        | Depth of the snow lying on the ground.                                                        | cm   |
+| {term}`temperature_air_mean_2m` | airTemperature | Air temperature, °C. | °C |
+| {term}`humidity` | relativeHumidity | Relative humidity of the air, %. | % |
+| {term}`wind_speed` | windSpeed | Wind speed, m/s. | m/s |
+| {term}`wind_gust_max` | windGust | Wind gust, m/s. The maximum gust over the hour. | m/s |
+| {term}`wind_direction` | windDirection | Wind direction, °. Values: 0 is from the north, 180 is from the south, and so on. | ° |
+| {term}`cloud_cover_total` | cloudCover | Cloud cover, %. Values: 0 is clear, 100 is overcast. Where the cloud cover cannot be determined, for example because of fog, null is returned. | % |
+| {term}`pressure_air_sea_level` | seaLevelPressure | Pressure at sea level, hPa. | hPa |
+| {term}`precipitation_height` | precipitation | Precipitation amount, mm. The precipitation sum over the hour. | mm |
+| {term}`snow_depth` | snowDepth | Thickness of the snow cover, cm. | cm |

--- a/docs/data/provider/meteofrance/observation/6_minutes.md
+++ b/docs/data/provider/meteofrance/observation/6_minutes.md
@@ -24,4 +24,4 @@
 
 | name                         | original name | description                                       | unit       |
 |------------------------------|---------------|---------------------------------------------------|------------|
-| {term}`precipitation_height` | RR            | Depth of precipitation collected over the period. | millimeter |
+| {term}`precipitation_height` | RR | Precipitation amount over 6 minutes. | millimeter |

--- a/docs/data/provider/meteofrance/observation/daily.md
+++ b/docs/data/provider/meteofrance/observation/daily.md
@@ -24,13 +24,13 @@
 
 | name                            | original name | description                                           | unit             |
 |---------------------------------|---------------|-------------------------------------------------------|------------------|
-| {term}`precipitation_height`    | RR            | Depth of precipitation collected over the period.     | millimeter       |
-| {term}`temperature_air_min_2m`  | TN            | Minimum air temperature at 2 m above ground.          | degree_celsius   |
-| {term}`temperature_air_max_2m`  | TX            | Maximum air temperature at 2 m above ground.          | degree_celsius   |
-| {term}`temperature_air_mean_2m` | TM            | Mean air temperature at 2 m above ground.             | degree_celsius   |
-| {term}`wind_speed`              | FFM           | Mean speed of the wind over the period.               | meter_per_second |
-| {term}`wind_gust_max`           | FXI           | Speed of the strongest gust of the period.            | meter_per_second |
-| {term}`wind_direction_gust_max` | DXI           | Direction the strongest gust of the period blew from. | degree           |
+| {term}`precipitation_height` | RR | Precipitation amount over 24 hours, from 06h UTC on day J to 06h UTC on day J+1. The value recorded at J+1 is attributed to day J. | millimeter |
+| {term}`temperature_air_min_2m` | TN | Minimum air temperature under shelter. | degree_celsius |
+| {term}`temperature_air_max_2m` | TX | Maximum air temperature under shelter. | degree_celsius |
+| {term}`temperature_air_mean_2m` | TM | Daily mean of the hourly air temperatures under shelter. | degree_celsius |
+| {term}`wind_speed` | FFM | Daily mean of the wind force averaged over 10 minutes, at 10 m. | meter_per_second |
+| {term}`wind_gust_max` | FXI | Daily maximum of the hourly maximum instantaneous wind force, at 10 m. | meter_per_second |
+| {term}`wind_direction_gust_max` | DXI | Direction of FXI, on the 360 degree compass. | degree |
 
 ### others
 
@@ -47,11 +47,11 @@
 
 | name                           | original name | description                                                                                   | unit                        |
 |--------------------------------|---------------|-----------------------------------------------------------------------------------------------|-----------------------------|
-| {term}`pressure_air_sea_level` | PMERM         | Air pressure reduced to mean sea level, so that stations at different heights compare.        | hectopascal                 |
-| {term}`pressure_vapor`         | TSVM          | Partial pressure of water vapour in the air.                                                  | hectopascal                 |
-| {term}`sunshine_duration`      | INST          | Length of time the sun shone unobstructed.                                                    | minute                      |
-| {term}`radiation_global`       | GLOT          | Global radiation received on a horizontal surface, accumulated as energy over the interval.   | joule_per_square_centimeter |
-| {term}`humidity`               | UM            | Relative humidity of the air, the fraction of the moisture it could hold at that temperature. | percent                     |
-| {term}`snow_depth`             | NEIGETOT06    | Depth of the snow lying on the ground.                                                        | centimeter                  |
-| {term}`snow_depth_new`         | HNEIGEF       | Depth of snow that fell during the period.                                                    | centimeter                  |
+| {term}`pressure_air_sea_level` | PMERM | Daily mean of the hourly sea level pressures. | hectopascal |
+| {term}`pressure_vapor` | TSVM | Mean vapour pressure. | hectopascal |
+| {term}`sunshine_duration` | INST | Daily sunshine duration. | minute |
+| {term}`radiation_global` | GLOT | Daily global radiation. | joule_per_square_centimeter |
+| {term}`humidity` | UM | Daily mean of the hourly relative humidities. | percent |
+| {term}`snow_depth` | NEIGETOT06 | Total depth of snow on the ground measured at 06h. | centimeter |
+| {term}`snow_depth_new` | HNEIGEF | Depth of fresh snow fallen over 24 hours, from 06h UTC on day J to 06h UTC on day J+1, that remains on the ground at 06h UTC. | centimeter |
 

--- a/docs/data/provider/meteofrance/observation/hourly.md
+++ b/docs/data/provider/meteofrance/observation/hourly.md
@@ -24,14 +24,14 @@
 
 | name                            | original name | description                                                    | unit             |
 |---------------------------------|---------------|----------------------------------------------------------------|------------------|
-| {term}`precipitation_height`    | RR1           | Depth of precipitation collected over the period.              | millimeter       |
-| {term}`temperature_air_min_2m`  | TN            | Minimum air temperature at 2 m above ground.                   | degree_celsius   |
-| {term}`temperature_air_max_2m`  | TX            | Maximum air temperature at 2 m above ground.                   | degree_celsius   |
-| {term}`temperature_air_mean_2m` | T             | Mean air temperature at 2 m above ground.                      | degree_celsius   |
-| {term}`wind_speed`              | FF            | Mean speed of the wind over the period.                        | meter_per_second |
-| {term}`wind_direction`          | DD            | Direction the wind is blowing from, clockwise from true north. | degree           |
-| {term}`wind_gust_max`           | FXY           | Speed of the strongest gust of the period.                     | meter_per_second |
-| {term}`wind_direction_gust_max` | DXY           | Direction the strongest gust of the period blew from.          | degree           |
+| {term}`precipitation_height` | RR1 | Precipitation amount over 1 hour. | millimeter |
+| {term}`temperature_air_min_2m` | TN | Minimum air temperature under shelter within the hour. | degree_celsius |
+| {term}`temperature_air_max_2m` | TX | Maximum air temperature under shelter within the hour. | degree_celsius |
+| {term}`temperature_air_mean_2m` | T | Instantaneous air temperature under shelter. | degree_celsius |
+| {term}`wind_speed` | FF | Wind force averaged over 10 minutes, measured at 10 m. | meter_per_second |
+| {term}`wind_direction` | DD | Direction of FF, on the 360 degree compass. | degree |
+| {term}`wind_gust_max` | FXY | Maximum value of FF within the hour. | meter_per_second |
+| {term}`wind_direction_gust_max` | DXY | Direction of FXY, on the 360 degree compass. | degree |
 
 ### others
 
@@ -48,11 +48,11 @@
 
 | name                                  | original name | description                                                                                   | unit                        |
 |---------------------------------------|---------------|-----------------------------------------------------------------------------------------------|-----------------------------|
-| {term}`temperature_dew_point_mean_2m` | TD            | Dew point at 2 m above ground, the temperature at which the air would become saturated.       | degree_celsius              |
-| {term}`humidity`                      | U             | Relative humidity of the air, the fraction of the moisture it could hold at that temperature. | percent                     |
-| {term}`pressure_air_sea_level`        | PMER          | Air pressure reduced to mean sea level, so that stations at different heights compare.        | hectopascal                 |
-| {term}`pressure_air_site`             | PSTAT         | Air pressure as measured at station height.                                                   | hectopascal                 |
-| {term}`cloud_cover_total`             | N             | Fraction of the sky covered by cloud of any kind.                                             | one_eighth                  |
-| {term}`visibility_range`              | VV            | Horizontal distance at which an object can still be made out.                                 | meter                       |
-| {term}`radiation_global`              | GLO           | Global radiation received on a horizontal surface, accumulated as energy over the interval.   | joule_per_square_centimeter |
-| {term}`sunshine_duration`             | INS           | Length of time the sun shone unobstructed.                                                    | minute                      |
+| {term}`temperature_dew_point_mean_2m` | TD | Dew point temperature. | degree_celsius |
+| {term}`humidity` | U | Relative humidity. | percent |
+| {term}`pressure_air_sea_level` | PMER | Sea level pressure, only for stations at an altitude of 750 m or less. | hectopascal |
+| {term}`pressure_air_site` | PSTAT | Station pressure. | hectopascal |
+| {term}`cloud_cover_total` | N | Total cloud amount, in octas. 9 means the sky was invisible through fog or another weather phenomenon. | one_eighth |
+| {term}`visibility_range` | VV | Visibility. | meter |
+| {term}`radiation_global` | GLO | Hourly global radiation, in UTC hours. | joule_per_square_centimeter |
+| {term}`sunshine_duration` | INS | Hourly sunshine duration, in UTC hours. | minute |

--- a/docs/data/provider/meteofrance/observation/monthly.md
+++ b/docs/data/provider/meteofrance/observation/monthly.md
@@ -24,16 +24,16 @@
 
 | name                                | original name | description                                                                                   | unit                        |
 |-------------------------------------|---------------|-----------------------------------------------------------------------------------------------|-----------------------------|
-| {term}`precipitation_height`        | RR            | Depth of precipitation collected over the period.                                             | millimeter                  |
-| {term}`temperature_air_min_2m_mean` | TN            | Mean of the daily minimum air temperature at 2 m above ground over the period.                | degree_celsius              |
-| {term}`temperature_air_max_2m_mean` | TX            | Mean of the daily maximum air temperature at 2 m above ground over the period.                | degree_celsius              |
-| {term}`temperature_air_mean_2m`     | TMM           | Mean air temperature at 2 m above ground.                                                     | degree_celsius              |
-| {term}`wind_speed`                  | FFM           | Mean speed of the wind over the period.                                                       | meter_per_second            |
-| {term}`wind_gust_max`               | FXIAB         | Speed of the strongest gust of the period.                                                    | meter_per_second            |
-| {term}`humidity`                    | UMM           | Relative humidity of the air, the fraction of the moisture it could hold at that temperature. | percent                     |
-| {term}`pressure_air_sea_level`      | PMERM         | Air pressure reduced to mean sea level, so that stations at different heights compare.        | hectopascal                 |
-| {term}`pressure_vapor`              | TSVM          | Partial pressure of water vapour in the air.                                                  | hectopascal                 |
-| {term}`sunshine_duration`           | INST          | Length of time the sun shone unobstructed.                                                    | minute                      |
-| {term}`radiation_global`            | GLOT          | Global radiation received on a horizontal surface, accumulated as energy over the interval.   | joule_per_square_centimeter |
-| {term}`snow_depth_new`              | HNEIGEFTOT    | Depth of snow that fell during the period.                                                    | centimeter                  |
+| {term}`precipitation_height` | RR | Monthly total of the precipitation depths. | millimeter |
+| {term}`temperature_air_min_2m_mean` | TN | Monthly mean of the daily minimum temperatures (TN). | degree_celsius |
+| {term}`temperature_air_max_2m_mean` | TX | Monthly mean of the daily maximum temperatures (TX). | degree_celsius |
+| {term}`temperature_air_mean_2m` | TMM | Monthly mean of the daily mean temperatures (TM). | degree_celsius |
+| {term}`wind_speed` | FFM | Monthly mean of the daily mean wind force averaged over 10 minutes (FFM), at 10 m. | meter_per_second |
+| {term}`wind_gust_max` | FXIAB | Monthly absolute maximum of the daily maximum instantaneous wind force, at 10 m. | meter_per_second |
+| {term}`humidity` | UMM | Monthly mean of the daily mean humidities (UM). | percent |
+| {term}`pressure_air_sea_level` | PMERM | Monthly mean of the daily mean sea level pressures (PMERM). | hectopascal |
+| {term}`pressure_vapor` | TSVM | Monthly mean of the vapour pressure. | hectopascal |
+| {term}`sunshine_duration` | INST | Monthly total of the daily sunshine durations. | minute |
+| {term}`radiation_global` | GLOT | Monthly total of the daily global radiation. | joule_per_square_centimeter |
+| {term}`snow_depth_new` | HNEIGEFTOT | Monthly total of the depth of fresh snow fallen over 24 hours (daily HNEIGEF). | centimeter |
 

--- a/docs/data/provider/metoffice/observation/daily.md
+++ b/docs/data/provider/metoffice/observation/daily.md
@@ -22,7 +22,7 @@
 
 | name                         | original name | description                                       | unit |
 |------------------------------|---------------|---------------------------------------------------|------|
-| {term}`precipitation_height` | prcp_amt      | Depth of precipitation collected over the period. | mm   |
+| {term}`precipitation_height` | prcp_amt | Precipitation amount, reported to the nearest 0.1 mm. | mm |
 
 ### temperature
 
@@ -37,9 +37,9 @@
 
 | name                              | original name | description                                     | unit |
 |-----------------------------------|---------------|-------------------------------------------------|------|
-| {term}`temperature_air_max_2m`    | max_air_temp  | Maximum air temperature at 2 m above ground.    | °C   |
-| {term}`temperature_air_min_2m`    | min_air_temp  | Minimum air temperature at 2 m above ground.    | °C   |
-| {term}`temperature_air_min_0_05m` | min_grss_temp | Minimum air temperature at 0.05 m above ground. | °C   |
+| {term}`temperature_air_max_2m` | max_air_temp | Maximum air temperature, to the nearest 0.1 deg C. | °C |
+| {term}`temperature_air_min_2m` | min_air_temp | Minimum air temperature, to the nearest 0.1 deg C. | °C |
+| {term}`temperature_air_min_0_05m` | min_grss_temp | Minimum grass temperature, to the nearest 0.1 deg C. | °C |
 
 ### weather
 
@@ -54,6 +54,6 @@
 
 | name                      | original name    | description                                | unit |
 |---------------------------|------------------|--------------------------------------------|------|
-| {term}`sunshine_duration` | drv_24hr_sun_dur | Length of time the sun shone unobstructed. | h    |
-| {term}`snow_depth`        | snow_depth       | Depth of the snow lying on the ground.     | cm   |
-| {term}`snow_depth_new`    | frsh_snw_amt     | Depth of snow that fell during the period. | cm   |
+| {term}`sunshine_duration` | drv_24hr_sun_dur | Derived 24 hour sunshine duration, for stations carrying radiation sensors only, which use the global radiation values to derive it. | h |
+| {term}`snow_depth` | snow_depth | Snow depth, cm. | cm |
+| {term}`snow_depth_new` | frsh_snw_amt | Fresh snow amount, cm. | cm |

--- a/docs/data/provider/metoffice/observation/hourly.md
+++ b/docs/data/provider/metoffice/observation/hourly.md
@@ -22,8 +22,8 @@
 
 | name                           | original name | description                                       | unit |
 |--------------------------------|---------------|---------------------------------------------------|------|
-| {term}`precipitation_height`   | prcp_amt      | Depth of precipitation collected over the period. | mm   |
-| {term}`precipitation_duration` | prcp_dur      | Length of time during which precipitation fell.   | min  |
+| {term}`precipitation_height` | prcp_amt | Precipitation amount, reported to the nearest 0.1 mm. | mm |
+| {term}`precipitation_duration` | prcp_dur | Precipitation duration over less than 24 hours, minutes. | min |
 
 ### weather
 
@@ -38,19 +38,19 @@
 
 | name                                  | original name    | description                                                                                   | unit |
 |---------------------------------------|------------------|-----------------------------------------------------------------------------------------------|------|
-| {term}`wind_direction`                | wind_direction   | Direction the wind is blowing from, clockwise from true north.                                | °    |
-| {term}`wind_speed`                    | wind_speed       | Mean speed of the wind over the period.                                                       | kn   |
-| {term}`wind_gust_max`                 | q10mnt_mxgst_spd | Speed of the strongest gust of the period.                                                    | kn   |
-| {term}`visibility_range`              | visibility       | Horizontal distance at which an object can still be made out.                                 | m    |
-| {term}`pressure_air_sea_level`        | msl_pressure     | Air pressure reduced to mean sea level, so that stations at different heights compare.        | hPa  |
-| {term}`pressure_air_site`             | stn_pres         | Air pressure as measured at station height.                                                   | hPa  |
-| {term}`temperature_air_mean_2m`       | air_temperature  | Mean air temperature at 2 m above ground.                                                     | °C   |
-| {term}`temperature_dew_point_mean_2m` | dewpoint         | Dew point at 2 m above ground, the temperature at which the air would become saturated.       | °C   |
-| {term}`humidity`                      | rltv_hum         | Relative humidity of the air, the fraction of the moisture it could hold at that temperature. | %    |
-| {term}`sunshine_duration`             | wmo_hr_sun_dur   | Length of time the sun shone unobstructed.                                                    | h    |
-| {term}`snow_depth`                    | snow_depth       | Depth of the snow lying on the ground.                                                        | cm   |
-| {term}`cloud_cover_total`             | cld_ttl_amt_id   | Fraction of the sky covered by cloud of any kind.                                             | 1/8  |
-| {term}`weather`                       | prst_wx_id       | Coded present weather at the time of observation.                                             | -    |
+| {term}`wind_direction` | wind_direction | Wind direction, that from which the wind blows, in degrees true. An east wind is 090, a south wind 180. | ° |
+| {term}`wind_speed` | wind_speed | Wind speed, knots. | kn |
+| {term}`wind_gust_max` | q10mnt_mxgst_spd | Maximum gust speed over 10 minutes, knots. | kn |
+| {term}`visibility_range` | visibility | Visibility, decametres. | m |
+| {term}`pressure_air_sea_level` | msl_pressure | Mean sea level air pressure, to the nearest 0.1 hPa. | hPa |
+| {term}`pressure_air_site` | stn_pres | Station air pressure, as measured at station level. No correction for altitude is applied. | hPa |
+| {term}`temperature_air_mean_2m` | air_temperature | Air temperature, to the nearest 0.1 deg C. | °C |
+| {term}`temperature_dew_point_mean_2m` | dewpoint | Dewpoint temperature: the temperature to which the air must be cooled to produce saturation with respect to water at its existing pressure and humidity. | °C |
+| {term}`humidity` | rltv_hum | Calculated relative humidity. | % |
+| {term}`sunshine_duration` | wmo_hr_sun_dur | Readings from the newer automatic sun sensor, which has replaced the Campbell Stokes recorder. | h |
+| {term}`snow_depth` | snow_depth | Snow depth, cm. | cm |
+| {term}`cloud_cover_total` | cld_ttl_amt_id | Total cloud amount code. | 1/8 |
+| {term}`weather` | prst_wx_id | Present weather code. | - |
 
 ### wind
 
@@ -65,10 +65,10 @@
 
 | name                            | original name   | description                                                    | unit |
 |---------------------------------|-----------------|----------------------------------------------------------------|------|
-| {term}`wind_direction`          | mean_wind_dir   | Direction the wind is blowing from, clockwise from true north. | °    |
-| {term}`wind_speed`              | mean_wind_speed | Mean speed of the wind over the period.                        | kn   |
-| {term}`wind_direction_gust_max` | max_gust_dir    | Direction the strongest gust of the period blew from.          | °    |
-| {term}`wind_gust_max`           | max_gust_speed  | Speed of the strongest gust of the period.                     | kn   |
+| {term}`wind_direction` | mean_wind_dir | Mean wind direction, that from which the wind blows, in degrees true. An east wind is 090, a south wind 180. | ° |
+| {term}`wind_speed` | mean_wind_speed | Mean wind speed, knots. | kn |
+| {term}`wind_direction_gust_max` | max_gust_dir | Direction of the maximum gust, degrees true. | ° |
+| {term}`wind_gust_max` | max_gust_speed | Speed of the maximum gust, knots. | kn |
 
 ### radiation
 
@@ -83,9 +83,9 @@
 
 | name                                     | original name | description                                                                                 | unit  |
 |------------------------------------------|---------------|---------------------------------------------------------------------------------------------|-------|
-| {term}`radiation_global`                 | glbl_irad_amt | Global radiation received on a horizontal surface, accumulated as energy over the interval. | kJ/m² |
-| {term}`radiation_sky_short_wave_diffuse` | difu_irad_amt | Diffuse short-wave radiation from the sky, accumulated as energy over the interval.         | kJ/m² |
-| {term}`radiation_sky_short_wave_direct`  | direct_irad   | Direct short-wave radiation from the sun, accumulated as energy over the interval.          | kJ/m² |
+| {term}`radiation_global` | glbl_irad_amt | Global solar irradiation amount, kJ per square metre over the observation period. | kJ/m² |
+| {term}`radiation_sky_short_wave_diffuse` | difu_irad_amt | Diffuse solar irradiation amount, kJ per square metre over the observation period. | kJ/m² |
+| {term}`radiation_sky_short_wave_direct` | direct_irad | Direct irradiation amount, kJ per square metre over the observation period. | kJ/m² |
 
 ### soil_temperature
 
@@ -100,8 +100,8 @@
 
 | name                                | original name    | description                            | unit |
 |-------------------------------------|------------------|----------------------------------------|------|
-| {term}`temperature_soil_mean_0_05m` | q5cm_soil_temp   | Mean soil temperature at 0.05 m depth. | °C   |
-| {term}`temperature_soil_mean_0_1m`  | q10cm_soil_temp  | Mean soil temperature at 0.1 m depth.  | °C   |
-| {term}`temperature_soil_mean_0_2m`  | q20cm_soil_temp  | Mean soil temperature at 0.2 m depth.  | °C   |
-| {term}`temperature_soil_mean_0_5m`  | q50cm_soil_temp  | Mean soil temperature at 0.5 m depth.  | °C   |
-| {term}`temperature_soil_mean_1m`    | q100cm_soil_temp | Mean soil temperature at 1 m depth.    | °C   |
+| {term}`temperature_soil_mean_0_05m` | q5cm_soil_temp | 5 cm soil temperature, to the nearest 0.1 deg C. | °C |
+| {term}`temperature_soil_mean_0_1m` | q10cm_soil_temp | 10 cm soil temperature, to the nearest 0.1 deg C. | °C |
+| {term}`temperature_soil_mean_0_2m` | q20cm_soil_temp | 20 cm soil temperature, to the nearest 0.1 deg C. | °C |
+| {term}`temperature_soil_mean_0_5m` | q50cm_soil_temp | 50 cm soil temperature, to the nearest 0.1 deg C. | °C |
+| {term}`temperature_soil_mean_1m` | q100cm_soil_temp | 100 cm soil temperature, to the nearest 0.1 deg C. | °C |

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -29,9 +29,13 @@ are taken as they come:
   statistical function and aggregation period ("Air temperature. Mean over 1 minute.")
 - AEMET: the ``metadatos`` payload that accompanies every response, translated from Spanish
 - SMHI: the parameter listing of the metobs API, translated from Swedish
+- LHMT: the field list on api.meteo.lt, translated from Lithuanian
+- Météo-France: the `*_descriptif_champs*.csv` published beside each resolution, translated from
+  French
+- Met Office: the MIDAS table dictionaries CEDA publishes, already in English
 
-The two translations are ours. Everything else in this table is the source's own wording, so a
-sentence here can be checked against what the provider says.
+The AEMET, SMHI, LHMT and Météo-France translations are ours. Everything else in this table is the
+source's own wording, so a sentence here can be checked against what the provider says.
 
 Keyed by metadata model name, then ``(resolution, dataset, name_original)``. Applied by
 ``build_metadata_model``.
@@ -1475,6 +1479,138 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("hourly", "data", "TD"): "Dew point temperature",
         ("hourly", "data", "U"): "Relative atmospheric humidity",
     },
+    "LhmtObservationMetadata": {
+        ("hourly", "data", "airTemperature"): "Air temperature, °C.",
+        ("hourly", "data", "cloudCover"): (
+            "Cloud cover, %. Values: 0 is clear, 100 is overcast. Where the cloud cover cannot be "
+            "determined, for example because of fog, null is returned."
+        ),
+        ("hourly", "data", "precipitation"): "Precipitation amount, mm. The precipitation sum over the hour.",
+        ("hourly", "data", "relativeHumidity"): "Relative humidity of the air, %.",
+        ("hourly", "data", "seaLevelPressure"): "Pressure at sea level, hPa.",
+        ("hourly", "data", "snowDepth"): "Thickness of the snow cover, cm.",
+        ("hourly", "data", "windDirection"): (
+            "Wind direction, °. Values: 0 is from the north, 180 is from the south, and so on."
+        ),
+        ("hourly", "data", "windGust"): "Wind gust, m/s. The maximum gust over the hour.",
+        ("hourly", "data", "windSpeed"): "Wind speed, m/s.",
+    },
+    "MetOfficeObservationMetadata": {
+        ("daily", "rain", "prcp_amt"): "Precipitation amount, reported to the nearest 0.1 mm.",
+        ("daily", "temperature", "max_air_temp"): "Maximum air temperature, to the nearest 0.1 deg C.",
+        ("daily", "temperature", "min_air_temp"): "Minimum air temperature, to the nearest 0.1 deg C.",
+        ("daily", "temperature", "min_grss_temp"): "Minimum grass temperature, to the nearest 0.1 deg C.",
+        ("daily", "weather", "drv_24hr_sun_dur"): (
+            "Derived 24 hour sunshine duration, for stations carrying radiation sensors only, which use the global "
+            "radiation values to derive it."
+        ),
+        ("daily", "weather", "frsh_snw_amt"): "Fresh snow amount, cm.",
+        ("daily", "weather", "snow_depth"): "Snow depth, cm.",
+        ("hourly", "radiation", "difu_irad_amt"): (
+            "Diffuse solar irradiation amount, kJ per square metre over the observation period."
+        ),
+        ("hourly", "radiation", "direct_irad"): (
+            "Direct irradiation amount, kJ per square metre over the observation period."
+        ),
+        ("hourly", "radiation", "glbl_irad_amt"): (
+            "Global solar irradiation amount, kJ per square metre over the observation period."
+        ),
+        ("hourly", "rain", "prcp_amt"): "Precipitation amount, reported to the nearest 0.1 mm.",
+        ("hourly", "rain", "prcp_dur"): "Precipitation duration over less than 24 hours, minutes.",
+        ("hourly", "soil_temperature", "q100cm_soil_temp"): "100 cm soil temperature, to the nearest 0.1 deg C.",
+        ("hourly", "soil_temperature", "q10cm_soil_temp"): "10 cm soil temperature, to the nearest 0.1 deg C.",
+        ("hourly", "soil_temperature", "q20cm_soil_temp"): "20 cm soil temperature, to the nearest 0.1 deg C.",
+        ("hourly", "soil_temperature", "q50cm_soil_temp"): "50 cm soil temperature, to the nearest 0.1 deg C.",
+        ("hourly", "soil_temperature", "q5cm_soil_temp"): "5 cm soil temperature, to the nearest 0.1 deg C.",
+        ("hourly", "weather", "air_temperature"): "Air temperature, to the nearest 0.1 deg C.",
+        ("hourly", "weather", "cld_ttl_amt_id"): "Total cloud amount code.",
+        ("hourly", "weather", "dewpoint"): (
+            "Dewpoint temperature: the temperature to which the air must be cooled to produce saturation with respect "
+            "to water at its existing pressure and humidity."
+        ),
+        ("hourly", "weather", "msl_pressure"): "Mean sea level air pressure, to the nearest 0.1 hPa.",
+        ("hourly", "weather", "prst_wx_id"): "Present weather code.",
+        ("hourly", "weather", "q10mnt_mxgst_spd"): "Maximum gust speed over 10 minutes, knots.",
+        ("hourly", "weather", "rltv_hum"): "Calculated relative humidity.",
+        ("hourly", "weather", "snow_depth"): "Snow depth, cm.",
+        ("hourly", "weather", "stn_pres"): (
+            "Station air pressure, as measured at station level. No correction for altitude is applied."
+        ),
+        ("hourly", "weather", "visibility"): "Visibility, decametres.",
+        ("hourly", "weather", "wind_direction"): (
+            "Wind direction, that from which the wind blows, in degrees true. An east wind is 090, a south wind 180."
+        ),
+        ("hourly", "weather", "wind_speed"): "Wind speed, knots.",
+        ("hourly", "weather", "wmo_hr_sun_dur"): (
+            "Readings from the newer automatic sun sensor, which has replaced the Campbell Stokes recorder."
+        ),
+        ("hourly", "wind", "max_gust_dir"): "Direction of the maximum gust, degrees true.",
+        ("hourly", "wind", "max_gust_speed"): "Speed of the maximum gust, knots.",
+        ("hourly", "wind", "mean_wind_dir"): (
+            "Mean wind direction, that from which the wind blows, in degrees true. An east wind is 090, a south wind "
+            "180."
+        ),
+        ("hourly", "wind", "mean_wind_speed"): "Mean wind speed, knots.",
+    },
+    "MeteoFranceObservationMetadata": {
+        ("6_minutes", "data", "RR"): "Precipitation amount over 6 minutes.",
+        ("daily", "core", "DXI"): "Direction of FXI, on the 360 degree compass.",
+        ("daily", "core", "FFM"): "Daily mean of the wind force averaged over 10 minutes, at 10 m.",
+        ("daily", "core", "FXI"): "Daily maximum of the hourly maximum instantaneous wind force, at 10 m.",
+        ("daily", "core", "RR"): (
+            "Precipitation amount over 24 hours, from 06h UTC on day J to 06h UTC on day J+1. The value recorded at "
+            "J+1 is attributed to day J."
+        ),
+        ("daily", "core", "TM"): "Daily mean of the hourly air temperatures under shelter.",
+        ("daily", "core", "TN"): "Minimum air temperature under shelter.",
+        ("daily", "core", "TX"): "Maximum air temperature under shelter.",
+        ("daily", "others", "GLOT"): "Daily global radiation.",
+        ("daily", "others", "HNEIGEF"): (
+            "Depth of fresh snow fallen over 24 hours, from 06h UTC on day J to 06h UTC on day J+1, that remains on "
+            "the ground at 06h UTC."
+        ),
+        ("daily", "others", "INST"): "Daily sunshine duration.",
+        ("daily", "others", "NEIGETOT06"): "Total depth of snow on the ground measured at 06h.",
+        ("daily", "others", "PMERM"): "Daily mean of the hourly sea level pressures.",
+        ("daily", "others", "TSVM"): "Mean vapour pressure.",
+        ("daily", "others", "UM"): "Daily mean of the hourly relative humidities.",
+        ("hourly", "core", "DD"): "Direction of FF, on the 360 degree compass.",
+        ("hourly", "core", "DXY"): "Direction of FXY, on the 360 degree compass.",
+        ("hourly", "core", "FF"): "Wind force averaged over 10 minutes, measured at 10 m.",
+        ("hourly", "core", "FXY"): "Maximum value of FF within the hour.",
+        ("hourly", "core", "RR1"): "Precipitation amount over 1 hour.",
+        ("hourly", "core", "T"): "Instantaneous air temperature under shelter.",
+        ("hourly", "core", "TN"): "Minimum air temperature under shelter within the hour.",
+        ("hourly", "core", "TX"): "Maximum air temperature under shelter within the hour.",
+        ("hourly", "others", "GLO"): "Hourly global radiation, in UTC hours.",
+        ("hourly", "others", "INS"): "Hourly sunshine duration, in UTC hours.",
+        ("hourly", "others", "N"): (
+            "Total cloud amount, in octas. 9 means the sky was invisible through fog or another weather phenomenon."
+        ),
+        ("hourly", "others", "PMER"): "Sea level pressure, only for stations at an altitude of 750 m or less.",
+        ("hourly", "others", "PSTAT"): "Station pressure.",
+        ("hourly", "others", "TD"): "Dew point temperature.",
+        ("hourly", "others", "U"): "Relative humidity.",
+        ("hourly", "others", "VV"): "Visibility.",
+        ("monthly", "data", "FFM"): (
+            "Monthly mean of the daily mean wind force averaged over 10 minutes (FFM), at 10 m."
+        ),
+        ("monthly", "data", "FXIAB"): (
+            "Monthly absolute maximum of the daily maximum instantaneous wind force, at 10 m."
+        ),
+        ("monthly", "data", "GLOT"): "Monthly total of the daily global radiation.",
+        ("monthly", "data", "HNEIGEFTOT"): (
+            "Monthly total of the depth of fresh snow fallen over 24 hours (daily HNEIGEF)."
+        ),
+        ("monthly", "data", "INST"): "Monthly total of the daily sunshine durations.",
+        ("monthly", "data", "PMERM"): "Monthly mean of the daily mean sea level pressures (PMERM).",
+        ("monthly", "data", "RR"): "Monthly total of the precipitation depths.",
+        ("monthly", "data", "TMM"): "Monthly mean of the daily mean temperatures (TM).",
+        ("monthly", "data", "TN"): "Monthly mean of the daily minimum temperatures (TN).",
+        ("monthly", "data", "TSVM"): "Monthly mean of the vapour pressure.",
+        ("monthly", "data", "TX"): "Monthly mean of the daily maximum temperatures (TX).",
+        ("monthly", "data", "UMM"): "Monthly mean of the daily mean humidities (UM).",
+    },
     "MeteoswissObservationMetadata": {
         ("10_minutes", "data", "dkl010z0"): "Wind direction; ten minutes mean",
         ("10_minutes", "data", "fkl010z0"): "Wind speed scalar; ten minutes mean in m/s",
@@ -2280,134 +2416,6 @@ DERIVED_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
             "Global radiation received on a horizontal surface, accumulated as energy over the interval."
         ),
         ("hourly", "data", "temperatura"): "Mean air temperature at 2 m above ground.",
-    },
-    "LhmtObservationMetadata": {
-        ("hourly", "data", "airTemperature"): "Mean air temperature at 2 m above ground.",
-        ("hourly", "data", "cloudCover"): "Fraction of the sky covered by cloud of any kind.",
-        ("hourly", "data", "precipitation"): "Depth of precipitation collected over the period.",
-        ("hourly", "data", "relativeHumidity"): (
-            "Relative humidity of the air, the fraction of the moisture it could hold at that temperature."
-        ),
-        ("hourly", "data", "seaLevelPressure"): (
-            "Air pressure reduced to mean sea level, so that stations at different heights compare."
-        ),
-        ("hourly", "data", "snowDepth"): "Depth of the snow lying on the ground.",
-        ("hourly", "data", "windDirection"): "Direction the wind is blowing from, clockwise from true north.",
-        ("hourly", "data", "windGust"): "Speed of the strongest gust of the period.",
-        ("hourly", "data", "windSpeed"): "Mean speed of the wind over the period.",
-    },
-    "MetOfficeObservationMetadata": {
-        ("daily", "rain", "prcp_amt"): "Depth of precipitation collected over the period.",
-        ("daily", "temperature", "max_air_temp"): "Maximum air temperature at 2 m above ground.",
-        ("daily", "temperature", "min_air_temp"): "Minimum air temperature at 2 m above ground.",
-        ("daily", "temperature", "min_grss_temp"): "Minimum air temperature at 0.05 m above ground.",
-        ("daily", "weather", "drv_24hr_sun_dur"): "Length of time the sun shone unobstructed.",
-        ("daily", "weather", "frsh_snw_amt"): "Depth of snow that fell during the period.",
-        ("daily", "weather", "snow_depth"): "Depth of the snow lying on the ground.",
-        ("hourly", "radiation", "difu_irad_amt"): (
-            "Diffuse short-wave radiation from the sky, accumulated as energy over the interval."
-        ),
-        ("hourly", "radiation", "direct_irad"): (
-            "Direct short-wave radiation from the sun, accumulated as energy over the interval."
-        ),
-        ("hourly", "radiation", "glbl_irad_amt"): (
-            "Global radiation received on a horizontal surface, accumulated as energy over the interval."
-        ),
-        ("hourly", "rain", "prcp_amt"): "Depth of precipitation collected over the period.",
-        ("hourly", "rain", "prcp_dur"): "Length of time during which precipitation fell.",
-        ("hourly", "soil_temperature", "q100cm_soil_temp"): "Mean soil temperature at 1 m depth.",
-        ("hourly", "soil_temperature", "q10cm_soil_temp"): "Mean soil temperature at 0.1 m depth.",
-        ("hourly", "soil_temperature", "q20cm_soil_temp"): "Mean soil temperature at 0.2 m depth.",
-        ("hourly", "soil_temperature", "q50cm_soil_temp"): "Mean soil temperature at 0.5 m depth.",
-        ("hourly", "soil_temperature", "q5cm_soil_temp"): "Mean soil temperature at 0.05 m depth.",
-        ("hourly", "weather", "air_temperature"): "Mean air temperature at 2 m above ground.",
-        ("hourly", "weather", "cld_ttl_amt_id"): "Fraction of the sky covered by cloud of any kind.",
-        ("hourly", "weather", "dewpoint"): (
-            "Dew point at 2 m above ground, the temperature at which the air would become saturated."
-        ),
-        ("hourly", "weather", "msl_pressure"): (
-            "Air pressure reduced to mean sea level, so that stations at different heights compare."
-        ),
-        ("hourly", "weather", "prst_wx_id"): "Coded present weather at the time of observation.",
-        ("hourly", "weather", "q10mnt_mxgst_spd"): "Speed of the strongest gust of the period.",
-        ("hourly", "weather", "rltv_hum"): (
-            "Relative humidity of the air, the fraction of the moisture it could hold at that temperature."
-        ),
-        ("hourly", "weather", "snow_depth"): "Depth of the snow lying on the ground.",
-        ("hourly", "weather", "stn_pres"): "Air pressure as measured at station height.",
-        ("hourly", "weather", "visibility"): "Horizontal distance at which an object can still be made out.",
-        ("hourly", "weather", "wind_direction"): "Direction the wind is blowing from, clockwise from true north.",
-        ("hourly", "weather", "wind_speed"): "Mean speed of the wind over the period.",
-        ("hourly", "weather", "wmo_hr_sun_dur"): "Length of time the sun shone unobstructed.",
-        ("hourly", "wind", "max_gust_dir"): "Direction the strongest gust of the period blew from.",
-        ("hourly", "wind", "max_gust_speed"): "Speed of the strongest gust of the period.",
-        ("hourly", "wind", "mean_wind_dir"): "Direction the wind is blowing from, clockwise from true north.",
-        ("hourly", "wind", "mean_wind_speed"): "Mean speed of the wind over the period.",
-    },
-    "MeteoFranceObservationMetadata": {
-        ("6_minutes", "data", "RR"): "Depth of precipitation collected over the period.",
-        ("daily", "core", "DXI"): "Direction the strongest gust of the period blew from.",
-        ("daily", "core", "FFM"): "Mean speed of the wind over the period.",
-        ("daily", "core", "FXI"): "Speed of the strongest gust of the period.",
-        ("daily", "core", "RR"): "Depth of precipitation collected over the period.",
-        ("daily", "core", "TM"): "Mean air temperature at 2 m above ground.",
-        ("daily", "core", "TN"): "Minimum air temperature at 2 m above ground.",
-        ("daily", "core", "TX"): "Maximum air temperature at 2 m above ground.",
-        ("daily", "others", "GLOT"): (
-            "Global radiation received on a horizontal surface, accumulated as energy over the interval."
-        ),
-        ("daily", "others", "HNEIGEF"): "Depth of snow that fell during the period.",
-        ("daily", "others", "INST"): "Length of time the sun shone unobstructed.",
-        ("daily", "others", "NEIGETOT06"): "Depth of the snow lying on the ground.",
-        ("daily", "others", "PMERM"): (
-            "Air pressure reduced to mean sea level, so that stations at different heights compare."
-        ),
-        ("daily", "others", "TSVM"): "Partial pressure of water vapour in the air.",
-        ("daily", "others", "UM"): (
-            "Relative humidity of the air, the fraction of the moisture it could hold at that temperature."
-        ),
-        ("hourly", "core", "DD"): "Direction the wind is blowing from, clockwise from true north.",
-        ("hourly", "core", "DXY"): "Direction the strongest gust of the period blew from.",
-        ("hourly", "core", "FF"): "Mean speed of the wind over the period.",
-        ("hourly", "core", "FXY"): "Speed of the strongest gust of the period.",
-        ("hourly", "core", "RR1"): "Depth of precipitation collected over the period.",
-        ("hourly", "core", "T"): "Mean air temperature at 2 m above ground.",
-        ("hourly", "core", "TN"): "Minimum air temperature at 2 m above ground.",
-        ("hourly", "core", "TX"): "Maximum air temperature at 2 m above ground.",
-        ("hourly", "others", "GLO"): (
-            "Global radiation received on a horizontal surface, accumulated as energy over the interval."
-        ),
-        ("hourly", "others", "INS"): "Length of time the sun shone unobstructed.",
-        ("hourly", "others", "N"): "Fraction of the sky covered by cloud of any kind.",
-        ("hourly", "others", "PMER"): (
-            "Air pressure reduced to mean sea level, so that stations at different heights compare."
-        ),
-        ("hourly", "others", "PSTAT"): "Air pressure as measured at station height.",
-        ("hourly", "others", "TD"): (
-            "Dew point at 2 m above ground, the temperature at which the air would become saturated."
-        ),
-        ("hourly", "others", "U"): (
-            "Relative humidity of the air, the fraction of the moisture it could hold at that temperature."
-        ),
-        ("hourly", "others", "VV"): "Horizontal distance at which an object can still be made out.",
-        ("monthly", "data", "FFM"): "Mean speed of the wind over the period.",
-        ("monthly", "data", "FXIAB"): "Speed of the strongest gust of the period.",
-        ("monthly", "data", "GLOT"): (
-            "Global radiation received on a horizontal surface, accumulated as energy over the interval."
-        ),
-        ("monthly", "data", "HNEIGEFTOT"): "Depth of snow that fell during the period.",
-        ("monthly", "data", "INST"): "Length of time the sun shone unobstructed.",
-        ("monthly", "data", "PMERM"): (
-            "Air pressure reduced to mean sea level, so that stations at different heights compare."
-        ),
-        ("monthly", "data", "RR"): "Depth of precipitation collected over the period.",
-        ("monthly", "data", "TMM"): "Mean air temperature at 2 m above ground.",
-        ("monthly", "data", "TN"): "Mean of the daily minimum air temperature at 2 m above ground over the period.",
-        ("monthly", "data", "TSVM"): "Partial pressure of water vapour in the air.",
-        ("monthly", "data", "TX"): "Mean of the daily maximum air temperature at 2 m above ground over the period.",
-        ("monthly", "data", "UMM"): (
-            "Relative humidity of the air, the fraction of the moisture it could hold at that temperature."
-        ),
     },
     "MeteoFranceSynopMetadata": {
         ("subdaily", "data", "dd"): "Direction the wind is blowing from, clockwise from true north.",


### PR DESCRIPTION
The first sweep concluded that DMI, Météo-France, RMI, Met Office, CHMI, LHMT and IPMA publish nothing machine-readable, and left all of them on the canonical sentence. Three of them do publish, and looking harder found them.

| provider | source | matched |
|---|---|---|
| Météo-France | `*_descriptif_champs*.csv`, published beside each resolution and linked from the data.gouv.fr dataset (75 daily / 107 hourly / 162 monthly / 8 six-minute documented fields) | **43 of 43** |
| Met Office | the MIDAS table dictionaries CEDA publishes as HTML, across nine table pages | **32 of 32** |
| LHMT | the field list on `api.meteo.lt` | **9 of 9** |

Météo-France is French and LHMT Lithuanian, so those are translated here — the same arrangement as AEMET and SMHI, and the module docstring says which are ours.

## What the canonical sentence could not say

- Météo-France daily precipitation runs **06h UTC to 06h UTC**, and the value recorded on day J+1 is attributed to day J
- its hourly cloud amount uses **9 for a sky invisible through fog** or another phenomenon
- Met Office station pressure is **not corrected for altitude**
- its daily sunshine duration is **derived from global radiation**, at stations carrying radiation sensors only
- LHMT returns **null where cloud cover cannot be determined** through fog — recorded nowhere in this repo until now

## What is left

224 derived descriptions, down from 310:

| | |
|---|---|
| DWD observation | 58 |
| DMI | 52 |
| RMI | 42 |
| CHMI | 25 |
| Météo-France synop | 17 |
| others | 30 |

DMI and RMI I checked and could not find a route: DMI's OGC `collections` metadata carries no parameter descriptions and its documentation paths 404, RMI's WFS `GetCapabilities` has no per-field abstracts. Météo-France's synop has no machine-readable descriptor either — its documentation PDF URL serves HTML.

## Verified

- `test_docs_parameter_descriptions_match_the_model` caught all 84 rows the moment the model changed, which is exactly what it is for; the docs tables follow
- `test_source_descriptions_reach_the_parameter_they_name` confirms each lands on the parameter it names — worth having here, since the Met Office keys had to be re-keyed after I guessed the dataset names wrong at first
- 119 offline tests pass; lint and `ty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)