### PR TITLE
feat: take CHMI and nine DWD forecast codes from the sources that document them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,13 @@ Types of changes:
 
 ### Changed
 
+- 34 more descriptions come from the source. CHMI publishes per-element metadata beside its csv
+  archive -- name, unit, sensor height and measurement schedule -- which gives all 25 of its
+  parameters, translated from Czech and carrying facts the canonical sentence cannot: its daily
+  temperature, humidity, pressure and wind speed are averages of the 06:00, 13:00 and 20:00
+  observations, its daily extremes are read at 20:00 and its snow depth at 06:00. DWD's
+  `MetElementDefinition.xml` covers nine more codes across swsmos, mosmix and dmo. 190 derived
+  descriptions remain
 - Resolution descriptions are written where the name underdetermines what arrives, and only there:
   Météo-France synop (SYNOP's native three-hourly interval), MET Norway's 6 hour, and the two
   `dynamic` networks, WSV and Hubeau, where the interval is a property of the station rather than

--- a/docs/data/provider/chmi/observation/10_minutes.md
+++ b/docs/data/provider/chmi/observation/10_minutes.md
@@ -15,7 +15,7 @@
 
 | name                            | original name | description                                                                                   | unit |
 |---------------------------------|---------------|-----------------------------------------------------------------------------------------------|------|
-| {term}`temperature_air_mean_2m` | T             | Mean air temperature at 2 m above ground.                                                     | °C   |
-| {term}`humidity`                | H             | Relative humidity of the air, the fraction of the moisture it could hold at that temperature. | %    |
-| {term}`pressure_air_site`       | P             | Air pressure as measured at station height.                                                   | hPa  |
-| {term}`wind_speed`              | F             | Mean speed of the wind over the period.                                                       | m/s  |
+| {term}`temperature_air_mean_2m` | T | Air temperature at 2 m, measured every ten minutes. | °C |
+| {term}`humidity` | H | Relative humidity at 2 m, measured every ten minutes. | % |
+| {term}`pressure_air_site` | P | Air pressure at station level, measured every ten minutes. | hPa |
+| {term}`wind_speed` | F | Wind speed at 10 m, measured every ten minutes. | m/s |

--- a/docs/data/provider/chmi/observation/annual.md
+++ b/docs/data/provider/chmi/observation/annual.md
@@ -15,7 +15,7 @@
 
 | name                            | original name | description                                       | unit |
 |---------------------------------|---------------|---------------------------------------------------|------|
-| {term}`temperature_air_mean_2m` | T             | Mean air temperature at 2 m above ground.         | °C   |
-| {term}`temperature_air_max_2m`  | TMA           | Maximum air temperature at 2 m above ground.      | °C   |
-| {term}`temperature_air_min_2m`  | TMI           | Minimum air temperature at 2 m above ground.      | °C   |
-| {term}`precipitation_height`    | SRA           | Depth of precipitation collected over the period. | mm   |
+| {term}`temperature_air_mean_2m` | T | Air temperature at 2 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations. | °C |
+| {term}`temperature_air_max_2m` | TMA | Maximum air temperature at 2 m, read at 20:00 each day. | °C |
+| {term}`temperature_air_min_2m` | TMI | Minimum air temperature at 2 m, read at 20:00 each day. | °C |
+| {term}`precipitation_height` | SRA | Precipitation, read at 06:00 each day. | mm |

--- a/docs/data/provider/chmi/observation/daily.md
+++ b/docs/data/provider/chmi/observation/daily.md
@@ -15,13 +15,13 @@
 
 | name                            | original name | description                                                                                   | unit |
 |---------------------------------|---------------|-----------------------------------------------------------------------------------------------|------|
-| {term}`temperature_air_mean_2m` | T             | Mean air temperature at 2 m above ground.                                                     | °C   |
-| {term}`temperature_air_max_2m`  | TMA           | Maximum air temperature at 2 m above ground.                                                  | °C   |
-| {term}`temperature_air_min_2m`  | TMI           | Minimum air temperature at 2 m above ground.                                                  | °C   |
-| {term}`humidity`                | H             | Relative humidity of the air, the fraction of the moisture it could hold at that temperature. | %    |
-| {term}`precipitation_height`    | SRA           | Depth of precipitation collected over the period.                                             | mm   |
-| {term}`pressure_air_site`       | P             | Air pressure as measured at station height.                                                   | hPa  |
-| {term}`wind_speed`              | F             | Mean speed of the wind over the period.                                                       | m/s  |
-| {term}`wind_gust_max`           | Fmax          | Speed of the strongest gust of the period.                                                    | m/s  |
-| {term}`snow_depth`              | SCE           | Depth of the snow lying on the ground.                                                        | cm   |
-| {term}`sunshine_duration`       | SSV           | Length of time the sun shone unobstructed.                                                    | h    |
+| {term}`temperature_air_mean_2m` | T | Air temperature at 2 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations. | °C |
+| {term}`temperature_air_max_2m` | TMA | Maximum air temperature at 2 m, read at 20:00. | °C |
+| {term}`temperature_air_min_2m` | TMI | Minimum air temperature at 2 m, read at 20:00. | °C |
+| {term}`humidity` | H | Relative humidity at 2 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations. | % |
+| {term}`precipitation_height` | SRA | Precipitation, read at 06:00. | mm |
+| {term}`pressure_air_site` | P | Air pressure at station level, the daily value being the average of the 06:00, 13:00 and 20:00 observations. | hPa |
+| {term}`wind_speed` | F | Wind speed at 10 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations. | m/s |
+| {term}`wind_gust_max` | Fmax | Maximum wind speed at 10 m. | m/s |
+| {term}`snow_depth` | SCE | Snow depth at ground level, read at 06:00. | cm |
+| {term}`sunshine_duration` | SSV | Sunshine duration, in hours. | h |

--- a/docs/data/provider/chmi/observation/hourly.md
+++ b/docs/data/provider/chmi/observation/hourly.md
@@ -15,6 +15,6 @@
 
 | name                                  | original name | description                                                                             | unit |
 |---------------------------------------|---------------|-----------------------------------------------------------------------------------------|------|
-| {term}`temperature_dew_point_mean_2m` | Td            | Dew point at 2 m above ground, the temperature at which the air would become saturated. | °C   |
-| {term}`precipitation_height`          | SRA1H         | Depth of precipitation collected over the period.                                       | mm   |
-| {term}`pressure_air_site`             | P             | Air pressure as measured at station height.                                             | hPa  |
+| {term}`temperature_dew_point_mean_2m` | Td | Dew point temperature at 2 m. | °C |
+| {term}`precipitation_height` | SRA1H | Precipitation over one hour. | mm |
+| {term}`pressure_air_site` | P | Air pressure at station level. | hPa |

--- a/docs/data/provider/chmi/observation/monthly.md
+++ b/docs/data/provider/chmi/observation/monthly.md
@@ -15,7 +15,7 @@
 
 | name                            | original name | description                                       | unit |
 |---------------------------------|---------------|---------------------------------------------------|------|
-| {term}`temperature_air_mean_2m` | T             | Mean air temperature at 2 m above ground.         | °C   |
-| {term}`temperature_air_max_2m`  | TMA           | Maximum air temperature at 2 m above ground.      | °C   |
-| {term}`temperature_air_min_2m`  | TMI           | Minimum air temperature at 2 m above ground.      | °C   |
-| {term}`precipitation_height`    | SRA           | Depth of precipitation collected over the period. | mm   |
+| {term}`temperature_air_mean_2m` | T | Air temperature at 2 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations. | °C |
+| {term}`temperature_air_max_2m` | TMA | Maximum air temperature at 2 m, read at 20:00 each day. | °C |
+| {term}`temperature_air_min_2m` | TMI | Minimum air temperature at 2 m, read at 20:00 each day. | °C |
+| {term}`precipitation_height` | SRA | Precipitation, read at 06:00 each day. | mm |

--- a/docs/data/provider/dwd/dmo/hourly.md
+++ b/docs/data/provider/dwd/dmo/hourly.md
@@ -29,7 +29,7 @@
 | {term}`cloud_base_convective`                              | h_bsc         | Cloud base of convective clouds                                                 | m     | >=0         |
 | {term}`cloud_cover_above_7km`                              | nh            | High cloud cover (>7 km)                                                        | %     | >=0,<=100   |
 | {term}`cloud_cover_below_500ft`                            | n05           | Cloud cover below 500 ft.                                                       | %     | >=0,<=100   |
-| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km) | % | >=0,<=100 |
+| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km). | % | >=0,<=100 |
 | {term}`cloud_cover_below_7km`                              | nlm           | Cloud cover low and mid level clouds below 7000 m                               | %     | >=0,<=100   |
 | {term}`cloud_cover_between_2km_to_7km`                     | nm            | Midlevel cloud cover (2-7 km)                                                   | %     | >=0,<=100   |
 | {term}`cloud_cover_effective`                              | neff          | Effective cloud cover                                                           | %     | >=0,<=100   |
@@ -87,7 +87,7 @@
 |------------------------------------------------------------------|---------------|-------------------------------------------------------------------------------------|-------|-------------|
 | {term}`cloud_cover_above_7km`                                    | nh            | High cloud cover (>7 km)                                                            | %     | >=0,<=100   |
 | {term}`cloud_cover_below_500ft`                                  | n05           | Cloud cover below 500 ft.                                                           | %     | >=0,<=100   |
-| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km) | % | >=0,<=100 |
+| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km). | % | >=0,<=100 |
 | {term}`cloud_cover_between_2km_to_7km`                           | nm            | Midlevel cloud cover (2-7 km)                                                       | %     | >=0,<=100   |
 | {term}`cloud_cover_effective`                                    | neff          | Effective cloud cover                                                               | %     | >=0,<=100   |
 | {term}`cloud_cover_total`                                        | n             | Total cloud cover                                                                   | %     | >=0,<=100   |
@@ -206,4 +206,4 @@
 | {term}`wind_speed`                                               | ff            | Wind speed                                                                          | m/s   | >=0         |
 | {term}`cloud_base_convective` | h_bsc | Cloud base of convective clouds | meter | - |
 | {term}`cloud_cover_below_7km` | nlm | Cloud cover low and mid level clouds below 7000 m | percent | - |
-| {term}`probability_precipitation_last_24h` | wwpd | Probability of precipitation of any kind over the preceding 24 hours. | percent | - |
+| {term}`probability_precipitation_last_24h` | wwpd | Probability: Occurrence of any precipitation within the last 24 hours | percent | - |

--- a/docs/data/provider/dwd/mosmix/hourly.md
+++ b/docs/data/provider/dwd/mosmix/hourly.md
@@ -68,7 +68,7 @@
 | {term}`wind_gust_max_last_3h`                              | fx3           | Maximum wind gust within the last 3 hours                                       | m/s   | >=0         |
 | {term}`wind_gust_max_last_12h`                             | fxh           | Maximum wind gust within the last 12 hours                                      | m/s   | >=0         |
 | {term}`wind_speed`                                         | ff            | Wind speed                                                                      | m/s   | >=0         |
-| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km). | percent | - |
+| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km) | percent | - |
 
 ### Large
 
@@ -206,6 +206,6 @@
 | {term}`wind_gust_max_last_12h`                                   | fxh           | Maximum wind gust within the last 12 hours                                          | m/s   | >=0         |
 | {term}`wind_speed`                                               | ff            | Wind speed                                                                          | m/s   | >=0         |
 | {term}`cloud_base_convective` | h_bsc | Cloud base of convective clouds | meter | - |
-| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km). | percent | - |
+| {term}`cloud_cover_below_1000ft` | nl | Low cloud cover (lower than 2 km) | percent | - |
 | {term}`cloud_cover_below_7km` | nlm | Cloud cover low and mid level clouds below 7000 m | percent | - |
-| {term}`probability_precipitation_last_24h` | wwpd | Probability of precipitation of any kind over the preceding 24 hours. | percent | - |
+| {term}`probability_precipitation_last_24h` | wwpd | Probability: Occurrence of any precipitation within the last 24 hours | percent | - |

--- a/docs/data/provider/dwd/swsmos/hourly.md
+++ b/docs/data/provider/dwd/swsmos/hourly.md
@@ -23,10 +23,10 @@
 | name                                                    | original name | description                                                              | unit |
 |---------------------------------------------------------|---------------|--------------------------------------------------------------------------|------|
 | {term}`temperature_air_mean_2m`                         | TL            | Temperature 2m above surface.                                            | °C   |
-| {term}`temperature_dew_point_mean_2m`                   | TD            | Dewpoint 2m above surface.                                               | °C   |
+| {term}`temperature_dew_point_mean_2m` | TD | DewpointTemperature 2m above surface, measured in Kelvin | °C |
 | {term}`temperature_surface_mean`                        | TS            | Mean temperature of the ground surface.                                  | °C   |
-| {term}`precipitation_height_liquid`                     | RRL1c         | Depth of the liquid part of the precipitation.                           | mm   |
-| {term}`precipitation_height_last_6h`                    | RR6           | Total precipitation during the last 6 hours.                             | mm   |
-| {term}`probability_precipitation_liquid_last_6h`        | WWL6          | Probability: Occurrence of liquid precipitation within the last 6 hours. | %    |
-| {term}`probability_precipitation_height_gt_5mm_last_6h` | R650          | Probability of precipitation > 5.0mm during the last 6 hours.            | %    |
+| {term}`precipitation_height_liquid` | RRL1c | Total liquid precipitation during the last hour consistent with significant weather | mm |
+| {term}`precipitation_height_last_6h` | RR6 | Total precipitation during the last 6 hours | mm |
+| {term}`probability_precipitation_liquid_last_6h` | WWL6 | Probability: Occurrence of liquid precipitation within the last 6 hours | % |
+| {term}`probability_precipitation_height_gt_5mm_last_6h` | R650 | Probability of precipitation > 5.0mm during the last 6 hours | % |
 | {term}`road_surface_condition`                          | RC            | Coded condition of the road surface, such as dry, wet or icy.            | -    |

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -46,6 +46,55 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("dynamic", "data", "H"): "Stage.",
         ("dynamic", "data", "Q"): "Flow.",
     },
+    "ChmiObservationMetadata": {
+        ("10_minutes", "data", "F"): "Wind speed at 10 m, measured every ten minutes.",
+        ("10_minutes", "data", "H"): "Relative humidity at 2 m, measured every ten minutes.",
+        ("10_minutes", "data", "P"): "Air pressure at station level, measured every ten minutes.",
+        ("10_minutes", "data", "T"): "Air temperature at 2 m, measured every ten minutes.",
+        ("annual", "data", "SRA"): "Precipitation, read at 06:00 each day.",
+        ("annual", "data", "T"): (
+            "Air temperature at 2 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations."
+        ),
+        ("annual", "data", "TMA"): "Maximum air temperature at 2 m, read at 20:00 each day.",
+        ("annual", "data", "TMI"): "Minimum air temperature at 2 m, read at 20:00 each day.",
+        ("daily", "data", "F"): (
+            "Wind speed at 10 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations."
+        ),
+        ("daily", "data", "Fmax"): "Maximum wind speed at 10 m.",
+        ("daily", "data", "H"): (
+            "Relative humidity at 2 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations."
+        ),
+        ("daily", "data", "P"): (
+            "Air pressure at station level, the daily value being the average of the 06:00, 13:00 and "
+            "20:00 observations."
+        ),
+        ("daily", "data", "SCE"): "Snow depth at ground level, read at 06:00.",
+        ("daily", "data", "SRA"): "Precipitation, read at 06:00.",
+        ("daily", "data", "SSV"): "Sunshine duration, in hours.",
+        ("daily", "data", "T"): (
+            "Air temperature at 2 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations."
+        ),
+        ("daily", "data", "TMA"): "Maximum air temperature at 2 m, read at 20:00.",
+        ("daily", "data", "TMI"): "Minimum air temperature at 2 m, read at 20:00.",
+        ("hourly", "data", "P"): "Air pressure at station level.",
+        ("hourly", "data", "SRA1H"): "Precipitation over one hour.",
+        ("hourly", "data", "Td"): "Dew point temperature at 2 m.",
+        ("monthly", "data", "SRA"): "Precipitation, read at 06:00 each day.",
+        ("monthly", "data", "T"): (
+            "Air temperature at 2 m, the daily value being the average of the 06:00, 13:00 and 20:00 observations."
+        ),
+        ("monthly", "data", "TMA"): "Maximum air temperature at 2 m, read at 20:00 each day.",
+        ("monthly", "data", "TMI"): "Minimum air temperature at 2 m, read at 20:00 each day.",
+    },
+    "DwdSwsmosMetadata": {
+        ("hourly", "data", "R650"): "Probability of precipitation > 5.0mm during the last 6 hours",
+        ("hourly", "data", "RR6"): "Total precipitation during the last 6 hours",
+        ("hourly", "data", "RRL1c"): (
+            "Total liquid precipitation during the last hour consistent with significant weather"
+        ),
+        ("hourly", "data", "TD"): "DewpointTemperature 2m above surface, measured in Kelvin",
+        ("hourly", "data", "WWL6"): "Probability: Occurrence of liquid precipitation within the last 6 hours",
+    },
     "DwdDerivedMetadata": {
         ("hourly", "radiation_global", "qn_952"): "Quality flag.",
         ("hourly", "sunshine_duration", "qn_952"): "Quality flag.",
@@ -146,6 +195,7 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("monthly", "soil", "summe von vrws_ag"): "sum of evaporation height for winter wheat on sand",
     },
     "DwdDmoMetadata": {
+        ("hourly", "icon", "wwpd"): "Probability: Occurrence of any precipitation within the last 24 hours",
         ("hourly", "icon", "nl"): "Low cloud cover (lower than 2 km).",
         ("hourly", "icon_eu", "nl"): "Low cloud cover (lower than 2 km).",
         ("hourly", "icon", "dd"): "Wind direction",
@@ -313,6 +363,9 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("hourly", "icon_eu", "wwmh"): "Probability for fog within the last 12 hours",
     },
     "DwdMosmixMetadata": {
+        ("hourly", "large", "nl"): "Low cloud cover (lower than 2 km)",
+        ("hourly", "small", "nl"): "Low cloud cover (lower than 2 km)",
+        ("hourly", "large", "wwpd"): "Probability: Occurrence of any precipitation within the last 24 hours",
         ("hourly", "large", "dd"): "Wind direction",
         ("hourly", "large", "drr1"): "Duration of precipitation within the last hour",
         ("hourly", "large", "e_dd"): "Absolute error wind direction",
@@ -2154,14 +2207,8 @@ DERIVED_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("monthly", "cooling_degreehours_16", "Kuehltage"): "Number of days on which cooling was required.",
         ("monthly", "cooling_degreehours_18", "Kuehltage"): "Number of days on which cooling was required.",
     },
-    "DwdDmoMetadata": {
-        ("hourly", "icon", "wwpd"): "Probability of precipitation of any kind over the preceding 24 hours.",
-    },
-    "DwdMosmixMetadata": {
-        ("hourly", "large", "nl"): "Low cloud cover (lower than 2 km).",
-        ("hourly", "large", "wwpd"): "Probability of precipitation of any kind over the preceding 24 hours.",
-        ("hourly", "small", "nl"): "Low cloud cover (lower than 2 km).",
-    },
+    "DwdDmoMetadata": {},
+    "DwdMosmixMetadata": {},
     "DwdObservationMetadata": {
         ("10_minutes", "precipitation", "qn"): (
             "Quality flag published by the source for the values in the same dataset."
@@ -2273,47 +2320,9 @@ DERIVED_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("subdaily", "wind", "qn_4"): "Quality flag published by the source for the values in the same dataset.",
     },
     "DwdSwsmosMetadata": {
-        ("hourly", "data", "R650"): "Probability of precipitation > 5.0mm during the last 6 hours.",
         ("hourly", "data", "RC"): "Coded condition of the road surface, such as dry, wet or icy.",
-        ("hourly", "data", "RR6"): "Total precipitation during the last 6 hours.",
-        ("hourly", "data", "RRL1c"): "Depth of the liquid part of the precipitation.",
-        ("hourly", "data", "TD"): "Dewpoint 2m above surface.",
         ("hourly", "data", "TL"): "Temperature 2m above surface.",
         ("hourly", "data", "TS"): "Mean temperature of the ground surface.",
-        ("hourly", "data", "WWL6"): "Probability: Occurrence of liquid precipitation within the last 6 hours.",
-    },
-    "ChmiObservationMetadata": {
-        ("10_minutes", "data", "F"): "Mean speed of the wind over the period.",
-        ("10_minutes", "data", "H"): (
-            "Relative humidity of the air, the fraction of the moisture it could hold at that temperature."
-        ),
-        ("10_minutes", "data", "P"): "Air pressure as measured at station height.",
-        ("10_minutes", "data", "T"): "Mean air temperature at 2 m above ground.",
-        ("annual", "data", "SRA"): "Depth of precipitation collected over the period.",
-        ("annual", "data", "T"): "Mean air temperature at 2 m above ground.",
-        ("annual", "data", "TMA"): "Maximum air temperature at 2 m above ground.",
-        ("annual", "data", "TMI"): "Minimum air temperature at 2 m above ground.",
-        ("daily", "data", "F"): "Mean speed of the wind over the period.",
-        ("daily", "data", "Fmax"): "Speed of the strongest gust of the period.",
-        ("daily", "data", "H"): (
-            "Relative humidity of the air, the fraction of the moisture it could hold at that temperature."
-        ),
-        ("daily", "data", "P"): "Air pressure as measured at station height.",
-        ("daily", "data", "SCE"): "Depth of the snow lying on the ground.",
-        ("daily", "data", "SRA"): "Depth of precipitation collected over the period.",
-        ("daily", "data", "SSV"): "Length of time the sun shone unobstructed.",
-        ("daily", "data", "T"): "Mean air temperature at 2 m above ground.",
-        ("daily", "data", "TMA"): "Maximum air temperature at 2 m above ground.",
-        ("daily", "data", "TMI"): "Minimum air temperature at 2 m above ground.",
-        ("hourly", "data", "P"): "Air pressure as measured at station height.",
-        ("hourly", "data", "SRA1H"): "Depth of precipitation collected over the period.",
-        ("hourly", "data", "Td"): (
-            "Dew point at 2 m above ground, the temperature at which the air would become saturated."
-        ),
-        ("monthly", "data", "SRA"): "Depth of precipitation collected over the period.",
-        ("monthly", "data", "T"): "Mean air temperature at 2 m above ground.",
-        ("monthly", "data", "TMA"): "Maximum air temperature at 2 m above ground.",
-        ("monthly", "data", "TMI"): "Minimum air temperature at 2 m above ground.",
     },
     "DmiObservationMetadata": {
         ("annual", "data", "acc_heating_degree_days_17"): (


### PR DESCRIPTION
Probing the providers still on the canonical fallback. Two more publish what they measure; the rest genuinely do not, and this records why so nobody probes them again.

## CHMI — all 25

CHMI puts `metadata/meta2.csv` beside its csv archive: one row per station and period carrying the element abbreviation, its Czech name, unit, sensor height and **measurement schedule**.

The schedule is the part worth having, because it is not guessable from the element name:

| | |
|---|---|
| daily `T`, `H`, `P`, `F` | the average of the **06:00, 13:00 and 20:00** observations |
| daily `TMA`, `TMI` | read at **20:00** |
| daily `SCE` (snow depth) | read at **06:00** |

Translated from Czech, the same arrangement as AEMET, SMHI, LHMT and Météo-France.

## DWD forecast codes — nine

`MetElementDefinition.xml` — already linked from the mosmix docs as its "description file", and never used — defines the forecast element codes: five of swsmos's eight, mosmix `nl` and `wwpd`, and dmo `wwpd`. Its wording is used as published.

## What the probe found elsewhere

Recorded so the same ground is not covered twice:

- **DWD observation's 58** are every one a **quality column** (`qn`, `qn_4`, `qn_8`, `qn_592`, …). They already describe what a quality flag is, which is the whole of what there is to say — the quality byte levels are a table in the docs, not per-column prose. Not a gap.
- **IMGW's 6** are Polish column names that already read as their own description (`suma opadu dzień`). `Opis.txt` documents how the files are organised, not what the columns mean.
- **swsmos `RC`, `TL`, `TS`** are road-MOS codes absent from `MetElementDefinition.xml`.
- **DMI (52) and RMI (42)**, the two largest remaining, were probed earlier: DMI's OGC collections metadata carries no parameter descriptions and its docs paths 404; RMI's WFS capabilities have no per-field abstracts.

## Where that leaves it

**190 derived**, down from 310 when this started: DWD observation 58 (quality columns), DMI 52, RMI 42, Météo-France synop 17, IPMA 7, IMGW 6, and 8 others. Of those, only IPMA and ECCC's two remain genuinely unprobed.

## Verified

119 offline tests, lint and `ty` clean; docs tables follow the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)