### PR TITLE
fix: do not tell swsmos users their dew point is in Kelvin

### DIFF
--- a/docs/data/provider/dwd/swsmos/hourly.md
+++ b/docs/data/provider/dwd/swsmos/hourly.md
@@ -23,7 +23,7 @@
 | name                                                    | original name | description                                                              | unit |
 |---------------------------------------------------------|---------------|--------------------------------------------------------------------------|------|
 | {term}`temperature_air_mean_2m`                         | TL            | Temperature 2m above surface.                                            | °C   |
-| {term}`temperature_dew_point_mean_2m` | TD | DewpointTemperature 2m above surface, measured in Kelvin | °C |
+| {term}`temperature_dew_point_mean_2m` | TD | Dew point temperature 2m above surface. | °C |
 | {term}`temperature_surface_mean`                        | TS            | Mean temperature of the ground surface.                                  | °C   |
 | {term}`precipitation_height_liquid` | RRL1c | Total liquid precipitation during the last hour consistent with significant weather | mm |
 | {term}`precipitation_height_last_6h` | RR6 | Total precipitation during the last 6 hours | mm |

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -33,6 +33,9 @@ are taken as they come:
 - Météo-France: the `*_descriptif_champs*.csv` published beside each resolution, translated from
   French
 - Met Office: the MIDAS table dictionaries CEDA publishes, already in English
+- DWD forecast codes: `MetElementDefinition.xml`. It defines the MOSMIX elements, and swsmos reuses
+  their names while publishing different units -- MOSMIX `TD` is Kelvin, swsmos `TD` is Celsius -- so
+  its wording is used only where it says nothing about the unit
 
 The AEMET, SMHI, LHMT and Météo-France translations are ours. Everything else in this table is the
 source's own wording, so a sentence here can be checked against what the provider says.
@@ -92,7 +95,7 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("hourly", "data", "RRL1c"): (
             "Total liquid precipitation during the last hour consistent with significant weather"
         ),
-        ("hourly", "data", "TD"): "DewpointTemperature 2m above surface, measured in Kelvin",
+        ("hourly", "data", "TD"): "Dew point temperature 2m above surface.",
         ("hourly", "data", "WWL6"): "Probability: Occurrence of liquid precipitation within the last 6 hours",
     },
     "DwdDerivedMetadata": {

--- a/tests/provider/dwd/swsmos/test_api.py
+++ b/tests/provider/dwd/swsmos/test_api.py
@@ -102,3 +102,10 @@ def test_swsmos_values() -> None:
     air = df.filter(pl.col("parameter") == "temperature_air_mean_2m")["value"].drop_nulls()
     assert air.min() > -40.0
     assert air.max() < 55.0
+    # dew point likewise -- swsmos publishes Celsius, unlike MOSMIX's Kelvin, and the whole of
+    # Germany reading above 250 would mean we had silently inherited the MOSMIX unit
+    dew_point = df.filter(pl.col("parameter") == "temperature_dew_point_mean_2m")["value"].drop_nulls()
+    assert dew_point.min() > -40.0
+    assert dew_point.max() < 40.0
+    # and it cannot exceed the air temperature it is measured against
+    assert dew_point.max() <= air.max()


### PR DESCRIPTION
#1832 took the swsmos element wording from DWD's `MetElementDefinition.xml`. That file defines the **MOSMIX** elements, and swsmos reuses their names — so for `TD` the description carried a unit claim into a place where it does not hold:

> DewpointTemperature 2m above surface, **measured in Kelvin**

while swsmos declares `degree_celsius` and the parser converts nothing.

## Which one is wrong

Checked against the data rather than reasoned about. Station A006, unit conversion off:

```
n=167  min=10.9  max=19.9  mean=15.8
```

Celsius. So the **declared unit is right and my description was wrong** — and MOSMIX really is Kelvin (`degree_kelvin` on both `td` and `ttt`), which is why the XML says what it says.

## Scope

Only `TD` carried a unit claim. The other four lifted from that file — `R650`, `RR6`, `RRL1c`, `WWL6` — are unit-neutral and unaffected.

The module docstring now records the constraint, so the next lift from `MetElementDefinition.xml` does not repeat it: its wording is usable for swsmos only where it says nothing about the unit.

Raised by Copilot on #1832 — a good catch, and the second time this week that writing a description next to a declaration exposed a disagreement between them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)