### PR TITLE
perf(frontend): stop fetching Plotly on mount and the station list twice

### DIFF
--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -22,11 +22,14 @@ Types of changes:
   the data viewer mounted -- before any chart existed, and regardless of the view mode, which
   defaults to the table. It is fetched the first time a chart is actually rendered now, so opening
   Explorer and reading the table no longer pays for it. Explorer is the only page that mounts the
-  data viewer, which is why it alone felt slow to appear
+  data viewer. This is not an initial-page-load fix: the viewer mounts after a query is run, and
+  Explorer measures the same as the other pages on first load
 - `[Explorer/History]` The station list was fetched twice, 332 KB each time for DWD daily climate
   summary. `useFetch` refetches on its own when its reactive query changes, and `fetchStations()`
   also calls `refresh()`; the request is driven explicitly here, so the automatic watch is off now.
-  Measured in a browser against a local build: one request where there were two
+  Measured in a browser against a local build: one request where there were two. Changing
+  parameters with a picker open refetches explicitly, which the automatic watch used to cover --
+  without it an expanded map lost its markers and stayed empty until it was reopened
 
 ### Changed
 

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -16,6 +16,14 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[Explorer]` Plotly, at 1.0 MB the largest chunk in the build, was fetched and parsed as soon as
+  the data viewer mounted -- before any chart existed, and regardless of the view mode, which
+  defaults to the table. It is fetched the first time a chart is actually rendered now, so opening
+  Explorer and reading the table no longer pays for it. Explorer is the only page that mounts the
+  data viewer, which is why it alone felt slow to appear
+
 ### Changed
 
 - `[Parameter selection]` Follow the nested shape `GET /api/coverage` now returns. Datasets were

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -23,6 +23,10 @@ Types of changes:
   defaults to the table. It is fetched the first time a chart is actually rendered now, so opening
   Explorer and reading the table no longer pays for it. Explorer is the only page that mounts the
   data viewer, which is why it alone felt slow to appear
+- `[Explorer/History]` The station list was fetched twice, 332 KB each time for DWD daily climate
+  summary. `useFetch` refetches on its own when its reactive query changes, and `fetchStations()`
+  also calls `refresh()`; the request is driven explicitly here, so the automatic watch is off now.
+  Measured in a browser against a local build: one request where there were two
 
 ### Changed
 

--- a/frontend/app/components/DataViewer.vue
+++ b/frontend/app/components/DataViewer.vue
@@ -54,6 +54,18 @@ const facetChartRefs = ref<Map<string, HTMLDivElement>>(new Map())
 // Plotly instance (loaded client-side only)
 const plotlyLoaded = ref(false)
 let Plotly: typeof import('plotly.js-basic-dist-min') | null = null
+// Plotly is ~1 MB, and the default view is the table -- so it is fetched when a chart is first
+// actually wanted rather than on mount. The promise is kept so concurrent callers share one import.
+let plotlyImport: Promise<typeof import('plotly.js-basic-dist-min')> | null = null
+
+async function ensurePlotly(): Promise<typeof import('plotly.js-basic-dist-min')> {
+  if (Plotly)
+    return Plotly
+  plotlyImport ??= import('plotly.js-basic-dist-min')
+  Plotly = await plotlyImport
+  plotlyLoaded.value = true
+  return Plotly
+}
 
 // Parameter label format options and chart display
 // Options: 'parameter' (default), 'dataset/parameter', 'resolution/dataset/parameter'
@@ -452,10 +464,11 @@ async function downloadValues(format: string, extension: string) {
 }
 
 async function downloadChartImage(format: 'png' | 'jpeg' | 'svg') {
-  if (!Plotly || !chartRef.value)
+  if (!chartRef.value)
     return
 
-  await Plotly.downloadImage(chartRef.value, {
+  const plotly = await ensurePlotly()
+  await plotly.downloadImage(chartRef.value, {
     format: format === 'jpeg' ? 'jpeg' : format === 'svg' ? 'svg' : 'png',
     filename: 'chart',
     // Plotly expects number | undefined for width/height; use undefined to let it auto-size
@@ -784,20 +797,22 @@ const plotlyConfig: Partial<PlotlyConfig> = {
 
 // Render chart helper functions
 async function renderMainChart() {
-  if (!Plotly || !plotlyLoaded.value || viewMode.value !== 'graph' || facetByParameter.value)
+  if (viewMode.value !== 'graph' || facetByParameter.value)
     return
+  const plotly = await ensurePlotly()
 
   await nextTick()
   if (chartRef.value && chartTraces.value.length > 0) {
     // Use newPlot for clean initialization
-    Plotly.purge(chartRef.value)
-    await Plotly.newPlot(chartRef.value, chartTraces.value, chartLayout.value, plotlyConfig)
+    plotly.purge(chartRef.value)
+    await plotly.newPlot(chartRef.value, chartTraces.value, chartLayout.value, plotlyConfig)
   }
 }
 
 async function renderFacetedCharts() {
-  if (!Plotly || !plotlyLoaded.value || viewMode.value !== 'graph' || !facetByParameter.value)
+  if (viewMode.value !== 'graph' || !facetByParameter.value)
     return
+  const plotly = await ensurePlotly()
 
   await nextTick()
   for (const facet of facetedChartData.value) {
@@ -817,17 +832,14 @@ async function renderFacetedCharts() {
         },
         autosize: true,
       }
-      await Plotly.react(el, facet.traces, layout, plotlyConfig)
+      await plotly.react(el, facet.traces, layout, plotlyConfig)
     }
   }
 }
 
-// Load Plotly and render charts
+// Render whatever the current view calls for. In table view -- the default -- this does no work
+// and, importantly, does not reach for Plotly.
 onMounted(async () => {
-  Plotly = await import('plotly.js-basic-dist-min')
-  plotlyLoaded.value = true
-
-  // Initial render after Plotly loads
   if (facetByParameter.value) {
     await renderFacetedCharts()
   }

--- a/frontend/app/components/DataViewer.vue
+++ b/frontend/app/components/DataViewer.vue
@@ -52,7 +52,6 @@ const chartRef = ref<HTMLDivElement | null>(null)
 const facetChartRefs = ref<Map<string, HTMLDivElement>>(new Map())
 
 // Plotly instance (loaded client-side only)
-const plotlyLoaded = ref(false)
 let Plotly: typeof import('plotly.js-basic-dist-min') | null = null
 // Plotly is ~1 MB, and the default view is the table -- so it is fetched when a chart is first
 // actually wanted rather than on mount. The promise is kept so concurrent callers share one import.
@@ -61,9 +60,14 @@ let plotlyImport: Promise<typeof import('plotly.js-basic-dist-min')> | null = nu
 async function ensurePlotly(): Promise<typeof import('plotly.js-basic-dist-min')> {
   if (Plotly)
     return Plotly
-  plotlyImport ??= import('plotly.js-basic-dist-min')
+  // A rejected import must not stay cached: every later call would await the same rejection and the
+  // chart would never render again, though a retry would have worked. The realistic cause is a
+  // redeploy invalidating the hashed chunk under an open tab.
+  plotlyImport ??= import('plotly.js-basic-dist-min').catch((error) => {
+    plotlyImport = null
+    throw error
+  })
   Plotly = await plotlyImport
-  plotlyLoaded.value = true
   return Plotly
 }
 

--- a/frontend/app/components/StationSelection.vue
+++ b/frontend/app/components/StationSelection.vue
@@ -56,8 +56,8 @@ const { data: stationsData, pending: stationsPending, error: stationsError, refr
     immediate: false,
     // The query is reactive, and `useFetch` refetches on its own when it changes -- which,
     // together with the explicit `refreshStations()` in `fetchStations`, fetched the whole
-    // station list twice. Fetching is driven explicitly here; a parameter change clears the
-    // list and resets `stationsLoaded`, so the next open refetches.
+    // station list twice. Fetching is driven explicitly here instead: a parameter change clears
+    // the list and refetches if a picker is open, otherwise the next open does it.
     watch: false,
     default: () => ({ stations: [] }),
   },
@@ -131,9 +131,10 @@ watch(() => props.parameterSelection, (ps) => {
   // Parameters changed -- any previously fetched station list is now stale.
   stationsData.value = { stations: [] }
   stationsLoaded.value = false
-  // Fetch right away only to restore stations preselected via a shared URL;
-  // otherwise wait until the picker is opened.
-  if (props.initialStationIds?.length && !hasRestoredInitialStations.value) {
+  // Fetch right away only to restore stations preselected via a shared URL, or when a picker is
+  // open on screen right now -- an expanded map whose markers were just cleared would otherwise
+  // stay empty until it is collapsed and reopened. Otherwise wait until the picker is opened.
+  if ((props.initialStationIds?.length && !hasRestoredInitialStations.value) || selectOpen.value || showMap.value) {
     fetchStations()
   }
 }, { deep: true, immediate: true })

--- a/frontend/app/components/StationSelection.vue
+++ b/frontend/app/components/StationSelection.vue
@@ -54,6 +54,11 @@ const { data: stationsData, pending: stationsPending, error: stationsError, refr
       all: 'true',
     })),
     immediate: false,
+    // The query is reactive, and `useFetch` refetches on its own when it changes -- which,
+    // together with the explicit `refreshStations()` in `fetchStations`, fetched the whole
+    // station list twice. Fetching is driven explicitly here; a parameter change clears the
+    // list and resets `stationsLoaded`, so the next open refetches.
+    watch: false,
     default: () => ({ stations: [] }),
   },
 )

--- a/frontend/tests/nuxt/components/station-selection.test.ts
+++ b/frontend/tests/nuxt/components/station-selection.test.ts
@@ -132,6 +132,60 @@ describe('stationSelection', () => {
     expect(vm.allStations).toEqual(stationsResponse.stations)
   })
 
+  it('fetches the station list once, not twice', async () => {
+    // `useFetch` refetches on its own when its reactive query changes, and `fetchStations` also
+    // refreshes explicitly -- which fetched the whole list (332 kB for dwd daily) twice per open.
+    let calls = 0
+    registerEndpoint('/api/stations', () => {
+      calls++
+      return stationsResponse
+    })
+
+    const wrapper = await mountSuspended(StationSelection, {
+      props: { parameterSelection, multiple: true },
+      attachTo: document.body,
+    })
+    const vm = wrapper.vm as any
+    vm.selectOpen = true
+    await wrapper.vm.$nextTick()
+    await new Promise(resolve => setTimeout(resolve, 100))
+    await wrapper.vm.$nextTick()
+
+    expect(calls).toBe(1)
+  })
+
+  it('refetches when parameters change while a picker is open', async () => {
+    // Changing parameters clears the list, since it is now for the wrong dataset. With a picker
+    // open on screen -- the map stays expanded while parameters are edited above it -- that leaves
+    // it visibly empty, so the refetch has to happen without waiting for a reopen.
+    let calls = 0
+    registerEndpoint('/api/stations', () => {
+      calls++
+      return stationsResponse
+    })
+
+    const wrapper = await mountSuspended(StationSelection, {
+      props: { parameterSelection, multiple: true },
+      attachTo: document.body,
+    })
+    const vm = wrapper.vm as any
+    vm.selectOpen = true
+    await wrapper.vm.$nextTick()
+    await new Promise(resolve => setTimeout(resolve, 100))
+    await wrapper.vm.$nextTick()
+
+    expect(calls).toBe(1)
+
+    await wrapper.setProps({
+      parameterSelection: { ...parameterSelection, dataset: 'precipitation_more', parameters: ['precipitation_height'] },
+    })
+    await new Promise(resolve => setTimeout(resolve, 100))
+    await wrapper.vm.$nextTick()
+
+    expect(calls).toBe(2)
+    expect(vm.allStations).toEqual(stationsResponse.stations)
+  })
+
   it('does not fetch anything while parameters are unselected', async () => {
     let calls = 0
     registerEndpoint('/api/stations', () => {


### PR DESCRIPTION
Two measured wins in the Explorer flow. **Neither is the reported "clicking Explorer in the nav is sometimes slow"** — I could not reproduce that, and the measurements are below so the next person does not start from scratch.

## What is fixed

**Plotly was fetched on mount, not on use.** `DataViewer.onMounted` did `await import('plotly.js-basic-dist-min')` — 1.0 MB, the largest chunk in the build — unconditionally, while `viewMode` defaults to `'table'`. It now loads inside a memoised `ensurePlotly()` called from the two render paths, which return early unless the view is a graph. Explorer is the only page that mounts `DataViewer`.

**The station list was fetched twice.** 332 KB each, for DWD daily climate summary. `useFetch` refetches on its own when its reactive `query` changes, and `fetchStations()` also calls `refresh()`. Fetching is driven explicitly here, so the automatic watch is off — `DataViewer` already does this for its values request. Traced in a browser before and after: two responses became one.

## What I measured, and did not find

Chromium via Playwright, cold cache, against the live site:

| page | ms (8 runs) |
|---|---|
| explorer | 650–914 |
| history | 635–692 |
| glossary | 453–485 |

~50 ms apart — not a user-visible difference. `/api/coverage` answered in 0.14–0.20 s every time. Locally against a production build, Explorer and History were identical at 248 ms.

For the nav-click path specifically, on a throttled connection (500 kB/s, 150 ms latency) with the click issued immediately so prefetch could not help:

| build | explorer | history |
|---|---|---|
| current | 1481 / 1465 / 1473 ms | 1483 / 1495 / 1521 ms |
| with conditional components made lazy | 1416 / 1394 / 1401 ms | 1411 / 1407 / 1411 ms |

Explorer tracks History in both. On a fast connection the nav click fetched **0 KB** — Nuxt's `NuxtLink` had already prefetched the route.

## What I tried and dropped

Making `DataViewer`, `DateRangeSelector` and `InterpolationSummarySelection` lazy — they are rendered only once a location is chosen, but were statically imported, so they sat in the route's eager chunk graph. That does cut it from 904 KB to 784 KB. But it produced no wall-clock improvement in the table above, and it breaks an Explorer test because async components resolve a tick later. Not worth the complexity for an unproven win, so it is not in this PR.

## Still open

I hit `500 - Too Many Requests` from `wetterdienst.eobs.org` while sampling it, and stopped. Worth considering as a candidate for the intermittent delay: if the limiter trips for real users, it would look exactly like one, and Explorer issues the most requests of any page.

## Verified

213 frontend tests, `pnpm typecheck` and `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)