### PR TITLE
fix(ci): stop redeploying the live frontend from pull requests

### DIFF
--- a/.github/workflows/docker-publish-frontend.yml
+++ b/.github/workflows/docker-publish-frontend.yml
@@ -98,13 +98,16 @@ jobs:
           echo "Labels:    ${{ steps.meta.outputs.labels }}"
 
   # Builds each platform natively on its own runner (no QEMU emulation) and
-  # pushes an untagged, digest-addressed image. linux/arm64 under QEMU
+  # pushes an untagged, digest-addressed image (release/nightly/manual only --
+  # a pull request is checked by build_and_test_frontend above, which does not
+  # push). linux/arm64 under QEMU
   # emulation on an amd64 runner took ~17 minutes (mostly `pnpm run build`,
   # which is CPU-bound and emulates very poorly); native arm64 runners
   # (free for public repos: https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/)
   # build at native speed instead.
   docker_frontend_build:
     needs: docker_meta
+    if: ${{ github.event_name != 'pull_request' }}
     strategy:
       fail-fast: false
       matrix:
@@ -163,9 +166,12 @@ jobs:
           retention-days: 1
 
   # Combines the per-platform digests into a single multi-arch manifest under
-  # the real tags, then deploys.
+  # the real tags, then deploys. Not on pull requests: the last step calls the Coolify deploy
+  # hook, which redeploys the live site, and a proposed change must not do that. The backend
+  # workflow guards its publish jobs the same way.
   docker_frontend_merge:
     needs: [ docker_meta, docker_frontend_build ]
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/docker-publish-frontend.yml
+++ b/.github/workflows/docker-publish-frontend.yml
@@ -54,11 +54,12 @@ jobs:
           cache-to: type=gha,mode=max
 
   # Computes the version/tags/labels once, shared by the per-platform build jobs
-  # and the final manifest-merge job.
+  # and the final manifest-merge job. Both of those are release/nightly only, so this is too --
+  # on a pull request it would compute tags no remaining job reads.
   docker_meta:
     needs: build_and_test_frontend
     runs-on: ubuntu-latest
-    if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
+    if: ${{ github.event_name != 'pull_request' && ! startsWith(github.actor, 'dependabot') }}
     outputs:
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
@@ -88,7 +89,6 @@ jobs:
             ghcr.io/${{ env.IMAGE_NAME_FRONTEND }}
           tags: |
             type=schedule,pattern=nightly
-            type=ref,event=pr
             type=semver,pattern={{version}},value=v${{ steps.version.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=v${{ steps.version.outputs.version }}
 
@@ -98,9 +98,10 @@ jobs:
           echo "Labels:    ${{ steps.meta.outputs.labels }}"
 
   # Builds each platform natively on its own runner (no QEMU emulation) and
-  # pushes an untagged, digest-addressed image (release/nightly/manual only --
-  # a pull request is checked by build_and_test_frontend above, which does not
-  # push). linux/arm64 under QEMU
+  # pushes an untagged, digest-addressed image. Releases and the nightly schedule only --
+  # a pull request is checked by build_and_test_frontend above, which does not push, and a
+  # workflow_dispatch produces tags only when it is dispatched from a frontend-v* tag.
+  # linux/arm64 under QEMU
   # emulation on an amd64 runner took ~17 minutes (mostly `pnpm run build`,
   # which is CPU-bound and emulates very poorly); native arm64 runners
   # (free for public repos: https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/)

--- a/.github/workflows/docker-publish-frontend.yml
+++ b/.github/workflows/docker-publish-frontend.yml
@@ -54,8 +54,8 @@ jobs:
           cache-to: type=gha,mode=max
 
   # Computes the version/tags/labels once, shared by the per-platform build jobs
-  # and the final manifest-merge job. Both of those are release/nightly only, so this is too --
-  # on a pull request it would compute tags no remaining job reads.
+  # and the final manifest-merge job. Skipped on pull requests along with both of them, so it
+  # does not burn a runner computing tags no remaining job reads.
   docker_meta:
     needs: build_and_test_frontend
     runs-on: ubuntu-latest
@@ -97,10 +97,11 @@ jobs:
           echo "Tags:      ${{ steps.meta.outputs.tags }}"
           echo "Labels:    ${{ steps.meta.outputs.labels }}"
 
-  # Builds each platform natively on its own runner (no QEMU emulation) and
-  # pushes an untagged, digest-addressed image. Releases and the nightly schedule only --
-  # a pull request is checked by build_and_test_frontend above, which does not push, and a
-  # workflow_dispatch produces tags only when it is dispatched from a frontend-v* tag.
+  # Builds each platform natively on its own runner (no QEMU emulation) and pushes an untagged,
+  # digest-addressed image. Not on pull requests: those are checked by build_and_test_frontend
+  # above, which builds the same target without pushing. Every other event does run this --
+  # a workflow_dispatch from a branch included, though that one cannot get as far as deploying,
+  # since no tag is computed for it and the merge job fails on the empty tag list.
   # linux/arm64 under QEMU
   # emulation on an amd64 runner took ~17 minutes (mostly `pnpm run build`,
   # which is CPU-bound and emulates very poorly); native arm64 runners


### PR DESCRIPTION
## What

`docker_frontend_merge` in `docker-publish-frontend.yml` ends by calling the Coolify deploy hook, and nothing kept it off pull requests. Every push to a branch touching `frontend/**` redeployed `wetterdienst.eobs.org`.

The backend workflow already guards both of its publish jobs this way (`docker-publish.yml:74` and `:146`); the frontend workflow simply never got the same guard.

## Evidence

Not inferred — run [31830468262](https://github.com/earthobservations/wetterdienst/actions/runs/31830468262), a `pull_request` event, executed step 9 *Deploy to Coolify* to success. All eight most recent runs of this workflow were `pull_request` events.

## Impact

Coolify pulls whatever tag its application is pinned to, so a proposed change was **not** shipped to production. But the live container was cycled on every push to every frontend branch. A cold Nitro start is a plausible source of the intermittent first-load slowness reported on the site, which never reproduced in local measurement and improved without the change that was supposed to fix it ever being merged.

## Change

`if: ${{ github.event_name != 'pull_request' }}` on the three jobs that exist only to publish:

- `docker_frontend_merge` — the job that deploys
- `docker_frontend_build` — which on a pull request pushed digest-addressed blobs to GHCR that no manifest ever referenced
- `docker_meta` — whose only consumers are the two above, so on a pull request it burned a runner computing tags nothing reads

Two things fall out of that: the `github.event.pull_request.head.repo.fork` condition on `docker_meta` is redundant once pull requests are excluded outright, and `type=ref,event=pr` could only ever have emitted on the event `docker_meta` no longer runs on. Both removed.

`build_and_test_frontend` is untouched: it still builds the production image on every pull request, it just does not push. `zizmor` reports no findings.

## Known tradeoff: arm64 is no longer built on pull requests

`build_and_test_frontend` builds only the runner's native platform (amd64, `load: true`, no `platforms:`), so the skipped `docker_frontend_build` matrix takes `linux/arm64` coverage with it. A `frontend/package.json` change pulling a dependency with no arm64 prebuilt binary — the esbuild/sharp/rollup family Nuxt drags in — would now pass PR CI and first fail in the 10:00 nightly.

Accepted deliberately: it is the same tradeoff the backend workflow already makes, and the alternative is either pushing from pull requests (the bug being fixed) or paying for a second matrix build on every PR. Flagging it so it is a decision rather than a surprise.

## Noted, not fixed here

`workflow_dispatch` from a branch cannot publish: `steps.version` falls through to `version=latest`, both `type=semver` entries get `value=vlatest` which is not valid semver, and no tag is produced — leaving `docker buildx imagetools create` with zero `-t` arguments. Pre-existing, out of scope for this fix; the job comment no longer claims manual runs are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)