### PR TITLE
fix(docker): copy frontend/shared into the production image, and serve a page from it in CI

### DIFF
--- a/.github/workflows/docker-publish-frontend.yml
+++ b/.github/workflows/docker-publish-frontend.yml
@@ -33,6 +33,9 @@ env:
 jobs:
   build_and_test_frontend:
     runs-on: ubuntu-latest
+    # a backstop under the 6h default: nothing here should take half an hour, and a job that hangs
+    # holds the concurrency group against every later push to the branch
+    timeout-minutes: 30
     steps:
       - name: Acquire sources
         uses: actions/checkout@v7
@@ -60,8 +63,13 @@ jobs:
         run: |
           docker run -d --name wd-frontend -p 4000:4000 wd-frontend:test
 
-          for _ in $(seq 40); do
-            if curl -fsS -o index.html http://127.0.0.1:4000/; then
+          # `--max-time` matters more than it looks: `-p` binds the host port the moment the
+          # container starts, so a server that accepts connections and then never answers -- one of
+          # the half-boots this step exists to catch -- would block the first curl indefinitely and
+          # hang the job rather than fail it. The deadline is wall clock for the same reason.
+          deadline=$((SECONDS + 90))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            if curl -fsS --max-time 5 -o index.html http://127.0.0.1:4000/; then
               served=1
               break
             fi
@@ -69,7 +77,7 @@ jobs:
           done
 
           if [ -z "${served:-}" ]; then
-            echo "::error::the image served nothing on :4000 within 80s"
+            echo "::error::the image served nothing on :4000 within 90s"
             docker logs wd-frontend
             exit 1
           fi

--- a/.github/workflows/docker-publish-frontend.yml
+++ b/.github/workflows/docker-publish-frontend.yml
@@ -53,6 +53,41 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # A build proves the image assembles, not that it boots. A missing runtime file, a bad CMD or
+      # a server that exits on start all produce an image that builds green and serves nothing, and
+      # this is the artifact that gets deployed -- so it is started and asked for a page first.
+      - name: Serve a page from the image
+        run: |
+          docker run -d --name wd-frontend -p 4000:4000 wd-frontend:test
+
+          for _ in $(seq 40); do
+            if curl -fsS -o index.html http://127.0.0.1:4000/; then
+              served=1
+              break
+            fi
+            sleep 2
+          done
+
+          if [ -z "${served:-}" ]; then
+            echo "::error::the image served nothing on :4000 within 80s"
+            docker logs wd-frontend
+            exit 1
+          fi
+
+          # 200 from something is not enough: it has to be our shell, with the client bundle
+          # mounted into it. SSR is off, so this page renders without the backend.
+          if ! grep -q '<title>Wetterdienst</title>' index.html || ! grep -q 'id="__nuxt"' index.html; then
+            echo "::error::the page served on :4000 is not the wetterdienst spa shell"
+            head -c 2000 index.html
+            docker logs wd-frontend
+            exit 1
+          fi
+
+      - name: Stop the image
+        if: always()
+        # cleanup must not turn a passing run red, nor mask why a failing one failed
+        run: docker rm -f wd-frontend || true
+
   # Computes the version/tags/labels once, shared by the per-platform build jobs
   # and the final manifest-merge job. Skipped on pull requests along with both of them, so it
   # does not burn a runner computing tags no remaining job reads.

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -62,6 +62,11 @@ Types of changes:
   temperature, leaving "Température maximale sous gazon (20 cm)" indistinguishable in kind from an
   air temperature. The head noun was dropped to avoid "Température du sol sous sol nu", but that
   only repeats where the cover names the soil itself, so it is kept everywhere else now
+- The production image never copied `frontend/shared`, though seven components import types from
+  it. Every one of those is an `import type`, which the transpiler strips before
+  resolving, so the image built regardless -- and would have kept building until the first value
+  exported from `shared/` turned one of those into a real import and broke the deploy instead. The
+  `dev` target copies the whole of `frontend/`, so only production was ever a step away from this
 
 ### Changed
 

--- a/docker/frontend.Dockerfile
+++ b/docker/frontend.Dockerfile
@@ -32,6 +32,10 @@ COPY frontend/app ./app
 COPY frontend/i18n ./i18n
 COPY frontend/public ./public
 COPY frontend/server ./server
+# Seven components import from `shared/`. Every one of those is an `import type`, which the
+# transpiler strips before resolving, so the build survives without it -- until the first value
+# exported from there turns one of them into a real import and the image stops building.
+COPY frontend/shared ./shared
 COPY frontend/nuxt.config.ts ./
 
 RUN pnpm run build

--- a/frontend/app/pages/glossary.vue
+++ b/frontend/app/pages/glossary.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { GlossaryEntry } from '~~/shared/types/api'
+import type { GlossaryEntry } from '#shared/types/api'
 
 const { t, locale } = useI18n()
 const { parameterLabel } = useParameterLabel()


### PR DESCRIPTION
## What

1. Adds `COPY frontend/shared ./shared` to the `build` stage of `docker/frontend.Dockerfile`.
2. Makes `build_and_test_frontend` live up to its name: it now runs the image it builds and asks it for a page.
3. Reaches `shared/` through `#shared/types/api` in `glossary.vue`, the alias the other six importers already use.

Plus a stray `frontend/--port` directory removed from local checkouts — never tracked, so it does not appear in the diff (see below).

## Why the `shared/` copy

Seven components import types from `frontend/shared`, which the `build` stage never copied:

```
app/components/MeteogramStationSearch.vue   import type { Station } from '#shared/types/api'
app/components/Meteogram.vue                import type { Value } from '#shared/types/api'
app/components/QueryPanel.vue               import type { Value } from '#shared/types/api'
app/pages/explorer.vue                      import type { Station } from '#shared/types/api'
app/pages/widget.vue                        import type { Station } from '#shared/types/api'
app/pages/meteogram.vue                     import type { Station } from '#shared/types/api'
app/pages/glossary.vue                      import type { GlossaryEntry } from '~~/shared/types/api'
```

**This is not a live bug — the production image builds today.** Every one of those is an `import type`, which the transpiler strips before it is resolved, so the missing directory never mattered. That is also why it went unnoticed for so long.

The fix is against the next commit that exports a *value* from `shared/` — a constant, a Zod schema, a helper. That turns one of these into a real import and breaks the production build, while `dev` (which copies the whole of `frontend/`) keeps working. A breaks-only-in-production build is an unpleasant one to debug, and the cost of avoiding it is one line.

## Why the smoke test

`docker build` proves the image assembles, not that it boots. A missing runtime file, a bad `CMD`, or a server that exits on start all produce an image that builds green and serves nothing — and this is the artifact that gets deployed to Coolify. The job now starts the container and requires a page back from it, checked for the app's own `<title>` and the `id="__nuxt"` mount point the client bundle attaches to, rather than accepting any 200 from any process. SSR is off, so that page renders without a backend.

It fails loudly: on timeout or a wrong page it prints `docker logs` and the first 2 KB of the response. Teardown is `if: always()` and `|| true`, so cleanup can neither redden a passing run nor mask why a failing one failed.

Note this makes the `shared/` fix above self-verifying from here on: if that directory ever becomes load-bearing and goes missing, the image stops booting and this job says so.

## Verification

- The two assertions were checked against ground truth, not guessed: running `.output/server/index.mjs` locally and requesting `/` returns 200 with both `<title>Wetterdienst</title>` and `id="__nuxt"`, with no backend running.
- Frontend suite green after the alias change: 24 files, 234 tests. `pnpm lint`, `pnpm typecheck` and `zizmor` all clean.
- Docker was not running on the machine this was written on, so the image itself was not built or run locally. `build_and_test_frontend` builds the `prod` target on pull requests touching `docker/frontend.Dockerfile` (it matches the workflow's path filter, and #1837 left that job deliberately unguarded), so this PR exercises the new step on itself.

## The `--port` directory

832K of `nuxt prepare` output under a directory created when nuxi took `--port` as a root directory argument. It was never tracked: its only contents (`.nuxt/`, `node_modules/`) are gitignored, so git saw an empty directory and reported nothing, which is how it survived. Removed from the local checkout; nothing to remove from the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)