### PR TITLE
perf(frontend): stream the API proxy and tighten what it forwards

### DIFF
--- a/frontend/server/api/[...].get.ts
+++ b/frontend/server/api/[...].get.ts
@@ -27,20 +27,26 @@ export default defineEventHandler(async (event): Promise<unknown> => {
   const url = `${apiBase}${path}${queryString ? `?${queryString}` : ''}`
 
   try {
-    return await $fetch(url, { method: 'GET' })
+    // Stream the upstream response straight through to the client. `$fetch` used to buffer the
+    // whole body, parse it into JS objects and re-serialize it, so a proxied request cost roughly
+    // three times the payload in heap -- and this route forwards anything under `/api`, so that
+    // payload is bounded by what the backend will return, not by what the UI asks for.
+    //
+    // `sendProxy` rather than `proxyRequest`: the latter also forwards the client's request
+    // headers (including `cookie` and `authorization`) to the backend, which `$fetch` never did.
+    // This route is GET-only, so there is no request body to carry over either.
+    //
+    // Backend errors need no special handling anymore: FastAPI's error body is already the shape
+    // we want, and `sendProxy` forwards a non-2xx status and body verbatim instead of throwing.
+    return await sendProxy(event, url)
   }
   catch (error: unknown) {
-    // Return FastAPI-compatible error format
-    const fetchError = error as { response?: { status?: number }, status?: number, data?: unknown, message?: string }
-    const statusCode = fetchError?.response?.status || fetchError?.status || 500
+    // Only reached when the backend is unreachable -- `sendProxy` raises a 502 with no upstream
+    // response to forward, so we synthesize the FastAPI-compatible error shape ourselves.
+    const fetchError = error as { statusCode?: number, status?: number, message?: string }
+    const statusCode = fetchError?.statusCode || fetchError?.status || 502
     setResponseStatus(event, statusCode)
 
-    // If the backend returned FastAPI error format, pass it through
-    if (fetchError?.data) {
-      return fetchError.data
-    }
-
-    // Otherwise, create FastAPI-compatible error response
     return {
       detail: fetchError?.message || 'An error occurred',
     } satisfies ApiErrorResponse

--- a/frontend/server/api/[...].get.ts
+++ b/frontend/server/api/[...].get.ts
@@ -41,14 +41,28 @@ export default defineEventHandler(async (event): Promise<unknown> => {
     return await sendProxy(event, url)
   }
   catch (error: unknown) {
-    // Only reached when the backend is unreachable -- `sendProxy` raises a 502 with no upstream
-    // response to forward, so we synthesize the FastAPI-compatible error shape ourselves.
-    const fetchError = error as { statusCode?: number, status?: number, message?: string }
+    // A failure part-way through the body cannot be reported as an error. `sendProxy` writes the
+    // status line with the first chunk, after which `setResponseStatus` is a no-op and h3 skips
+    // `res.end()` for an already-handled event -- leaving the client on a truncated 200 that hangs
+    // until it times out. Destroy the socket instead, so the transfer visibly breaks.
+    if (event.handled) {
+      event.node.res.destroy()
+      return
+    }
+
+    // Backend unreachable. h3 wraps the connection failure as a 502 whose `message` is the constant
+    // "Bad Gateway", so the diagnostic worth surfacing (ECONNREFUSED, DNS failure) is on `cause`.
+    const fetchError = error as {
+      statusCode?: number
+      status?: number
+      message?: string
+      cause?: { message?: string }
+    }
     const statusCode = fetchError?.statusCode || fetchError?.status || 502
     setResponseStatus(event, statusCode)
 
     return {
-      detail: fetchError?.message || 'An error occurred',
+      detail: fetchError?.cause?.message || fetchError?.message || 'An error occurred',
     } satisfies ApiErrorResponse
   }
 })

--- a/frontend/server/api/[...].get.ts
+++ b/frontend/server/api/[...].get.ts
@@ -38,7 +38,23 @@ export default defineEventHandler(async (event): Promise<unknown> => {
     //
     // Backend errors need no special handling anymore: FastAPI's error body is already the shape
     // we want, and `sendProxy` forwards a non-2xx status and body verbatim instead of throwing.
-    return await sendProxy(event, url)
+    return await sendProxy(event, url, {
+      // Streaming also relays the backend's response headers, which buffering never did. Most are
+      // harmless, but a few are the backend's to own rather than ours to republish under this
+      // origin. `onResponse` runs after `sendProxy` has set them and before the first chunk, so
+      // they can still be removed.
+      onResponse() {
+        // The backend sets no cookies today, but if that ever changes they would land scoped to the
+        // frontend's origin instead of the backend's -- a session boundary we should not move by
+        // accident.
+        event.node.res.removeHeader('set-cookie')
+        // Advertises HTTP/3 for whatever origin serves the response, so relaying it here would
+        // claim support on the frontend's behalf.
+        event.node.res.removeHeader('alt-svc')
+        // No reason to tell clients which server stack sits behind the proxy.
+        event.node.res.removeHeader('server')
+      },
+    })
   }
   catch (error: unknown) {
     // A failure part-way through the body cannot be reported as an error. `sendProxy` writes the

--- a/frontend/tests/e2e/proxy.spec.ts
+++ b/frontend/tests/e2e/proxy.spec.ts
@@ -7,20 +7,26 @@ import { expect, test } from '@playwright/test'
 // what needs guarding is fidelity: status codes, bodies and query parameters must survive the hop.
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3000'
 
+// Playwright defaults to 30s for both a test and a single API request, which is tight for a backend
+// that may still be downloading from DWD opendata on a cold cache.
+const REQUEST_TIMEOUT = 90_000
+const LARGE_PAYLOAD_TIMEOUT = 240_000
+
 test.describe('API proxy', () => {
   test('forwards a JSON response unchanged', async ({ request }) => {
-    const viaProxy = await request.get('/api/coverage')
+    const viaProxy = await request.get('/api/coverage', { timeout: REQUEST_TIMEOUT })
     expect(viaProxy.ok()).toBeTruthy()
     expect(viaProxy.headers()['content-type']).toContain('application/json')
 
-    const direct = await request.get(`${BACKEND_URL}/api/coverage`)
+    const direct = await request.get(`${BACKEND_URL}/api/coverage`, { timeout: REQUEST_TIMEOUT })
+    expect(direct.ok()).toBeTruthy()
     expect(await viaProxy.json()).toEqual(await direct.json())
   })
 
   test('preserves the backend error status and FastAPI error shape', async ({ request }) => {
     // `/api/values` without parameters is a validation error. The proxy must not turn it into a
     // 500 or swallow `detail`, because the UI renders that field verbatim.
-    const response = await request.get('/api/values')
+    const response = await request.get('/api/values', { timeout: REQUEST_TIMEOUT })
     expect([400, 422]).toContain(response.status())
 
     const body = await response.json()
@@ -30,31 +36,36 @@ test.describe('API proxy', () => {
   test('forwards repeated query parameters', async ({ request }) => {
     const query = 'provider=dwd&network=observation&parameters=daily/kl&station=00011&station=00003'
 
-    const viaProxy = await request.get(`/api/stations?${query}`)
-    const direct = await request.get(`${BACKEND_URL}/api/stations?${query}`)
-    expect(viaProxy.status()).toBe(direct.status())
+    const viaProxy = await request.get(`/api/stations?${query}`, { timeout: REQUEST_TIMEOUT })
+    // Assert success rather than branching on it: if the backend fails, both sides fail the same
+    // way and a `viaProxy.ok()` guard would let the test pass while comparing nothing.
+    expect(viaProxy.ok()).toBeTruthy()
+
+    const direct = await request.get(`${BACKEND_URL}/api/stations?${query}`, { timeout: REQUEST_TIMEOUT })
+    expect(direct.ok()).toBeTruthy()
 
     // A dropped repeat would silently return one station instead of two, so compare the payloads
     // rather than just the status.
-    if (viaProxy.ok()) {
-      expect(await viaProxy.json()).toEqual(await direct.json())
-    }
+    expect(await viaProxy.json()).toEqual(await direct.json())
   })
 
   test('streams a large payload without truncating it', async ({ request }) => {
-    // Decades of daily data for one station is a few MB -- enough that a body which is buffered,
-    // re-encoded or cut short shows up as a length mismatch against the direct response.
+    // Decades of daily data for one station is a few MB (~3.2 MB at the time of writing) -- enough
+    // that a body which is buffered, re-encoded or cut short shows up as a length mismatch against
+    // the direct response. CI runs this against a cold cache, so the backend has to pull from DWD
+    // opendata first; both the test and each request get their own generous budget.
+    test.setTimeout(LARGE_PAYLOAD_TIMEOUT)
     const query = 'provider=dwd&network=observation&parameters=daily/kl&station=00011&date=1990-01-01/2024-12-31'
 
-    const viaProxy = await request.get(`/api/values?${query}`)
-    const direct = await request.get(`${BACKEND_URL}/api/values?${query}`)
-    expect(viaProxy.status()).toBe(direct.status())
+    const viaProxy = await request.get(`/api/values?${query}`, { timeout: REQUEST_TIMEOUT })
+    expect(viaProxy.ok()).toBeTruthy()
 
-    if (viaProxy.ok()) {
-      const proxied = await viaProxy.body()
-      const expected = await direct.body()
-      expect(proxied.byteLength).toBe(expected.byteLength)
-      expect(proxied.equals(expected)).toBe(true)
-    }
+    const direct = await request.get(`${BACKEND_URL}/api/values?${query}`, { timeout: REQUEST_TIMEOUT })
+    expect(direct.ok()).toBeTruthy()
+
+    const proxied = await viaProxy.body()
+    const expected = await direct.body()
+    expect(proxied.byteLength).toBe(expected.byteLength)
+    expect(proxied.equals(expected)).toBe(true)
   })
 })

--- a/frontend/tests/e2e/proxy.spec.ts
+++ b/frontend/tests/e2e/proxy.spec.ts
@@ -23,6 +23,20 @@ test.describe('API proxy', () => {
     expect(await viaProxy.json()).toEqual(await direct.json())
   })
 
+  test('does not republish the backend\'s own response headers', async ({ request }) => {
+    // Streaming relays upstream response headers, which buffering never did. uvicorn sends
+    // `server: uvicorn` on every response, so this asserts against something the backend really
+    // emits rather than passing vacuously.
+    const viaProxy = await request.get('/api/coverage', { timeout: REQUEST_TIMEOUT })
+    expect(viaProxy.ok()).toBeTruthy()
+
+    const headers = viaProxy.headers()
+    expect(headers.server).not.toBe('uvicorn')
+    expect(headers['alt-svc']).toBeUndefined()
+    // The backend sets no cookies today; this guards the boundary if that ever changes.
+    expect(headers['set-cookie']).toBeUndefined()
+  })
+
   test('preserves the backend error status and FastAPI error shape', async ({ request }) => {
     // `/api/values` without parameters is a validation error. The proxy must not turn it into a
     // 500 or swallow `detail`, because the UI renders that field verbatim.

--- a/frontend/tests/e2e/proxy.spec.ts
+++ b/frontend/tests/e2e/proxy.spec.ts
@@ -1,0 +1,60 @@
+import process from 'node:process'
+import { expect, test } from '@playwright/test'
+
+// Every request here goes through the frontend's own catch-all at `server/api/[...].get.ts`
+// (relative URLs resolve against `baseURL`, port 4000), unlike `api.spec.ts` which talks to the
+// backend directly on port 3000. That handler streams the upstream response straight through, so
+// what needs guarding is fidelity: status codes, bodies and query parameters must survive the hop.
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3000'
+
+test.describe('API proxy', () => {
+  test('forwards a JSON response unchanged', async ({ request }) => {
+    const viaProxy = await request.get('/api/coverage')
+    expect(viaProxy.ok()).toBeTruthy()
+    expect(viaProxy.headers()['content-type']).toContain('application/json')
+
+    const direct = await request.get(`${BACKEND_URL}/api/coverage`)
+    expect(await viaProxy.json()).toEqual(await direct.json())
+  })
+
+  test('preserves the backend error status and FastAPI error shape', async ({ request }) => {
+    // `/api/values` without parameters is a validation error. The proxy must not turn it into a
+    // 500 or swallow `detail`, because the UI renders that field verbatim.
+    const response = await request.get('/api/values')
+    expect([400, 422]).toContain(response.status())
+
+    const body = await response.json()
+    expect(body).toHaveProperty('detail')
+  })
+
+  test('forwards repeated query parameters', async ({ request }) => {
+    const query = 'provider=dwd&network=observation&parameters=daily/kl&station=00011&station=00003'
+
+    const viaProxy = await request.get(`/api/stations?${query}`)
+    const direct = await request.get(`${BACKEND_URL}/api/stations?${query}`)
+    expect(viaProxy.status()).toBe(direct.status())
+
+    // A dropped repeat would silently return one station instead of two, so compare the payloads
+    // rather than just the status.
+    if (viaProxy.ok()) {
+      expect(await viaProxy.json()).toEqual(await direct.json())
+    }
+  })
+
+  test('streams a large payload without truncating it', async ({ request }) => {
+    // Decades of daily data for one station is a few MB -- enough that a body which is buffered,
+    // re-encoded or cut short shows up as a length mismatch against the direct response.
+    const query = 'provider=dwd&network=observation&parameters=daily/kl&station=00011&date=1990-01-01/2024-12-31'
+
+    const viaProxy = await request.get(`/api/values?${query}`)
+    const direct = await request.get(`${BACKEND_URL}/api/values?${query}`)
+    expect(viaProxy.status()).toBe(direct.status())
+
+    if (viaProxy.ok()) {
+      const proxied = await viaProxy.body()
+      const expected = await direct.body()
+      expect(proxied.byteLength).toBe(expected.byteLength)
+      expect(proxied.equals(expected)).toBe(true)
+    }
+  })
+})


### PR DESCRIPTION
`frontend/server/api/[...].get.ts` is a catch-all that forwards anything under `/api` to the backend. It used `$fetch`, which buffers the whole response body, parses it into JS objects, and lets Nitro re-serialize it — so the raw body, the object graph, and the encoded output are all live at once.

Because the route is a catch-all, the size of that payload is bounded by **what the backend will return**, not by what the UI asks for. A single station's `daily/kl` over 1990–2024 is already 3.2 MB / 17,834 records.

This swaps it for `sendProxy`, which pipes the upstream response straight through — and then tightens the two things that streaming changes: what crosses the proxy in each direction, and how failures are reported once bytes are already on the wire.

## Memory

Six concurrent 3.2 MB `values` requests, three rounds, same server:

| implementation | baseline RSS | peak RSS | delta |
|---|---|---|---|
| `$fetch` (before) | 593 MB | 727 MB | **134 MB** |
| `sendProxy` (after) | 518 MB | 540 MB | **22 MB** |

Memory no longer scales with payload size.

## Request headers: why `sendProxy` and not `proxyRequest`

`proxyRequest` forwards the client's request headers to the backend — h3 strips only 8 hop-by-hop ones, so `cookie` and `authorization` would go through, which `$fetch` never did. This route is GET-only, so `proxyRequest`'s request-body handling buys nothing either. `sendProxy` sends no client headers upstream, matching today's behaviour.

## Response headers

Streaming relays the backend's response headers; buffering never did. Diffing what the browser actually receives, main vs this branch:

| header | main (`$fetch`) | branch (`sendProxy`) |
|---|---|---|
| `server: uvicorn` | — | relayed → **stripped** |
| `alt-svc: h3=":443"` | — | relayed → **stripped** |
| `set-cookie` | — | would relay → **stripped** |
| `vary: Accept-Encoding` | — | relayed (kept — accurate caching metadata) |
| `content-length` | present | → `transfer-encoding: chunked` (inherent to streaming) |
| nuxt-security headers + CORS | present | unchanged |

`set-cookie` is the one that matters. The backend sets no cookies today — no `set_cookie` call, no `SessionMiddleware`, none on the wire — but `sendProxy` collects and re-emits them, so the day one appears it would be scoped to the **frontend's** origin rather than the backend's, moving a session boundary by accident.

Those three are stripped in `onResponse`, which h3 runs after the headers are set and before the first chunk. Verified against a stand-in backend emitting all of them: the three are removed and an unrelated header survives, so the strip is targeted rather than blanket.

## Errors

Streaming moves the failure boundary, which needs care in three places.

**Backend returns an error.** No reshaping needed anymore: FastAPI's error body is already the shape the UI reads (`err.data?.detail`), and `sendProxy` forwards a non-2xx status and body verbatim rather than throwing.

**Backend dies mid-body.** `sendProxy` writes the status line with the first chunk, so a failure part-way through lands in the `catch` with the response already on the wire. `setResponseStatus` is then a no-op and h3 skips `res.end()` for a handled event — stranding the client on a truncated 200. Verified against a backend that cuts the socket mid-body:

| | curl exit | time |
|---|---|---|
| without the guard | 28 (timeout) | 30.0 s hang |
| with the guard | 18 (partial body) | 0.33 s |

The handler now destroys the socket when `event.handled`, making the truncation visible and retryable.

**Backend unreachable.** h3 wraps connection failures as `createError({ statusMessage: 'Bad Gateway', cause })`, and `createError` resolves `message` from `input.message ?? input.statusMessage` — so `error.message` is always the constant `"Bad Gateway"` and the real `ECONNREFUSED`/DNS detail survives only on `cause`. `detail` now reads `cause` first.

## Tests

Adds `tests/e2e/proxy.spec.ts` — the first coverage of this route. The existing `api.spec.ts` points at `BACKEND_URL` (port 3000) and talks to the backend directly, so it never exercised the proxy at all.

The new specs assert:
- JSON passthrough is byte-for-byte equal to the direct response
- the backend's `server` / `alt-svc` / `set-cookie` headers do not reach the browser
- error status and `detail` shape survive the hop
- repeated query params (`station=X&station=Y`) are not collapsed
- a multi-megabyte payload arrives byte-identical, catching truncation or re-encoding

Each asserts `ok()` rather than branching on it, so a backend failure fails the test instead of silently skipping the comparison. The header case asserts `server !== 'uvicorn'` — something uvicorn really does send on every response — so it fails if the strip regresses rather than passing vacuously. Explicit request/test timeouts are set too: Playwright defaults to 30 s for both, which is tight for the large-payload case against a cold cache that must pull from DWD opendata first.

## Verification

- `pnpm lint`, `pnpm typecheck` — clean
- `pnpm test:ci` — 234 passed / 24 files
- `pnpm test:e2e tests/e2e/proxy.spec.ts` — 5 passed against the live backend
- CI `E2E Tests` — 52 passed, versus 47 on main

Note: `vulnerable` fails on `main` and other branches too (`cryptography 49.0.0`, `pypdf 6.14.2`) and is not caused by this PR. The `coverage` and macOS-intel reds are remote-dependency flakes — a kaleido map render and live met.no Frost calls respectively, neither reachable from a frontend TypeScript change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
