### PR TITLE
feat(metadata): declare interpolation on the canonical parameter, and extend it to 343 parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,15 +29,21 @@ Types of changes:
   the last 12 hours") need not hold for the one borrowing them
 - The provider docs tables carry a `description` column for the 46 pages that had none, and 41 rows
   for parameters that were declared but never listed at all
-- 230 more parameters can be interpolated and summarized, 357 of 514 rather than 127. Soil
-  temperature under a named cover and depth (128, NOAA GHCNd), forecast probabilities (65, MOSMIX
+- 216 more parameters can be interpolated and summarized, 343 of 514 rather than 127. Soil
+  temperature under a named cover and depth (114, NOAA GHCNd), forecast probabilities (65, MOSMIX
   and DMO), soil moisture (12, DWD's agrometeorological model), evaporation per crop and soil (6),
   concrete slab temperature (3), humidex and mean radiant temperature, cloud cover in a fixed
   height band, climatological normals, and — at the shorter radius — precipitation intensity and
   visibility. The classification was never about the data being unavailable, only about which names
   had been written into the list by hand. What stays out stays out on purpose: coded observations,
   quality flags, counts, quantities tied to one body of water, a station's own measurement errors,
-  and directions, which cannot be averaged linearly at all
+  directions, which cannot be averaged linearly at all, and the 14 GHCNd soil temperatures whose
+  surface cover is recorded as `unknown` — the rest of that family qualifies because the cover is
+  part of the name, which is precisely what an unrecorded cover does not give you.
+  One cost to know about: `interpolate()` and `summarize()` stop querying stations once *every*
+  requested parameter has enough of them, so a whole-dataset request against MOSMIX or DMO now has
+  65 probabilities to satisfy and will walk further down the station ranking than it used to.
+  Requesting the parameters you actually want keeps it where it was
 
 ### Changed
 
@@ -94,6 +100,9 @@ Types of changes:
   `_OCCURRENCE_BASED_PARAMETERS` is gone; ask the table, `PARAMETERS[name].zero_inflated`.
   The parameter glossary in the docs now states per parameter whether it can be interpolated and
   from how far away
+- **Breaking**, mildly: `TimeseriesRequest.interpolatable_parameters` is a `frozenset` rather than
+  a `list`. Every caller in the library only tests membership, but it is a public class attribute,
+  so code that indexes or slices it, or relies on its order, needs updating
 
 - **Breaking**: irradiance (`power_per_area`) is now returned in W/m² rather than W/cm², so
   affected values are 10⁴ times larger. W/m² is what WMO specifies and what every source in this

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ Types of changes:
   the last 12 hours") need not hold for the one borrowing them
 - The provider docs tables carry a `description` column for the 46 pages that had none, and 41 rows
   for parameters that were declared but never listed at all
+- 230 more parameters can be interpolated and summarized, 357 of 514 rather than 127. Soil
+  temperature under a named cover and depth (128, NOAA GHCNd), forecast probabilities (65, MOSMIX
+  and DMO), soil moisture (12, DWD's agrometeorological model), evaporation per crop and soil (6),
+  concrete slab temperature (3), humidex and mean radiant temperature, cloud cover in a fixed
+  height band, climatological normals, and — at the shorter radius — precipitation intensity and
+  visibility. The classification was never about the data being unavailable, only about which names
+  had been written into the list by hand. What stays out stays out on purpose: coded observations,
+  quality flags, counts, quantities tied to one body of water, a station's own measurement errors,
+  and directions, which cannot be averaged linearly at all
 
 ### Changed
 
@@ -70,9 +79,21 @@ Types of changes:
   parameter names — `TimeseriesRequest.interpolatable_parameters`, interpolation's
   occurrence-based set and the `ts_geo_station_distance` defaults — used it purely to spell a
   lowercased string, and now spell the canonical name directly. All 186 references resolve to the
-  same 126/30/30 names as before. `test_internal_parameter_lists_are_canonical` replaces the
-  typo-safety the enum was providing, since a misspelled string would otherwise quietly mean "never
-  interpolated" or "keeps the default search radius" rather than failing
+  same 126/30/30 names as before. Those three lists have since moved into the canonical parameter
+  table, see below
+
+- How a parameter behaves in space is declared once, on `CanonicalParameter`, rather than as three
+  hand-maintained name lists that had to agree with each other:
+  `TimeseriesRequest.interpolatable_parameters`, the `ts_geo_station_distance` defaults in
+  `Settings` and `_OCCURRENCE_BASED_PARAMETERS` in `core.interpolate` are all views of the new
+  `interpolation` (`"homogeneous"` at the 40 km default radius, `"heterogeneous"` at 20 km, or
+  `None` for a quantity that is not interpolated) and `zero_inflated` (whether interpolated values
+  are thresholded on occurrence) fields. The two are separate because they are separate facts:
+  visibility decorrelates over a few kilometres without being zero-inflated, and a precipitation
+  normal is as orographically variable as precipitation while never being zero.
+  `_OCCURRENCE_BASED_PARAMETERS` is gone; ask the table, `PARAMETERS[name].zero_inflated`.
+  The parameter glossary in the docs now states per parameter whether it can be interpolated and
+  from how far away
 
 - **Breaking**: irradiance (`power_per_area`) is now returned in W/m² rather than W/cm², so
   affected values are 10⁴ times larger. W/m² is what WMO specifies and what every source in this

--- a/docs/_ext/parameter_glossary.py
+++ b/docs/_ext/parameter_glossary.py
@@ -15,6 +15,7 @@ from sphinx.util.docutils import SphinxDirective
 
 from wetterdienst.metadata.parameter_table import PARAMETER_TABLE
 from wetterdienst.model.unit import UnitConverter
+from wetterdienst.settings import Settings
 
 if TYPE_CHECKING:
     from docutils import nodes
@@ -30,6 +31,8 @@ class ParameterGlossaryDirective(SphinxDirective):
     def run(self) -> list[nodes.Node]:
         """Build the glossary from the canonical parameter table."""
         unit_converter = UnitConverter()
+        # the default radii, read from the setting itself rather than restated here
+        station_distance = Settings().ts_geo_station_distance
         lines = ["```{glossary}"]
         for parameter in PARAMETER_TABLE:
             target = unit_converter.targets[parameter.unit_type]
@@ -37,6 +40,17 @@ class ParameterGlossaryDirective(SphinxDirective):
             lines.append(f"  {parameter.description}")
             lines.append("")
             lines.append(f"  Unit type `{parameter.unit_type}`, returned in `{target.name}` ({target.symbol}).")
+            lines.append("")
+            if not parameter.interpolation:
+                lines.append("  Not interpolatable.")
+            else:
+                sentence = (
+                    f"  Interpolatable, using stations up to {station_distance[parameter.name]:g} km from the "
+                    f"target point."
+                )
+                if parameter.zero_inflated:
+                    sentence += " Interpolated values are thresholded on occurrence."
+                lines.append(sentence)
             lines.append("")
         lines.append("```")
         return self.parse_text_to_nodes("\n".join(lines))

--- a/docs/_ext/parameter_glossary.py
+++ b/docs/_ext/parameter_glossary.py
@@ -15,7 +15,7 @@ from sphinx.util.docutils import SphinxDirective
 
 from wetterdienst.metadata.parameter_table import PARAMETER_TABLE
 from wetterdienst.model.unit import UnitConverter
-from wetterdienst.settings import Settings
+from wetterdienst.settings import _default_geo_station_distance
 
 if TYPE_CHECKING:
     from docutils import nodes
@@ -31,8 +31,9 @@ class ParameterGlossaryDirective(SphinxDirective):
     def run(self) -> list[nodes.Node]:
         """Build the glossary from the canonical parameter table."""
         unit_converter = UnitConverter()
-        # the default radii, read from the setting itself rather than restated here
-        station_distance = Settings().ts_geo_station_distance
+        # the built-in default radii rather than `Settings()`, which would read WD_* env vars and a
+        # .env from wherever the docs are built and so document the builder's configuration
+        station_distance = _default_geo_station_distance()
         lines = ["```{glossary}"]
         for parameter in PARAMETER_TABLE:
             target = unit_converter.targets[parameter.unit_type]

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -94,16 +94,30 @@ df
 
 ### Supported parameters
 
-Interpolation is only meaningful for parameters whose fields vary smoothly in space. Two
-default search radii apply depending on how strongly a parameter is spatially correlated:
+Interpolation is only meaningful for parameters whose fields vary smoothly in space. Which
+parameters those are is declared per parameter in the
+[parameter glossary](../data/parameters.md), which says for each name whether it can be
+interpolated and out of how far stations may be drawn. Two default search radii apply,
+depending on how strongly a parameter is spatially correlated:
 
 **Large spatial correlation (~40 km default search radius)** — homogeneous fields that vary
-slowly across regions: air, soil, dew-point, wet-bulb and surface temperatures, humidity,
-wind speed/gust, snow depth (accumulated), sunshine and radiation, air pressure, cloud
-cover and evapotranspiration/evaporation.
+slowly across regions: air, soil, concrete, dew-point, wet-bulb and surface temperatures,
+humidity, wind speed/gust, snow depth (accumulated), sunshine and radiation, air pressure,
+cloud cover, soil moisture, evapotranspiration/evaporation and forecast probabilities.
 
 **Short spatial correlation (~20 km default search radius)** — heterogeneous fields that
-vary more locally: precipitation (all variants) and new-snow-per-period parameters.
+vary more locally: precipitation (all variants), new-snow-per-period parameters and
+visibility.
+
+Parameters that are not interpolated at all are those with no meaningful value between two
+stations: coded observations such as weather type or cloud genus, quality flags and counts,
+quantities tied to one body of water such as discharge or stage, a station's own measurement
+errors, and directions — interpolating 350° and 10° linearly would give south.
+
+For the zero-inflated parameters — precipitation and fresh snow, which are zero whenever
+nothing fell — interpolation additionally thresholds on occurrence: the value is set to zero
+unless at least half of the surrounding stations recorded something, so that a station with
+rain and a station without do not average into a drizzle that fell nowhere.
 
 ### Settings
 
@@ -112,7 +126,7 @@ Several settings control the interpolation behaviour (see also the
 
 | Name                               | Type             | Default                                                       | Description                                                                                                                     |
 |------------------------------------|------------------|--------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| ts_geo_station_distance            | dict[str, float] | 20.0 (precipitation and new-snow variants)<br/>40.0 (other)  | Max distance for stations used for interpolation (in km).                                                                       |
+| ts_geo_station_distance            | dict[str, float] | 20.0 (heterogeneous parameters)<br/>40.0 (other)             | Max distance for stations used for interpolation (in km).                                                                       |
 | ts_geo_use_nearby_station_distance | float            | 1.0                                                          | Distance (in km) up to which a nearby station's value is used directly instead of interpolating.                               |
 | ts_geo_min_gain_of_value_pairs     | float            | 0.1                                                          | Minimum gain of value pairs for an additional station to be included, to avoid using every station in a dense network.         |
 | ts_geo_num_additional_stations     | int              | 3                                                            | Number of additional stations used regardless of the gain, to guarantee a minimum number of stations.                          |
@@ -152,9 +166,10 @@ the summarized values of the parameter ``temperature_air_mean_2m`` from multiple
 
 ![summary example](../assets/summary.png)
 
-It currently only works for ``DwdObservationRequest`` and individual parameters. Currently
-the following parameters are supported (more will be added if useful):
-``temperature_air_mean_2m``, ``wind_speed``, ``precipitation_height``.
+It currently only works for ``DwdObservationRequest`` and individual parameters. It supports
+the same parameters as interpolation, listed in the
+[parameter glossary](../data/parameters.md), and applies the same per-parameter search radius
+when deciding whether a station is close enough to be used.
 
 ```{code-cell}
 ---

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -17,6 +17,7 @@ from shapely.geometry import Point, Polygon
 from tqdm import tqdm
 
 from wetterdienst.core.util import _ParameterData, extract_station_values
+from wetterdienst.metadata.parameter_table import PARAMETERS
 from wetterdienst.metadata.resolution import Frequency
 from wetterdienst.model.metadata import ParameterModel
 from wetterdienst.util.logging import TqdmToLogger
@@ -28,51 +29,12 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-# Parameters for which precipitation-occurrence thresholding is applied during interpolation:
-# linear interpolation between zero-value and non-zero-value stations can produce spurious small
-# positives.  We suppress those by also interpolating a binary occurrence field and zeroing out
-# the result when fewer than half of the surrounding stations recorded a positive value.
-# This applies to all accumulation-type parameters that can legitimately be zero
-# (i.e. "it didn't rain / snow at this timestep"), but NOT to continuous fields like accumulated
-# snow depth or evaporation that are rarely exactly zero and have a different physical character.
-_OCCURRENCE_BASED_PARAMETERS: frozenset[str] = frozenset(
-    (
-        # precipitation height — all temporal variants
-        "precipitation_height",
-        "precipitation_height_day",
-        "precipitation_height_night",
-        "precipitation_height_liquid",
-        "precipitation_height_droplet",
-        "precipitation_height_rocker",
-        "precipitation_height_last_1h",
-        "precipitation_height_last_3h",
-        "precipitation_height_last_6h",
-        "precipitation_height_last_9h",
-        "precipitation_height_last_12h",
-        "precipitation_height_last_15h",
-        "precipitation_height_last_18h",
-        "precipitation_height_last_21h",
-        "precipitation_height_last_24h",
-        "precipitation_height_multiday",
-        "precipitation_height_significant_weather_last_1h",
-        "precipitation_height_significant_weather_last_3h",
-        "precipitation_height_significant_weather_last_6h",
-        "precipitation_height_significant_weather_last_12h",
-        "precipitation_height_significant_weather_last_24h",
-        "precipitation_height_liquid_significant_weather_last_1h",
-        "precipitation_height_max",
-        # precipitation duration — zero when no precipitation occurred
-        "precipitation_duration",
-        # new snow per period — heterogeneous and zero-inflated like precipitation
-        "snow_depth_new",
-        "snow_depth_new_multiday",
-        "snow_depth_new_max",
-        # new snow water equivalent — same zero-inflated character
-        "water_equivalent_snow_depth_new",
-        "water_equivalent_snow_depth_new_last_1h",
-        "water_equivalent_snow_depth_new_last_3h",
-    )
-)
+# Occurrence thresholding is applied to the quantities the canonical parameter table marks
+# `zero_inflated`: linear interpolation between a station that recorded rain and one that recorded
+# none produces a spurious small positive, a drizzle that fell nowhere. We suppress those by also
+# interpolating a binary occurrence field and zeroing out the result when fewer than half of the
+# surrounding stations recorded a positive value. Which quantities those are is a property of the
+# quantity, so it is declared once in `metadata.parameter_table` rather than listed here.
 
 
 def get_interpolated_df(request: TimeseriesRequest, latitude: float, longitude: float) -> pl.DataFrame:
@@ -377,7 +339,7 @@ def apply_interpolation(
     distance_mean = sum(distances) / len(distances)
     f = LinearNDInterpolator(points=(xs, ys), values=list(vals.values()))
     value = f(utm_x, utm_y)
-    if parameter in _OCCURRENCE_BASED_PARAMETERS:
+    if PARAMETERS[parameter].zero_inflated:
         f_index = LinearNDInterpolator(points=(xs, ys), values=[float(v > 0) for v in list(vals.values())])
         value_index = f_index(utm_x, utm_y)
         value = value if value_index >= 0.5 else 0

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -26,15 +26,40 @@ to that source, belong in the provider metadata instead.
 
 The descriptions feed the docs glossary, the REST API and the MCP tools, all of which previously
 exposed parameter names with no explanation of what they measure.
+
+``interpolation`` and ``zero_inflated`` say how the quantity behaves in space, which is the other
+thing that is true of a quantity rather than of a provider. They used to be spelled out as three
+hand-maintained name lists -- ``TimeseriesRequest.interpolatable_parameters``, the
+``ts_geo_station_distance`` defaults in ``settings`` and ``_OCCURRENCE_BASED_PARAMETERS`` in
+``core.interpolate`` -- which had to agree about the same names and could only be kept in step by a
+test. All three are derived from these two fields now.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from wetterdienst.metadata.unit_type import UnitType
+
+# How far a quantity stays correlated in space, which sets the default search radius for
+# interpolation and summarization (``Settings.ts_geo_station_distance``):
+#
+# - "homogeneous": a smooth regional field -- temperature, pressure, humidity, wind, radiation,
+#   lying snow, model probabilities. Meaningful out to the wide default radius.
+# - "heterogeneous": a field that decorrelates over a much shorter distance -- precipitation and
+#   fresh snow, which are convectively driven, and visibility, which is made and unmade by fog
+#   banks a few kilometres across. Halved radius.
+# - ``None``: not interpolated at all. Coded observations (weather type, cloud genus, road surface
+#   condition), quality flags, counts and bookkeeping have no meaningful value between two
+#   stations, and neither do quantities tied to a particular body of water (discharge, stage,
+#   water temperature) or to a station's own instrument (measurement errors, uncertainties).
+#   Directions are excluded too: interpolating 350 deg and 10 deg linearly gives south.
+#
+# A ``Literal`` rather than an enum, for the same reason as ``UnitType``: a typo in a table entry
+# is then a type error under ``ty`` rather than something only a test can catch.
+Interpolation = Literal["homogeneous", "heterogeneous"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,6 +71,16 @@ class CanonicalParameter:
     # required rather than defaulted: every parameter has one, and a new entry without a
     # description should not be constructible in the first place
     description: str
+    # defaulted, unlike the fields above: not being interpolated is the safe answer for a quantity
+    # nobody has classified, and it is what the majority of the table is
+    interpolation: Interpolation | None = None
+    # whether zero is a normal, frequent value meaning "the event did not happen here" -- true of
+    # rainfall and fresh snow, false of a temperature or a climatological normal. Interpolation
+    # thresholds these on occurrence, so that a station that recorded rain and one that recorded
+    # none do not average out into a drizzle that fell nowhere. Independent of ``interpolation``:
+    # visibility decorrelates quickly without being zero-inflated, and a precipitation normal is
+    # heterogeneous without ever being zero.
+    zero_inflated: bool = False
 
 
 PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
@@ -57,19 +92,46 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "climate_correction_factor", "dimensionless", "Factor correcting a degree-day total for the local climate."
     ),
     CanonicalParameter(
-        "cloud_base_convective", "length_medium", "Height above ground of the base of convective cloud."
+        "cloud_base_convective",
+        "length_medium",
+        "Height above ground of the base of convective cloud.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("cloud_cover_above_7km", "fraction", "Fraction of the sky covered by cloud above 7 km."),
-    CanonicalParameter("cloud_cover_below_1000ft", "fraction", "Fraction of the sky covered by cloud below 1000 ft."),
-    CanonicalParameter("cloud_cover_below_500ft", "fraction", "Fraction of the sky covered by cloud below 500 ft."),
-    CanonicalParameter("cloud_cover_below_7km", "fraction", "Fraction of the sky covered by cloud below 7 km."),
     CanonicalParameter(
-        "cloud_cover_between_2km_to_7km", "fraction", "Fraction of the sky covered by cloud between 2 km and 7 km."
+        "cloud_cover_above_7km",
+        "fraction",
+        "Fraction of the sky covered by cloud above 7 km.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "cloud_cover_below_1000ft",
+        "fraction",
+        "Fraction of the sky covered by cloud below 1000 ft.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "cloud_cover_below_500ft",
+        "fraction",
+        "Fraction of the sky covered by cloud below 500 ft.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "cloud_cover_below_7km",
+        "fraction",
+        "Fraction of the sky covered by cloud below 7 km.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "cloud_cover_between_2km_to_7km",
+        "fraction",
+        "Fraction of the sky covered by cloud between 2 km and 7 km.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "cloud_cover_effective",
         "fraction",
         "Effective cloud cover, weighting each layer by how much it attenuates radiation.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "cloud_cover_layer1", "fraction", "Fraction of the sky covered by cloud in the lowest reported layer."
@@ -83,7 +145,12 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
     CanonicalParameter(
         "cloud_cover_layer4", "fraction", "Fraction of the sky covered by cloud in the fourth reported layer."
     ),
-    CanonicalParameter("cloud_cover_total", "fraction", "Fraction of the sky covered by cloud of any kind."),
+    CanonicalParameter(
+        "cloud_cover_total",
+        "fraction",
+        "Fraction of the sky covered by cloud of any kind.",
+        interpolation="homogeneous",
+    ),
     CanonicalParameter(
         "cloud_cover_total_measurement_method",
         "dimensionless",
@@ -93,21 +160,25 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "cloud_cover_total_midnight_to_midnight",
         "fraction",
         "Mean total cloud cover over the calendar day, midnight to midnight.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "cloud_cover_total_midnight_to_midnight_manual",
         "fraction",
         "Mean total cloud cover over the calendar day, midnight to midnight, from manual observation.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "cloud_cover_total_sunrise_to_sunset",
         "fraction",
         "Mean total cloud cover over the daylight hours, sunrise to sunset.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "cloud_cover_total_sunrise_to_sunset_manual",
         "fraction",
         "Mean total cloud cover over the daylight hours, sunrise to sunset, from manual observation.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter("cloud_density", "dimensionless", "Optical density of the cloud."),
     CanonicalParameter(
@@ -130,11 +201,13 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "cooling_degree_day",
         "degree_day",
         "Cooling degree days, the temperature excess above a base value summed over each day.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "cooling_degree_hour",
         "degree_hour",
         "Cooling degree hours, the temperature excess above a base value summed over each hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter("count_days_cooling_degree", "dimensionless", "Number of days on which cooling was required."),
     CanonicalParameter("count_days_heating_degree", "dimensionless", "Number of days on which heating was required."),
@@ -251,53 +324,74 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "error_absolute_wind_direction", "angle", "Absolute error attached to the reported wind direction."
     ),
     CanonicalParameter("error_absolute_wind_speed", "speed", "Absolute error attached to the reported wind speed."),
-    CanonicalParameter("evaporation_height", "precipitation", "Depth of water evaporated from the surface."),
     CanonicalParameter(
-        "evaporation_height_corn_loamysilt", "precipitation", "Depth of water evaporated from loamy silt under corn."
+        "evaporation_height",
+        "precipitation",
+        "Depth of water evaporated from the surface.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "evaporation_height_corn_sand", "precipitation", "Depth of water evaporated from sand under corn."
+        "evaporation_height_corn_loamysilt",
+        "precipitation",
+        "Depth of water evaporated from loamy silt under corn.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "evaporation_height_gras_loamysilt", "precipitation", "Depth of water evaporated from loamy silt under grass."
+        "evaporation_height_corn_sand",
+        "precipitation",
+        "Depth of water evaporated from sand under corn.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "evaporation_height_gras_sand", "precipitation", "Depth of water evaporated from sand under grass."
+        "evaporation_height_gras_loamysilt",
+        "precipitation",
+        "Depth of water evaporated from loamy silt under grass.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "evaporation_height_gras_sand",
+        "precipitation",
+        "Depth of water evaporated from sand under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "evaporation_height_multiday",
         "precipitation",
         "Depth of water evaporated over several days, reported as one total.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "evaporation_height_winterwheat_loamysilt",
         "precipitation",
         "Depth of water evaporated from loamy silt under winter wheat.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "evaporation_height_winterwheat_sand",
         "precipitation",
         "Depth of water evaporated from sand under winter wheat.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "evapotranspiration_potential_gras_fao_last_24h",
         "precipitation",
         "Potential evapotranspiration over grass in the preceding 24 hours, after the FAO reference method.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "evapotranspiration_potential_gras_haude_last_24h",
         "precipitation",
         "Potential evapotranspiration over grass in the preceding 24 hours, after the Haude method.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "evapotranspiration_potential_last_24h",
         "precipitation",
         "Potential evapotranspiration in the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "flow_direction",
-        "angle",
-        "Direction the water current is flowing towards, clockwise from magnetic north.",
+        "flow_direction", "angle", "Direction the water current is flowing towards, clockwise from magnetic north."
     ),
     CanonicalParameter("flow_speed", "speed", "Speed at which the water is flowing past the gauge."),
     CanonicalParameter(
@@ -319,435 +413,641 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "heating_degree_day",
         "degree_day",
         "Heating degree days, the temperature shortfall below a base value summed over each day.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "humidity",
         "fraction",
         "Relative humidity of the air, the fraction of the moisture it could hold at that temperature.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "humidity_absolute", "mass_per_volume", "Absolute humidity, the mass of water vapour per volume of air."
+        "humidity_absolute",
+        "mass_per_volume",
+        "Absolute humidity, the mass of water vapour per volume of air.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("humidity_max", "fraction", "Highest relative humidity over the period."),
-    CanonicalParameter("humidity_min", "fraction", "Lowest relative humidity over the period."),
+    CanonicalParameter(
+        "humidity_max", "fraction", "Highest relative humidity over the period.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "humidity_min", "fraction", "Lowest relative humidity over the period.", interpolation="homogeneous"
+    ),
     CanonicalParameter("ice_on_water_thickness", "length_short", "Thickness of the ice covering the water surface."),
     CanonicalParameter("number_of_days_per_month", "dimensionless", "Number of days in the month the record covers."),
     CanonicalParameter("number_of_hours_per_month", "dimensionless", "Number of hours in the month the record covers."),
     CanonicalParameter("oxygen_level", "concentration", "Concentration of oxygen dissolved in the water."),
     CanonicalParameter("ph_value", "dimensionless", "Acidity of the water on the pH scale."),
-    CanonicalParameter("precipitation_duration", "time", "Length of time during which precipitation fell."),
+    CanonicalParameter(
+        "precipitation_duration",
+        "time",
+        "Length of time during which precipitation fell.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
+    ),
     CanonicalParameter(
         "precipitation_form", "dimensionless", "Coded form of the precipitation, such as rain, snow or freezing rain."
     ),
-    CanonicalParameter("precipitation_height", "precipitation", "Depth of precipitation collected over the period."),
     CanonicalParameter(
-        "precipitation_height_day", "precipitation", "Depth of precipitation collected during the daytime hours."
+        "precipitation_height",
+        "precipitation",
+        "Depth of precipitation collected over the period.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
+    ),
+    CanonicalParameter(
+        "precipitation_height_day",
+        "precipitation",
+        "Depth of precipitation collected during the daytime hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_droplet",
         "precipitation",
         "Depth of precipitation measured by the droplet sensor of the gauge.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_last_12h",
         "precipitation",
         "Depth of precipitation collected over the preceding 12 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_last_15h",
         "precipitation",
         "Depth of precipitation collected over the preceding 15 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_last_18h",
         "precipitation",
         "Depth of precipitation collected over the preceding 18 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
-        "precipitation_height_last_1h", "precipitation", "Depth of precipitation collected over the preceding hour."
+        "precipitation_height_last_1h",
+        "precipitation",
+        "Depth of precipitation collected over the preceding hour.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_last_21h",
         "precipitation",
         "Depth of precipitation collected over the preceding 21 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_last_24h",
         "precipitation",
         "Depth of precipitation collected over the preceding 24 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
-        "precipitation_height_last_3h", "precipitation", "Depth of precipitation collected over the preceding 3 hours."
+        "precipitation_height_last_3h",
+        "precipitation",
+        "Depth of precipitation collected over the preceding 3 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
-        "precipitation_height_last_6h", "precipitation", "Depth of precipitation collected over the preceding 6 hours."
+        "precipitation_height_last_6h",
+        "precipitation",
+        "Depth of precipitation collected over the preceding 6 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
-        "precipitation_height_last_9h", "precipitation", "Depth of precipitation collected over the preceding 9 hours."
+        "precipitation_height_last_9h",
+        "precipitation",
+        "Depth of precipitation collected over the preceding 9 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
-        "precipitation_height_liquid", "precipitation", "Depth of the liquid part of the precipitation."
+        "precipitation_height_liquid",
+        "precipitation",
+        "Depth of the liquid part of the precipitation.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_liquid_significant_weather_last_1h",
         "precipitation",
         "Depth of liquid precipitation from significant weather in the preceding hour.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_max",
         "precipitation",
         "Greatest precipitation depth recorded in any single interval of the period.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_multiday",
         "precipitation",
         "Depth of precipitation over several days, reported as one total.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
-        "precipitation_height_night", "precipitation", "Depth of precipitation collected during the night hours."
+        "precipitation_height_night",
+        "precipitation",
+        "Depth of precipitation collected during the night hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_normal",
         "precipitation",
         "Climatological normal of the precipitation height for the period.",
+        interpolation="heterogeneous",
     ),
     CanonicalParameter(
         "precipitation_height_rocker",
         "precipitation",
         "Depth of precipitation measured by the tipping-bucket sensor of the gauge.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_significant_weather_last_12h",
         "precipitation",
         "Depth of precipitation from significant weather over the preceding 12 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_significant_weather_last_1h",
         "precipitation",
         "Depth of precipitation from significant weather over the preceding hour.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_significant_weather_last_24h",
         "precipitation",
         "Depth of precipitation from significant weather over the preceding 24 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_significant_weather_last_3h",
         "precipitation",
         "Depth of precipitation from significant weather over the preceding 3 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "precipitation_height_significant_weather_last_6h",
         "precipitation",
         "Depth of precipitation from significant weather over the preceding 6 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter("precipitation_index", "dimensionless", "Coded indicator of whether precipitation occurred."),
-    CanonicalParameter("precipitation_intensity", "precipitation_intensity", "Rate at which precipitation is falling."),
+    CanonicalParameter(
+        "precipitation_intensity",
+        "precipitation_intensity",
+        "Rate at which precipitation is falling.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
+    ),
     CanonicalParameter(
         "pressure_air_sea_level",
         "pressure",
         "Air pressure reduced to mean sea level, so that stations at different heights compare.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("pressure_air_site", "pressure", "Air pressure as measured at station height."),
+    CanonicalParameter(
+        "pressure_air_site", "pressure", "Air pressure as measured at station height.", interpolation="homogeneous"
+    ),
     CanonicalParameter(
         "pressure_air_site_delta_last_3h",
         "pressure",
         "Change in air pressure at station height over the preceding 3 hours.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("pressure_air_site_max", "pressure", "Highest air pressure at station height over the period."),
-    CanonicalParameter("pressure_air_site_min", "pressure", "Lowest air pressure at station height over the period."),
     CanonicalParameter(
-        "pressure_air_site_reduced", "pressure", "Air pressure at station height reduced to a reference level."
+        "pressure_air_site_max",
+        "pressure",
+        "Highest air pressure at station height over the period.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("pressure_vapor", "pressure", "Partial pressure of water vapour in the air."),
     CanonicalParameter(
-        "probability_drizzle_last_12h", "fraction", "Probability of drizzle over the preceding 12 hours."
+        "pressure_air_site_min",
+        "pressure",
+        "Lowest air pressure at station height over the period.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("probability_drizzle_last_1h", "fraction", "Probability of drizzle over the preceding hour."),
-    CanonicalParameter("probability_drizzle_last_6h", "fraction", "Probability of drizzle over the preceding 6 hours."),
-    CanonicalParameter("probability_fog_last_12h", "fraction", "Probability of fog over the preceding 12 hours."),
-    CanonicalParameter("probability_fog_last_1h", "fraction", "Probability of fog over the preceding hour."),
-    CanonicalParameter("probability_fog_last_24h", "fraction", "Probability of fog over the preceding 24 hours."),
-    CanonicalParameter("probability_fog_last_6h", "fraction", "Probability of fog over the preceding 6 hours."),
+    CanonicalParameter(
+        "pressure_air_site_reduced",
+        "pressure",
+        "Air pressure at station height reduced to a reference level.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "pressure_vapor", "pressure", "Partial pressure of water vapour in the air.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "probability_drizzle_last_12h",
+        "fraction",
+        "Probability of drizzle over the preceding 12 hours.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "probability_drizzle_last_1h",
+        "fraction",
+        "Probability of drizzle over the preceding hour.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "probability_drizzle_last_6h",
+        "fraction",
+        "Probability of drizzle over the preceding 6 hours.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "probability_fog_last_12h",
+        "fraction",
+        "Probability of fog over the preceding 12 hours.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "probability_fog_last_1h",
+        "fraction",
+        "Probability of fog over the preceding hour.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "probability_fog_last_24h",
+        "fraction",
+        "Probability of fog over the preceding 24 hours.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "probability_fog_last_6h",
+        "fraction",
+        "Probability of fog over the preceding 6 hours.",
+        interpolation="homogeneous",
+    ),
     CanonicalParameter(
         "probability_precipitation_convective_last_12h",
         "fraction",
         "Probability of convective precipitation over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_convective_last_1h",
         "fraction",
         "Probability of convective precipitation over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_convective_last_6h",
         "fraction",
         "Probability of convective precipitation over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_freezing_last_12h",
         "fraction",
         "Probability of freezing precipitation over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_freezing_last_1h",
         "fraction",
         "Probability of freezing precipitation over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_freezing_last_6h",
         "fraction",
         "Probability of freezing precipitation over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_0mm_last_12h",
         "fraction",
         "Probability that more than 0.0 mm of precipitation fell over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_0mm_last_24h",
         "fraction",
         "Probability that more than 0.0 mm of precipitation fell over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_0mm_last_6h",
         "fraction",
         "Probability that more than 0.0 mm of precipitation fell over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_1mm_last_1h",
         "fraction",
         "Probability that more than 0.1 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_2mm_last_12h",
         "fraction",
         "Probability that more than 0.2 mm of precipitation fell over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_2mm_last_1h",
         "fraction",
         "Probability that more than 0.2 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_2mm_last_24h",
         "fraction",
         "Probability that more than 0.2 mm of precipitation fell over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_2mm_last_6h",
         "fraction",
         "Probability that more than 0.2 mm of precipitation fell over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_3mm_last_1h",
         "fraction",
         "Probability that more than 0.3 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_5mm_last_1h",
         "fraction",
         "Probability that more than 0.5 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_0_7mm_last_1h",
         "fraction",
         "Probability that more than 0.7 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_10mm_last_1h",
         "fraction",
         "Probability that more than 10 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_15mm_last_1h",
         "fraction",
         "Probability that more than 15 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_1mm_last_12h",
         "fraction",
         "Probability that more than 1 mm of precipitation fell over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_1mm_last_1h",
         "fraction",
         "Probability that more than 1 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_1mm_last_24h",
         "fraction",
         "Probability that more than 1 mm of precipitation fell over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_1mm_last_6h",
         "fraction",
         "Probability that more than 1 mm of precipitation fell over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_25mm_last_1h",
         "fraction",
         "Probability that more than 25 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_2mm_last_1h",
         "fraction",
         "Probability that more than 2 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_3mm_last_1h",
         "fraction",
         "Probability that more than 3 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_5mm_last_12h",
         "fraction",
         "Probability that more than 5 mm of precipitation fell over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_5mm_last_1h",
         "fraction",
         "Probability that more than 5 mm of precipitation fell over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_5mm_last_24h",
         "fraction",
         "Probability that more than 5 mm of precipitation fell over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_height_gt_5mm_last_6h",
         "fraction",
         "Probability that more than 5 mm of precipitation fell over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_last_12h",
         "fraction",
         "Probability of precipitation of any kind over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_last_1h",
         "fraction",
         "Probability of precipitation of any kind over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_last_24h",
         "fraction",
         "Probability of precipitation of any kind over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_last_6h",
         "fraction",
         "Probability of precipitation of any kind over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_liquid_last_12h",
         "fraction",
         "Probability of liquid precipitation over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_liquid_last_1h",
         "fraction",
         "Probability of liquid precipitation over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_liquid_last_6h",
         "fraction",
         "Probability of liquid precipitation over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_solid_last_12h",
         "fraction",
         "Probability of solid precipitation over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_solid_last_1h",
         "fraction",
         "Probability of solid precipitation over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_solid_last_6h",
         "fraction",
         "Probability of solid precipitation over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_stratiform_last_12h",
         "fraction",
         "Probability of stratiform precipitation over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_stratiform_last_1h",
         "fraction",
         "Probability of stratiform precipitation over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_precipitation_stratiform_last_6h",
         "fraction",
         "Probability of stratiform precipitation over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_radiation_global_last_1h",
         "fraction",
         "Probability of measurable global radiation over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_sunshine_duration_relative_gt_0pct_last_24h",
         "fraction",
         "Probability that sunshine lasted more than 0 % of the possible duration over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_sunshine_duration_relative_gt_30pct_last_24h",
         "fraction",
         "Probability that sunshine lasted more than 30 % of the possible duration over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_sunshine_duration_relative_gt_60pct_last_24h",
         "fraction",
         "Probability that sunshine lasted more than 60 % of the possible duration over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "probability_thunder_last_12h", "fraction", "Probability of thunderstorm over the preceding 12 hours."
+        "probability_thunder_last_12h",
+        "fraction",
+        "Probability of thunderstorm over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "probability_thunder_last_1h", "fraction", "Probability of thunderstorm over the preceding hour."
+        "probability_thunder_last_1h",
+        "fraction",
+        "Probability of thunderstorm over the preceding hour.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "probability_thunder_last_24h", "fraction", "Probability of thunderstorm over the preceding 24 hours."
+        "probability_thunder_last_24h",
+        "fraction",
+        "Probability of thunderstorm over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "probability_thunder_last_6h", "fraction", "Probability of thunderstorm over the preceding 6 hours."
+        "probability_thunder_last_6h",
+        "fraction",
+        "Probability of thunderstorm over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "probability_visibility_below_1000m", "fraction", "Probability that visibility falls below 1000 m."
+        "probability_visibility_below_1000m",
+        "fraction",
+        "Probability that visibility falls below 1000 m.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_wind_gust_ge_25kn_last_12h",
         "fraction",
         "Probability of a wind gust reaching 25 kn or more over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_wind_gust_ge_25kn_last_6h",
         "fraction",
         "Probability of a wind gust reaching 25 kn or more over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_wind_gust_ge_40kn_last_12h",
         "fraction",
         "Probability of a wind gust reaching 40 kn or more over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_wind_gust_ge_40kn_last_6h",
         "fraction",
         "Probability of a wind gust reaching 40 kn or more over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_wind_gust_ge_55kn_last_12h",
         "fraction",
         "Probability of a wind gust reaching 55 kn or more over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "probability_wind_gust_ge_55kn_last_6h",
         "fraction",
         "Probability of a wind gust reaching 55 kn or more over the preceding 6 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "quality", "dimensionless", "Quality flag published by the source for the values in the same dataset."
@@ -828,14 +1128,19 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "radiation_global",
         "energy_per_area",
         "Global radiation received on a horizontal surface, accumulated as energy over the interval.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "radiation_global_intensity",
         "power_per_area",
         "Global irradiance on a horizontal surface, reported as power rather than energy.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "radiation_global_last_3h", "energy_per_area", "Global radiation accumulated over the preceding 3 hours."
+        "radiation_global_last_3h",
+        "energy_per_area",
+        "Global radiation accumulated over the preceding 3 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "radiation_global_uncertainty", "energy_per_area", "Uncertainty attached to the reported global radiation."
@@ -844,112 +1149,157 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "radiation_sky_long_wave",
         "energy_per_area",
         "Downward long-wave radiation from the sky, accumulated as energy over the interval.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "radiation_sky_long_wave_intensity",
         "power_per_area",
         "Downward long-wave irradiance from the sky, reported as power.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "radiation_sky_long_wave_last_3h",
         "energy_per_area",
         "Downward long-wave radiation from the sky over the preceding 3 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "radiation_sky_short_wave_diffuse",
         "energy_per_area",
         "Diffuse short-wave radiation from the sky, accumulated as energy over the interval.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "radiation_sky_short_wave_diffuse_intensity",
         "power_per_area",
         "Diffuse short-wave irradiance from the sky, reported as power.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "radiation_sky_short_wave_direct",
         "energy_per_area",
         "Direct short-wave radiation from the sun, accumulated as energy over the interval.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "road_surface_condition", "dimensionless", "Coded condition of the road surface, such as dry, wet or icy."
     ),
-    CanonicalParameter("snow_depth", "length_short", "Depth of the snow lying on the ground."),
     CanonicalParameter(
-        "snow_depth_excelled", "length_short", "Depth of the snow cover where it exceeded the measuring range."
+        "snow_depth", "length_short", "Depth of the snow lying on the ground.", interpolation="homogeneous"
     ),
     CanonicalParameter(
-        "snow_depth_manual", "length_short", "Depth of the snow lying on the ground, from manual observation."
+        "snow_depth_excelled",
+        "length_short",
+        "Depth of the snow cover where it exceeded the measuring range.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("snow_depth_max", "length_short", "Greatest snow depth over the period."),
-    CanonicalParameter("snow_depth_new", "length_short", "Depth of snow that fell during the period."),
-    CanonicalParameter("snow_depth_new_max", "length_short", "Greatest depth of fresh snow recorded over the period."),
     CanonicalParameter(
-        "snow_depth_new_multiday", "length_short", "Depth of fresh snow over several days, reported as one total."
+        "snow_depth_manual",
+        "length_short",
+        "Depth of the snow lying on the ground, from manual observation.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "snow_depth_max", "length_short", "Greatest snow depth over the period.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "snow_depth_new",
+        "length_short",
+        "Depth of snow that fell during the period.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
+    ),
+    CanonicalParameter(
+        "snow_depth_new_max",
+        "length_short",
+        "Greatest depth of fresh snow recorded over the period.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
+    ),
+    CanonicalParameter(
+        "snow_depth_new_multiday",
+        "length_short",
+        "Depth of fresh snow over several days, reported as one total.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "snow_depth_new_normal",
         "length_short",
         "Climatological normal of the fresh snow total for the period.",
+        interpolation="heterogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_corn_loamysilt_00cm_60cm",
         "fraction",
         "Soil moisture in loamy silt under corn, between the surface and 60 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_corn_sand_00cm_60cm",
         "fraction",
         "Soil moisture in sand under corn, between the surface and 60 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_gras_loamysilt_00cm_10cm",
         "fraction",
         "Soil moisture in loamy silt under grass, between the surface and 10 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_gras_loamysilt_00cm_60cm",
         "fraction",
         "Soil moisture in loamy silt under grass, between the surface and 60 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_gras_loamysilt_10cm_20cm",
         "fraction",
         "Soil moisture in loamy silt under grass, between 10 cm and 20 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_gras_loamysilt_20cm_30cm",
         "fraction",
         "Soil moisture in loamy silt under grass, between 20 cm and 30 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_gras_loamysilt_30cm_40cm",
         "fraction",
         "Soil moisture in loamy silt under grass, between 30 cm and 40 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_gras_loamysilt_40cm_50cm",
         "fraction",
         "Soil moisture in loamy silt under grass, between 40 cm and 50 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_gras_loamysilt_50cm_60cm",
         "fraction",
         "Soil moisture in loamy silt under grass, between 50 cm and 60 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_gras_sand_00cm_60cm",
         "fraction",
         "Soil moisture in sand under grass, between the surface and 60 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_winterwheat_loamysilt_00cm_60cm",
         "fraction",
         "Soil moisture in loamy silt under winter wheat, between the surface and 60 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_moisture_winterwheat_sand_00cm_60cm",
         "fraction",
         "Soil moisture in sand under winter wheat, between the surface and 60 cm.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "soil_state_index",
@@ -961,694 +1311,1038 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
     CanonicalParameter("stage_mean", "length_short", "Mean water level at the gauge over the period."),
     CanonicalParameter("stage_min", "length_short", "Lowest water level at the gauge over the period."),
     CanonicalParameter("sun_zenith_angle", "angle", "Angle between the sun and the vertical."),
-    CanonicalParameter("sunshine_duration", "time", "Length of time the sun shone unobstructed."),
     CanonicalParameter(
-        "sunshine_duration_last_3h", "time", "Length of time the sun shone unobstructed in the preceding 3 hours."
+        "sunshine_duration", "time", "Length of time the sun shone unobstructed.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "sunshine_duration_last_3h",
+        "time",
+        "Length of time the sun shone unobstructed in the preceding 3 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "sunshine_duration_normal",
         "time",
         "Climatological normal of the sunshine duration for the period.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "sunshine_duration_relative",
         "fraction",
         "Sunshine duration as a fraction of the longest possible for the location and date.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "sunshine_duration_relative_last_24h", "fraction", "Relative sunshine duration over the preceding 24 hours."
+        "sunshine_duration_relative_last_24h",
+        "fraction",
+        "Relative sunshine duration over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "sunshine_duration_uncertainty", "time", "Uncertainty attached to the reported sunshine duration."
     ),
     CanonicalParameter(
-        "sunshine_duration_yesterday", "time", "Length of time the sun shone unobstructed on the previous day."
+        "sunshine_duration_yesterday",
+        "time",
+        "Length of time the sun shone unobstructed on the previous day.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_air_2m", "temperature", "Air temperature at 2 m above ground, the standard screen height."
+        "temperature_air_2m",
+        "temperature",
+        "Air temperature at 2 m above ground, the standard screen height.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("temperature_air_max_0_05m", "temperature", "Maximum air temperature at 0.05 m above ground."),
-    CanonicalParameter("temperature_air_max_2m", "temperature", "Maximum air temperature at 2 m above ground."),
+    CanonicalParameter(
+        "temperature_air_max_0_05m",
+        "temperature",
+        "Maximum air temperature at 0.05 m above ground.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_air_max_2m",
+        "temperature",
+        "Maximum air temperature at 2 m above ground.",
+        interpolation="homogeneous",
+    ),
     CanonicalParameter(
         "temperature_air_max_2m_last_24h",
         "temperature",
         "Maximum air temperature at 2 m above ground over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_air_max_2m_mean",
         "temperature",
         "Mean of the daily maximum air temperature at 2 m above ground over the period.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_air_max_2m_multiday",
         "temperature",
         "Maximum air temperature at 2 m above ground, covering several days where a station did not report daily.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("temperature_air_mean_0_05m", "temperature", "Mean air temperature at 0.05 m above ground."),
-    CanonicalParameter("temperature_air_mean_0_1m", "temperature", "Mean air temperature at 0.1 m above ground."),
-    CanonicalParameter("temperature_air_mean_2m", "temperature", "Mean air temperature at 2 m above ground."),
+    CanonicalParameter(
+        "temperature_air_mean_0_05m",
+        "temperature",
+        "Mean air temperature at 0.05 m above ground.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_air_mean_0_1m",
+        "temperature",
+        "Mean air temperature at 0.1 m above ground.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_air_mean_2m",
+        "temperature",
+        "Mean air temperature at 2 m above ground.",
+        interpolation="homogeneous",
+    ),
     CanonicalParameter(
         "temperature_air_mean_2m_last_24h",
         "temperature",
         "Mean air temperature at 2 m above ground over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_air_mean_2m_normal",
         "temperature",
         "Climatological normal of the mean air temperature at 2 m above ground.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("temperature_air_min_0_05m", "temperature", "Minimum air temperature at 0.05 m above ground."),
+    CanonicalParameter(
+        "temperature_air_min_0_05m",
+        "temperature",
+        "Minimum air temperature at 0.05 m above ground.",
+        interpolation="homogeneous",
+    ),
     CanonicalParameter(
         "temperature_air_min_0_05m_last_12h",
         "temperature",
         "Minimum air temperature at 0.05 m above ground over the preceding 12 hours.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("temperature_air_min_2m", "temperature", "Minimum air temperature at 2 m above ground."),
+    CanonicalParameter(
+        "temperature_air_min_2m",
+        "temperature",
+        "Minimum air temperature at 2 m above ground.",
+        interpolation="homogeneous",
+    ),
     CanonicalParameter(
         "temperature_air_min_2m_last_24h",
         "temperature",
         "Minimum air temperature at 2 m above ground over the preceding 24 hours.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_air_min_2m_mean",
         "temperature",
         "Mean of the daily minimum air temperature at 2 m above ground over the period.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_air_min_2m_multiday",
         "temperature",
         "Minimum air temperature at 2 m above ground, covering several days where a station did not report daily.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_concrete_max_0m", "temperature", "Maximum temperature at the surface of a concrete slab."
+        "temperature_concrete_max_0m",
+        "temperature",
+        "Maximum temperature at the surface of a concrete slab.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_concrete_mean_0m", "temperature", "Mean temperature at the surface of a concrete slab."
+        "temperature_concrete_mean_0m",
+        "temperature",
+        "Mean temperature at the surface of a concrete slab.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_concrete_min_0m", "temperature", "Minimum temperature at the surface of a concrete slab."
+        "temperature_concrete_min_0m",
+        "temperature",
+        "Minimum temperature at the surface of a concrete slab.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_dew_point_mean_2m",
         "temperature",
         "Dew point at 2 m above ground, the temperature at which the air would become saturated.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_humidex",
         "temperature",
         "Humidex, the apparent temperature combining air temperature and humidity.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_radiant_mean_2m",
         "temperature",
         "Mean radiant temperature, the temperature a body feels from surrounding surfaces.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("temperature_soil_max_0_1m", "temperature", "Maximum soil temperature at 0.1 m depth."),
-    CanonicalParameter("temperature_soil_max_0_2m", "temperature", "Maximum soil temperature at 0.2 m depth."),
-    CanonicalParameter("temperature_soil_max_0_5m", "temperature", "Maximum soil temperature at 0.5 m depth."),
-    CanonicalParameter("temperature_soil_max_1m", "temperature", "Maximum soil temperature at 1 m depth."),
-    CanonicalParameter("temperature_soil_max_2m", "temperature", "Maximum soil temperature at 2 m depth."),
+    CanonicalParameter(
+        "temperature_soil_max_0_1m",
+        "temperature",
+        "Maximum soil temperature at 0.1 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_max_0_2m",
+        "temperature",
+        "Maximum soil temperature at 0.2 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_max_0_5m",
+        "temperature",
+        "Maximum soil temperature at 0.5 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_max_1m", "temperature", "Maximum soil temperature at 1 m depth.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "temperature_soil_max_2m", "temperature", "Maximum soil temperature at 2 m depth.", interpolation="homogeneous"
+    ),
     CanonicalParameter(
         "temperature_soil_max_bare_ground_0_05m",
         "temperature",
         "Maximum soil temperature at 0.05 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_ground_0_1m",
         "temperature",
         "Maximum soil temperature at 0.1 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_ground_0_2m",
         "temperature",
         "Maximum soil temperature at 0.2 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_ground_0_5m",
         "temperature",
         "Maximum soil temperature at 0.5 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_ground_1_5m",
         "temperature",
         "Maximum soil temperature at 1.5 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_ground_1_8m",
         "temperature",
         "Maximum soil temperature at 1.8 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_bare_ground_1m", "temperature", "Maximum soil temperature at 1 m depth under bare ground."
+        "temperature_soil_max_bare_ground_1m",
+        "temperature",
+        "Maximum soil temperature at 1 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_muck_0_05m",
         "temperature",
         "Maximum soil temperature at 0.05 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_muck_0_1m",
         "temperature",
         "Maximum soil temperature at 0.1 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_muck_0_2m",
         "temperature",
         "Maximum soil temperature at 0.2 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_muck_0_5m",
         "temperature",
         "Maximum soil temperature at 0.5 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_muck_1_5m",
         "temperature",
         "Maximum soil temperature at 1.5 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_muck_1_8m",
         "temperature",
         "Maximum soil temperature at 1.8 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_bare_muck_1m",
         "temperature",
         "Maximum soil temperature at 1 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_brome_grass_0_05m",
         "temperature",
         "Maximum soil temperature at 0.05 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_brome_grass_0_1m",
         "temperature",
         "Maximum soil temperature at 0.1 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_brome_grass_0_2m",
         "temperature",
         "Maximum soil temperature at 0.2 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_brome_grass_0_5m",
         "temperature",
         "Maximum soil temperature at 0.5 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_brome_grass_1_5m",
         "temperature",
         "Maximum soil temperature at 1.5 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_brome_grass_1_8m",
         "temperature",
         "Maximum soil temperature at 1.8 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_brome_grass_1m", "temperature", "Maximum soil temperature at 1 m depth under brome grass."
+        "temperature_soil_max_brome_grass_1m",
+        "temperature",
+        "Maximum soil temperature at 1 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_fallow_0_05m",
         "temperature",
         "Maximum soil temperature at 0.05 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_fallow_0_1m",
         "temperature",
         "Maximum soil temperature at 0.1 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_fallow_0_2m",
         "temperature",
         "Maximum soil temperature at 0.2 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_fallow_0_5m",
         "temperature",
         "Maximum soil temperature at 0.5 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_fallow_1_5m",
         "temperature",
         "Maximum soil temperature at 1.5 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_fallow_1_8m",
         "temperature",
         "Maximum soil temperature at 1.8 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_fallow_1m", "temperature", "Maximum soil temperature at 1 m depth under fallow ground."
+        "temperature_soil_max_fallow_1m",
+        "temperature",
+        "Maximum soil temperature at 1 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_grass_0_05m", "temperature", "Maximum soil temperature at 0.05 m depth under grass."
+        "temperature_soil_max_grass_0_05m",
+        "temperature",
+        "Maximum soil temperature at 0.05 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_grass_0_1m", "temperature", "Maximum soil temperature at 0.1 m depth under grass."
+        "temperature_soil_max_grass_0_1m",
+        "temperature",
+        "Maximum soil temperature at 0.1 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_grass_0_2m", "temperature", "Maximum soil temperature at 0.2 m depth under grass."
+        "temperature_soil_max_grass_0_2m",
+        "temperature",
+        "Maximum soil temperature at 0.2 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_grass_0_5m", "temperature", "Maximum soil temperature at 0.5 m depth under grass."
+        "temperature_soil_max_grass_0_5m",
+        "temperature",
+        "Maximum soil temperature at 0.5 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_grass_1_5m", "temperature", "Maximum soil temperature at 1.5 m depth under grass."
+        "temperature_soil_max_grass_1_5m",
+        "temperature",
+        "Maximum soil temperature at 1.5 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_grass_1_8m", "temperature", "Maximum soil temperature at 1.8 m depth under grass."
+        "temperature_soil_max_grass_1_8m",
+        "temperature",
+        "Maximum soil temperature at 1.8 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_grass_1m", "temperature", "Maximum soil temperature at 1 m depth under grass."
+        "temperature_soil_max_grass_1m",
+        "temperature",
+        "Maximum soil temperature at 1 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_grass_muck_0_05m",
         "temperature",
         "Maximum soil temperature at 0.05 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_grass_muck_0_1m",
         "temperature",
         "Maximum soil temperature at 0.1 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_grass_muck_0_2m",
         "temperature",
         "Maximum soil temperature at 0.2 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_grass_muck_0_5m",
         "temperature",
         "Maximum soil temperature at 0.5 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_grass_muck_1_5m",
         "temperature",
         "Maximum soil temperature at 1.5 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_grass_muck_1_8m",
         "temperature",
         "Maximum soil temperature at 1.8 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_grass_muck_1m",
         "temperature",
         "Maximum soil temperature at 1 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_sod_0_05m", "temperature", "Maximum soil temperature at 0.05 m depth under sod."
+        "temperature_soil_max_sod_0_05m",
+        "temperature",
+        "Maximum soil temperature at 0.05 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_sod_0_1m", "temperature", "Maximum soil temperature at 0.1 m depth under sod."
+        "temperature_soil_max_sod_0_1m",
+        "temperature",
+        "Maximum soil temperature at 0.1 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_sod_0_2m", "temperature", "Maximum soil temperature at 0.2 m depth under sod."
+        "temperature_soil_max_sod_0_2m",
+        "temperature",
+        "Maximum soil temperature at 0.2 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_sod_0_5m", "temperature", "Maximum soil temperature at 0.5 m depth under sod."
+        "temperature_soil_max_sod_0_5m",
+        "temperature",
+        "Maximum soil temperature at 0.5 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_sod_1_5m", "temperature", "Maximum soil temperature at 1.5 m depth under sod."
+        "temperature_soil_max_sod_1_5m",
+        "temperature",
+        "Maximum soil temperature at 1.5 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_sod_1_8m", "temperature", "Maximum soil temperature at 1.8 m depth under sod."
+        "temperature_soil_max_sod_1_8m",
+        "temperature",
+        "Maximum soil temperature at 1.8 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_sod_1m", "temperature", "Maximum soil temperature at 1 m depth under sod."
+        "temperature_soil_max_sod_1m",
+        "temperature",
+        "Maximum soil temperature at 1 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_straw_mulch_0_05m",
         "temperature",
         "Maximum soil temperature at 0.05 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_straw_mulch_0_1m",
         "temperature",
         "Maximum soil temperature at 0.1 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_straw_mulch_0_2m",
         "temperature",
         "Maximum soil temperature at 0.2 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_straw_mulch_0_5m",
         "temperature",
         "Maximum soil temperature at 0.5 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_straw_mulch_1_5m",
         "temperature",
         "Maximum soil temperature at 1.5 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_straw_mulch_1_8m",
         "temperature",
         "Maximum soil temperature at 1.8 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_max_straw_mulch_1m", "temperature", "Maximum soil temperature at 1 m depth under straw mulch."
+        "temperature_soil_max_straw_mulch_1m",
+        "temperature",
+        "Maximum soil temperature at 1 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_0_05m",
         "temperature",
         "Maximum soil temperature at 0.05 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_0_1m",
         "temperature",
         "Maximum soil temperature at 0.1 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_0_2m",
         "temperature",
         "Maximum soil temperature at 0.2 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_0_5m",
         "temperature",
         "Maximum soil temperature at 0.5 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_1_5m",
         "temperature",
         "Maximum soil temperature at 1.5 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_1_8m",
         "temperature",
         "Maximum soil temperature at 1.8 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_1m",
         "temperature",
         "Maximum soil temperature at 1 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("temperature_soil_mean_0_02m", "temperature", "Mean soil temperature at 0.02 m depth."),
-    CanonicalParameter("temperature_soil_mean_0_05m", "temperature", "Mean soil temperature at 0.05 m depth."),
-    CanonicalParameter("temperature_soil_mean_0_1m", "temperature", "Mean soil temperature at 0.1 m depth."),
-    CanonicalParameter("temperature_soil_mean_0_2m", "temperature", "Mean soil temperature at 0.2 m depth."),
-    CanonicalParameter("temperature_soil_mean_0_5m", "temperature", "Mean soil temperature at 0.5 m depth."),
-    CanonicalParameter("temperature_soil_mean_1m", "temperature", "Mean soil temperature at 1 m depth."),
-    CanonicalParameter("temperature_soil_mean_2m", "temperature", "Mean soil temperature at 2 m depth."),
+    CanonicalParameter(
+        "temperature_soil_mean_0_02m",
+        "temperature",
+        "Mean soil temperature at 0.02 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_mean_0_05m",
+        "temperature",
+        "Mean soil temperature at 0.05 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_mean_0_1m",
+        "temperature",
+        "Mean soil temperature at 0.1 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_mean_0_2m",
+        "temperature",
+        "Mean soil temperature at 0.2 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_mean_0_5m",
+        "temperature",
+        "Mean soil temperature at 0.5 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_mean_1m", "temperature", "Mean soil temperature at 1 m depth.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "temperature_soil_mean_2m", "temperature", "Mean soil temperature at 2 m depth.", interpolation="homogeneous"
+    ),
     CanonicalParameter(
         "temperature_soil_mean_loamysand_0_05m",
         "temperature",
         "Mean soil temperature at 0.05 m depth under loamy sand.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_mean_loamysilt_0_05m",
         "temperature",
         "Mean soil temperature at 0.05 m depth under loamy silt.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("temperature_soil_min_0_1m", "temperature", "Minimum soil temperature at 0.1 m depth."),
-    CanonicalParameter("temperature_soil_min_0_2m", "temperature", "Minimum soil temperature at 0.2 m depth."),
-    CanonicalParameter("temperature_soil_min_0_5m", "temperature", "Minimum soil temperature at 0.5 m depth."),
-    CanonicalParameter("temperature_soil_min_1m", "temperature", "Minimum soil temperature at 1 m depth."),
-    CanonicalParameter("temperature_soil_min_2m", "temperature", "Minimum soil temperature at 2 m depth."),
+    CanonicalParameter(
+        "temperature_soil_min_0_1m",
+        "temperature",
+        "Minimum soil temperature at 0.1 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_min_0_2m",
+        "temperature",
+        "Minimum soil temperature at 0.2 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_min_0_5m",
+        "temperature",
+        "Minimum soil temperature at 0.5 m depth.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "temperature_soil_min_1m", "temperature", "Minimum soil temperature at 1 m depth.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "temperature_soil_min_2m", "temperature", "Minimum soil temperature at 2 m depth.", interpolation="homogeneous"
+    ),
     CanonicalParameter(
         "temperature_soil_min_bare_ground_0_05m",
         "temperature",
         "Minimum soil temperature at 0.05 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_ground_0_1m",
         "temperature",
         "Minimum soil temperature at 0.1 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_ground_0_2m",
         "temperature",
         "Minimum soil temperature at 0.2 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_ground_0_5m",
         "temperature",
         "Minimum soil temperature at 0.5 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_ground_1_5m",
         "temperature",
         "Minimum soil temperature at 1.5 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_ground_1_8m",
         "temperature",
         "Minimum soil temperature at 1.8 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_bare_ground_1m", "temperature", "Minimum soil temperature at 1 m depth under bare ground."
+        "temperature_soil_min_bare_ground_1m",
+        "temperature",
+        "Minimum soil temperature at 1 m depth under bare ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_muck_0_05m",
         "temperature",
         "Minimum soil temperature at 0.05 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_muck_0_1m",
         "temperature",
         "Minimum soil temperature at 0.1 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_muck_0_2m",
         "temperature",
         "Minimum soil temperature at 0.2 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_muck_0_5m",
         "temperature",
         "Minimum soil temperature at 0.5 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_muck_1_5m",
         "temperature",
         "Minimum soil temperature at 1.5 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_muck_1_8m",
         "temperature",
         "Minimum soil temperature at 1.8 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_bare_muck_1m",
         "temperature",
         "Minimum soil temperature at 1 m depth under bare muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_brome_grass_0_05m",
         "temperature",
         "Minimum soil temperature at 0.05 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_brome_grass_0_1m",
         "temperature",
         "Minimum soil temperature at 0.1 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_brome_grass_0_2m",
         "temperature",
         "Minimum soil temperature at 0.2 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_brome_grass_0_5m",
         "temperature",
         "Minimum soil temperature at 0.5 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_brome_grass_1_5m",
         "temperature",
         "Minimum soil temperature at 1.5 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_brome_grass_1_8m",
         "temperature",
         "Minimum soil temperature at 1.8 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_brome_grass_1m", "temperature", "Minimum soil temperature at 1 m depth under brome grass."
+        "temperature_soil_min_brome_grass_1m",
+        "temperature",
+        "Minimum soil temperature at 1 m depth under brome grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_fallow_0_05m",
         "temperature",
         "Minimum soil temperature at 0.05 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_fallow_0_1m",
         "temperature",
         "Minimum soil temperature at 0.1 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_fallow_0_2m",
         "temperature",
         "Minimum soil temperature at 0.2 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_fallow_0_5m",
         "temperature",
         "Minimum soil temperature at 0.5 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_fallow_1_5m",
         "temperature",
         "Minimum soil temperature at 1.5 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_fallow_1_8m",
         "temperature",
         "Minimum soil temperature at 1.8 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_fallow_1m", "temperature", "Minimum soil temperature at 1 m depth under fallow ground."
+        "temperature_soil_min_fallow_1m",
+        "temperature",
+        "Minimum soil temperature at 1 m depth under fallow ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_grass_0_05m", "temperature", "Minimum soil temperature at 0.05 m depth under grass."
+        "temperature_soil_min_grass_0_05m",
+        "temperature",
+        "Minimum soil temperature at 0.05 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_grass_0_1m", "temperature", "Minimum soil temperature at 0.1 m depth under grass."
+        "temperature_soil_min_grass_0_1m",
+        "temperature",
+        "Minimum soil temperature at 0.1 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_grass_0_2m", "temperature", "Minimum soil temperature at 0.2 m depth under grass."
+        "temperature_soil_min_grass_0_2m",
+        "temperature",
+        "Minimum soil temperature at 0.2 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_grass_0_5m", "temperature", "Minimum soil temperature at 0.5 m depth under grass."
+        "temperature_soil_min_grass_0_5m",
+        "temperature",
+        "Minimum soil temperature at 0.5 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_grass_1_5m", "temperature", "Minimum soil temperature at 1.5 m depth under grass."
+        "temperature_soil_min_grass_1_5m",
+        "temperature",
+        "Minimum soil temperature at 1.5 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_grass_1_8m", "temperature", "Minimum soil temperature at 1.8 m depth under grass."
+        "temperature_soil_min_grass_1_8m",
+        "temperature",
+        "Minimum soil temperature at 1.8 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_grass_1m", "temperature", "Minimum soil temperature at 1 m depth under grass."
+        "temperature_soil_min_grass_1m",
+        "temperature",
+        "Minimum soil temperature at 1 m depth under grass.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_grass_muck_0_05m",
         "temperature",
         "Minimum soil temperature at 0.05 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_grass_muck_0_1m",
         "temperature",
         "Minimum soil temperature at 0.1 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_grass_muck_0_2m",
         "temperature",
         "Minimum soil temperature at 0.2 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_grass_muck_0_5m",
         "temperature",
         "Minimum soil temperature at 0.5 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_grass_muck_1_5m",
         "temperature",
         "Minimum soil temperature at 1.5 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_grass_muck_1_8m",
         "temperature",
         "Minimum soil temperature at 1.8 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_grass_muck_1m",
         "temperature",
         "Minimum soil temperature at 1 m depth under grass over muck soil.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_sod_0_05m", "temperature", "Minimum soil temperature at 0.05 m depth under sod."
+        "temperature_soil_min_sod_0_05m",
+        "temperature",
+        "Minimum soil temperature at 0.05 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_sod_0_1m", "temperature", "Minimum soil temperature at 0.1 m depth under sod."
+        "temperature_soil_min_sod_0_1m",
+        "temperature",
+        "Minimum soil temperature at 0.1 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_sod_0_2m", "temperature", "Minimum soil temperature at 0.2 m depth under sod."
+        "temperature_soil_min_sod_0_2m",
+        "temperature",
+        "Minimum soil temperature at 0.2 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_sod_0_5m", "temperature", "Minimum soil temperature at 0.5 m depth under sod."
+        "temperature_soil_min_sod_0_5m",
+        "temperature",
+        "Minimum soil temperature at 0.5 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_sod_1_5m", "temperature", "Minimum soil temperature at 1.5 m depth under sod."
+        "temperature_soil_min_sod_1_5m",
+        "temperature",
+        "Minimum soil temperature at 1.5 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_sod_1_8m", "temperature", "Minimum soil temperature at 1.8 m depth under sod."
+        "temperature_soil_min_sod_1_8m",
+        "temperature",
+        "Minimum soil temperature at 1.8 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_sod_1m", "temperature", "Minimum soil temperature at 1 m depth under sod."
+        "temperature_soil_min_sod_1m",
+        "temperature",
+        "Minimum soil temperature at 1 m depth under sod.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_straw_mulch_0_05m",
         "temperature",
         "Minimum soil temperature at 0.05 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_straw_mulch_0_1m",
         "temperature",
         "Minimum soil temperature at 0.1 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_straw_mulch_0_2m",
         "temperature",
         "Minimum soil temperature at 0.2 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_straw_mulch_0_5m",
         "temperature",
         "Minimum soil temperature at 0.5 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_straw_mulch_1_5m",
         "temperature",
         "Minimum soil temperature at 1.5 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_straw_mulch_1_8m",
         "temperature",
         "Minimum soil temperature at 1.8 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
-        "temperature_soil_min_straw_mulch_1m", "temperature", "Minimum soil temperature at 1 m depth under straw mulch."
+        "temperature_soil_min_straw_mulch_1m",
+        "temperature",
+        "Minimum soil temperature at 1 m depth under straw mulch.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_0_05m",
         "temperature",
         "Minimum soil temperature at 0.05 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_0_1m",
         "temperature",
         "Minimum soil temperature at 0.1 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_0_2m",
         "temperature",
         "Minimum soil temperature at 0.2 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_0_5m",
         "temperature",
         "Minimum soil temperature at 0.5 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_1_5m",
         "temperature",
         "Minimum soil temperature at 1.5 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_1_8m",
         "temperature",
         "Minimum soil temperature at 1.8 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_1m",
         "temperature",
         "Minimum soil temperature at 1 m depth under an unrecorded surface cover.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("temperature_surface_mean", "temperature", "Mean temperature of the ground surface."),
+    CanonicalParameter(
+        "temperature_surface_mean",
+        "temperature",
+        "Mean temperature of the ground surface.",
+        interpolation="homogeneous",
+    ),
     CanonicalParameter("temperature_water", "temperature", "Temperature of the water."),
     CanonicalParameter(
         "temperature_water_evaporation_pan_max",
@@ -1668,11 +2362,17 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "dimensionless",
         "Whether ice had formed on the thermometer during the wet bulb measurement.",
     ),
-    CanonicalParameter("temperature_wet_mean_2m", "temperature", "Wet-bulb temperature at 2 m above ground."),
+    CanonicalParameter(
+        "temperature_wet_mean_2m",
+        "temperature",
+        "Wet-bulb temperature at 2 m above ground.",
+        interpolation="homogeneous",
+    ),
     CanonicalParameter(
         "temperature_wind_chill",
         "temperature",
         "Wind chill, the temperature the air feels like once wind is accounted for.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter("thawing_thickness_bare", "length_short", "Depth to which bare ground has thawed."),
     CanonicalParameter(
@@ -1696,7 +2396,10 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
     ),
     CanonicalParameter("turbidity", "turbidity", "Cloudiness of the water caused by suspended particles."),
     CanonicalParameter(
-        "visibility_range", "length_medium", "Horizontal distance at which an object can still be made out."
+        "visibility_range",
+        "length_medium",
+        "Horizontal distance at which an object can still be made out.",
+        interpolation="heterogeneous",
     ),
     CanonicalParameter(
         "visibility_range_index",
@@ -1712,26 +2415,34 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "water_equivalent_snow_depth",
         "precipitation",
         "Depth of water that would result from melting the snow on the ground.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "water_equivalent_snow_depth_excelled",
         "precipitation",
         "Water equivalent of the snow cover where it exceeded the gauge range.",
+        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "water_equivalent_snow_depth_new",
         "precipitation",
         "Depth of water that would result from melting the freshly fallen snow.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "water_equivalent_snow_depth_new_last_1h",
         "precipitation",
         "Water equivalent of the snow that fell in the preceding hour.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "water_equivalent_snow_depth_new_last_3h",
         "precipitation",
         "Water equivalent of the snow that fell in the preceding 3 hours.",
+        interpolation="heterogeneous",
+        zero_inflated=True,
     ),
     CanonicalParameter(
         "water_film_thickness", "length_short", "Thickness of the film of water lying on the road surface."
@@ -1861,27 +2572,72 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "wind_direction_gust_max_5sec", "angle", "Direction of the strongest gust averaged over five seconds."
     ),
     CanonicalParameter("wind_direction_gust_max_instant", "angle", "Direction of the strongest instantaneous gust."),
-    CanonicalParameter("wind_force_beaufort", "wind_scale", "Wind strength on the Beaufort scale."),
-    CanonicalParameter("wind_gust_max", "speed", "Speed of the strongest gust of the period."),
-    CanonicalParameter("wind_gust_max_1mile", "speed", "Strongest gust measured over a one-mile passage of air."),
-    CanonicalParameter("wind_gust_max_1min", "speed", "Strongest gust averaged over one minute."),
-    CanonicalParameter("wind_gust_max_2min", "speed", "Strongest gust averaged over two minutes."),
-    CanonicalParameter("wind_gust_max_5sec", "speed", "Strongest gust averaged over five seconds."),
-    CanonicalParameter("wind_gust_max_instant", "speed", "Strongest instantaneous gust."),
-    CanonicalParameter("wind_gust_max_last_12h", "speed", "Strongest gust over the preceding 12 hours."),
-    CanonicalParameter("wind_gust_max_last_1h", "speed", "Strongest gust over the preceding hour."),
-    CanonicalParameter("wind_gust_max_last_3h", "speed", "Strongest gust over the preceding 3 hours."),
-    CanonicalParameter("wind_gust_max_last_6h", "speed", "Strongest gust over the preceding 6 hours."),
+    CanonicalParameter(
+        "wind_force_beaufort", "wind_scale", "Wind strength on the Beaufort scale.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "wind_gust_max", "speed", "Speed of the strongest gust of the period.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "wind_gust_max_1mile",
+        "speed",
+        "Strongest gust measured over a one-mile passage of air.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter(
+        "wind_gust_max_1min", "speed", "Strongest gust averaged over one minute.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "wind_gust_max_2min", "speed", "Strongest gust averaged over two minutes.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "wind_gust_max_5sec", "speed", "Strongest gust averaged over five seconds.", interpolation="homogeneous"
+    ),
+    CanonicalParameter("wind_gust_max_instant", "speed", "Strongest instantaneous gust.", interpolation="homogeneous"),
+    CanonicalParameter(
+        "wind_gust_max_last_12h", "speed", "Strongest gust over the preceding 12 hours.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "wind_gust_max_last_1h", "speed", "Strongest gust over the preceding hour.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "wind_gust_max_last_3h", "speed", "Strongest gust over the preceding 3 hours.", interpolation="homogeneous"
+    ),
+    CanonicalParameter(
+        "wind_gust_max_last_6h", "speed", "Strongest gust over the preceding 6 hours.", interpolation="homogeneous"
+    ),
     CanonicalParameter(
         "wind_movement_24h",
         "length_long",
         "Wind run, the distance a parcel of air travelled past the station in 24 hours.",
+        interpolation="homogeneous",
     ),
-    CanonicalParameter("wind_movement_multiday", "length_long", "Wind run over several days, reported as one total."),
-    CanonicalParameter("wind_speed", "speed", "Mean speed of the wind over the period."),
-    CanonicalParameter("wind_speed_arithmetic", "speed", "Arithmetic mean of the wind speed, unweighted by direction."),
-    CanonicalParameter("wind_speed_min", "speed", "Lowest wind speed over the period."),
-    CanonicalParameter("wind_speed_rolling_mean_max", "speed", "Highest rolling mean wind speed over the period."),
+    CanonicalParameter(
+        "wind_movement_multiday",
+        "length_long",
+        "Wind run over several days, reported as one total.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter("wind_speed", "speed", "Mean speed of the wind over the period.", interpolation="homogeneous"),
+    CanonicalParameter(
+        "wind_speed_arithmetic",
+        "speed",
+        "Arithmetic mean of the wind speed, unweighted by direction.",
+        interpolation="homogeneous",
+    ),
+    CanonicalParameter("wind_speed_min", "speed", "Lowest wind speed over the period.", interpolation="homogeneous"),
+    CanonicalParameter(
+        "wind_speed_rolling_mean_max",
+        "speed",
+        "Highest rolling mean wind speed over the period.",
+        interpolation="homogeneous",
+    ),
 )
 
 PARAMETERS: dict[str, CanonicalParameter] = {parameter.name: parameter for parameter in PARAMETER_TABLE}
+
+# the names a request may interpolate or summarize over, i.e. everything the table classifies at
+# all. A frozenset rather than the list this used to be: membership is what every caller tests.
+INTERPOLATABLE_PARAMETERS: frozenset[str] = frozenset(
+    parameter.name for parameter in PARAMETER_TABLE if parameter.interpolation
+)

--- a/src/wetterdienst/metadata/parameter_table.py
+++ b/src/wetterdienst/metadata/parameter_table.py
@@ -55,7 +55,10 @@ if TYPE_CHECKING:
 #   condition), quality flags, counts and bookkeeping have no meaningful value between two
 #   stations, and neither do quantities tied to a particular body of water (discharge, stage,
 #   water temperature) or to a station's own instrument (measurement errors, uncertainties).
-#   Directions are excluded too: interpolating 350 deg and 10 deg linearly gives south.
+#   Directions are excluded too: interpolating 350 deg and 10 deg linearly gives south. So are the
+#   soil temperatures whose surface cover is recorded as "unknown": the rest of that family is
+#   interpolatable because the cover is part of the name, and that is exactly what does not hold
+#   when the cover was never recorded and two stations may be measuring under different surfaces.
 #
 # A ``Literal`` rather than an enum, for the same reason as ``UnitType``: a typo in a table entry
 # is then a type error under ``ty`` rather than something only a test can catch.
@@ -1849,43 +1852,36 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "temperature_soil_max_unknown_0_05m",
         "temperature",
         "Maximum soil temperature at 0.05 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_0_1m",
         "temperature",
         "Maximum soil temperature at 0.1 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_0_2m",
         "temperature",
         "Maximum soil temperature at 0.2 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_0_5m",
         "temperature",
         "Maximum soil temperature at 0.5 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_1_5m",
         "temperature",
         "Maximum soil temperature at 1.5 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_1_8m",
         "temperature",
         "Maximum soil temperature at 1.8 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_max_unknown_1m",
         "temperature",
         "Maximum soil temperature at 1 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_mean_0_02m",
@@ -2299,43 +2295,36 @@ PARAMETER_TABLE: tuple[CanonicalParameter, ...] = (
         "temperature_soil_min_unknown_0_05m",
         "temperature",
         "Minimum soil temperature at 0.05 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_0_1m",
         "temperature",
         "Minimum soil temperature at 0.1 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_0_2m",
         "temperature",
         "Minimum soil temperature at 0.2 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_0_5m",
         "temperature",
         "Minimum soil temperature at 0.5 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_1_5m",
         "temperature",
         "Minimum soil temperature at 1.5 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_1_8m",
         "temperature",
         "Minimum soil temperature at 1.8 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_soil_min_unknown_1m",
         "temperature",
         "Minimum soil temperature at 1 m depth under an unrecorded surface cover.",
-        interpolation="homogeneous",
     ),
     CanonicalParameter(
         "temperature_surface_mean",

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -25,6 +25,7 @@ from wetterdienst.exceptions import (
     StartDateEndDateError,
     StationNotFoundError,
 )
+from wetterdienst.metadata.parameter_table import INTERPOLATABLE_PARAMETERS
 from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.model.metadata import (
     DatasetModel,
@@ -117,165 +118,10 @@ class TimeseriesRequest:
         "state",
     )
 
-    #   - heterogeneous parameters such as precipitation_height (short distance, ~20 km)
-    #   - homogeneous parameters such as temperature_air_2m (large distance, ~40 km)
-    interpolatable_parameters: ClassVar = [
-        # ---- temperature ----
-        # air temperature at 2 m — large spatial correlation, suitable for ~40 km interpolation
-        "temperature_air_2m",
-        "temperature_air_mean_2m",
-        "temperature_air_mean_2m_last_24h",
-        "temperature_air_max_2m",
-        "temperature_air_max_2m_last_24h",
-        "temperature_air_max_2m_mean",
-        "temperature_air_max_2m_multiday",
-        "temperature_air_min_2m",
-        "temperature_air_min_2m_last_24h",
-        "temperature_air_min_2m_mean",
-        "temperature_air_min_2m_multiday",
-        # air temperature at 0.05 m / 0.1 m (near-surface)
-        "temperature_air_mean_0_05m",
-        "temperature_air_mean_0_1m",
-        "temperature_air_max_0_05m",
-        "temperature_air_min_0_05m",
-        "temperature_air_min_0_05m_last_12h",
-        # derived air temperature quantities
-        "temperature_dew_point_mean_2m",
-        "temperature_wet_mean_2m",
-        "temperature_wind_chill",
-        # surface temperature
-        "temperature_surface_mean",
-        # soil temperature — depth-dependent but spatially smooth at regional scale
-        "temperature_soil_mean_0_02m",
-        "temperature_soil_mean_0_05m",
-        "temperature_soil_mean_0_1m",
-        "temperature_soil_mean_0_2m",
-        "temperature_soil_mean_0_5m",
-        "temperature_soil_mean_1m",
-        "temperature_soil_mean_2m",
-        "temperature_soil_min_0_1m",
-        "temperature_soil_min_0_2m",
-        "temperature_soil_min_0_5m",
-        "temperature_soil_min_1m",
-        "temperature_soil_min_2m",
-        "temperature_soil_max_0_1m",
-        "temperature_soil_max_0_2m",
-        "temperature_soil_max_0_5m",
-        "temperature_soil_max_1m",
-        "temperature_soil_max_2m",
-        # derived temperature aggregates
-        "heating_degree_day",
-        "cooling_degree_day",
-        "cooling_degree_hour",
-        # ---- humidity ----
-        # all humidity variants are spatially smooth (~40 km)
-        "humidity",
-        "humidity_absolute",
-        "humidity_max",
-        "humidity_min",
-        # ---- wind ----
-        # wind speed variants — regional-scale field (~40 km)
-        "wind_speed",
-        "wind_speed_arithmetic",
-        "wind_speed_min",
-        "wind_speed_rolling_mean_max",
-        "wind_force_beaufort",
-        "wind_movement_24h",
-        "wind_movement_multiday",
-        # wind gust variants — regional-scale (~40 km)
-        "wind_gust_max",
-        "wind_gust_max_last_1h",
-        "wind_gust_max_last_3h",
-        "wind_gust_max_last_6h",
-        "wind_gust_max_last_12h",
-        "wind_gust_max_5sec",
-        "wind_gust_max_1min",
-        "wind_gust_max_2min",
-        "wind_gust_max_instant",
-        "wind_gust_max_1mile",
-        # ---- precipitation ----
-        # precipitation is heterogeneous — shorter spatial correlation length (~20 km)
-        "precipitation_height",
-        "precipitation_height_day",
-        "precipitation_height_night",
-        "precipitation_height_liquid",
-        "precipitation_height_droplet",
-        "precipitation_height_rocker",
-        "precipitation_height_last_1h",
-        "precipitation_height_last_3h",
-        "precipitation_height_last_6h",
-        "precipitation_height_last_9h",
-        "precipitation_height_last_12h",
-        "precipitation_height_last_15h",
-        "precipitation_height_last_18h",
-        "precipitation_height_last_21h",
-        "precipitation_height_last_24h",
-        "precipitation_height_multiday",
-        "precipitation_height_significant_weather_last_1h",
-        "precipitation_height_significant_weather_last_3h",
-        "precipitation_height_significant_weather_last_6h",
-        "precipitation_height_significant_weather_last_12h",
-        "precipitation_height_significant_weather_last_24h",
-        "precipitation_height_liquid_significant_weather_last_1h",
-        "precipitation_height_max",
-        "precipitation_duration",
-        # ---- snow ----
-        # accumulated snow depth — smooth regional field (~40 km)
-        "snow_depth",
-        "snow_depth_excelled",
-        "snow_depth_manual",
-        "snow_depth_max",
-        # new snow per period — more heterogeneous like precipitation (~20 km)
-        "snow_depth_new",
-        "snow_depth_new_multiday",
-        "snow_depth_new_max",
-        # ---- water equivalent ----
-        # accumulated SWE — smooth regional field (~40 km)
-        "water_equivalent_snow_depth",
-        "water_equivalent_snow_depth_excelled",
-        # new SWE — heterogeneous like precipitation (~20 km)
-        "water_equivalent_snow_depth_new",
-        "water_equivalent_snow_depth_new_last_1h",
-        "water_equivalent_snow_depth_new_last_3h",
-        # ---- solar / radiation ----
-        # sunshine and radiation — driven by synoptic cloud patterns, large spatial correlation (~40 km)
-        "sunshine_duration",
-        "sunshine_duration_last_3h",
-        "sunshine_duration_yesterday",
-        "sunshine_duration_relative",
-        "sunshine_duration_relative_last_24h",
-        "radiation_global",
-        "radiation_global_intensity",
-        "radiation_global_last_3h",
-        "radiation_sky_short_wave_diffuse",
-        "radiation_sky_short_wave_diffuse_intensity",
-        "radiation_sky_short_wave_direct",
-        "radiation_sky_long_wave",
-        "radiation_sky_long_wave_intensity",
-        "radiation_sky_long_wave_last_3h",
-        # ---- pressure ----
-        # pressure — synoptic-scale field, most spatially homogeneous of all met parameters (~40 km)
-        "pressure_air_sea_level",
-        "pressure_air_site",
-        "pressure_air_site_reduced",
-        "pressure_air_site_max",
-        "pressure_air_site_min",
-        "pressure_air_site_delta_last_3h",
-        "pressure_vapor",
-        # ---- cloud cover ----
-        # cloud cover — regional-scale field, viable for ~40 km interpolation
-        "cloud_cover_total",
-        "cloud_cover_total_midnight_to_midnight",
-        "cloud_cover_total_sunrise_to_sunset",
-        "cloud_cover_effective",
-        # ---- evapotranspiration ----
-        # driven by temperature, humidity, radiation — large spatial correlation (~40 km)
-        "evapotranspiration_potential_last_24h",
-        "evapotranspiration_potential_gras_fao_last_24h",
-        "evapotranspiration_potential_gras_haude_last_24h",
-        "evaporation_height",
-        "evaporation_height_multiday",
-    ]
+    # The parameters that may be interpolated or summarized, which is a property of the measured
+    # quantity rather than of a request -- see `CanonicalParameter.interpolation`. Kept here as a
+    # class attribute because that is where callers look for it.
+    interpolatable_parameters: ClassVar = INTERPOLATABLE_PARAMETERS
 
     @staticmethod
     def _parse_station_id(series: pl.Series) -> pl.Series:

--- a/src/wetterdienst/settings.py
+++ b/src/wetterdienst/settings.py
@@ -15,6 +15,7 @@ import platformdirs
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from wetterdienst.metadata.parameter_table import PARAMETER_TABLE
 from wetterdienst.model.unit import UnitConverter
 
 log = logging.getLogger(__name__)
@@ -62,45 +63,24 @@ class Auth(BaseModel):
         return str(as_tuple[0]), str(as_tuple[1])
 
 
+#: how far a station may be from the target point to still be used, in km
+_STATION_DISTANCE_HOMOGENEOUS = 40.0
+#: the same for a quantity that decorrelates faster -- see `CanonicalParameter.interpolation`
+_STATION_DISTANCE_HETEROGENEOUS = 20.0
+
+
 def _default_geo_station_distance() -> defaultdict[str, float]:
-    d: defaultdict[str, float] = defaultdict(lambda: 40.0)
-    # heterogeneous parameters: shorter spatial correlation length, use 20 km
-    # precipitation — all variants are convectively driven and spatially variable
-    for name in (
-        "precipitation_height",
-        "precipitation_height_day",
-        "precipitation_height_night",
-        "precipitation_height_liquid",
-        "precipitation_height_droplet",
-        "precipitation_height_rocker",
-        "precipitation_height_last_1h",
-        "precipitation_height_last_3h",
-        "precipitation_height_last_6h",
-        "precipitation_height_last_9h",
-        "precipitation_height_last_12h",
-        "precipitation_height_last_15h",
-        "precipitation_height_last_18h",
-        "precipitation_height_last_21h",
-        "precipitation_height_last_24h",
-        "precipitation_height_multiday",
-        "precipitation_height_significant_weather_last_1h",
-        "precipitation_height_significant_weather_last_3h",
-        "precipitation_height_significant_weather_last_6h",
-        "precipitation_height_significant_weather_last_12h",
-        "precipitation_height_significant_weather_last_24h",
-        "precipitation_height_liquid_significant_weather_last_1h",
-        "precipitation_height_max",
-        "precipitation_duration",
-        # new snow per period — heterogeneous like precipitation
-        "snow_depth_new",
-        "snow_depth_new_multiday",
-        "snow_depth_new_max",
-        # new SWE — heterogeneous like precipitation
-        "water_equivalent_snow_depth_new",
-        "water_equivalent_snow_depth_new_last_1h",
-        "water_equivalent_snow_depth_new_last_3h",
-    ):
-        d[name] = 20.0
+    """Build the per-parameter search radius from the canonical parameter table.
+
+    Which names get the shorter radius used to be written out here, a copy of a classification the
+    table already holds. Only those names are put in the dict; the default factory answers for
+    every other parameter, so the setting a user sees and overrides stays the short list of
+    exceptions rather than all 514 names.
+    """
+    d: defaultdict[str, float] = defaultdict(lambda: _STATION_DISTANCE_HOMOGENEOUS)
+    for parameter in PARAMETER_TABLE:
+        if parameter.interpolation == "heterogeneous":
+            d[parameter.name] = _STATION_DISTANCE_HETEROGENEOUS
     return d
 
 

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -11,11 +11,11 @@ from polars.testing import assert_frame_equal
 
 from wetterdienst import Settings
 from wetterdienst.core.interpolate import (
-    _OCCURRENCE_BASED_PARAMETERS,
     apply_interpolation,
     get_valid_station_groups,
 )
 from wetterdienst.exceptions import StationNotFoundError
+from wetterdienst.metadata.parameter_table import PARAMETERS
 from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
 from wetterdienst.provider.dwd.observation import (
     DwdObservationRequest,
@@ -136,19 +136,19 @@ def test_occurrence_threshold_applies_to_snow_depth_new() -> None:
 
 
 def test_occurrence_based_parameters_set_contains_all_precipitation_variants() -> None:
-    """Smoke-test that _OCCURRENCE_BASED_PARAMETERS covers core precipitation and new-snow parameters."""
+    """Smoke-test that the zero-inflated flag covers core precipitation and new-snow parameters."""
     required = {
         "precipitation_height",
         "precipitation_height_liquid",
         "precipitation_height_last_1h",
         "precipitation_height_last_24h",
         "precipitation_duration",
+        "precipitation_intensity",
         "snow_depth_new",
         "water_equivalent_snow_depth_new",
     }
-    assert required.issubset(_OCCURRENCE_BASED_PARAMETERS), (
-        f"Missing from _OCCURRENCE_BASED_PARAMETERS: {required - _OCCURRENCE_BASED_PARAMETERS}"
-    )
+    missing = sorted(name for name in required if not PARAMETERS[name].zero_inflated)
+    assert not missing, f"not marked zero_inflated in the canonical parameter table: {missing}"
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -194,27 +194,39 @@ def test_parameter_table_descriptions() -> None:
     assert not duplicated, f"descriptions shared by more than one parameter: {duplicated}"
 
 
-def test_internal_parameter_lists_are_canonical() -> None:
-    """Test that the parameter names hard-coded inside the library are real canonical names.
+def test_interpolation_behaviour_derives_from_parameter_table() -> None:
+    """Test that nothing keeps its own copy of which parameters may be interpolated.
 
-    These lists used to be written as `Parameter.PRECIPITATION_HEIGHT` members, so a misspelling
-    was an AttributeError at import. They are plain strings now, which reads better but catches
-    nothing on its own -- a typo would silently mean "this parameter is never interpolated" or
-    "this parameter keeps the default 40 km search radius", both of which change results quietly
-    rather than failing. This test is what replaces the enum's guard.
+    Which parameters may be interpolated, which get the shorter search radius and which get
+    occurrence thresholding used to be three hand-written name lists in three modules, kept in step
+    by a test that they were at least spelled correctly. They are views of
+    `CanonicalParameter.interpolation` and `.zero_inflated` now, and this asserts they still are --
+    a list written out again by hand would drift from the table exactly as before.
     """
-    from wetterdienst.core.interpolate import _OCCURRENCE_BASED_PARAMETERS  # noqa: PLC0415
     from wetterdienst.model.request import TimeseriesRequest  # noqa: PLC0415
-    from wetterdienst.settings import _default_geo_station_distance  # noqa: PLC0415
+    from wetterdienst.settings import (  # noqa: PLC0415
+        _STATION_DISTANCE_HETEROGENEOUS,
+        _default_geo_station_distance,
+    )
 
-    hard_coded = {
-        "TimeseriesRequest.interpolatable_parameters": TimeseriesRequest.interpolatable_parameters,
-        "interpolate._OCCURRENCE_BASED_PARAMETERS": _OCCURRENCE_BASED_PARAMETERS,
-        "settings ts_geo_station_distance defaults": _default_geo_station_distance(),
+    assert set(TimeseriesRequest.interpolatable_parameters) == {p.name for p in PARAMETER_TABLE if p.interpolation}
+    shorter_radius = {
+        name
+        for name, distance in _default_geo_station_distance().items()
+        if distance == _STATION_DISTANCE_HETEROGENEOUS
     }
-    for label, names in hard_coded.items():
-        unknown = sorted(name for name in names if name not in PARAMETERS)
-        assert not unknown, f"{label} contains names that are not canonical parameters: {unknown}"
+    assert shorter_radius == {p.name for p in PARAMETER_TABLE if p.interpolation == "heterogeneous"}
+
+
+def test_parameter_table_zero_inflated_parameters_are_interpolated() -> None:
+    """Test that no parameter asks for occurrence thresholding it will never receive.
+
+    `zero_inflated` is only ever read while interpolating, so marking a parameter that is not
+    interpolated at all says something about it that nothing acts on -- a declaration that reads as
+    intent but has no effect.
+    """
+    unreachable = sorted(p.name for p in PARAMETER_TABLE if p.zero_inflated and not p.interpolation)
+    assert not unreachable, f"zero_inflated but never interpolated: {unreachable}"
 
 
 def test_parameter_table_names_unique() -> None:


### PR DESCRIPTION
## What

How a parameter behaves in space is a property of the measured quantity, like its unit type. It was written out as three hand-maintained name lists that had to agree with each other:

| was | now |
|---|---|
| `TimeseriesRequest.interpolatable_parameters` (a 129-line list) | `INTERPOLATABLE_PARAMETERS`, derived from the table |
| the `ts_geo_station_distance` defaults in `Settings` | loops the table for `"heterogeneous"` |
| `_OCCURRENCE_BASED_PARAMETERS` in `core.interpolate` | deleted — `PARAMETERS[parameter].zero_inflated` |

A test checked those lists were at least spelled correctly; nothing checked they said the same thing. `CanonicalParameter` now carries the classification once:

- **`interpolation`** — `"homogeneous"` (the 40 km default search radius), `"heterogeneous"` (20 km), or `None` for a quantity that is not interpolated at all
- **`zero_inflated`** — whether interpolated values are thresholded on occurrence

The two stay separate because they are separate facts. Visibility decorrelates over a few kilometres without being zero-inflated, and a precipitation *normal* is as orographically variable as precipitation while never being zero; neither is expressible with a single flag. Both are `Literal`/`bool` rather than enums for the same reason as `unit_type` — a typo in a table entry is a type error under `ty` rather than something only a test can catch.

## Extended coverage: 127 → 343 of 514 parameters

The classification was never about the data being unavailable, only about which names had been written into the list by hand.

Added at 40 km: soil temperature under a named cover and depth (114, NOAA GHCNd — the cover is part of the name, so two stations reporting the same parameter measure the same thing), forecast probabilities (65, MOSMIX and DMO), soil moisture (12), evaporation per crop and soil (6), concrete slab temperature (3), humidex and mean radiant temperature, cloud cover in a fixed height band, and climatological normals. At 20 km: precipitation intensity (zero-inflated) plus precipitation and fresh-snow normals (not zero-inflated) and visibility.

Deliberately still excluded: coded observations (weather type, cloud genus, road surface condition), quality flags, counts, quantities tied to one body of water (discharge, stage, water temperature), a station's own measurement errors and uncertainties, every direction — interpolating 350° and 10° linearly gives south — and the 14 GHCNd soil temperatures whose cover is recorded as `unknown`, where the cover-is-in-the-name argument is precisely what fails.

## Cost to know about

`interpolate()` and `summarize()` stop querying stations only once *every* requested parameter has enough of them. A whole-dataset request against MOSMIX or DMO now has 65 probabilities to satisfy, so it walks further down the station ranking than before. Requesting the parameters you actually want keeps it where it was. Noted in the changelog.

## Breaking, mildly

`TimeseriesRequest.interpolatable_parameters` is a `frozenset` rather than a `list`. Every caller in the library only tests membership, but it is a public class attribute, so code that indexes or slices it, or relies on its order, needs updating.

## Tests

`test_internal_parameter_lists_are_canonical` is replaced by two tests: one that the three consumers still derive from the table (a list written out again by hand would drift exactly as before), and one that `zero_inflated` is never set on a parameter that is never interpolated, since nothing would ever act on it.

The parameter table's entry tuple was regenerated by script and reformatted, so the diff is large but mechanical — the `(name, unit_type, description)` payload is byte-identical to `main`, verified by loading both tables and comparing them.

Run locally: `poe format`, `poe typecheck`, `tests/test_api.py` (132 passed), `tests/test_settings.py`, `tests/core/` (22 passed), `tests/ui/test_restapi.py -k "glossary or coverage"`.

## Docs

The parameter glossary now states per parameter whether it can be interpolated and from how far, reading the built-in defaults rather than `Settings()` so the published page does not document whatever `WD_*` variables the docs builder happens to have set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)