### PR TITLE
fix(core): summarize searched 20 km for every parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,12 @@ Types of changes:
 
 ### Fixed
 
+- `summarize()` searched for stations within 20 km whatever the parameter. It bounded its search
+  with `max(ts_geo_station_distance.values())`, and that mapping only holds entries for the
+  parameters that get the *shorter* radius — everything else is answered by the default factory and
+  so is not in `values()` at all. It now takes the widest radius among the requested parameters, as
+  interpolation already did, so a summary of e.g. `temperature_air_mean_2m` reaches the full 40 km
+  and finds stations it used to walk past
 - **Breaking**: MET Norway's in-band codes are decoded rather than returned as measurements. Frost
   states both in the element descriptions it publishes and then writes them into the value itself:
   snow depth -1 is "no snow", which is a depth of zero rather than an absent one, and cloud cover

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -44,7 +44,12 @@ def request_stations(request: TimeseriesRequest, latitude: float, longitude: flo
     param_dict = {}
     stations_dict = {}
     settings = cast("Settings", request.settings)
-    distance = max(settings.ts_geo_station_distance.values())
+    # the widest radius any requested parameter may draw on, as in `interpolate.request_stations`.
+    # `max(...values())` used to stand here, which is the widest radius of the *populated* keys --
+    # only the heterogeneous 20 km ones -- and so capped the search at 20 km for every parameter,
+    # including the ones the setting gives 40 km
+    parameter_names = {parameter.name for parameter in request.parameters if isinstance(parameter, ParameterModel)}
+    distance = max(settings.ts_geo_station_distance[parameter_name] for parameter_name in parameter_names)
     stations_ranked = request.filter_by_distance(latlon=(latitude, longitude), distance=distance)
     df_stations_ranked = stations_ranked.df
     tqdm_out = TqdmToLogger(log, level=logging.INFO)
@@ -81,10 +86,10 @@ def apply_station_values_per_parameter(
             log.info(f"parameter {parameter.name} can not be interpolated")
             continue
         ts_interpolation_station_distance = settings.ts_geo_station_distance
-        if station["distance"] > ts_interpolation_station_distance.get(
-            parameter.name,
-            ts_interpolation_station_distance["default"],
-        ):
+        # a defaultdict, so an unlisted parameter answers with the default radius on its own; the
+        # explicit "default" key this used to fall back to was inserted into the mapping as a side
+        # effect of being read
+        if station["distance"] > ts_interpolation_station_distance[parameter.name]:
             log.info(f"Station for parameter {parameter.name} is too far away")
             continue
         param_key = (dataset.resolution.name, dataset.name, parameter.name)


### PR DESCRIPTION
## The bug

`core/summarize.py::request_stations` bounded its station search with:

```python
distance = max(settings.ts_geo_station_distance.values())
```

`ts_geo_station_distance` is a `defaultdict` that holds entries **only** for the parameters given the *shorter* radius — precipitation, fresh snow and their water equivalents at 20 km. Every other parameter is answered by the default factory and is therefore not in `values()` at all. So `max(...)` is 20 km, always, whatever was requested — while the per-parameter check further down in `apply_station_values_per_parameter` happily allows 40 km.

A summary of `temperature_air_mean_2m` therefore stopped at 20 km and walked past stations it was entitled to use, silently returning fewer filled timestamps than the settings promise.

## The fix

Take the widest radius among the *requested* parameters, which is exactly what `interpolate.request_stations` already does one module over:

```python
parameter_names = {parameter.name for parameter in request.parameters if isinstance(parameter, ParameterModel)}
distance = max(settings.ts_geo_station_distance[parameter_name] for parameter_name in parameter_names)
```

The per-parameter check loses its `.get(name, dict["default"])` fallback along with it. The mapping is a `defaultdict`, so an unlisted parameter answers with the default radius on its own — and reading the explicit `"default"` key *inserted* it into the mapping as a side effect, which then widened the `max(...)` above on every later call. Two calls to `summarize()` in one process could search different radii.

## Effect

Summaries of homogeneous parameters (temperature, humidity, wind, pressure, radiation, …) now reach the full 40 km and fill timestamps they previously left null. Precipitation and fresh snow are unaffected — they were already at 20 km by declaration. More candidate stations means more downloads for sparse historical series, which is the cost of the setting doing what it says.

`tests/core/test_summary.py` passes unchanged (4 passed): the pinned test filters to three dates whose values come from stations at 13.42 km, 5.05 km and 0.0 km, all inside the old bound, and the nearest-station-with-data choice cannot change by adding *farther* candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)