### PR TITLE
feat: document the MCP endpoint on the API page, and report whether it is served

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Types of changes:
   the last 12 hours") need not hold for the one borrowing them
 - The provider docs tables carry a `description` column for the 46 pages that had none, and 41 rows
   for parameters that were declared but never listed at all
+- `GET /api/version` reports `mcp_enabled` alongside the version. The MCP endpoint sits behind the
+  optional `[mcp]` extra, so whether `/mcp` exists is a property of the installation, and a client
+  had no way to find out short of probing `/mcp` -- which on the streamable-HTTP transport means
+  opening a session rather than asking a question. The index page has always known (it prints the
+  endpoint only when mounted); this exposes the same flag over JSON
 - 216 more parameters can be interpolated and summarized, 343 of 514 rather than 127. Soil
   temperature under a named cover and depth (114, NOAA GHCNd), forecast probabilities (65, MOSMIX
   and DMO), soil moisture (12, DWD's agrometeorological model), evaporation per crop and soil (6),

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -21,7 +21,9 @@ Types of changes:
 - `[API]` The API page documents the MCP endpoint the app has been serving unannounced: what it is,
   the URL, a ready-to-paste client configuration, and that it needs no key or account. The URL is
   built from the origin the page is served from rather than hard-coded, so a self-hosted or local
-  instance shows its own address and the snippet can be copied as-is
+  instance shows its own address and the snippet can be copied as-is. The card appears only when
+  the backend reports `mcp_enabled`: the endpoint is behind an optional extra, and an instance
+  installed without it would otherwise hand every visitor a client configuration pointing at a 404
 
 ### Fixed
 

--- a/CHANGELOG_FRONTEND.md
+++ b/CHANGELOG_FRONTEND.md
@@ -16,6 +16,13 @@ Types of changes:
 
 ## [Unreleased]
 
+### Added
+
+- `[API]` The API page documents the MCP endpoint the app has been serving unannounced: what it is,
+  the URL, a ready-to-paste client configuration, and that it needs no key or account. The URL is
+  built from the origin the page is served from rather than hard-coded, so a self-hosted or local
+  instance shows its own address and the snippet can be copied as-is
+
 ### Fixed
 
 - `[Explorer]` Plotly, at 1.0 MB the largest chunk in the build, was fetched and parsed as soon as

--- a/docs/usage/restapi.md
+++ b/docs/usage/restapi.md
@@ -148,7 +148,14 @@ Point any MCP client (streamable HTTP) at that URL — for example:
 ```
 
 Without the `[mcp]` extra installed, the REST API behaves exactly as before and the `/mcp` route is
-simply absent.
+simply absent. `GET /api/version` says which of the two an instance is:
+
+```json
+{"version": "0.132.0", "mcp_enabled": true}
+```
+
+The app reads that flag before offering an MCP client configuration, so an instance installed
+without the extra is never advertised as having an endpoint it does not serve.
 
 ### Hosted instance
 

--- a/frontend/app/pages/api.vue
+++ b/frontend/app/pages/api.vue
@@ -1,6 +1,16 @@
 <script setup lang="ts">
 const { t } = useI18n()
 
+// The MCP endpoint is served on this app's own origin: the frontend proxies /mcp through to the
+// backend, preserving the streamable-HTTP transport. Reading the origin rather than hard-coding
+// the public URL means the snippet is also correct on a self-hosted or local instance.
+const mcpUrl = computed(() => `${useRequestURL().origin}/mcp`)
+const mcpClientConfig = computed(() => JSON.stringify(
+  { mcpServers: { wetterdienst: { url: mcpUrl.value } } },
+  null,
+  2,
+))
+
 const endpoints = [
   { name: 'coverage', path: '/api/coverage', descKey: 'api.endpoints.coverage' },
   { name: 'stations', path: '/api/stations', descKey: 'api.endpoints.stations' },
@@ -105,6 +115,41 @@ const examples = [
         <li><code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">geojson</code> - {{ t('api.formatGeojson') }}</li>
         <li><code class="bg-gray-100 dark:bg-gray-800 px-1 rounded">html</code> - {{ t('api.formatHtml') }}</li>
       </ul>
+    </UCard>
+
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-bot" class="text-primary-500 shrink-0" />
+          <h2 class="text-lg font-bold">
+            {{ t('api.mcpTitle') }}
+          </h2>
+        </div>
+      </template>
+      <p class="text-gray-600 dark:text-gray-400 mb-4">
+        {{ t('api.mcpText') }}
+      </p>
+      <p class="text-gray-600 dark:text-gray-400 mb-2">
+        {{ t('api.mcpUrlLabel') }}
+      </p>
+      <pre class="bg-gray-100 dark:bg-gray-800 rounded p-3 mb-4 overflow-x-auto text-sm"><code>{{ mcpUrl }}</code></pre>
+      <p class="text-gray-600 dark:text-gray-400 mb-2">
+        {{ t('api.mcpClientLabel') }}
+      </p>
+      <pre class="bg-gray-100 dark:bg-gray-800 rounded p-3 mb-4 overflow-x-auto text-sm"><code>{{ mcpClientConfig }}</code></pre>
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t('api.mcpNoAuth') }}
+      </p>
+      <UButton
+        to="https://wetterdienst.readthedocs.io/en/latest/usage/restapi.html#mcp-endpoint"
+        target="_blank"
+        size="sm"
+        variant="link"
+        icon="i-lucide-book-open"
+        class="px-0"
+      >
+        {{ t('api.mcpDocs') }}
+      </UButton>
     </UCard>
 
     <UCard>

--- a/frontend/app/pages/api.vue
+++ b/frontend/app/pages/api.vue
@@ -1,6 +1,15 @@
 <script setup lang="ts">
 const { t } = useI18n()
 
+// Whether this backend serves an MCP endpoint at all: it lives behind the optional `[mcp]` extra,
+// so an instance installed without it has no /mcp route and must not be told to point a client at
+// one. The backend reports it next to its version, which is the only thing the card waits for.
+// `$fetch` rather than `useFetch`: the answer is a fact about the backend, not page state, and
+// `useFetch` would key it by URL and hand back whatever the app shell already cached for
+// /api/version -- which is the version, fetched before this page existed.
+const backend = await $fetch<{ version: string, mcp_enabled?: boolean }>('/api/version').catch(() => null)
+const mcpEnabled = computed(() => backend?.mcp_enabled === true)
+
 // The MCP endpoint is served on this app's own origin: the frontend proxies /mcp through to the
 // backend, preserving the streamable-HTTP transport. Reading the origin rather than hard-coding
 // the public URL means the snippet is also correct on a self-hosted or local instance.
@@ -117,7 +126,7 @@ const examples = [
       </ul>
     </UCard>
 
-    <UCard>
+    <UCard v-if="mcpEnabled">
       <template #header>
         <div class="flex items-center gap-2">
           <UIcon name="i-lucide-bot" class="text-primary-500 shrink-0" />

--- a/frontend/i18n/locales/cs.json
+++ b/frontend/i18n/locales/cs.json
@@ -218,6 +218,12 @@
       "stripesValues": "Hodnoty klimatických pruhů (teplota)",
       "stripesImage": "Obrázek klimatických pruhů (teplota)"
     },
+    "mcpTitle": "Koncový bod MCP",
+    "mcpText": "Wetterdienst mluví také protokolem Model Context Protocol, takže asistenti s umělou inteligencí mohou získávat meteorologická data jako nástroje: najít stanici a pak přečíst její měření. K dispozici jsou stejné koncové body jako výše, přes přenos streamable HTTP.",
+    "mcpUrlLabel": "URL koncového bodu",
+    "mcpClientLabel": "Konfigurace klienta",
+    "mcpNoAuth": "Není potřeba API klíč ani účet.",
+    "mcpDocs": "Dokumentace MCP",
     "params": {
       "provider": "Poskytovatel dat (např. dwd, noaa)",
       "network": "Síť dat (např. observation, forecast)",

--- a/frontend/i18n/locales/da.json
+++ b/frontend/i18n/locales/da.json
@@ -218,6 +218,12 @@
       "stripesValues": "Klimastriber-værdier (temperatur)",
       "stripesImage": "Klimastriber-billede (temperatur)"
     },
+    "mcpTitle": "MCP-endepunkt",
+    "mcpText": "Wetterdienst taler også Model Context Protocol, så AI-assistenter kan hente vejrdata som værktøjer: find en station, og læs derefter dens målinger. De samme endepunkter som ovenfor er tilgængelige via streamable HTTP-transporten.",
+    "mcpUrlLabel": "Endepunkts-URL",
+    "mcpClientLabel": "Klientkonfiguration",
+    "mcpNoAuth": "Der kræves ingen API-nøgle eller konto.",
+    "mcpDocs": "MCP-dokumentation",
     "params": {
       "provider": "Dataudbyder (f.eks. dwd, noaa)",
       "network": "Datanetværk (f.eks. observation, forecast)",

--- a/frontend/i18n/locales/de-hh.json
+++ b/frontend/i18n/locales/de-hh.json
@@ -218,6 +218,12 @@
       "stripesValues": "Klimastreifen-Werte (Temperatur)",
       "stripesImage": "Klimastreifen-Bild (Temperatur)"
     },
+    "mcpTitle": "MCP-Endpunkt",
+    "mcpText": "Wetterdienst schnackt auch Model Context Protocol: KI-Assistenten können Wetterdaten als Werkzeuge abfragen – erst 'ne Station finden, dann ihre Messwerte lesen. Es gibt dieselben Endpunkte wie oben, über den Streamable-HTTP-Transport.",
+    "mcpUrlLabel": "Endpunkt-URL",
+    "mcpClientLabel": "Client-Konfiguration",
+    "mcpNoAuth": "Kein API-Schlüssel und kein Konto nötig.",
+    "mcpDocs": "MCP-Dokumentation",
     "params": {
       "provider": "Datenanbieter (z. B. dwd, noaa)",
       "network": "Datennetzwerk (z. B. observation, forecast)",

--- a/frontend/i18n/locales/de.json
+++ b/frontend/i18n/locales/de.json
@@ -218,6 +218,12 @@
       "stripesValues": "Klimastreifen-Werte (Temperatur)",
       "stripesImage": "Klimastreifen-Bild (Temperatur)"
     },
+    "mcpTitle": "MCP-Endpunkt",
+    "mcpText": "Wetterdienst spricht auch das Model Context Protocol: KI-Assistenten können Wetterdaten als Werkzeuge abfragen – erst eine Station finden, dann deren Messwerte lesen. Bereitgestellt werden dieselben Endpunkte wie oben, über den Streamable-HTTP-Transport.",
+    "mcpUrlLabel": "Endpunkt-URL",
+    "mcpClientLabel": "Client-Konfiguration",
+    "mcpNoAuth": "Kein API-Schlüssel und kein Konto nötig.",
+    "mcpDocs": "MCP-Dokumentation",
     "params": {
       "provider": "Datenanbieter (z. B. dwd, noaa)",
       "network": "Datennetzwerk (z. B. observation, forecast)",

--- a/frontend/i18n/locales/en.json
+++ b/frontend/i18n/locales/en.json
@@ -218,6 +218,12 @@
       "stripesValues": "Climate Stripes Values (Temperature)",
       "stripesImage": "Climate Stripes Image (Temperature)"
     },
+    "mcpTitle": "MCP endpoint",
+    "mcpText": "Wetterdienst also speaks the Model Context Protocol, so AI assistants can query weather data as tools: find a station, then read its measurements. The same endpoints as above are exposed, over the streamable HTTP transport.",
+    "mcpUrlLabel": "Endpoint URL",
+    "mcpClientLabel": "Client configuration",
+    "mcpNoAuth": "No API key or account needed.",
+    "mcpDocs": "MCP documentation",
     "params": {
       "provider": "Data provider (e.g., dwd, noaa)",
       "network": "Data network (e.g., observation, forecast)",

--- a/frontend/i18n/locales/es.json
+++ b/frontend/i18n/locales/es.json
@@ -218,6 +218,12 @@
       "stripesValues": "Valores de franjas climáticas (temperatura)",
       "stripesImage": "Imagen de franjas climáticas (temperatura)"
     },
+    "mcpTitle": "Punto de acceso MCP",
+    "mcpText": "Wetterdienst también habla el Model Context Protocol, de modo que los asistentes de IA pueden consultar datos meteorológicos como herramientas: buscar una estación y luego leer sus mediciones. Se exponen los mismos puntos de acceso que arriba, mediante el transporte HTTP en streaming.",
+    "mcpUrlLabel": "URL del punto de acceso",
+    "mcpClientLabel": "Configuración del cliente",
+    "mcpNoAuth": "No hace falta clave de API ni cuenta.",
+    "mcpDocs": "Documentación de MCP",
     "params": {
       "provider": "Proveedor de datos (p. ej. dwd, noaa)",
       "network": "Red de datos (p. ej. observation, forecast)",

--- a/frontend/i18n/locales/fr.json
+++ b/frontend/i18n/locales/fr.json
@@ -218,6 +218,12 @@
       "stripesValues": "Valeurs des bandes climatiques (température)",
       "stripesImage": "Image des bandes climatiques (température)"
     },
+    "mcpTitle": "Point d'accès MCP",
+    "mcpText": "Wetterdienst parle aussi le Model Context Protocol : les assistants IA peuvent interroger les données météo comme des outils — trouver une station, puis lire ses mesures. Les mêmes points d'accès que ci-dessus sont exposés, via le transport HTTP en flux.",
+    "mcpUrlLabel": "URL du point d'accès",
+    "mcpClientLabel": "Configuration du client",
+    "mcpNoAuth": "Aucune clé d'API ni compte n'est nécessaire.",
+    "mcpDocs": "Documentation MCP",
     "params": {
       "provider": "Fournisseur de données (p. ex. dwd, noaa)",
       "network": "Réseau de données (p. ex. observation, forecast)",

--- a/frontend/i18n/locales/it.json
+++ b/frontend/i18n/locales/it.json
@@ -218,6 +218,12 @@
       "stripesValues": "Valori delle strisce climatiche (temperatura)",
       "stripesImage": "Immagine delle strisce climatiche (temperatura)"
     },
+    "mcpTitle": "Endpoint MCP",
+    "mcpText": "Wetterdienst parla anche il Model Context Protocol: gli assistenti IA possono interrogare i dati meteo come strumenti — trovare una stazione e poi leggerne le misurazioni. Sono esposti gli stessi endpoint indicati sopra, tramite il trasporto HTTP in streaming.",
+    "mcpUrlLabel": "URL dell'endpoint",
+    "mcpClientLabel": "Configurazione del client",
+    "mcpNoAuth": "Non servono chiave API né account.",
+    "mcpDocs": "Documentazione MCP",
     "params": {
       "provider": "Fornitore di dati (es. dwd, noaa)",
       "network": "Rete di dati (es. observation, forecast)",

--- a/frontend/i18n/locales/lb.json
+++ b/frontend/i18n/locales/lb.json
@@ -218,6 +218,12 @@
       "stripesValues": "Klimasträifen-Wäerter (Temperatur)",
       "stripesImage": "Klimasträifen-Bild (Temperatur)"
     },
+    "mcpTitle": "MCP-Endpunkt",
+    "mcpText": "Wetterdienst schwätzt och d'Model Context Protocol, sou datt KI-Assistenten Wiederdaten als Tools ofruffe kënnen: eng Statioun fannen an duerno hir Miessunge liesen. Et ginn déiselwecht Endpunkten wéi hei uewen, iwwer den Streamable-HTTP-Transport.",
+    "mcpUrlLabel": "Endpunkt-URL",
+    "mcpClientLabel": "Client-Konfiguratioun",
+    "mcpNoAuth": "Keen API-Schlëssel a kee Kont néideg.",
+    "mcpDocs": "MCP-Dokumentatioun",
     "params": {
       "provider": "Datenubidder (z.B. dwd, noaa)",
       "network": "Datennetzwierk (z.B. observation, forecast)",

--- a/frontend/i18n/locales/nl.json
+++ b/frontend/i18n/locales/nl.json
@@ -218,6 +218,12 @@
       "stripesValues": "Klimaatstrepen-waarden (temperatuur)",
       "stripesImage": "Klimaatstrepen-afbeelding (temperatuur)"
     },
+    "mcpTitle": "MCP-eindpunt",
+    "mcpText": "Wetterdienst spreekt ook het Model Context Protocol, zodat AI-assistenten weergegevens als tools kunnen opvragen: eerst een station zoeken, daarna de metingen lezen. Dezelfde eindpunten als hierboven zijn beschikbaar, via het streamable HTTP-transport.",
+    "mcpUrlLabel": "Eindpunt-URL",
+    "mcpClientLabel": "Clientconfiguratie",
+    "mcpNoAuth": "Geen API-sleutel of account nodig.",
+    "mcpDocs": "MCP-documentatie",
     "params": {
       "provider": "Gegevensaanbieder (bijv. dwd, noaa)",
       "network": "Gegevensnetwerk (bijv. observation, forecast)",

--- a/frontend/i18n/locales/pl.json
+++ b/frontend/i18n/locales/pl.json
@@ -218,6 +218,12 @@
       "stripesValues": "Wartości pasków klimatycznych (temperatura)",
       "stripesImage": "Obraz pasków klimatycznych (temperatura)"
     },
+    "mcpTitle": "Punkt końcowy MCP",
+    "mcpText": "Wetterdienst mówi także w Model Context Protocol, dzięki czemu asystenci AI mogą pobierać dane pogodowe jako narzędzia: znaleźć stację, a potem odczytać jej pomiary. Udostępnione są te same punkty końcowe co powyżej, przez transport streamable HTTP.",
+    "mcpUrlLabel": "URL punktu końcowego",
+    "mcpClientLabel": "Konfiguracja klienta",
+    "mcpNoAuth": "Nie jest potrzebny klucz API ani konto.",
+    "mcpDocs": "Dokumentacja MCP",
     "params": {
       "provider": "Dostawca danych (np. dwd, noaa)",
       "network": "Sieć danych (np. observation, forecast)",

--- a/frontend/tests/nuxt/pages/api.test.ts
+++ b/frontend/tests/nuxt/pages/api.test.ts
@@ -1,6 +1,12 @@
-import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ApiPage from '~/pages/api.vue'
+
+// the page asks the backend whether it serves an MCP endpoint, through `$fetch` rather than the
+// global one, so the endpoint is registered instead of the fetch being stubbed. Registered once:
+// re-registering the same path in a later test does not replace the handler
+let backend = { version: '0.0.0', mcp_enabled: true }
+registerEndpoint('/api/version', () => backend)
 
 describe('aPI Page', () => {
   beforeEach(() => {
@@ -54,10 +60,8 @@ describe('aPI Page', () => {
     expect(text).toContain('Examples')
   })
 
-  it('advertises the MCP endpoint on this origin', async () => {
-    vi.mocked(globalThis.fetch).mockResolvedValue(
-      new Response(JSON.stringify({}), { status: 200 }),
-    )
+  it('advertises the MCP endpoint on this origin when the backend serves one', async () => {
+    backend = { version: '0.0.0', mcp_enabled: true }
 
     const wrapper = await mountSuspended(ApiPage)
     const text = wrapper.text()
@@ -70,5 +74,18 @@ describe('aPI Page', () => {
     // and the config snippet a user pastes carries that same URL
     expect(text).toContain('mcpServers')
     expect(text).toContain(`"url": "${window.location.origin}/mcp"`)
+  })
+
+  it('says nothing about MCP when the backend has no such endpoint', async () => {
+    // an instance installed without the [mcp] extra has no /mcp route, so a paste-ready client
+    // config would send every user to a 404
+    backend = { version: '0.0.0', mcp_enabled: false }
+
+    const wrapper = await mountSuspended(ApiPage)
+    const text = wrapper.text()
+
+    expect(text).toContain('Endpoints')
+    expect(text).not.toContain('MCP endpoint')
+    expect(text).not.toContain('mcpServers')
   })
 })

--- a/frontend/tests/nuxt/pages/api.test.ts
+++ b/frontend/tests/nuxt/pages/api.test.ts
@@ -53,4 +53,19 @@ describe('aPI Page', () => {
 
     expect(text).toContain('Examples')
   })
+
+  it('advertises the MCP endpoint on this origin', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    )
+
+    const wrapper = await mountSuspended(ApiPage)
+    const text = wrapper.text()
+
+    expect(text).toContain('MCP endpoint')
+    // the URL is built from the request origin rather than hard-coded, so a self-hosted instance
+    // shows its own address and the config snippet can be pasted as-is
+    expect(text).toContain('/mcp')
+    expect(text).toContain('mcpServers')
+  })
 })

--- a/frontend/tests/nuxt/pages/api.test.ts
+++ b/frontend/tests/nuxt/pages/api.test.ts
@@ -63,9 +63,12 @@ describe('aPI Page', () => {
     const text = wrapper.text()
 
     expect(text).toContain('MCP endpoint')
-    // the URL is built from the request origin rather than hard-coded, so a self-hosted instance
-    // shows its own address and the config snippet can be pasted as-is
-    expect(text).toContain('/mcp')
+    // the whole point is that the URL follows the origin the page is served from rather than being
+    // hard-coded to the hosted instance, so assert the origin this test runs under -- `/mcp` alone
+    // would pass on a hard-coded wetterdienst.eobs.org too
+    expect(text).toContain(`${window.location.origin}/mcp`)
+    // and the config snippet a user pastes carries that same URL
     expect(text).toContain('mcpServers')
+    expect(text).toContain(`"url": "${window.location.origin}/mcp"`)
   })
 })

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -233,8 +233,15 @@ def health() -> JSONResponse:
 
 @app.get("/api/version")
 def version() -> JSONResponse:
-    """Get version information."""
-    return JSONResponse(content={"version": __version__})
+    """Get version information, and whether this instance serves an MCP endpoint.
+
+    `mcp_enabled` is read at request time rather than captured at import: `_mount_mcp` sets it at
+    the bottom of this module, after the routes are declared. It is reported here because the
+    endpoint is optional -- an instance installed without the `[mcp]` extra has no `/mcp` route --
+    and a client has no other way to find out short of probing `/mcp`, which on the streamable-HTTP
+    transport means opening a session rather than asking a question.
+    """
+    return JSONResponse(content={"version": __version__, "mcp_enabled": mcp_enabled})
 
 
 # OAuth discovery endpoints. The `/mcp` server is open (no auth), so MCP clients such as Claude

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -8,8 +8,9 @@ import pytest
 from dirty_equals import IsApprox, IsNumber, IsStr
 from starlette.testclient import TestClient
 
-from wetterdienst import Settings
+from wetterdienst import Settings, __version__
 from wetterdienst.metadata.parameter_table import PARAMETER_TABLE
+from wetterdienst.ui import restapi
 from wetterdienst.ui.core import get_glossary
 from wetterdienst.ui.restapi import REQUEST_EXAMPLES
 
@@ -53,6 +54,21 @@ def test_health(client: TestClient) -> None:
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "OK"}
+
+
+def test_version(client: TestClient) -> None:
+    """Test that the version endpoint reports the version and whether MCP is served.
+
+    `mcp_enabled` is what the app reads before offering an MCP client configuration: the endpoint
+    is behind the optional `[mcp]` extra, so an instance without it must not be advertised as
+    having one. The value tracks `_mount_mcp`, which is why this asserts agreement with the module
+    flag rather than a fixed answer -- the test suite installs the extra, a bare install does not.
+    """
+    response = client.get("/api/version")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["version"] == __version__
+    assert data["mcp_enabled"] is restapi.mcp_enabled
 
 
 @pytest.mark.remote


### PR DESCRIPTION
The app has been serving an MCP endpoint at `/mcp` since the backend grew one — the frontend proxies it through to the backend, preserving the streamable-HTTP transport — but nothing in the UI said so. Anyone who wanted to point an AI assistant at Wetterdienst had to find it in the docs.

## Frontend

The API page has a card for it, between the response formats and the common parameters: what it is, the endpoint URL, a client configuration to paste, that it needs no API key or account, and a link to the MCP section of the documentation.

The URL is read from the origin the page is served from rather than hard-coded, so a self-hosted or local instance shows its own address and the config snippet works as-is:

```ts
const mcpUrl = computed(() => `${useRequestURL().origin}/mcp`)
```

Translated into all eleven locales.

## Backend: `mcp_enabled` on `/api/version`

The MCP endpoint lives behind the optional `[mcp]` extra, so an instance installed with `pip install wetterdienst[restapi]` has **no `/mcp` route at all**. The backend already knows this — its index page prints the endpoint only when `_mount_mcp` succeeded — but nothing exposed it over JSON, so the card would have shown a paste-ready client configuration pointing at a 404 on any such instance.

`GET /api/version` now answers `{"version": …, "mcp_enabled": …}`, and the card renders only when that is true. The flag is the honest answer and cheap to ask for; probing `/mcp` is not, because on the streamable-HTTP transport a request opens a session rather than asking a question.

The page reads it with `$fetch` rather than `useFetch`: it is a fact about the backend rather than page state, and `useFetch` keys by URL, so it would hand back whatever the app shell had already cached for `/api/version`.

## Tests

- `test_version` asserts the endpoint reports the version and that `mcp_enabled` agrees with the module flag, rather than a fixed answer — the suite installs the extra, a bare install does not
- the page test registers `/api/version` instead of stubbing the global fetch, the way `glossary.test.ts` already does, and covers both directions
- both new assertions are mutation-checked: hard-coding the URL fails the origin test, and dropping the `v-if` fails the "says nothing about MCP" test

## Reviews

Copilot's first two attempts errored out; the third passed with one suppressed comment, which was right: the origin test asserted only that `/mcp` appeared somewhere, which a hard-coded `wetterdienst.eobs.org` would also satisfy. Fixed in `d475762b`. A second review found the `[mcp]`-extra case above, fixed in `a3f2f881`.

Verified: `poe format`, `poe typecheck`, `pytest tests/ui/test_restapi.py -m "not remote"` (37 passed), `pnpm lint`, `pnpm test:ci` (236 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)