### PR TITLE
fix(app): the footer still called the app "Frontend", and so did the rest

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,4 +15,4 @@
 - [ ] Tests added or updated
 - [ ] `uv run poe format` passed
 - [ ] Remote/slow tests verified if network code was touched
-- [ ] Frontend changes tested locally (if applicable)
+- [ ] App changes tested locally (if applicable)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,9 @@ Types of changes:
   publish-day breakage are most often caught in that window. The lockfile records it as a relative
   span (`exclude-newer-span = "P3D"`), not a timestamp, so it does not churn between runs and
   `uv lock --check` stays stable
+- Docs: the REST API page's "Web Frontend" section is "Web App", matching what the app has been
+  called since it moved to `app/`. The stripes page and the pull-request checklist follow, as do
+  the Météo-France comments that explain which caller depends on a populated `start_date`
 - Docs: the README states what the project stands for, in the same four lines the app closes with,
   and opens with "Global warming is not an opinion" rather than the Fridays for Future chant -- the
   one claim a weather-data library backs up by existing. Anthropic gets a logo next to JetBrains

--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -73,6 +73,11 @@ Types of changes:
 
 ### Changed
 
+- `[Footer]` The version line says `App` rather than `Frontend`. The rename below moved the
+  directory, the image and the release tags, but left the one place a visitor actually reads the
+  name -- so the footer went on calling the app by a name nothing else in the project uses. The
+  backend half is untouched; `frontendVersion` is `appVersion`, and its counterpart is
+  `backendVersion` rather than a bare `version`, since the two sit side by side
 - `[Build]` **Breaking for anyone pulling the image or tagging a release.** `frontend/` is now
   `app/`, and every artifact named after it followed: the image is
   `ghcr.io/earthobservations/wetterdienst-app`, releases are tagged `app-v*` rather than

--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -78,6 +78,11 @@ Types of changes:
   name -- so the footer went on calling the app by a name nothing else in the project uses. The
   backend half is untouched; `frontendVersion` is `appVersion`, and its counterpart is
   `backendVersion` rather than a bare `version`, since the two sit side by side
+- `[Build]` The word "frontend" is gone from the rest of the app too -- the proxy and route
+  comments, the parameter-label lookup chain, and the E2E guide, which told the reader to start a
+  "frontend dev server" that no longer goes by that name. Two references stay on purpose: the
+  `COOLIFY_FRONTEND_UUID` deploy secret, whose name lives in GitHub settings rather than in this
+  repo, and the release-strategy note recording what the tags and image used to be called
 - `[Build]` **Breaking for anyone pulling the image or tagging a release.** `frontend/` is now
   `app/`, and every artifact named after it followed: the image is
   `ghcr.io/earthobservations/wetterdienst-app`, releases are tagged `app-v*` rather than

--- a/app/app/app.vue
+++ b/app/app/app.vue
@@ -18,8 +18,8 @@ const isWidget = computed(() => route.path.startsWith('/widget'))
 
 const { data: versionData } = await useFetch<{ version: string }>('/api/version')
 
-const version = computed(() => versionData.value?.version ?? 'unknown')
-const frontendVersion = pkg.version || 'unknown'
+const backendVersion = computed(() => versionData.value?.version ?? 'unknown')
+const appVersion = pkg.version || 'unknown'
 
 // The same four statements the home page spells out, as icons here: the footer is on every page,
 // and four sentences at the foot of every one of them is a banner rather than a footer. The full
@@ -259,9 +259,9 @@ const items = computed<NavigationMenuItem[]>(() =>
     <UFooter v-if="!isWidget">
       <div class="w-full flex flex-col items-center gap-2 text-center">
         <div class="text-xs text-gray-400 dark:text-gray-600">
-          <span class="text-green-600 dark:text-green-400 font-medium">Frontend</span> {{ frontendVersion === 'unknown' ? frontendVersion : `v${frontendVersion}` }}
+          <span class="text-green-600 dark:text-green-400 font-medium">App</span> {{ appVersion === 'unknown' ? appVersion : `v${appVersion}` }}
           <span class="mx-1">|</span>
-          <span class="text-blue-600 dark:text-blue-400 font-medium">Backend</span> {{ version === 'unknown' ? version : `v${version}` }}
+          <span class="text-blue-600 dark:text-blue-400 font-medium">Backend</span> {{ backendVersion === 'unknown' ? backendVersion : `v${backendVersion}` }}
         </div>
         <!-- Two rows by kind rather than one list of six. In one row the values statements sat in
              the same register as the links, separated by the same pipe, and the separators -- flex

--- a/app/app/composables/useParameterLabel.ts
+++ b/app/app/composables/useParameterLabel.ts
@@ -29,7 +29,7 @@ const glossaries: Record<string, typeof glossaryEn> = {
  * Maps backend identifiers (parameters, resolutions, datasets) to human-friendly
  * labels.
  *
- * Lookup chain (hybrid, frontend-first):
+ * Lookup chain (hybrid, app-first):
  *   1. curated glossary for the active locale
  *   2. prettified raw id (underscores -> spaces, capitalised)
  *

--- a/app/app/pages/api.vue
+++ b/app/app/pages/api.vue
@@ -10,7 +10,7 @@ const { t } = useI18n()
 const backend = await $fetch<{ version: string, mcp_enabled?: boolean }>('/api/version').catch(() => null)
 const mcpEnabled = computed(() => backend?.mcp_enabled === true)
 
-// The MCP endpoint is served on this app's own origin: the frontend proxies /mcp through to the
+// The MCP endpoint is served on this app's own origin: the app proxies /mcp through to the
 // backend, preserving the streamable-HTTP transport. Reading the origin rather than hard-coding
 // the public URL means the snippet is also correct on a self-hosted or local instance.
 const mcpUrl = computed(() => `${useRequestURL().origin}/mcp`)

--- a/app/server/api/[...].get.ts
+++ b/app/server/api/[...].get.ts
@@ -45,11 +45,11 @@ export default defineEventHandler(async (event): Promise<unknown> => {
       // they can still be removed.
       onResponse() {
         // The backend sets no cookies today, but if that ever changes they would land scoped to the
-        // frontend's origin instead of the backend's -- a session boundary we should not move by
+        // app's origin instead of the backend's -- a session boundary we should not move by
         // accident.
         event.node.res.removeHeader('set-cookie')
         // Advertises HTTP/3 for whatever origin serves the response, so relaying it here would
-        // claim support on the frontend's behalf.
+        // claim support on the app's behalf.
         event.node.res.removeHeader('alt-svc')
         // No reason to tell clients which server stack sits behind the proxy.
         event.node.res.removeHeader('server')

--- a/app/server/routes/mcp/index.ts
+++ b/app/server/routes/mcp/index.ts
@@ -1,2 +1,2 @@
-// Proxy `/mcp` on the frontend origin to the backend's MCP endpoint. See ~/server/utils/mcpProxy.
+// Proxy `/mcp` on the app origin to the backend's MCP endpoint. See ~/server/utils/mcpProxy.
 export default mcpProxyHandler()

--- a/app/server/utils/mcpProxy.ts
+++ b/app/server/utils/mcpProxy.ts
@@ -1,5 +1,5 @@
-// Shared handler that proxies the frontend's `/mcp` (and any sub-path) through to the backend's MCP
-// endpoint so it is reachable on the frontend origin (e.g. https://wetterdienst.eobs.org/mcp).
+// Shared handler that proxies the app's `/mcp` (and any sub-path) through to the backend's MCP
+// endpoint so it is reachable on the app origin (e.g. https://wetterdienst.eobs.org/mcp).
 //
 // Unlike the JSON `/api/**` proxy, MCP uses the streamable-HTTP transport (POST for requests, GET for
 // the SSE stream, DELETE to end a session, plus the `mcp-session-id` header), so this forwards the

--- a/app/tests/e2e/README.md
+++ b/app/tests/e2e/README.md
@@ -1,6 +1,6 @@
 # E2E Testing Guide
 
-This directory contains end-to-end (E2E) tests using Playwright that test the frontend with a real backend.
+This directory contains end-to-end (E2E) tests using Playwright that test the app with a real backend.
 
 ## Browsers
 
@@ -36,7 +36,7 @@ npx playwright install chromium webkit
 
 The E2E test suite includes automatic health checks that verify:
 - ✅ Backend API is running and accessible (via `/health` endpoint)
-- ✅ Frontend dev server is running
+- ✅ App dev server is running
 
 If the backend is not available, you'll see a clear error message:
 
@@ -77,8 +77,8 @@ pip install -e .
 wetterdienst restapi --listen 0.0.0.0:3000
 ```
 
-### Frontend Server
-The Playwright config is set to automatically start the frontend dev server on `http://localhost:4000`
+### App Server
+The Playwright config is set to automatically start the app dev server on `http://localhost:4000`
 
 ## Running E2E Tests
 
@@ -123,7 +123,7 @@ npx playwright test  # Runs on all configured browsers
 
 ```
 tests/e2e/
-├── global-setup.ts       # Health checks for backend/frontend
+├── global-setup.ts       # Health checks for backend/app
 ├── api.spec.ts           # API endpoint tests
 ├── pages.spec.ts         # Page navigation and UI tests
 └── integration.spec.ts   # Full user flow tests
@@ -143,7 +143,7 @@ tests/e2e/
 
 ### Integration Tests (`integration.spec.ts`)
 - Tests complete user workflows
-- Verifies frontend-backend integration
+- Verifies app-backend integration
 - Tests data loading and API calls
 
 ## Environment Variables
@@ -151,7 +151,7 @@ tests/e2e/
 You can override the URLs for testing:
 
 ```bash
-# Override frontend URL
+# Override app URL
 BASE_URL=http://localhost:4000 npm run test:e2e
 
 # Override backend URL
@@ -164,7 +164,7 @@ BASE_URL=http://localhost:4000 BACKEND_URL=http://localhost:3000 npm run test:e2
 **Note:** The health check will verify the backend is accessible before running any tests.
 ## CI/CD
 
-For continuous integration, ensure both backend and frontend are running:
+For continuous integration, ensure both backend and app are running:
 
 ```bash
 # Start backend

--- a/app/tests/e2e/proxy.spec.ts
+++ b/app/tests/e2e/proxy.spec.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 import { expect, test } from '@playwright/test'
 
-// Every request here goes through the frontend's own catch-all at `server/api/[...].get.ts`
+// Every request here goes through the app's own catch-all at `server/api/[...].get.ts`
 // (relative URLs resolve against `baseURL`, port 4000), unlike `api.spec.ts` which talks to the
 // backend directly on port 3000. That handler streams the upstream response straight through, so
 // what needs guarding is fidelity: status codes, bodies and query parameters must survive the hop.

--- a/docs/usage/restapi.md
+++ b/docs/usage/restapi.md
@@ -8,9 +8,9 @@ wetterdienst restapi
 
 There's also a hosted version at [wetterdienst.eobs.org](https://www.wetterdienst.eobs.org).
 
-## Web Frontend
+## Web App
 
-The REST API is complemented by a modern web frontend built with Nuxt.js, providing an interactive interface for exploring weather data.
+The REST API is complemented by a modern web app built with Nuxt.js, providing an interactive interface for exploring weather data.
 
 ### Features
 
@@ -159,7 +159,7 @@ without the extra is never advertised as having an endpoint it does not serve.
 
 ### Hosted instance
 
-The `[mcp]` extra is included in the backend Docker image, and the frontend proxies `/mcp` through
+The `[mcp]` extra is included in the backend Docker image, and the app proxies `/mcp` through
 to the backend (preserving the streamable-HTTP POST/SSE transport), so the hosted app serves the MCP
 endpoint on its own origin:
 

--- a/docs/usage/stripes.md
+++ b/docs/usage/stripes.md
@@ -12,7 +12,7 @@ Wetterdienst can generate climate stripes from **DWD** daily observations for tw
 - `precipitation` — based on the annual precipitation sum
 
 The feature is exposed via the [command line interface](#command-line-interface) and the
-[REST API](#rest-api). The hosted [web frontend](https://www.wetterdienst.eobs.org) also
+[REST API](#rest-api). The hosted [web app](https://www.wetterdienst.eobs.org) also
 offers an interactive Climate Stripes view.
 
 ## Command Line Interface

--- a/src/wetterdienst/provider/meteofrance/observation/api.py
+++ b/src/wetterdienst/provider/meteofrance/observation/api.py
@@ -892,6 +892,6 @@ class MeteoFranceObservationRequest(TimeseriesRequest):
             pl.col("alt").cast(pl.Float64, strict=False).alias("height"),
             pl.col("start_date").str.to_datetime("%Y-%m-%d", strict=False).dt.replace_time_zone("UTC"),
             # nullable: still-open stations (the vast majority) have no end_date, matching how
-            # the frontend already treats a missing end_date as "still reporting"
+            # the app already treats a missing end_date as "still reporting"
             pl.col("end_date").str.to_datetime("%Y-%m-%d", strict=False).dt.replace_time_zone("UTC"),
         )

--- a/src/wetterdienst/provider/meteofrance/synop/api.py
+++ b/src/wetterdienst/provider/meteofrance/synop/api.py
@@ -126,7 +126,7 @@ class MeteoFranceSynopValues(TimeseriesValues):
         read_columns = ["geo_id_wmo", "validity_time", *parameter_columns]
         dfs = []
         # clamp to the years actually covered by the archive: station opening dates (used as a
-        # fallback start_date by e.g. the frontend) can predate 1996, and requesting a year
+        # fallback start_date by e.g. the app) can predate 1996, and requesting a year
         # outside [1996, current_year] would 404
         first_year = max(start_date.year, _SYNOP_ARCHIVE_START_YEAR)
         last_year = min(end_date.year, current_year)

--- a/tests/provider/meteofrance/observation/test_api.py
+++ b/tests/provider/meteofrance/observation/test_api.py
@@ -43,9 +43,9 @@ def test_meteofrance_observation_api_daily_stations() -> None:
     df = request.df
     assert not df.is_empty()
     assert df.get_column("name").to_list() == ["TOULOUSE-BLAGNAC"]
-    # regression check: start_date must be populated, since the frontend seeds its date-range
+    # regression check: start_date must be populated, since the app seeds its date-range
     # picker from it; end_date is legitimately null here since the station is still open (the
-    # frontend already falls back to "today" for a null end_date)
+    # app already falls back to "today" for a null end_date)
     assert df.get_column("start_date").is_not_null().all()
 
 


### PR DESCRIPTION
## What

The rename in c1c6e9dc (#1848) moved the directory, the image and the release tags, but left the name behind everywhere it was written in prose — starting with the one place a visitor actually reads it.

**The footer.** The version line at the foot of every page said "Frontend":

```diff
-<span class="…">Frontend</span> {{ frontendVersion === 'unknown' ? … }}
+<span class="…">App</span> {{ appVersion === 'unknown' ? … }}
```

The backend half is untouched. `frontendVersion` becomes `appVersion`, and its counterpart is renamed from a bare `version` to `backendVersion` — the two sit side by side in the same line, so neither should be the unqualified one. Both are local to `app.vue`.

**The rest**, in a second commit: proxy and route comments (`server/utils/mcpProxy.ts`, `server/routes/mcp/index.ts`, `server/api/[...].get.ts`), the parameter-label lookup chain, `tests/e2e/proxy.spec.ts`, the E2E guide — which told the reader to start a "frontend dev server" that no longer goes by that name — the REST API page's `## Web Frontend` section, the stripes page, the pull-request checklist, and the Météo-France comments naming the caller that depends on a populated `start_date`.

### What deliberately stays

- `COOLIFY_FRONTEND_UUID` in `docker-publish-app.yml` — a repository secret whose name lives in GitHub settings, not in this repo. Renaming the reference would only break the deploy; the existing comment says so.
- The `RELEASE_STRATEGY.md` note recording that tags and the image used to be `frontend-*`. That is history, and rewriting it would make it wrong.
- Both changelogs' historical entries, for the same reason.

No inbound links pointed at the `#web-frontend` anchor, so renaming that heading breaks nothing.

## Verification

Rendered against a local dev server (SSR is disabled, so the footer only exists after hydration — the served HTML does not show it):

> App v0.12.1 | Backend v0.132.0

- `pnpm lint` — clean
- `pnpm test:ci` — 248 passed, 25 files. No test asserted on the old string
- `uv run poe lint` — clean
- `uv run pytest tests/provider/meteofrance` — 25 passed (comment-only changes there)
- `grep -ri frontend` over the repo now returns only the deliberate exceptions listed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)