### PR TITLE
chore(ci): let Dependabot see the app, and the Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,10 +14,23 @@ updates:
         patterns:
           - "*"
 
+  # Both Dockerfiles live in docker/ (docker/Dockerfile for the backend,
+  # docker/app.Dockerfile for the app), not at the root.
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/docker"
     schedule:
       interval: "weekly"
+
+  # The app is a pnpm workspace under app/; Dependabot reads pnpm-lock.yaml under
+  # the "npm" ecosystem.
+  - package-ecosystem: "npm"
+    directory: "/app"
+    schedule:
+      interval: "weekly"
+    groups:
+      app:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ Types of changes:
 
 ### Changed
 
+- Dependabot's `docker` entry pointed at `/`, where there is no Dockerfile -- both of them live in
+  `docker/`. It has therefore never proposed a base-image update for either image; it now reads
+  the directory they are actually in
 - Locked dependencies refreshed to their latest compatible versions (cryptography 50, fastapi
   0.141.1, starlette 1.6, uvicorn 0.52.3, numpy 2.5.2, zarr 3.3, mcp 1.29, and others), and the dev
   toolchain with them (ruff 0.16.3, ty 0.0.72, zizmor 1.29) -- both still pass with no source

--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -73,6 +73,10 @@ Types of changes:
 
 ### Changed
 
+- `[Build]` Dependabot watches the app's dependencies. There was no `npm` entry at all, so the
+  ~50 packages under `app/` had never been offered an update by it -- only the Python side and the
+  GitHub Actions were covered. Grouped into one weekly pull request, the way the Python group
+  already is
 - `[Footer]` The version line says `App` rather than `Frontend`. The rename below moved the
   directory, the image and the release tags, but left the one place a visitor actually reads the
   name -- so the footer went on calling the app by a name nothing else in the project uses. The


### PR DESCRIPTION
## What

Two gaps in `.github/dependabot.yml`, both confirmed against the PR history: Dependabot has opened **python** and **github-actions** pull requests for months, and never an **npm** or a **docker** one.

**The app was not covered at all.** There was no `npm` entry, so the ~50 packages under `app/` have never been offered an update. Added one for `/app` — Dependabot reads `pnpm-lock.yaml` under the `npm` ecosystem — grouped into a single weekly PR, the way the `python` group already is.

```yaml
  - package-ecosystem: "npm"
    directory: "/app"
    schedule:
      interval: "weekly"
    groups:
      app:
        patterns: ["*"]
```

**The docker entry pointed at a directory with no Dockerfile.** It said `directory: "/"`, but both images live in `docker/` — `docker/Dockerfile` (backend, `python:3.14-slim-trixie`) and `docker/app.Dockerfile` (app, `node:24-alpine`). So it has never proposed a base-image bump for either. Now points at `/docker`. That covers the app's own base image, which is why it is in this change rather than a separate one.

No cooldown is declared here. The three-day wait the Python side has comes from `tool.uv.exclude-newer` in `pyproject.toml`, which is a uv feature; npm has no lockfile-level equivalent, so app updates are offered as soon as they publish.

## Verification

- The config parses, and every declared directory actually holds the manifest its ecosystem needs:

| ecosystem | directory | manifest present |
|---|---|---|
| uv | `/` | `pyproject.toml`, `uv.lock` |
| docker | `/docker` | `Dockerfile`, `app.Dockerfile` |
| npm | `/app` | `package.json`, `pnpm-lock.yaml` |
| github-actions | `/` | `.github/workflows/` |

- Both gaps were established from `gh pr list --author app/dependabot` rather than assumed: the last 15 Dependabot PRs are all `python group` or GitHub Actions bumps, with no npm or base-image update among them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)