### PR TITLE
chore(ci): rename the Coolify deploy secret to COOLIFY_APP_UUID

### DIFF
--- a/.github/workflows/docker-publish-app.yml
+++ b/.github/workflows/docker-publish-app.yml
@@ -274,11 +274,8 @@ jobs:
           git describe --tags
           git status
 
-      # COOLIFY_FRONTEND_UUID keeps its old name on purpose: it is a repository secret in
-      # GitHub settings, not a file in this repo, so renaming it here would only break the
-      # deploy. Rename the secret in settings first, then this reference.
       - name: Deploy to Coolify
         run: |
           curl --fail --request GET \
             --header "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
-            'https://coolify.eobs.org/api/v1/deploy?uuid=${{ secrets.COOLIFY_FRONTEND_UUID }}&force=false'
+            'https://coolify.eobs.org/api/v1/deploy?uuid=${{ secrets.COOLIFY_APP_UUID }}&force=false'

--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -73,6 +73,10 @@ Types of changes:
 
 ### Changed
 
+- `[Build]` The Coolify deploy secret is `COOLIFY_APP_UUID`, not `COOLIFY_FRONTEND_UUID`, closing
+  the last reference the rename had to leave behind: the name lived in GitHub settings rather than
+  in this repo, so it could only follow once the secret itself had been re-created. The value is
+  unchanged -- the same Coolify resource, under the name everything else already uses
 - `[Build]` Dependabot watches the app's dependencies. There was no `npm` entry at all, so the
   ~50 packages under `app/` had never been offered an update by it -- only the Python side and the
   GitHub Actions were covered. Grouped into one weekly pull request, the way the Python group


### PR DESCRIPTION
> **Do not merge until `COOLIFY_APP_UUID` exists as a repository secret.** The workflow reads the name; if the secret is missing the deploy step sends an empty `uuid` and the app stops being redeployed on release. Secret values cannot be read back through the API, so the new secret has to be created by hand — see below.

## What

The last reference the `frontend` → `app` rename had to leave behind. The name lives in GitHub settings rather than in this repo, so it could only follow once the secret itself had been re-created — which is why the workflow carried a comment saying it kept the old name on purpose. That comment goes with it.

```diff
-      # COOLIFY_FRONTEND_UUID keeps its old name on purpose: it is a repository secret in
-      # GitHub settings, not a file in this repo, so renaming it here would only break the
-      # deploy. Rename the secret in settings first, then this reference.
       - name: Deploy to Coolify
         run: |
           curl --fail --request GET \
             --header "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
-            'https://coolify.eobs.org/api/v1/deploy?uuid=${{ secrets.COOLIFY_FRONTEND_UUID }}&force=false'
+            'https://coolify.eobs.org/api/v1/deploy?uuid=${{ secrets.COOLIFY_APP_UUID }}&force=false'
```

The value is unchanged: the same Coolify resource, under the name everything else already uses.

## Order of operations

1. `gh secret set COOLIFY_APP_UUID` — paste the same UUID `COOLIFY_FRONTEND_UUID` holds (from the Coolify dashboard, or wherever you keep it)
2. Merge this
3. After the next app release deploys successfully, `gh secret delete COOLIFY_FRONTEND_UUID`

## While you are in there

Four Coolify secrets are referenced by nothing in `.github/` and look like leftovers:

- `COOLIFY_FRONTEND_TOKEN` (2026-05-26)
- `COOLIFY_FRONTEND_WEBHOOK` (2026-05-26)
- `COOLIFY_BACKEND_TOKEN` (2026-06-07)
- `COOLIFY_BACKEND_WEBHOOK` (2026-06-07)

Only `COOLIFY_API_TOKEN`, `COOLIFY_BACKEND_UUID` and the renamed `COOLIFY_APP_UUID` are actually used. Not touched here — deleting credentials is your call, and something outside this repo may still rely on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)