### PR TITLE
chore(docker): build with uv 0.12.5, not 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ Types of changes:
 
 ### Changed
 
+- The backend image builds with uv 0.12.5 rather than 0.8.4, four minor versions back. 0.8.4 could
+  not parse `exclude-newer = "3 days"` and responded by discarding the whole `[tool.uv]` table --
+  `warning: Failed to parse pyproject.toml during settings discovery` -- taking `[tool.uv.audit]`
+  with it. The build still succeeded, because `uv sync --frozen` installs from the lockfile and
+  needs none of those settings, so this was a silent degradation rather than a failure. Dependabot
+  will keep the pin current from here, now that it reads `docker/`
 - Dependabot's `docker` entry pointed at `/`, where there is no Dockerfile -- both of them live in
   `docker/`. It has therefore never proposed a base-image update for either image; it now reads
   the directory they are actually in

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.14-slim-trixie AS build
 
-COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.5 /uv /bin/
 
 ENV UV_NO_DEV=1
 ENV UV_COMPILE_BYTECODE=1
@@ -27,7 +27,7 @@ RUN --mount=type=cache,id=uv,target=/root/.cache/uv \
 # Installs the same extras and OS packages as the final stage for feature parity.
 FROM python:3.14-slim-trixie AS dev
 
-COPY --from=ghcr.io/astral-sh/uv:0.8.4 /uv /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.5 /uv /bin/
 
 ENV UV_NO_DEV=1
 ENV UV_LINK_MODE=copy


### PR DESCRIPTION
## What

`docker/Dockerfile` pinned `ghcr.io/astral-sh/uv:0.8.4` in both the build and dev stages — four minor versions back, and far enough back to no longer understand this repo's own configuration.

Given the `exclude-newer = "3 days"` added in #1849, uv 0.8.4 does this:

```
warning: Failed to parse `pyproject.toml` during settings discovery:
  TOML parse error at line 412, column 17
  412 | exclude-newer = "3 days"
      |                 ^^^^^^^^
  failed to parse year in date "3 days"
```

It discards the **whole `[tool.uv]` table**, `[tool.uv.audit]` included, and carries on.

**This was not breaking the image**, and it is worth being precise about why: the build runs `uv sync --frozen`, which installs from `uv.lock` and needs none of those settings. So the image was correct; uv was simply ignoring configuration it could not read, quietly. CI was right to be green.

Bumped both stages to 0.12.5, the current release and the version used locally and in CI.

Dependabot will keep this pin current from here — #1851 repointed its `docker` entry at `/docker`, where it can finally see these files. This is the first bump it would have proposed.

## Verification

Built and ran the image rather than relying on CI:

```
$ docker build -f docker/Dockerfile -t wd-uv-test:local .
… naming to docker.io/library/wd-uv-test:local done

$ docker run --rm wd-uv-test:local wetterdienst --version
0.132.0

$ curl -s localhost:33000/api/version          # container on the default CMD
{"version":"0.132.0","mcp_enabled":true}
```

The parse warning is gone from the build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)