### PR TITLE
fix(ci): POST to the Coolify deploy endpoint

### DIFF
--- a/.github/workflows/docker-publish-app.yml
+++ b/.github/workflows/docker-publish-app.yml
@@ -276,6 +276,9 @@ jobs:
 
       - name: Deploy to Coolify
         run: |
-          curl --fail --request GET \
+          # POST, not GET: Coolify's /api/v1/deploy is declared POST-only in its OpenAPI spec, and a
+          # GET is answered with a bare 405 that `--fail` alone reports as "exit code 22".
+          # `--fail-with-body` keeps Coolify's explanation of the rejection in the log.
+          curl --fail-with-body --silent --show-error --request POST \
             --header "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
             'https://coolify.eobs.org/api/v1/deploy?uuid=${{ secrets.COOLIFY_APP_UUID }}&force=false'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -189,6 +189,9 @@ jobs:
 
       - name: Deploy to Coolify
         run: |
-          curl --fail --request GET \
+          # POST, not GET: Coolify's /api/v1/deploy is declared POST-only in its OpenAPI spec, and a
+          # GET is answered with a bare 405 that `--fail` alone reports as "exit code 22".
+          # `--fail-with-body` keeps Coolify's explanation of the rejection in the log.
+          curl --fail-with-body --silent --show-error --request POST \
             --header "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
             'https://coolify.eobs.org/api/v1/deploy?uuid=${{ secrets.COOLIFY_BACKEND_UUID }}&force=false'


### PR DESCRIPTION
## What happened

The `v0.133.0` and `app-v0.13.0` release runs both built and pushed their images successfully and
then failed on the last step:

```
curl: (22) The requested URL returned error: 405
```

`ghcr.io/earthobservations/wetterdienst:0.133.0` exists (pushed 08:54:45Z) and
`…/wetterdienst-app:0.13.0` exists (09:01:57Z), but `wetterdienst.eobs.org` still reports
`{"version":"0.132.0"}` because the deploy call never reached Coolify.

## Why

Coolify's own OpenAPI spec declares the endpoint POST-only:

```
/deploy    POST
   POST: Deploy  params=[('tag','query'), ('uuid','query'), ('force','query'), …]
```

Both steps sent `--request GET`, which Laravel answers with 405 Method Not Allowed. The `uuid` and
`force` query parameters were already correct — only the method was wrong.

This is not a new regression from the release: the scheduled run on 2026-08-18 failed at the same
step for the same reason.

## The fix

`GET` → `POST` in `docker-publish.yml` and `docker-publish-app.yml`.

Also swapped `--fail` for `--fail-with-body --silent --show-error`. With plain `--fail`, curl
discards the response body, so a 405 surfaces only as `Process completed with exit code 22` — the
server's own message (`The GET method is not supported for route api/v1/deploy. Supported methods:
POST.`) would have identified this immediately.

## Separate issue, not fixed here — needs repository access

The app deploy has a **second, independent fault**. Its URL rendered with an empty uuid:

```
backend:  https://coolify.eobs.org/api/v1/deploy?uuid=***&force=false     <- masked, so populated
app:      https://coolify.eobs.org/api/v1/deploy?uuid=&force=false        <- empty
```

`COOLIFY_APP_UUID` is present in the repository secrets (last updated 2026-08-19T05:55:42Z) but
resolves to an empty string — GitHub masks a non-empty secret as `***`, and nothing was masked. The
`docker_app_merge` job declares no `environment:`, so this is not environment-secret shadowing. The
secret value itself needs to be re-set; with the method fixed the app deploy would otherwise trade
a 405 for a failure on the missing uuid.

## Verification

- Method confirmed against `coollabsio/coolify` `openapi.json` on `main`, not inferred from the
  error code.
- `uv run poe zizmor` — clean.
- Not verifiable from CI: the deploy itself, which needs `COOLIFY_API_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
