### PR TITLE
feat(wsv)!: report under the interval each station records at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ Types of changes:
 
 ### Changed
 
+- **Breaking**: WSV Pegelonline reports under the interval it actually records at, so its single
+  `dynamic` resolution is replaced by `1_minute`, `5_minutes`, `10_minutes`, `15_minutes` and
+  `hourly`, and a request for `dynamic/data/...` no longer resolves. Pegelonline publishes an
+  `equidistance` on every timeseries in the station listing the provider already downloads, so the
+  interval was never something that had to be guessed -- it was simply not read. Each station is
+  listed under the resolution it records the requested parameters at, and the 77 of 787 stations
+  that record different parameters at different intervals (Passau reads stage every 15 minutes and
+  air temperature every 60) appear under each, serving only the parameters that belong there. To
+  find a station's resolution, request the parameter at every interval that could carry it and read
+  the `resolution` column of the station list. In exchange `ts_complete` works, which was
+  short-circuited for a dynamic resolution, and the interpolation search radius scales by resolution
+  like every other provider's rather than falling back to a factor of 1.0
 - **Breaking**: the heterogeneous search radius follows the resolution of the request, so an
   interpolation or summary that already worked returns different values without anything being
   changed by hand: daily precipitation is drawn from 40 km rather than 20, `minute_10` from 15 km

--- a/docs/data/provider/wsv/pegel/10_minutes.md
+++ b/docs/data/provider/wsv/pegel/10_minutes.md
@@ -1,0 +1,48 @@
+# 10_minutes
+
+## metadata
+
+| property      | value                                                        |
+|---------------|--------------------------------------------------------------|
+| name          | 10_minutes                                                   |
+| original name | 10_minutes                                                   |
+| url           | [here](https://www.pegelonline.wsv.de/webservice/ueberblick) |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                                        |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | data                                                         |
+| original name | data                                                         |
+| description   | Recent data (last 30 days) of German waterways including water level and discharge for most stations but may also include chemical, meteorologic and other types of values ([details](https://www.pegelonline.wsv.de/webservice/ueberblick)) |
+| access        | [here](https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json?includeTimeseries=true)                                                                                                                                          |
+
+#### parameters
+
+| name                            | original name           | description                                            | unit  | constraints |
+|---------------------------------|-------------------------|--------------------------------------------------------|-------|-------------|
+| {term}`chlorid_concentration`   | CL                      | average chlorid concentration during time scale        | mg/l  | -           |
+| {term}`clearance_height`        | DFH                     | average clearance height during time scale             | cm    | -           |
+| {term}`discharge`               | Q                       | average discharge during time scale                    | m³/s  | >=0         |
+| {term}`electric_conductivity`   | LF                      | average electric conductivity during time scale        | μS/cm | -           |
+| {term}`flow_direction`          | R                       | direction of the water current                         | °     | >=0,<=360   |
+| {term}`flow_speed`              | VA                      | average flow speed during time scale                   | m/s   | -           |
+| {term}`groundwater_level`       | GRU                     | average groundwater level during time scale            | m     | -           |
+| {term}`humidity`                | HL                      | average relative humidity of the air during time scale | %     | >=0,<=100   |
+| {term}`oxygen_level`            | O2                      | average oxygen level during time scale                 | mg/l  | >=0         |
+| {term}`ph_value`                | PH                      | average pH during time scale                           | -     | -           |
+| {term}`precipitation_height`    | NIEDERSCHLAG            | average precipitation height during time scale         | mm    | >=0         |
+| {term}`precipitation_intensity` | NIEDERSCHLAGSINTENSITÄT | average precipitation intensity during time scale      | mm/h  | >=0         |
+| {term}`stage`                   | W                       | average water level during time scale                  | cm    | >=0         |
+| {term}`temperature_air_mean_2m` | LT                      | average air temperature during time scale              | °C    | -           |
+| {term}`temperature_water`       | WT                      | average water temperature during time scale            | °C    | -           |
+| {term}`turbidity`               | TR                      | average turbidity during time scale                    | NTU   | -           |
+| {term}`wave_height_max`         | MAXH                    | max wave height during time scale                      | cm    | -           |
+| {term}`wave_height_sign`        | SIGH                    | average significant wave height during time scale      | cm    | -           |
+| {term}`wave_period`             | TP                      | average wave period during time scale                  | s     | >=0         |
+| {term}`wind_direction`          | WR                      | average wind direction during time scale               | °     | >=0,<=360   |
+| {term}`wind_speed`              | WG                      | average wind speed during time scale                   | m/s   | -           |

--- a/docs/data/provider/wsv/pegel/15_minutes.md
+++ b/docs/data/provider/wsv/pegel/15_minutes.md
@@ -1,12 +1,11 @@
-# dynamic
+# 15_minutes
 
 ## metadata
 
 | property      | value                                                        |
 |---------------|--------------------------------------------------------------|
-| name          | dynamic                                                      |
-| original name | dynamic                                                      |
-| description   | The interval is a property of the station rather than of the network: 15 minutes at most gauges, 10 at some. |
+| name          | 15_minutes                                                   |
+| original name | 15_minutes                                                   |
 | url           | [here](https://www.pegelonline.wsv.de/webservice/ueberblick) |
 
 ## datasets
@@ -17,8 +16,8 @@
 
 | property      | value                                                                                                                                                                                                                                        |
 |---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| name          | data                                                                                                                                                                                                                                         |
-| original name | data                                                                                                                                                                                                                                         |
+| name          | data                                                         |
+| original name | data                                                         |
 | description   | Recent data (last 30 days) of German waterways including water level and discharge for most stations but may also include chemical, meteorologic and other types of values ([details](https://www.pegelonline.wsv.de/webservice/ueberblick)) |
 | access        | [here](https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json?includeTimeseries=true)                                                                                                                                          |
 

--- a/docs/data/provider/wsv/pegel/1_minute.md
+++ b/docs/data/provider/wsv/pegel/1_minute.md
@@ -1,0 +1,48 @@
+# 1_minute
+
+## metadata
+
+| property      | value                                                        |
+|---------------|--------------------------------------------------------------|
+| name          | 1_minute                                                     |
+| original name | 1_minute                                                     |
+| url           | [here](https://www.pegelonline.wsv.de/webservice/ueberblick) |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                                        |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | data                                                         |
+| original name | data                                                         |
+| description   | Recent data (last 30 days) of German waterways including water level and discharge for most stations but may also include chemical, meteorologic and other types of values ([details](https://www.pegelonline.wsv.de/webservice/ueberblick)) |
+| access        | [here](https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json?includeTimeseries=true)                                                                                                                                          |
+
+#### parameters
+
+| name                            | original name           | description                                            | unit  | constraints |
+|---------------------------------|-------------------------|--------------------------------------------------------|-------|-------------|
+| {term}`chlorid_concentration`   | CL                      | average chlorid concentration during time scale        | mg/l  | -           |
+| {term}`clearance_height`        | DFH                     | average clearance height during time scale             | cm    | -           |
+| {term}`discharge`               | Q                       | average discharge during time scale                    | m³/s  | >=0         |
+| {term}`electric_conductivity`   | LF                      | average electric conductivity during time scale        | μS/cm | -           |
+| {term}`flow_direction`          | R                       | direction of the water current                         | °     | >=0,<=360   |
+| {term}`flow_speed`              | VA                      | average flow speed during time scale                   | m/s   | -           |
+| {term}`groundwater_level`       | GRU                     | average groundwater level during time scale            | m     | -           |
+| {term}`humidity`                | HL                      | average relative humidity of the air during time scale | %     | >=0,<=100   |
+| {term}`oxygen_level`            | O2                      | average oxygen level during time scale                 | mg/l  | >=0         |
+| {term}`ph_value`                | PH                      | average pH during time scale                           | -     | -           |
+| {term}`precipitation_height`    | NIEDERSCHLAG            | average precipitation height during time scale         | mm    | >=0         |
+| {term}`precipitation_intensity` | NIEDERSCHLAGSINTENSITÄT | average precipitation intensity during time scale      | mm/h  | >=0         |
+| {term}`stage`                   | W                       | average water level during time scale                  | cm    | >=0         |
+| {term}`temperature_air_mean_2m` | LT                      | average air temperature during time scale              | °C    | -           |
+| {term}`temperature_water`       | WT                      | average water temperature during time scale            | °C    | -           |
+| {term}`turbidity`               | TR                      | average turbidity during time scale                    | NTU   | -           |
+| {term}`wave_height_max`         | MAXH                    | max wave height during time scale                      | cm    | -           |
+| {term}`wave_height_sign`        | SIGH                    | average significant wave height during time scale      | cm    | -           |
+| {term}`wave_period`             | TP                      | average wave period during time scale                  | s     | >=0         |
+| {term}`wind_direction`          | WR                      | average wind direction during time scale               | °     | >=0,<=360   |
+| {term}`wind_speed`              | WG                      | average wind speed during time scale                   | m/s   | -           |

--- a/docs/data/provider/wsv/pegel/5_minutes.md
+++ b/docs/data/provider/wsv/pegel/5_minutes.md
@@ -1,0 +1,48 @@
+# 5_minutes
+
+## metadata
+
+| property      | value                                                        |
+|---------------|--------------------------------------------------------------|
+| name          | 5_minutes                                                    |
+| original name | 5_minutes                                                    |
+| url           | [here](https://www.pegelonline.wsv.de/webservice/ueberblick) |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                                        |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | data                                                         |
+| original name | data                                                         |
+| description   | Recent data (last 30 days) of German waterways including water level and discharge for most stations but may also include chemical, meteorologic and other types of values ([details](https://www.pegelonline.wsv.de/webservice/ueberblick)) |
+| access        | [here](https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json?includeTimeseries=true)                                                                                                                                          |
+
+#### parameters
+
+| name                            | original name           | description                                            | unit  | constraints |
+|---------------------------------|-------------------------|--------------------------------------------------------|-------|-------------|
+| {term}`chlorid_concentration`   | CL                      | average chlorid concentration during time scale        | mg/l  | -           |
+| {term}`clearance_height`        | DFH                     | average clearance height during time scale             | cm    | -           |
+| {term}`discharge`               | Q                       | average discharge during time scale                    | m³/s  | >=0         |
+| {term}`electric_conductivity`   | LF                      | average electric conductivity during time scale        | μS/cm | -           |
+| {term}`flow_direction`          | R                       | direction of the water current                         | °     | >=0,<=360   |
+| {term}`flow_speed`              | VA                      | average flow speed during time scale                   | m/s   | -           |
+| {term}`groundwater_level`       | GRU                     | average groundwater level during time scale            | m     | -           |
+| {term}`humidity`                | HL                      | average relative humidity of the air during time scale | %     | >=0,<=100   |
+| {term}`oxygen_level`            | O2                      | average oxygen level during time scale                 | mg/l  | >=0         |
+| {term}`ph_value`                | PH                      | average pH during time scale                           | -     | -           |
+| {term}`precipitation_height`    | NIEDERSCHLAG            | average precipitation height during time scale         | mm    | >=0         |
+| {term}`precipitation_intensity` | NIEDERSCHLAGSINTENSITÄT | average precipitation intensity during time scale      | mm/h  | >=0         |
+| {term}`stage`                   | W                       | average water level during time scale                  | cm    | >=0         |
+| {term}`temperature_air_mean_2m` | LT                      | average air temperature during time scale              | °C    | -           |
+| {term}`temperature_water`       | WT                      | average water temperature during time scale            | °C    | -           |
+| {term}`turbidity`               | TR                      | average turbidity during time scale                    | NTU   | -           |
+| {term}`wave_height_max`         | MAXH                    | max wave height during time scale                      | cm    | -           |
+| {term}`wave_height_sign`        | SIGH                    | average significant wave height during time scale      | cm    | -           |
+| {term}`wave_period`             | TP                      | average wave period during time scale                  | s     | >=0         |
+| {term}`wind_direction`          | WR                      | average wind direction during time scale               | °     | >=0,<=360   |
+| {term}`wind_speed`              | WG                      | average wind speed during time scale                   | m/s   | -           |

--- a/docs/data/provider/wsv/pegel/hourly.md
+++ b/docs/data/provider/wsv/pegel/hourly.md
@@ -1,0 +1,48 @@
+# hourly
+
+## metadata
+
+| property      | value                                                        |
+|---------------|--------------------------------------------------------------|
+| name          | hourly                                                       |
+| original name | hourly                                                       |
+| url           | [here](https://www.pegelonline.wsv.de/webservice/ueberblick) |
+
+## datasets
+
+### data
+
+#### metadata
+
+| property      | value                                                                                                                                                                                                                                        |
+|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| name          | data                                                         |
+| original name | data                                                         |
+| description   | Recent data (last 30 days) of German waterways including water level and discharge for most stations but may also include chemical, meteorologic and other types of values ([details](https://www.pegelonline.wsv.de/webservice/ueberblick)) |
+| access        | [here](https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json?includeTimeseries=true)                                                                                                                                          |
+
+#### parameters
+
+| name                            | original name           | description                                            | unit  | constraints |
+|---------------------------------|-------------------------|--------------------------------------------------------|-------|-------------|
+| {term}`chlorid_concentration`   | CL                      | average chlorid concentration during time scale        | mg/l  | -           |
+| {term}`clearance_height`        | DFH                     | average clearance height during time scale             | cm    | -           |
+| {term}`discharge`               | Q                       | average discharge during time scale                    | m³/s  | >=0         |
+| {term}`electric_conductivity`   | LF                      | average electric conductivity during time scale        | μS/cm | -           |
+| {term}`flow_direction`          | R                       | direction of the water current                         | °     | >=0,<=360   |
+| {term}`flow_speed`              | VA                      | average flow speed during time scale                   | m/s   | -           |
+| {term}`groundwater_level`       | GRU                     | average groundwater level during time scale            | m     | -           |
+| {term}`humidity`                | HL                      | average relative humidity of the air during time scale | %     | >=0,<=100   |
+| {term}`oxygen_level`            | O2                      | average oxygen level during time scale                 | mg/l  | >=0         |
+| {term}`ph_value`                | PH                      | average pH during time scale                           | -     | -           |
+| {term}`precipitation_height`    | NIEDERSCHLAG            | average precipitation height during time scale         | mm    | >=0         |
+| {term}`precipitation_intensity` | NIEDERSCHLAGSINTENSITÄT | average precipitation intensity during time scale      | mm/h  | >=0         |
+| {term}`stage`                   | W                       | average water level during time scale                  | cm    | >=0         |
+| {term}`temperature_air_mean_2m` | LT                      | average air temperature during time scale              | °C    | -           |
+| {term}`temperature_water`       | WT                      | average water temperature during time scale            | °C    | -           |
+| {term}`turbidity`               | TR                      | average turbidity during time scale                    | NTU   | -           |
+| {term}`wave_height_max`         | MAXH                    | max wave height during time scale                      | cm    | -           |
+| {term}`wave_height_sign`        | SIGH                    | average significant wave height during time scale      | cm    | -           |
+| {term}`wave_period`             | TP                      | average wave period during time scale                  | s     | >=0         |
+| {term}`wind_direction`          | WR                      | average wind direction during time scale               | °     | >=0,<=360   |
+| {term}`wind_speed`              | WG                      | average wind speed during time scale                   | m/s   | -           |

--- a/docs/data/provider/wsv/pegel/index.md
+++ b/docs/data/provider/wsv/pegel/index.md
@@ -6,9 +6,13 @@ The administration of German waterways (WSV) is providing data of certain statio
 for maximum last 30 days. Data is provided kindly over a 
 [REST API](https://www.pegelonline.wsv.de/webservices/rest-api/v2/stations.json). Measured parameters include
 water level and discharge for most stations but may also include chemical, meteorologic and other types
-of values. The values of WSV Pegelonline have no fixed frequency but may be one of 1 minute, 5 minutes,
-15 minutes or 60 minutes. Besides continuously measured values there are also a number of
-statistical values which are fragmentary provided per each station:
+of values. The recording interval is a property of the station rather than of the network, so the
+resolutions below are not periods the network as a whole reports in: each station is listed under the
+one it actually records at, which the API publishes as the `equidistance` of the timeseries. A station
+that records different parameters at different intervals -- stage every 15 minutes, air temperature
+every 60, say -- appears under both, and each parameter is only served under the resolution it belongs
+to. Besides continuously measured values there are also a number of statistical values which are
+fragmentary provided per each station:
 
 - m_i -> first flood marking
 - m_ii -> second flood marking
@@ -22,5 +26,9 @@ statistical values which are fragmentary provided per each station:
 ```{toctree}
 :hidden:
 
-dynamic.md
+1_minute.md
+5_minutes.md
+10_minutes.md
+15_minutes.md
+hourly.md
 ```

--- a/src/wetterdienst/metadata/resolution.py
+++ b/src/wetterdienst/metadata/resolution.py
@@ -57,7 +57,6 @@ class Frequency(Enum):
     MINUTE_6 = "6m"
     MINUTE_10 = "10m"
     MINUTE_15 = "15m"
-    MINUTE_60 = "60m"  # similar to hourly, needed for WSV frequency detection
     HOURLY = "1h"
     HOUR_6 = "6h"
     SUBDAILY = HOURLY

--- a/src/wetterdienst/metadata/source_descriptions.py
+++ b/src/wetterdienst/metadata/source_descriptions.py
@@ -44,6 +44,40 @@ Keyed by metadata model name, then ``(resolution, dataset, name_original)``. App
 ``build_metadata_model``.
 """
 
+# Pegelonline serves the same parameters at whatever interval each station records at, so these are
+# declared once and expanded over the resolutions below rather than written out five times. The
+# resolution names must stay in step with `_EQUIDISTANCE_TO_RESOLUTION` in the provider module; a
+# name that drifts out of step leaves its parameters with no description, which
+# `test_wsv_every_parameter_is_described` catches.
+_WSV_PEGEL_RESOLUTIONS = ("1_minute", "5_minutes", "10_minutes", "15_minutes", "hourly")
+
+# Pegelonline names each timeseries in German; the meaning below is the API's own ``longname`` for
+# that shortname, e.g. HL is LUFTFEUCHTE and SIGH SIGNIFIKANTEWELLENHÖHE.
+_WSV_PEGEL_PARAMETERS = {
+    "CL": "average chlorid concentration during time scale",
+    "DFH": "average clearance height during time scale",
+    "GRU": "average groundwater level during time scale",
+    "HL": "average relative humidity of the air during time scale",
+    "LF": "average electric conductivity during time scale",
+    "LT": "average air temperature during time scale",
+    "MAXH": "max wave height during time scale",
+    "NIEDERSCHLAG": "average precipitation height during time scale",
+    "NIEDERSCHLAGSINTENSITÄT": "average precipitation intensity during time scale",
+    "O2": "average oxygen level during time scale",
+    "PH": "average pH during time scale",
+    "Q": "average discharge during time scale",
+    "R": "direction of the water current",
+    "SIGH": "average significant wave height during time scale",
+    "TP": "average wave period during time scale",
+    "TR": "average turbidity during time scale",
+    "VA": "average flow speed during time scale",
+    "W": "average water level during time scale",
+    "WG": "average wind speed during time scale",
+    "WR": "average wind direction during time scale",
+    "WT": "average water temperature during time scale",
+}
+
+
 SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
     "HubeauMetadata": {
         ("dynamic", "data", "H"): "Stage.",
@@ -1484,29 +1518,9 @@ SOURCE_DESCRIPTIONS: dict[str, dict[tuple[str, str, str], str]] = {
         ("hourly", "data", "windspeed"): "wind speed",
     },
     "WsvPegelMetadata": {
-        # Pegelonline names each timeseries in German; the meaning below is the API's own
-        # ``longname`` for that shortname, e.g. HL is LUFTFEUCHTE and SIGH SIGNIFIKANTEWELLENHÖHE.
-        ("dynamic", "data", "CL"): "average chlorid concentration during time scale",
-        ("dynamic", "data", "DFH"): "average clearance height during time scale",
-        ("dynamic", "data", "GRU"): "average groundwater level during time scale",
-        ("dynamic", "data", "HL"): "average relative humidity of the air during time scale",
-        ("dynamic", "data", "LF"): "average electric conductivity during time scale",
-        ("dynamic", "data", "LT"): "average air temperature during time scale",
-        ("dynamic", "data", "MAXH"): "max wave height during time scale",
-        ("dynamic", "data", "NIEDERSCHLAG"): "average precipitation height during time scale",
-        ("dynamic", "data", "NIEDERSCHLAGSINTENSITÄT"): "average precipitation intensity during time scale",
-        ("dynamic", "data", "O2"): "average oxygen level during time scale",
-        ("dynamic", "data", "PH"): "average pH during time scale",
-        ("dynamic", "data", "Q"): "average discharge during time scale",
-        ("dynamic", "data", "R"): "direction of the water current",
-        ("dynamic", "data", "SIGH"): "average significant wave height during time scale",
-        ("dynamic", "data", "TP"): "average wave period during time scale",
-        ("dynamic", "data", "TR"): "average turbidity during time scale",
-        ("dynamic", "data", "VA"): "average flow speed during time scale",
-        ("dynamic", "data", "W"): "average water level during time scale",
-        ("dynamic", "data", "WG"): "average wind speed during time scale",
-        ("dynamic", "data", "WR"): "average wind direction during time scale",
-        ("dynamic", "data", "WT"): "average water temperature during time scale",
+        (resolution, "data", name_original): description
+        for resolution in _WSV_PEGEL_RESOLUTIONS
+        for name_original, description in _WSV_PEGEL_PARAMETERS.items()
     },
     "AemetObservationMetadata": {
         ("annual", "data", "p_max"): "Greatest daily precipitation of the year, and its date.",
@@ -2279,10 +2293,11 @@ DATASET_DESCRIPTIONS: dict[str, dict[tuple[str, str], str]] = {
         ),
     },
     "WsvPegelMetadata": {
-        ("dynamic", "data"): (
+        (resolution, "data"): (
             "Recent data (last 30 days) of German waterways including water level and discharge for "
             "most stations but may also include chemical, meteorologic and other types of values."
-        ),
+        )
+        for resolution in _WSV_PEGEL_RESOLUTIONS
     },
 }
 
@@ -2304,12 +2319,6 @@ RESOLUTION_DESCRIPTIONS: dict[str, dict[str, str]] = {
     },
     "MetnoFrostMetadata": {
         "6_hour": "Synoptic observations reported every six hours.",
-    },
-    "WsvPegelMetadata": {
-        "dynamic": (
-            "The interval is a property of the station rather than of the network: 15 minutes at "
-            "most gauges, 10 at some."
-        ),
     },
 }
 

--- a/src/wetterdienst/provider/wsv/pegel/api.py
+++ b/src/wetterdienst/provider/wsv/pegel/api.py
@@ -63,6 +63,189 @@ _SOURCE_UNIT_FACTORS: dict[str, dict[str, float]] = {
 }
 
 
+# Pegelonline publishes an ``equidistance`` in minutes on every timeseries it serves, so a station's
+# resolution is a fact read from the station listing rather than something to infer from the data.
+# These are the five values the service uses. A timeseries carrying anything else has no matching
+# resolution; ``_log_unmapped_equidistances`` reports it rather than letting it disappear.
+_EQUIDISTANCE_TO_RESOLUTION: dict[int, str] = {
+    1: "1_minute",
+    5: "5_minutes",
+    10: "10_minutes",
+    15: "15_minutes",
+    60: "hourly",
+}
+_RESOLUTION_TO_EQUIDISTANCE: dict[str, int] = {
+    resolution: equidistance for equidistance, resolution in _EQUIDISTANCE_TO_RESOLUTION.items()
+}
+
+
+@dataclass(frozen=True)
+class TimeseriesMeta:
+    """What a station declares about one of its own timeseries.
+
+    Both fields are optional because they are read from the listing rather than promised by it:
+    every timeseries carries them today, but a missing one has to mean "unknown" rather than
+    silently defaulting to whatever the metadata declares.
+    """
+
+    unit: str | None
+    equidistance: int | None
+
+    @property
+    def resolution(self) -> str | None:
+        """The resolution name this interval belongs to, or None if the service uses a new one."""
+        if self.equidistance is None:
+            return None
+        return _EQUIDISTANCE_TO_RESOLUTION.get(self.equidistance)
+
+
+# reported once per process rather than per request: the listing is scanned whole every time
+# `_all` runs, and `filter_by_name` and `filter_by_rank` each run it twice, so a single new
+# interval anywhere in the network would otherwise warn on every call
+_reported_equidistances: set[int] = set()
+
+
+def _log_unmapped_equidistances(df: pl.DataFrame) -> None:
+    """Report intervals the service publishes that no resolution covers.
+
+    A timeseries recorded at an interval absent from ``_EQUIDISTANCE_TO_RESOLUTION`` belongs to no
+    resolution, so it is served under none and its station is listed only for whatever other
+    timeseries it records at a mapped interval. That is the right outcome -- better than filing it
+    under a neighbouring interval and quietly misdescribing it -- but it is a silent one, and the
+    service adding a sixth interval is exactly the change that would need a new member here.
+    """
+    equidistances = (
+        df.select(pl.col("timeseries").list.eval(pl.element().struct.field("equidistance")))
+        .explode("timeseries", empty_as_null=True)
+        .to_series()
+        .drop_nulls()
+        .unique()
+        .to_list()
+    )
+    unmapped = sorted(e for e in equidistances if e not in _EQUIDISTANCE_TO_RESOLUTION)
+    unreported = [e for e in unmapped if e not in _reported_equidistances]
+    if unreported:
+        _reported_equidistances.update(unreported)
+        log.warning(
+            f"WSV Pegelonline publishes timeseries at {unreported} minute intervals, which no "
+            f"resolution covers; those timeseries are not served under any resolution",
+        )
+
+
+# Declared once and shared by every resolution below. Which of these a station publishes, and at
+# which interval, is a property of that station rather than of the network, and the station listing
+# is what answers it -- so a parameter that no station happens to serve at some interval simply
+# yields no stations there. `build_metadata_model` copies each parameter dict per resolution, so
+# sharing the list here cannot leak one resolution's description into another.
+_PARAMETERS = [
+    {
+        "name": "stage",
+        "name_original": "W",
+        "unit": "centimeter",
+    },
+    {
+        "name": "discharge",
+        "name_original": "Q",
+        "unit": "cubic_meter_per_second",
+    },
+    {
+        "name": "temperature_water",
+        "name_original": "WT",
+        "unit": "degree_celsius",
+    },
+    {
+        "name": "electric_conductivity",
+        "name_original": "LF",
+        "unit": "microsiemens_per_centimeter",
+    },
+    {
+        "name": "clearance_height",
+        "name_original": "DFH",
+        "unit": "centimeter",
+    },
+    {
+        "name": "temperature_air_mean_2m",
+        "name_original": "LT",
+        "unit": "degree_celsius",
+    },
+    {
+        "name": "flow_speed",
+        "name_original": "VA",
+        "unit": "meter_per_second",
+    },
+    {
+        "name": "groundwater_level",
+        "name_original": "GRU",
+        "unit": "meter",
+    },
+    {
+        "name": "wind_speed",
+        "name_original": "WG",
+        "unit": "meter_per_second",
+    },
+    {
+        "name": "humidity",
+        "name_original": "HL",
+        "unit": "percent",
+    },
+    {
+        "name": "oxygen_level",
+        "name_original": "O2",
+        "unit": "milligram_per_liter",
+    },
+    {
+        "name": "turbidity",
+        "name_original": "TR",
+        "unit": "nephelometric_turbidity",
+    },
+    {
+        "name": "flow_direction",
+        "name_original": "R",
+        "unit": "degree",
+    },
+    {
+        "name": "wind_direction",
+        "name_original": "WR",
+        "unit": "degree",
+    },
+    {
+        "name": "precipitation_height",
+        "name_original": "NIEDERSCHLAG",
+        "unit": "millimeter",
+    },
+    {
+        "name": "precipitation_intensity",
+        "name_original": "NIEDERSCHLAGSINTENSITÄT",
+        "unit": "millimeter_per_hour",
+    },
+    {
+        "name": "wave_period",
+        "name_original": "TP",
+        "unit": "second",
+    },
+    {
+        "name": "wave_height_sign",
+        "name_original": "SIGH",
+        "unit": "centimeter",
+    },
+    {
+        "name": "wave_height_max",
+        "name_original": "MAXH",
+        "unit": "centimeter",
+    },
+    {
+        "name": "ph_value",
+        "name_original": "PH",
+        "unit": "dimensionless",
+    },
+    {
+        "name": "chlorid_concentration",
+        "name_original": "CL",
+        "unit": "milligram_per_liter",
+    },
+]
+
+
 WsvPegelMetadata = {
     "name_short": "WSV",
     "name_english": "Federal Waterways and Shipping Administration",
@@ -75,8 +258,8 @@ WsvPegelMetadata = {
     "timezone_data": "Europe/Berlin",
     "resolutions": [
         {
-            "name": "dynamic",
-            "name_original": "dynamic",
+            "name": resolution,
+            "name_original": resolution,
             "periods": ["recent"],
             "date_required": True,
             "datasets": [
@@ -84,116 +267,11 @@ WsvPegelMetadata = {
                     "name": DATASET_NAME_DEFAULT,
                     "name_original": DATASET_NAME_DEFAULT,
                     "grouped": False,
-                    "parameters": [
-                        {
-                            "name": "stage",
-                            "name_original": "W",
-                            "unit": "centimeter",
-                        },
-                        {
-                            "name": "discharge",
-                            "name_original": "Q",
-                            "unit": "cubic_meter_per_second",
-                        },
-                        {
-                            "name": "temperature_water",
-                            "name_original": "WT",
-                            "unit": "degree_celsius",
-                        },
-                        {
-                            "name": "electric_conductivity",
-                            "name_original": "LF",
-                            "unit": "microsiemens_per_centimeter",
-                        },
-                        {
-                            "name": "clearance_height",
-                            "name_original": "DFH",
-                            "unit": "centimeter",
-                        },
-                        {
-                            "name": "temperature_air_mean_2m",
-                            "name_original": "LT",
-                            "unit": "degree_celsius",
-                        },
-                        {
-                            "name": "flow_speed",
-                            "name_original": "VA",
-                            "unit": "meter_per_second",
-                        },
-                        {
-                            "name": "groundwater_level",
-                            "name_original": "GRU",
-                            "unit": "meter",
-                        },
-                        {
-                            "name": "wind_speed",
-                            "name_original": "WG",
-                            "unit": "meter_per_second",
-                        },
-                        {
-                            "name": "humidity",
-                            "name_original": "HL",
-                            "unit": "percent",
-                        },
-                        {
-                            "name": "oxygen_level",
-                            "name_original": "O2",
-                            "unit": "milligram_per_liter",
-                        },
-                        {
-                            "name": "turbidity",
-                            "name_original": "TR",
-                            "unit": "nephelometric_turbidity",
-                        },
-                        {
-                            "name": "flow_direction",
-                            "name_original": "R",
-                            "unit": "degree",
-                        },
-                        {
-                            "name": "wind_direction",
-                            "name_original": "WR",
-                            "unit": "degree",
-                        },
-                        {
-                            "name": "precipitation_height",
-                            "name_original": "NIEDERSCHLAG",
-                            "unit": "millimeter",
-                        },
-                        {
-                            "name": "precipitation_intensity",
-                            "name_original": "NIEDERSCHLAGSINTENSITÄT",
-                            "unit": "millimeter_per_hour",
-                        },
-                        {
-                            "name": "wave_period",
-                            "name_original": "TP",
-                            "unit": "second",
-                        },
-                        {
-                            "name": "wave_height_sign",
-                            "name_original": "SIGH",
-                            "unit": "centimeter",
-                        },
-                        {
-                            "name": "wave_height_max",
-                            "name_original": "MAXH",
-                            "unit": "centimeter",
-                        },
-                        {
-                            "name": "ph_value",
-                            "name_original": "PH",
-                            "unit": "dimensionless",
-                        },
-                        {
-                            "name": "chlorid_concentration",
-                            "name_original": "CL",
-                            "unit": "milligram_per_liter",
-                        },
-                    ],
+                    "parameters": _PARAMETERS,
                 },
             ],
-        },
+        }
+        for resolution in _EQUIDISTANCE_TO_RESOLUTION.values()
     ],
 }
 WsvPegelMetadata = build_metadata_model(WsvPegelMetadata, "WsvPegelMetadata")
@@ -203,23 +281,28 @@ class WsvPegelValues(TimeseriesValues):
     """Values class for WSV Pegelonline."""
 
     _endpoint = "https://pegelonline.wsv.de/webservices/rest-api/v2/stations/{station_id}/{parameter}/measurements.json"
-    # Used for getting frequency of timeseries
-    _station_endpoint = "https://pegelonline.wsv.de/webservices/rest-api/v2/stations/{station_id}/{parameter}/"
-    _source_units_cache: dict[tuple[str, str], str] | None = None
+    _timeseries_meta_cache: dict[tuple[str, str], TimeseriesMeta] | None = None
 
-    def _source_units(self, settings: Settings) -> dict[tuple[str, str], str]:
-        """Map (station id, parameter) to the unit that station publishes that parameter in.
+    def _timeseries_meta(self, settings: Settings) -> dict[tuple[str, str], TimeseriesMeta]:
+        """Map (station id, parameter) to what that station declares about that timeseries.
 
-        Pegelonline reports the unit per *timeseries*, and stations disagree: water level is cm at
-        most gauges but m+NN at 66 of them, conductivity µS/cm or mS/cm, wave height cm or m, wave
-        period s or 1/100s. No single declaration in the metadata can be right for all of them, so
-        the value has to be scaled to the declared unit per station.
+        Two things are declared per *timeseries* rather than per parameter, and stations disagree
+        on both:
+
+        - the unit. Water level is cm at most gauges but m+NN at 66 of them, conductivity µS/cm or
+          mS/cm, wave height cm or m, wave period s or 1/100s. No single declaration in the
+          metadata can be right for all of them, so the value is scaled to the declared unit per
+          station.
+        - the ``equidistance``, the interval in minutes. It is what makes a station belong to one
+          of the resolutions rather than another, and 77 of 787 stations mix intervals across
+          their own parameters -- PASSAU DONAU records stage every 15 minutes and air temperature
+          every 60 -- so it has to be read per timeseries too.
 
         Read from the same station listing the request already downloads, so this costs no extra
         request beyond what a cached response serves.
         """
-        if self._source_units_cache is not None:
-            return self._source_units_cache
+        if self._timeseries_meta_cache is not None:
+            return self._timeseries_meta_cache
         file = download_file(
             url=_STATIONS_ENDPOINT,
             cache_dir=settings.cache_dir,
@@ -234,14 +317,17 @@ class WsvPegelValues(TimeseriesValues):
             # skip every scaled parameter for the lifetime of the process, long after the listing
             # became reachable again
             return {}
-        units: dict[tuple[str, str], str] = {}
+        meta: dict[tuple[str, str], TimeseriesMeta] = {}
         for station in json.load(file.content):
             for timeseries in station.get("timeseries") or []:
-                shortname, unit = timeseries.get("shortname"), timeseries.get("unit")
-                if shortname and unit:
-                    units[station["number"], shortname] = unit
-        self._source_units_cache = units
-        return units
+                shortname = timeseries.get("shortname")
+                if shortname:
+                    meta[station["number"], shortname] = TimeseriesMeta(
+                        unit=timeseries.get("unit"),
+                        equidistance=timeseries.get("equidistance"),
+                    )
+        self._timeseries_meta_cache = meta
+        return meta
 
     def _collect_station_parameter_or_dataset(  # ty: ignore[invalid-method-override]
         self,
@@ -256,7 +342,23 @@ class WsvPegelValues(TimeseriesValues):
         from typing import cast  # noqa: PLC0415
 
         settings = cast("Settings", self.sr.stations.settings)
-        url = self._endpoint.format(station_id=station_id, parameter=parameter_or_dataset.name_original)
+        name_original = parameter_or_dataset.name_original
+        meta = self._timeseries_meta(settings).get((station_id, name_original))
+        requested_resolution = parameter_or_dataset.dataset.resolution.name
+        if meta is None or meta.resolution != requested_resolution:
+            # A station that mixes intervals across its own parameters is in the station list under
+            # every resolution any of them uses, so asking it for `hourly/data` reaches this method
+            # for its 15-minute stage too. Serving that would label a 15-minute series hourly and,
+            # with `ts_complete`, reindex it onto an hourly grid that throws away three values in
+            # four. The station list already says which resolution this parameter belongs to.
+            #
+            # `meta is None` is treated the same rather than waved through: it means the station
+            # does not publish this timeseries at all, or that the listing was unreachable. In the
+            # first case there is nothing to download and the request would only spend a 404; in
+            # the second the interval is unknown, and stamping the series with whatever resolution
+            # happened to be asked for is the mislabelling this guard exists to prevent.
+            return pl.DataFrame()
+        url = self._endpoint.format(station_id=station_id, parameter=name_original)
         file = download_file(
             url=url,
             cache_dir=settings.cache_dir,
@@ -274,14 +376,13 @@ class WsvPegelValues(TimeseriesValues):
         df = pl.read_json(file.content)
         df = df.rename(mapping={"timestamp": "date", "value": "value"})
 
-        name_original = parameter_or_dataset.name_original
         factors = _SOURCE_UNIT_FACTORS.get(name_original)
         factor = 1.0
         if factors is not None:
-            source_unit = self._source_units(settings).get((station_id, name_original))
+            source_unit = meta.unit
             if source_unit is None:
-                # either the station listing was unreachable or this station does not publish the
-                # timeseries; in both cases the unit is unknown rather than known to be unhandled
+                # the timeseries is listed but declares no unit, so the unit is unknown rather than
+                # known to be unhandled; the unreachable-listing case is already gone by here
                 log.error(
                     f"WSV station {station_id} has no published unit for {name_original} in the "
                     f"station listing; skipping rather than assuming {parameter_or_dataset.unit}",
@@ -301,7 +402,7 @@ class WsvPegelValues(TimeseriesValues):
             factor = factors[source_unit]
 
         return df.with_columns(
-            pl.lit(parameter_or_dataset.dataset.resolution.name, dtype=pl.String).alias("resolution"),
+            pl.lit(requested_resolution, dtype=pl.String).alias("resolution"),
             pl.lit(parameter_or_dataset.dataset.name, dtype=pl.String).alias("dataset"),
             # not lowercased: `_create_humanized_parameters_mapping` keys on `name_original` as
             # declared, so a lowercased value never matched and WSV silently never humanized --
@@ -383,6 +484,7 @@ class WsvPegelRequest(TimeseriesRequest):
                     pl.Struct(
                         {
                             "shortname": pl.String,
+                            "equidistance": pl.Int64,
                             "gaugeZero": pl.Struct(
                                 {
                                     "value": pl.Float64,
@@ -401,16 +503,57 @@ class WsvPegelRequest(TimeseriesRequest):
                 ),
             },
         )
+        _log_unmapped_equidistances(df)
         df = df.lazy()
         df = df.rename(mapping={"number": "station_id", "shortname": "name", "km": "river_kilometer"})
+        # matched as published: Pegelonline names every timeseries in upper case, the same case the
+        # parameters are declared in, so there is nothing to normalize away here
+        # the requested parameters grouped by the resolution they were requested at. Matching the
+        # two independently -- any requested parameter, at any requested interval -- lets a station
+        # in on a pair nobody asked for: `15_minutes/stage` plus `hourly/temperature_air_mean_2m`
+        # would list the gauges that record air temperature every 15 minutes and no stage at all,
+        # which then cost a 404 apiece at collection and return nothing
+        requested: dict[str, list[str]] = {}
+        for parameter in self.parameters:
+            if isinstance(parameter, ParameterModel):
+                requested.setdefault(parameter.dataset.resolution.name, []).append(parameter.name_original)
+        if not requested:
+            # unreachable while the dataset stays `grouped: False`, since a dataset request then
+            # expands to its parameters. It guards the `concat_list` below, which builds one branch
+            # per requested resolution and has no inputs at all to concatenate if there are none
+            return pl.LazyFrame()
         df = df.with_columns(
             pl.col("water").struct.field("shortname"),
-            # matched as published: Pegelonline names every timeseries in upper case, the same case
-            # the parameters are declared in, so there is nothing to normalize away here
-            pl.col("timeseries").list.eval(pl.element().struct.field("shortname")).alias("ts"),
+            # a station belongs to a resolution because it records one of the parameters requested
+            # there at that very interval -- not because of anything the network as a whole does.
+            # Stations that mix intervals get one row per resolution they record in, and the values
+            # class then serves each row only the parameters that belong to it.
+            pl.concat_list(
+                # ordered by the mapping rather than by the request, so a station that records at
+                # two intervals lands in the station list in the same order on every run
+                pl.when(
+                    pl.col("timeseries")
+                    .list.eval(
+                        pl.element().filter(
+                            pl.element().struct.field("shortname").is_in(requested[resolution])
+                            & (pl.element().struct.field("equidistance") == _RESOLUTION_TO_EQUIDISTANCE[resolution]),
+                        ),
+                    )
+                    .list.len()
+                    > 0,
+                )
+                .then(pl.lit(resolution, dtype=pl.String))
+                .otherwise(pl.lit(None, dtype=pl.String))
+                for resolution in _EQUIDISTANCE_TO_RESOLUTION.values()
+                if resolution in requested
+            )
+            .list.drop_nulls()
+            .alias("resolution"),
         )
-        parameters = {parameter.name_original for parameter in self.parameters if isinstance(parameter, ParameterModel)}
-        df = df.filter(pl.col("ts").list.set_intersection(list(parameters)).list.len() > 0)
+        # `empty_as_null=False` drops the row outright: an empty list means this station records
+        # none of the requested parameters at any of the requested resolutions, which is the same
+        # thing the parameter filter used to say and not a station with an unknown resolution
+        df = df.explode("resolution", empty_as_null=False)
         df = df.with_columns(
             pl.col("timeseries")
             .list.eval(pl.element().filter(pl.element().struct.field("shortname") == "W"))
@@ -418,9 +561,9 @@ class WsvPegelRequest(TimeseriesRequest):
             .alias("ts_water"),
         )
         return df.select(
-            pl.lit(self.metadata[0].name, dtype=pl.String).alias("resolution"),
-            pl.lit(self.metadata[0][0].name, dtype=pl.String).alias("dataset"),
-            pl.all().exclude(["timeseries", "ts", "ts_water"]),
+            pl.col("resolution"),
+            pl.lit(DATASET_NAME_DEFAULT, dtype=pl.String).alias("dataset"),
+            pl.all().exclude(["timeseries", "ts_water", "resolution"]),
             # must match the name in `_base_columns`, or the reindex there drops it and leaves an
             # all-null `gauge_zero` -- which is the column that says which datum a stage is on
             pl.col("ts_water").struct.field("gaugeZero").struct.field("value").alias("gauge_zero"),

--- a/tests/provider/wsv/pegel/test_api.py
+++ b/tests/provider/wsv/pegel/test_api.py
@@ -2,10 +2,13 @@
 # Distributed under the MIT License. See LICENSE for more info.
 """Tests for WSV Pegelonline, in particular its per-station source units."""
 
+import json
+
 import pytest
 
 from wetterdienst.provider.wsv.pegel import WsvPegelRequest
 from wetterdienst.provider.wsv.pegel.api import _SOURCE_UNIT_FACTORS
+from wetterdienst.util.network import File
 
 
 def test_wsv_source_unit_factors_are_identity_for_the_declared_unit() -> None:
@@ -65,7 +68,7 @@ def test_wsv_wave_height_is_comparable_across_stations() -> None:
     """
     values = {}
     for station_id in ("9420010", "9460041"):
-        request = WsvPegelRequest(parameters=[("dynamic", "data", "wave_height_sign")])
+        request = WsvPegelRequest(parameters=[("1_minute", "data", "wave_height_sign")])
         df = request.filter_by_station_id(station_id).values.all().df
         series = df.get_column("value").drop_nulls()
         assert not series.is_empty(), f"no data for {station_id}"
@@ -84,7 +87,7 @@ def test_wsv_wave_period_is_seconds() -> None:
     publishes seconds at one station and hundredths of a second at another.
     """
     for station_id in ("9420010", "9460041"):
-        request = WsvPegelRequest(parameters=[("dynamic", "data", "wave_period")])
+        request = WsvPegelRequest(parameters=[("1_minute", "data", "wave_period")])
         df = request.filter_by_station_id(station_id).values.all().df
         series = df.get_column("value").drop_nulls()
         assert not series.is_empty(), f"no data for {station_id}"
@@ -100,7 +103,7 @@ def test_wsv_flow_direction_is_a_bearing() -> None:
     Pegelonline gives `R` the unit `MGN`, degrees relative to magnetic north, which had been read
     as a magnetic quantity and declared as magnetic field strength in A/m.
     """
-    df = WsvPegelRequest(parameters=[("dynamic", "data", "flow_direction")]).all().values.all().df
+    df = WsvPegelRequest(parameters=[("5_minutes", "data", "flow_direction")]).all().values.all().df
     series = df.get_column("value").drop_nulls()
     assert not series.is_empty()
     assert series.min() >= 0
@@ -115,7 +118,7 @@ def test_wsv_stage_is_scaled_for_metre_gauges() -> None:
     level, which used to be reported unscaled as centimetres -- 56.5 where the true figure is 5650.
     The datum still differs between the two groups; `gauge_zero` in the station metadata says which.
     """
-    stations = WsvPegelRequest(parameters=[("dynamic", "data", "stage")]).filter_by_station_id("27800090")
+    stations = WsvPegelRequest(parameters=[("1_minute", "data", "stage")]).filter_by_station_id("27800090")
     series = stations.values.all().df.get_column("value").drop_nulls()
     assert not series.is_empty()
     # metres above sea level for this canal gauge, so thousands of centimetres rather than tens
@@ -131,7 +134,7 @@ def test_wsv_multiple_parameters_with_missing_data() -> None:
     width 0`.
     """
     request = WsvPegelRequest(
-        parameters=[("dynamic", "data", p) for p in ("wave_period", "flow_direction", "wave_height_sign")],
+        parameters=[("1_minute", "data", p) for p in ("wave_period", "flow_direction", "wave_height_sign")],
     )
     df = request.filter_by_station_id("9460041").values.all().df
     # flow_direction has no data at this station while the other two do, which is the whole point:
@@ -140,11 +143,11 @@ def test_wsv_multiple_parameters_with_missing_data() -> None:
     assert "wave_height_sign" in df.get_column("parameter").unique().to_list()
 
 
-def test_wsv_source_units_are_not_cached_when_the_listing_is_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that a failed station listing is retried rather than remembered as "no units known".
+def test_wsv_timeseries_meta_is_not_cached_when_the_listing_is_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that a failed station listing is retried rather than remembered as "nothing known".
 
-    An empty mapping cached after a transient failure makes every unit lookup miss, which skips
-    every scaled parameter for the lifetime of the process -- long after the listing came back.
+    An empty mapping cached after a transient failure makes every lookup miss, which skips every
+    scaled parameter for the lifetime of the process -- long after the listing came back.
     """
     from io import BytesIO  # noqa: PLC0415
 
@@ -152,12 +155,12 @@ def test_wsv_source_units_are_not_cached_when_the_listing_is_unreachable(monkeyp
 
     from wetterdienst.model.result import StationsFilter, StationsResult  # noqa: PLC0415
     from wetterdienst.provider.wsv.pegel import api  # noqa: PLC0415
-    from wetterdienst.provider.wsv.pegel.api import WsvPegelValues  # noqa: PLC0415
+    from wetterdienst.provider.wsv.pegel.api import TimeseriesMeta, WsvPegelValues  # noqa: PLC0415
     from wetterdienst.util.network import File, NoInternetError  # noqa: PLC0415
 
     # deliberately not `.all()`: that eagerly downloads the 1.2 MB station listing, which would
     # make this a network test in all but the marker
-    request = WsvPegelRequest(parameters=[("dynamic", "data", "stage")])
+    request = WsvPegelRequest(parameters=[("1_minute", "data", "stage")])
     values = WsvPegelValues(
         sr=StationsResult(
             stations=request,
@@ -173,13 +176,214 @@ def test_wsv_source_units_are_not_cached_when_the_listing_is_unreachable(monkeyp
         "download_file",
         lambda **kwargs: File(url=kwargs["url"], content=NoInternetError(), status=-1),
     )
-    assert values._source_units(settings) == {}  # noqa: SLF001
-    assert values._source_units_cache is None, "a failed listing must not be cached"  # noqa: SLF001
+    assert values._timeseries_meta(settings) == {}  # noqa: SLF001
+    assert values._timeseries_meta_cache is None, "a failed listing must not be cached"  # noqa: SLF001
 
-    listing = b'[{"number": "1", "timeseries": [{"shortname": "W", "unit": "cm"}]}]'
+    listing = b'[{"number": "1", "timeseries": [{"shortname": "W", "unit": "cm", "equidistance": 15}]}]'
     monkeypatch.setattr(
         api,
         "download_file",
         lambda **kwargs: File(url=kwargs["url"], content=BytesIO(listing), status=200),
     )
-    assert values._source_units(settings) == {("1", "W"): "cm"}  # noqa: SLF001
+    assert values._timeseries_meta(settings) == {  # noqa: SLF001
+        ("1", "W"): TimeseriesMeta(unit="cm", equidistance=15),
+    }
+
+
+def test_wsv_every_parameter_is_described() -> None:
+    """Test that expanding the descriptions over the resolutions actually reaches all of them.
+
+    The parameter descriptions are declared once and keyed by resolution name, so they attach only
+    to resolutions spelled the same way in both places. A resolution added to the provider but not
+    to `_WSV_PEGEL_RESOLUTIONS` would leave a whole resolution's worth of parameters undescribed in
+    the docs, the REST API and the MCP tools, without anything failing.
+    """
+    undescribed = sorted(
+        f"{resolution.name}/{dataset.name}/{parameter.name}"
+        for resolution in WsvPegelRequest.metadata
+        for dataset in resolution
+        for parameter in dataset.parameters
+        if not parameter.description
+    )
+    # NIEDERSCHLAG and NIEDERSCHLAGSINTENSITAET are declared but served by no station today, so
+    # they are described here and simply never appear in a station list
+    assert not undescribed, f"parameters with no description: {undescribed}"
+
+
+def test_wsv_resolutions_are_the_intervals_the_service_publishes() -> None:
+    """Test that the resolutions and the interval mapping cannot drift apart.
+
+    The resolutions are built from `_EQUIDISTANCE_TO_RESOLUTION`, and the station list assigns a
+    station to a resolution by looking its published `equidistance` up in the same mapping. An
+    interval mapped to a resolution that is not declared would silently produce station rows under
+    a resolution nothing can be requested for.
+    """
+    from wetterdienst.metadata.source_descriptions import _WSV_PEGEL_RESOLUTIONS  # noqa: PLC0415
+    from wetterdienst.provider.wsv.pegel.api import _EQUIDISTANCE_TO_RESOLUTION  # noqa: PLC0415
+
+    declared = [resolution.name for resolution in WsvPegelRequest.metadata]
+    assert declared == list(_EQUIDISTANCE_TO_RESOLUTION.values())
+    assert declared == list(_WSV_PEGEL_RESOLUTIONS)
+
+
+@pytest.mark.remote
+def test_wsv_station_mixing_intervals_serves_each_parameter_at_its_own_resolution() -> None:
+    """Test that a station recording at two intervals does not report either under the other.
+
+    PASSAU DONAU records stage every 15 minutes and air and water temperature every 60, so it is in
+    the station list under both resolutions. Serving every requested parameter for both rows would
+    label the 15-minute stage hourly -- and with `ts_complete` reindex it onto an hourly grid,
+    discarding three values in four.
+    """
+    parameters = [
+        (resolution, "data", parameter)
+        for resolution in ("15_minutes", "hourly")
+        for parameter in ("stage", "temperature_air_mean_2m")
+    ]
+    request = WsvPegelRequest(parameters=parameters).filter_by_station_id("10091008")
+    assert set(request.df.get_column("resolution")) == {"15_minutes", "hourly"}
+    df = request.values.all().df
+    served = {
+        (row["resolution"], row["parameter"]) for row in df.select("resolution", "parameter").unique().rows(named=True)
+    }
+    assert served == {("15_minutes", "stage"), ("hourly", "temperature_air_mean_2m")}
+
+
+def test_wsv_unmapped_equidistance_is_reported(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that an interval no resolution covers is announced rather than silently dropped.
+
+    A station recording at an interval absent from `_EQUIDISTANCE_TO_RESOLUTION` belongs to no
+    resolution and so appears in no station list. That is the right outcome -- better than filing
+    it under a neighbouring interval and misdescribing it -- but on its own it is indistinguishable
+    from the station not existing, and the service adding a sixth interval is exactly the change
+    that would need a new member in the mapping.
+    """
+    import logging  # noqa: PLC0415
+
+    import polars as pl  # noqa: PLC0415
+
+    from wetterdienst.provider.wsv.pegel import api  # noqa: PLC0415
+
+    # the reporter remembers what it has already said, for the lifetime of the process
+    monkeypatch.setattr(api, "_reported_equidistances", set())
+    schema = {"timeseries": pl.List(pl.Struct({"equidistance": pl.Int64}))}
+    unmapped = pl.DataFrame({"timeseries": [[{"equidistance": 15}, {"equidistance": 30}]]}, schema=schema)
+
+    caplog.set_level(logging.WARNING)
+    api._log_unmapped_equidistances(  # noqa: SLF001
+        pl.DataFrame({"timeseries": [[{"equidistance": 15}], []]}, schema=schema),
+    )
+    assert not caplog.messages, "the five known intervals must not warn"
+
+    api._log_unmapped_equidistances(unmapped)  # noqa: SLF001
+    assert len(caplog.messages) == 1
+    # only the unknown interval is named; 15 minutes has a resolution and is not a problem
+    assert "[30]" in caplog.messages[0]
+
+    # `_all` scans the whole listing on every call, and `filter_by_name`/`filter_by_rank` call it
+    # twice, so repeating the warning per request would drown the one that carries the news
+    api._log_unmapped_equidistances(unmapped)  # noqa: SLF001
+    assert len(caplog.messages) == 1, "an interval already reported must not warn again"
+
+
+def test_wsv_unmapped_equidistance_is_not_served_under_a_neighbouring_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a timeseries at an unknown interval is skipped rather than mislabelled.
+
+    The station list already omits such a station, so this is the second half of the same rule: a
+    caller reaching the values class for it directly -- by station id, say -- must not get a
+    30-minute series labelled as one of the five declared resolutions.
+    """
+    import polars as pl  # noqa: PLC0415
+
+    from wetterdienst.model.result import StationsFilter, StationsResult  # noqa: PLC0415
+    from wetterdienst.provider.wsv.pegel import api  # noqa: PLC0415
+    from wetterdienst.provider.wsv.pegel.api import TimeseriesMeta, WsvPegelValues  # noqa: PLC0415
+
+    request = WsvPegelRequest(parameters=[("15_minutes", "data", "stage")])
+    values = WsvPegelValues(
+        sr=StationsResult(
+            stations=request,
+            df=pl.DataFrame(),
+            df_all=pl.DataFrame(),
+            stations_filter=StationsFilter.ALL,
+        ),
+    )
+    values._timeseries_meta_cache = {  # noqa: SLF001
+        ("1", "W"): TimeseriesMeta(unit="cm", equidistance=30),
+        ("2", "W"): TimeseriesMeta(unit="cm", equidistance=60),
+    }
+
+    def _fail(**kwargs: object) -> None:
+        msg = f"skipped series must not be downloaded: {kwargs['url']}"
+        raise AssertionError(msg)
+
+    # the guard has to come before the request, or a skipped series still costs a round trip
+    monkeypatch.setattr(api, "download_file", _fail)
+    parameter = request.metadata["15_minutes"]["data"]["stage"]
+    # 30 minutes maps to no resolution at all, 60 maps to one other than the requested one
+    assert values._collect_station_parameter_or_dataset("1", parameter).is_empty()  # noqa: SLF001
+    assert values._collect_station_parameter_or_dataset("2", parameter).is_empty()  # noqa: SLF001
+
+
+def test_wsv_station_list_pairs_each_resolution_with_the_parameters_asked_for_there(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that a station qualifies on a requested pair, not on either half of one.
+
+    Matching the requested parameters and the requested resolutions as two independent sets lets a
+    station in on a combination nobody asked for. Requesting stage every 15 minutes and air
+    temperature hourly used to list the four gauges that record air temperature every 15 minutes
+    and no stage at all, purely because `15_minutes` and `LT` were each requested somewhere. Every
+    one of them then cost a 404 for a stage series that does not exist and returned nothing.
+    """
+    from io import BytesIO  # noqa: PLC0415
+
+    from wetterdienst.provider.wsv.pegel import api  # noqa: PLC0415
+
+    def _station(number: str, timeseries: dict[str, int]) -> dict:
+        return {
+            "number": number,
+            "shortname": number,
+            "km": 1.0,
+            "latitude": 50.0,
+            "longitude": 10.0,
+            "water": {"shortname": "TEST"},
+            "timeseries": [
+                {"shortname": shortname, "equidistance": equidistance, "characteristicValues": []}
+                for shortname, equidistance in timeseries.items()
+            ],
+        }
+
+    listing = json.dumps(
+        [
+            _station("matches-both", {"W": 15, "LT": 60}),
+            _station("matches-stage-only", {"W": 15, "LT": 15}),
+            _station("matches-neither", {"LT": 15, "WG": 15}),
+            _station("stage-at-another-interval", {"W": 1}),
+        ],
+    ).encode()
+    monkeypatch.setattr(
+        api,
+        "download_file",
+        lambda **kwargs: File(url=kwargs["url"], content=BytesIO(listing), status=200),
+    )
+
+    df = (
+        WsvPegelRequest(
+            parameters=[("15_minutes", "data", "stage"), ("hourly", "data", "temperature_air_mean_2m")],
+        )
+        .all()
+        .df
+    )
+    assert sorted(df.select("resolution", "station_id").rows()) == [
+        # air temperature at 15 minutes is not the hourly air temperature that was asked for, and
+        # stage at one minute is not the 15-minute stage
+        ("15_minutes", "matches-both"),
+        ("15_minutes", "matches-stage-only"),
+        ("hourly", "matches-both"),
+    ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -606,7 +606,8 @@ def test_api_noaa_ghcn_daily(default_settings: Settings) -> None:
 
 def test_api_wsv_pegel(default_settings: Settings) -> None:
     """Test wsv pegel API."""
-    request = WsvPegelRequest(parameters=[("dynamic", "data", "stage")], settings=default_settings).all()
+    # stage at the 15-minute gauges, which is two thirds of the network
+    request = WsvPegelRequest(parameters=[("15_minutes", "data", "stage")], settings=default_settings).all()
     assert not request.df.is_empty()
     assert set(request.df.columns).issuperset(DF_STATIONS_MINIMUM_COLUMNS)
     assert _is_complete_stations_df(


### PR DESCRIPTION
## What

WSV Pegelonline's single `dynamic` resolution is replaced by the five intervals the service actually uses: `1_minute`, `5_minutes`, `10_minutes`, `15_minutes` and `hourly`.

Pegelonline publishes an `equidistance` in minutes on **every** timeseries in the station listing the provider already downloads — 0 missing out of 1177 — so the recording interval was never something that had to be guessed. It was simply not read. Reading it costs no extra request: `_all` already parses the `timeseries` list, and the values class already caches the same listing for its per-station unit scaling.

Observed distribution across the network, which maps exactly onto existing `Resolution` members:

| equidistance | 1 min | 5 min | 10 min | 15 min | 60 min |
|---|---|---|---|---|---|
| timeseries | 364 | 10 | 16 | 673 | 114 |

## How

- `_EQUIDISTANCE_TO_RESOLUTION` is the single source of the five resolution names — the metadata is built from its values and `_all` assigns stations by looking `equidistance` up in it.
- The parameter list is declared once and shared across the five resolutions. `build_metadata_model` copies each parameter dict per resolution, so descriptions cannot leak between them.
- A station qualifies for a resolution on a requested **(resolution, parameter) pair**, not on either half of one. Matching the two independently listed 4 gauges that record air temperature every 15 minutes and no stage at all, for a request of 15-minute stage plus hourly air temperature.
- **77 of 787 stations record different parameters at different intervals** — Passau reads stage every 15 minutes and air temperature every 60. They appear under each resolution and serve only the parameters belonging to it. Without that guard a 15-minute series would come back labelled hourly and, under `ts_complete`, be reindexed onto an hourly grid that discards three values in four.
- An interval the mapping does not cover is served under no resolution and reported once per process — the service adding a sixth interval is exactly the change that would need a new member.

## Breaking

`dynamic/data/...` no longer resolves. To find a station's resolution, request the parameter at every interval that could carry it and read the `resolution` column of the station list.

In exchange `ts_complete` works — it was short-circuited for a dynamic resolution — and the interpolation search radius scales by resolution like every other provider's rather than falling back to a factor of 1.0.

## Also removed

Two leftovers of the old frequency-detection scheme with no remaining reference anywhere: `WsvPegelValues._station_endpoint` and `Frequency.MINUTE_60`.

## Verified against the live service

| check | result |
|---|---|
| `stage` station list splits | 15min 504, 1min 223, 10min 10, 5min 1 — exactly the raw `equidistance` counts |
| mixed station 10091008 (Passau) | stage → 960 rows under `15_minutes`, air/water temp → 240 each under `hourly`, no crossover |
| pair matching | 535 station rows, 0 matching no requested pair (was 539 with 4 spurious) |
| `ts_complete` | produces a clean 15-minute grid, uniform 900 s spacing |
| station ordering | stable across runs |

Six new tests, all mutation-checked by reverting the behaviour they cover. `poe format`, `poe lint`, `poe typecheck` clean; `poe docs` builds.

## Known follow-up, not in this PR

`_widen_df` keys the wide skeleton on `(station_id, resolution, dataset, date)` but joins each parameter on `date` alone, inner. A request spanning two resolutions therefore duplicates shared timestamps and puts both resolutions' values on both rows. This is **pre-existing** — reproducible on DWD (`daily/kl` + `hourly/temperature_air`) on an unmodified tree — but WSV can now reach it, so a cross-resolution WSV wide request is worse than the old `dynamic` behaviour.

Joining on `["resolution", "dataset", "date"]` with `how="left"` fixes it and is correct for WSV, but it fails `test_dwd_observation_data_result_wide_two_datasets`, which asserts that with two datasets at one resolution every parameter lands on every skeleton row. Changing that is a decision about what wide output means for a multi-dataset request and alters DWD's output, so it belongs in its own PR rather than riding in on a provider change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iR3vKY6sctURdAD9v4wcL
