### PR TITLE
refactor(core): build the interpolation and summary date grid in one place

### DIFF
--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -16,13 +16,14 @@ from scipy.interpolate import LinearNDInterpolator
 from shapely.geometry import Point, Polygon
 from tqdm import tqdm
 
-from wetterdienst.core.util import _ParameterData, extract_station_values
+from wetterdienst.core.util import _ParameterData, build_date_grid, extract_station_values
 from wetterdienst.metadata.parameter_table import PARAMETERS
-from wetterdienst.metadata.resolution import Frequency
 from wetterdienst.model.metadata import ParameterModel
 from wetterdienst.util.logging import TqdmToLogger
 
 if TYPE_CHECKING:
+    import datetime as dt
+
     from wetterdienst.model.request import TimeseriesRequest
     from wetterdienst.model.result import StationsResult
     from wetterdienst.settings import Settings
@@ -150,22 +151,13 @@ def apply_station_values_per_parameter(
         if result_series_param.drop_nulls("value").is_empty():
             continue
         if param_key not in param_dict:
-            if stations_ranked.stations.start_date is None or stations_ranked.stations.end_date is None:
+            # cast, not parsed: the request declares its dates as `str | datetime | None` because
+            # that is what a caller may hand it, and resolves them to datetimes in `__post_init__`
+            start_date = cast("dt.datetime | None", stations_ranked.stations.start_date)
+            end_date = cast("dt.datetime | None", stations_ranked.stations.end_date)
+            if start_date is None or end_date is None:
                 continue
-            frequency = Frequency[dataset.resolution.value.name].value
-            df = pl.DataFrame(
-                {
-                    "date": pl.datetime_range(
-                        start=stations_ranked.stations.start_date,
-                        end=stations_ranked.stations.end_date,
-                        interval=frequency,
-                        time_zone="UTC",
-                        eager=True,
-                    ).dt.round(frequency),
-                },
-                orient="col",
-            )
-            param_dict[param_key] = _ParameterData(df)
+            param_dict[param_key] = _ParameterData(build_date_grid(dataset.resolution.value, start_date, end_date))
         result_series_param = (
             param_dict[param_key].values.select("date").join(result_series_param, on="date", how="left")
         )

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -10,12 +10,13 @@ from typing import TYPE_CHECKING, cast
 import polars as pl
 from tqdm import tqdm
 
-from wetterdienst.core.util import _ParameterData, extract_station_values
-from wetterdienst.metadata.resolution import Frequency
+from wetterdienst.core.util import _ParameterData, build_date_grid, extract_station_values
 from wetterdienst.model.metadata import ParameterModel
 from wetterdienst.util.logging import TqdmToLogger
 
 if TYPE_CHECKING:
+    import datetime as dt
+
     from wetterdienst.model.request import TimeseriesRequest
     from wetterdienst.model.result import StationsResult
     from wetterdienst.settings import Settings
@@ -109,22 +110,13 @@ def apply_station_values_per_parameter(
         if result_series_param.drop_nulls("value").is_empty():
             continue
         if param_key not in param_dict:
-            if stations_ranked.stations.start_date is None or stations_ranked.stations.end_date is None:
+            # cast, not parsed: the request declares its dates as `str | datetime | None` because
+            # that is what a caller may hand it, and resolves them to datetimes in `__post_init__`
+            start_date = cast("dt.datetime | None", stations_ranked.stations.start_date)
+            end_date = cast("dt.datetime | None", stations_ranked.stations.end_date)
+            if start_date is None or end_date is None:
                 continue
-            frequency = Frequency[dataset.resolution.value.name].value
-            df = pl.DataFrame(
-                {
-                    "date": pl.datetime_range(
-                        start=stations_ranked.stations.start_date,
-                        end=stations_ranked.stations.end_date,
-                        interval=frequency,
-                        time_zone="UTC",
-                        eager=True,
-                    ).dt.round(frequency),
-                },
-                orient="col",
-            )
-            param_dict[param_key] = _ParameterData(df)
+            param_dict[param_key] = _ParameterData(build_date_grid(dataset.resolution.value, start_date, end_date))
         result_series_param = (
             param_dict[param_key].values.select("date").join(result_series_param, on="date", how="left")
         )

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -2,9 +2,19 @@
 # Distributed under the MIT License. See LICENSE for more info.
 """Tools for timeseries."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import polars as pl
+
+from wetterdienst.metadata.resolution import Frequency
+
+if TYPE_CHECKING:
+    import datetime as dt
+
+    from wetterdienst.metadata.resolution import Resolution
 
 
 @dataclass
@@ -13,6 +23,40 @@ class _ParameterData:
     station_ids: list[str] | None = None
     additional_station_counter: int = 0
     finished: bool = False
+
+
+def build_date_grid(resolution: Resolution, start_date: dt.datetime, end_date: dt.datetime) -> pl.DataFrame:
+    """Lay out the timestamps an interpolation or a summary answers for, as a single `date` column.
+
+    Every station's readings are joined onto this grid, so it is what decides which timestamps the
+    result has an answer for, and the join is exact -- a reading taken off the grid contributes to
+    neither.
+
+    The range is generated from the window and then rounded to the same interval, which is what
+    snaps a request opening at half past onto the wall clock rather than carrying its own phase
+    through the whole series.
+
+    The interval comes from `Frequency` rather than from `resolution.reading_interval`, which is
+    the only place the two differ: `Frequency` answers for `subdaily` and calls it hourly, where
+    `reading_interval` declines to, since subdaily is a bucket rather than an interval and its
+    providers disagree on one -- DWD takes three Termin readings a day where Meteo-France SYNOP
+    reports every three hours. Naming an interval too fine over-completes the grid, leaving rows
+    no station has a reading for, which is harmless here in a way it is not where a station is
+    being measured against how much of a window it filled.
+    """
+    frequency = Frequency[resolution.name].value
+    return pl.DataFrame(
+        {
+            "date": pl.datetime_range(
+                start=start_date,
+                end=end_date,
+                interval=frequency,
+                time_zone="UTC",
+                eager=True,
+            ).dt.round(frequency),
+        },
+        orient="col",
+    )
 
 
 def extract_station_values(

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2018-2025, earthobservations developers.
+# Distributed under the MIT License. See LICENSE for more info.
+"""Tests for shared interpolation and summary tools."""
+
+import datetime as dt
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from wetterdienst.core.util import build_date_grid
+from wetterdienst.metadata.resolution import Resolution, reading_interval
+
+UTC = ZoneInfo("UTC")
+
+
+@pytest.mark.parametrize(
+    ("resolution", "start_date", "end_date", "expected_height", "expected_first"),
+    [
+        (
+            Resolution.MINUTE_10,
+            dt.datetime(2024, 1, 1, tzinfo=UTC),
+            dt.datetime(2024, 1, 2, tzinfo=UTC),
+            145,
+            dt.datetime(2024, 1, 1, tzinfo=UTC),
+        ),
+        (
+            Resolution.DAILY,
+            dt.datetime(2020, 1, 1, tzinfo=UTC),
+            dt.datetime(2020, 3, 1, tzinfo=UTC),
+            61,
+            dt.datetime(2020, 1, 1, tzinfo=UTC),
+        ),
+        (
+            # a monthly reading is dated to the first, which is what the range is rounded onto
+            Resolution.MONTHLY,
+            dt.datetime(2020, 1, 15, tzinfo=UTC),
+            dt.datetime(2021, 6, 1, tzinfo=UTC),
+            17,
+            dt.datetime(2020, 1, 1, tzinfo=UTC),
+        ),
+        (
+            Resolution.ANNUAL,
+            dt.datetime(2000, 1, 1, tzinfo=UTC),
+            dt.datetime(2010, 1, 1, tzinfo=UTC),
+            11,
+            dt.datetime(2000, 1, 1, tzinfo=UTC),
+        ),
+    ],
+)
+def test_build_date_grid_spans_the_window_at_the_resolution(
+    resolution: Resolution,
+    start_date: dt.datetime,
+    end_date: dt.datetime,
+    expected_height: int,
+    expected_first: dt.datetime,
+) -> None:
+    """Test that the grid covers the window at the interval the resolution records at."""
+    df = build_date_grid(resolution, start_date, end_date)
+
+    assert df.columns == ["date"]
+    assert df.height == expected_height
+    assert df.get_column("date").min() == expected_first
+
+
+def test_build_date_grid_snaps_an_off_phase_window_to_the_wall_clock() -> None:
+    """Test that a window opening at half past does not carry its phase through the whole series.
+
+    The range is generated from the window and then rounded to the same interval, so a request
+    from 00:30 answers for whole hours rather than for every half past -- which is what every
+    station's readings are joined onto, by an exact join.
+    """
+    df = build_date_grid(
+        Resolution.HOURLY,
+        dt.datetime(2024, 1, 1, 0, 30, tzinfo=UTC),
+        dt.datetime(2024, 1, 1, 6, 30, tzinfo=UTC),
+    )
+
+    assert df.get_column("date").dt.minute().unique().to_list() == [0]
+    assert df.get_column("date").min() == dt.datetime(2024, 1, 1, 1, tzinfo=UTC)
+
+
+def test_build_date_grid_treats_subdaily_as_hourly() -> None:
+    """Test that subdaily gets a grid, at the one interval available for it.
+
+    `reading_interval` declines to name an interval for subdaily -- it is a bucket rather than an
+    interval, and DWD takes three Termin readings a day where Meteo-France SYNOP reports every
+    three hours. A grid still needs one, and naming it too fine only leaves rows no station has a
+    reading for, which is harmless here in a way it is not where a station is measured against how
+    much of a window it filled.
+    """
+    assert reading_interval(Resolution.SUBDAILY) is None
+
+    df = build_date_grid(
+        Resolution.SUBDAILY,
+        dt.datetime(2024, 1, 1, tzinfo=UTC),
+        dt.datetime(2024, 1, 2, tzinfo=UTC),
+    )
+
+    assert df.height == 25  # hourly, both ends included


### PR DESCRIPTION
## Description

`interpolate.py` and `summarize.py` each carried a byte-identical thirteen-line block laying out the timestamps their result answers for. Both now call `build_date_grid()` in `core/util.py`, next to the `_ParameterData` and `extract_station_values` they already share — and `Frequency` goes from three consumers to one.

Net: +62 / −34 across three files, plus a new test module.

## No behaviour change, verified rather than assumed

The grids were compared old against new across every resolution, including an off-phase window and both calendar resolutions:

```
MINUTE_10  identical,   145 rows, first=2024-01-01 00:00:00+00:00
HOURLY     identical,     7 rows, first=2024-01-01 01:00:00+00:00
SUBDAILY   identical,    49 rows, first=2024-01-01 00:00:00+00:00
DAILY      identical,    61 rows, first=2020-01-01 00:00:00+00:00
MONTHLY    identical,    17 rows, first=2020-01-01 00:00:00+00:00
ANNUAL     identical,    11 rows, first=2000-01-01 00:00:00+00:00
```

The hourly row is the one worth reading twice: a window opening at **00:30 comes back starting at 01:00**. The range is generated at the interval and then `.dt.round`ed to it, so the grid snaps to the wall clock rather than carrying the request's phase through the series. That was undocumented and exactly the kind of thing an extraction loses silently — it now has a docstring paragraph and a test.

The only other change at the call sites is binding `start_date` / `end_date` to locals before the `None` guard, with a `cast` — the request declares them `str | datetime | None` and resolves them in `__post_init__`, and `ty` will not narrow an attribute across statements. `cast` is a runtime no-op.

## Subdaily keeps using `Frequency` on purpose

`resolution.reading_interval()` declines to name an interval for `subdaily`, because it is a bucket rather than an interval and its two providers disagree — DWD takes three Termin readings a day (06/12/18 UTC), Météo-France SYNOP reports every three hours. A grid needs *some* interval, and naming one too fine only leaves rows no station has a reading for: harmless when laying out a grid, and not harmless when measuring how much of a window a station filled, which is why the two functions differ at all. The docstring says so and a test asserts both halves, so the divergence reads as deliberate rather than as an oversight for someone to "fix".

## Type of change

- [ ] Bug fix
- [ ] New feature / provider
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `uv run poe format` passed
- [x] Remote/slow tests verified if network code was touched
- [ ] App changes tested locally (if applicable)

Six tests in a new `tests/core/test_util.py`. No changelog entry: there is no user-visible effect, and that file records notable changes.

### A note on the test runs

The full `tests/core` run showed `test_summary_temperature_air_mean_2m_daily` failing on a value (`-7.0` vs `-5.5`, i.e. a different nearest-station-with-data) — the shape a real regression takes, so I chased it rather than waving it off. It passes on clean `main`, it passes on this branch run alone, and on a re-run of the summary suite a *different* test failed (`test_provider_dwd_mosmix`) while that one passed. The failure rotates with load: DWD throttling under sustained concurrent downloads.

Two things noticed in passing, neither addressed here: `test_provider_dwd_mosmix` fails as `RuntimeError: generator raised StopIteration` (PEP 479 — a `StopIteration` escaping a generator in the MOSMIX metaindex), the same error `tests/examples/test_examples.py` hit; and these grids are joined to station readings by an **exact** join, so a reading off the grid contributes to neither interpolation nor summary — the same footgun `ts_complete` had before #1866 removed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)