### PR TITLE
refactor(metadata)!: drop the resolutions and periods nothing serves

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage
 
-# Same inputs as the test matrix - see tests.yml for why the provider pages, the two app
+# Same inputs as the test matrix - see tests.yml for why the provider pages, the three app
 # entries and the three root files are in here.
 on:
   push:
@@ -11,6 +11,7 @@ on:
       - 'docs/data/provider/**'
       - 'app/i18n/**'
       - 'app/app/pages/index.vue'
+      - 'app/shared/types/api.ts'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'README.md'
@@ -26,6 +27,7 @@ on:
       - 'docs/data/provider/**'
       - 'app/i18n/**'
       - 'app/app/pages/index.vue'
+      - 'app/shared/types/api.ts'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'README.md'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,10 @@ name: Tests
 # tests/test_docs.py checks the provider pages under docs/data/provider against the metadata model -
 # and three root files: the README is doctested and CITATION.cff is tied to it and to the changelog.
 # The suite also reaches into the app: tests/test_app_i18n.py reads the translation catalogs under
-# app/i18n and the home page, to catch a parameter that gained a name here but not there. Those two
-# entries are the whole of the app it reads - a test that starts reading more has to widen them.
+# app/i18n and the home page, to catch a parameter that gained a name here but not there, and
+# tests/metadata/test_resolution.py reads the resolution union in app/shared/types/api.ts, to catch
+# a resolution that gained a name here but not there. Those three entries are the whole of the app
+# it reads - a test that starts reading more has to widen them.
 on:
   pull_request:
     paths:
@@ -15,6 +17,7 @@ on:
       - 'docs/data/provider/**'
       - 'app/i18n/**'
       - 'app/app/pages/index.vue'
+      - 'app/shared/types/api.ts'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'README.md'
@@ -30,6 +33,7 @@ on:
       - 'docs/data/provider/**'
       - 'app/i18n/**'
       - 'app/app/pages/index.vue'
+      - 'app/shared/types/api.ts'
       - 'pyproject.toml'
       - 'uv.lock'
       - 'README.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ Types of changes:
   date plus the value. Both reporter groups are covered -- the ~6600-station *Jahresmelder* and
   the ~1200-station *Sofortmelder* -- with their own station catalogues
 
+### Removed
+
+- `Resolution.UNDEFINED` and `Period.UNDEFINED`, which no provider declared any more. They were
+  what the sources without a stated interval were served under, and the last of those went when
+  WSV and Hubeau started reporting the interval each station records at. `undefined` was still
+  accepted as a key of `ts_geo_station_distance_resolution_factors`, which validates its keys
+  against `Resolution` and was the one place the enum was read as a closed vocabulary, so it was a
+  setting that could be written and never read. `Resolution.UNDEFINED` also had no `Frequency`
+  member of its own name, which is how `create_date_range` looks the interval up, so anything that
+  had reached it would have raised a KeyError rather than being served coarsely. `PeriodType` goes
+  with `Period.UNDEFINED`, the only thing that read it, as `ResolutionType` did before it, and
+  `Frequency.MINUTE_2` goes too, having named a resolution that never existed.
+  `periods="undefined"` now raises `InvalidEnumerationError` where it used to parse and then
+  match no dataset, which is the one visible change
+
 ### Fixed
 
 - Network: the fsspec listings cache silently never hit for `CacheExpiry.INFINITE`. The expiry
@@ -71,6 +86,11 @@ Types of changes:
   on the quality-marked historical record, carried through the concatenation as an explicit rank,
   and stations settle on their most current description. This is visible for the first time on the
   10-minute urban datasets, whose three periods used to resolve to the same directory
+- The app's `Resolution` type restates the backend enum, and had drifted both ways: it still
+  offered `undefined` and `dynamic`, and had never gained `6_minutes`, which Meteo-France is
+  served under. A test now holds the two together, as it does for `Frequency`, whose members are
+  looked up by resolution name, and for the interpolation radius factors, which are keyed by
+  resolution
 
 ## [0.134.0] - 2026-08-22
 

--- a/app/shared/types/api.ts
+++ b/app/shared/types/api.ts
@@ -2,6 +2,7 @@
 export type Resolution
   = '1_minute'
     | '5_minutes'
+    | '6_minutes'
     | '10_minutes'
     | '15_minutes'
     | 'hourly'
@@ -10,8 +11,6 @@ export type Resolution
     | 'daily'
     | 'monthly'
     | 'annual'
-    | 'undefined'
-    | 'dynamic'
 
 // ============================================================================
 // Coverage API

--- a/src/wetterdienst/metadata/period.py
+++ b/src/wetterdienst/metadata/period.py
@@ -6,14 +6,6 @@ import functools
 from enum import Enum
 
 
-class PeriodType(Enum):
-    """Enumeration for period types."""
-
-    FIXED = "fixed"
-    MULTI = "multi"
-    UNDEFINED = "undefined"
-
-
 @functools.total_ordering
 class OrderedPeriod(Enum):
     """Enumeration for period types and values."""
@@ -23,7 +15,6 @@ class OrderedPeriod(Enum):
         # IMPORTANT: THIS DEPENDS ON THE NAMING CONVENTIONS USED IN THE Period
         # ENUMERATION AS SHOWN BELOW
         return {
-            Period.UNDEFINED.name: -1,
             Period.HISTORICAL.name: 0,
             Period.RECENT.name: 1,
             Period.NOW.name: 2,
@@ -59,13 +50,11 @@ class Period(OrderedPeriod):
     """Enumeration for different period types of storage on dwd server.
 
     Source: https://stackoverflow.com/questions/39268052/how-to-compare-enums-in-python
-    Ordering is required for the PeriodType enumeration in order for it to be sorted.
-    PeriodType needs to be sortable for the request definition where for the case of
-    requesting data for several periods, we want preferably the historical data with
-    quality marks and drop overlapping values from other periods.
+    Ordering is required for the request definition, where for the case of requesting data for
+    several periods, we want preferably the historical data with quality marks and drop
+    overlapping values from other periods.
     """
 
-    UNDEFINED = PeriodType.UNDEFINED.value
     HISTORICAL = "historical"
     RECENT = "recent"
     NOW = "now"

--- a/src/wetterdienst/metadata/resolution.py
+++ b/src/wetterdienst/metadata/resolution.py
@@ -23,15 +23,16 @@ class Resolution(Enum):
     MONTHLY = "monthly"  # used by DWD for file server
     ANNUAL = "annual"  # used by DWD for file server
 
-    # For sources without resolution
-    UNDEFINED = "undefined"
-
 
 class Frequency(Enum):
-    """Enumeration for frequency of the weather observation."""
+    """The interval each resolution is completed onto, named after the resolution it answers for.
+
+    Looked up as `Frequency[resolution.name]`, so a resolution without a member of the same name
+    is a KeyError rather than a fallback -- which is why this carries a member for every
+    `Resolution`, `SUBDAILY` included, and none besides.
+    """
 
     MINUTE_1 = "1m"
-    MINUTE_2 = "2m"
     MINUTE_5 = "5m"
     MINUTE_6 = "6m"
     MINUTE_10 = "10m"
@@ -46,10 +47,10 @@ class Frequency(Enum):
 
 # the interval between two readings of a resolution, as a polars interval string.
 #
-# `SUBDAILY` is deliberately absent, and so is `UNDEFINED`: subdaily is a bucket for "coarser than
-# hourly, finer than daily" rather than an interval, and its two providers do not agree on one --
-# DWD takes three Termin readings a day (06/12/18 UTC) while Meteo-France SYNOP reports every three
-# hours. Naming either as the interval would misjudge the other by a factor of nearly three.
+# `SUBDAILY` is deliberately absent: it is a bucket for "coarser than hourly, finer than daily"
+# rather than an interval, and its two providers do not agree on one -- DWD takes three Termin
+# readings a day (06/12/18 UTC) while Meteo-France SYNOP reports every three hours. Naming either
+# as the interval would misjudge the other by a factor of nearly three.
 #
 # `Frequency` above spells the same intervals for the date ranges `interpolate` and `summarize`
 # build, but it does answer for subdaily, since over-completing a grid is harmless where measuring

--- a/src/wetterdienst/settings.py
+++ b/src/wetterdienst/settings.py
@@ -103,7 +103,8 @@ _STATION_DISTANCE_RESOLUTION_FACTORS: dict[str, float] = {
     Resolution.MONTHLY.value: 2.0,
     Resolution.ANNUAL.value: 2.0,
 }
-#: a resolution the factors say nothing about -- `undefined` -- is left as it is
+#: every `Resolution` is named above, so this catches a resolution name from outside that
+#: vocabulary, which is left as it is rather than guessed at
 _STATION_DISTANCE_RESOLUTION_FACTOR_DEFAULT = 1.0
 
 

--- a/tests/metadata/test_resolution.py
+++ b/tests/metadata/test_resolution.py
@@ -1,13 +1,17 @@
 """Tests for resolution metadata."""
 
 import datetime as dt
+import re
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
 
-from wetterdienst.metadata.resolution import Resolution, count_readings, reading_interval
+from wetterdienst.metadata.resolution import Frequency, Resolution, count_readings, reading_interval
 
 UTC = ZoneInfo("UTC")
+ROOT = Path(__file__).parent.parent.parent
+API_TYPES = ROOT / "app" / "shared" / "types" / "api.ts"
 
 
 @pytest.mark.parametrize(
@@ -61,8 +65,7 @@ def test_count_readings_of_a_calendar_step(
     assert count_readings(resolution, start_date, end_date) == expected
 
 
-@pytest.mark.parametrize("resolution", [Resolution.UNDEFINED, Resolution.SUBDAILY])
-def test_count_readings_of_a_resolution_without_an_interval(resolution: Resolution) -> None:
+def test_count_readings_of_a_resolution_without_an_interval() -> None:
     """Test that a resolution naming no interval answers with nothing rather than with a number.
 
     `subdaily` is a bucket for "coarser than hourly, finer than daily" rather than an interval,
@@ -71,6 +74,7 @@ def test_count_readings_of_a_resolution_without_an_interval(resolution: Resoluti
     since over-completing a grid is harmless -- would measure a DWD station that delivered every
     one of its 90 January readings against 721 and skip it for being seven-eighths empty.
     """
+    resolution = Resolution.SUBDAILY
     assert reading_interval(resolution) is None
     assert count_readings(resolution, dt.datetime(2026, 1, 1, tzinfo=UTC), dt.datetime(2026, 2, 1, tzinfo=UTC)) is None
 
@@ -82,3 +86,33 @@ def test_reading_interval_answers_for_every_resolution_that_can_be_counted() -> 
         assert (reading_interval(resolution) is None) == (count_readings(resolution, start_date, end_date) is None), (
             resolution
         )
+
+
+def test_frequency_answers_for_every_resolution() -> None:
+    """Test that the grid `interpolate` and `summarize` build can be built for any resolution.
+
+    `create_date_range` looks the interval up as `Frequency[resolution.name]`, so a resolution
+    without a member of that name raises a KeyError there rather than falling back -- and a
+    `Frequency` member no resolution is named after is reached by nothing at all.
+
+    Read through `__members__` rather than by iterating, which skips `SUBDAILY`: it is declared as
+    an alias of `HOURLY`, the one resolution whose grid is deliberately finer than its readings.
+    """
+    assert set(Frequency.__members__) == {resolution.name for resolution in Resolution}
+
+
+def test_the_app_names_the_same_resolutions() -> None:
+    """Test that the app's `Resolution` union restates this enum and nothing else.
+
+    The app is TypeScript and cannot import the enum, so it declares the same vocabulary a second
+    time -- and it drifted both ways: it carried `undefined` and `dynamic` long after the
+    providers resolving to them started reporting a real interval, and never gained `6_minutes`,
+    which Meteo-France has been served under all along. A missing member is a type error at every
+    call site handling that resolution; a surplus one is a value the app offers and the backend
+    rejects.
+    """
+    source = API_TYPES.read_text(encoding="utf-8")
+    union = re.search(r"export type Resolution\n(.*?)\n\n", source, re.DOTALL)
+    assert union, f"no `Resolution` union found in {API_TYPES}"
+    declared = set(re.findall(r"'([^']+)'", union.group(1)))
+    assert declared == {resolution.value for resolution in Resolution}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,8 @@ from tests.conftest import IS_CI, IS_WINDOWS
 from wetterdienst import Settings
 from wetterdienst.api import Wetterdienst
 from wetterdienst.metadata.parameter_table import PARAMETER_TABLE, PARAMETERS
+from wetterdienst.metadata.period import Period
+from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.metadata.unit_type import UnitType
 from wetterdienst.model.metadata import ParameterModel
 from wetterdienst.model.unit import UnitConverter
@@ -163,6 +165,30 @@ def test_unit_type_matches_unit_converter(unit_converter: UnitConverter) -> None
     """
     assert set(get_args(UnitType)) == set(unit_converter.units)
     assert set(get_args(UnitType)) == set(unit_converter.targets)
+
+
+def test_every_resolution_and_period_is_served_by_a_provider() -> None:
+    """Test that neither vocabulary carries a member no provider declares.
+
+    Both are closed vocabularies rather than free labels: `Resolution` validates the keys of
+    `ts_geo_station_distance_resolution_factors`, is looked up by name in `Frequency`, and is
+    restated in the app's types. A member nothing serves is therefore a setting that can be
+    written and never read, and a value the app can offer that no request answers. That is what
+    `undefined` and `dynamic` became once the providers resolving to them started reporting the
+    interval each station records at.
+
+    dwd/radar and dwd/alerts declare no metadata model and so are not counted here; radar's own
+    resolutions are `5_minutes`, `hourly` and `daily`, all of which other networks declare too.
+    """
+    resolutions = set()
+    periods = set()
+    for metadata in ALL_METADATA:
+        for resolution in metadata:
+            resolutions.add(resolution.value)
+            for dataset in resolution:
+                periods.update(dataset.periods)
+    assert resolutions == set(Resolution)
+    assert periods == set(Period)
 
 
 def test_parameter_table_unit_types(unit_converter: UnitConverter) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -11,7 +11,8 @@ from unittest import mock
 import pytest
 from pydantic import ValidationError
 
-from wetterdienst.settings import Settings
+from wetterdienst.metadata.resolution import Resolution
+from wetterdienst.settings import _STATION_DISTANCE_RESOLUTION_FACTORS, Settings
 
 WD_CACHE_DIR_PATTERN = re.compile(r"[\s\S]*wetterdienst(\\Cache)?")
 WD_CACHE_ENABLED_PATTERN = re.compile(r"Wetterdienst cache is enabled [CACHE_DIR:[\s\S]*wetterdienst(\\Cache)?]$")
@@ -170,8 +171,19 @@ def test_settings_geo_station_distance_for_scales_with_resolution() -> None:
     assert settings.ts_geo_station_distance_for("precipitation_height", "6_hour") == 30.0
     assert settings.ts_geo_station_distance_for("precipitation_height", "daily") == 40.0
     assert settings.ts_geo_station_distance_for("precipitation_height", "annual") == 40.0
-    # a resolution the factors say nothing about is left as it is
-    assert settings.ts_geo_station_distance_for("precipitation_height", "undefined") == 20.0
+    # a name from outside the resolution vocabulary is left as it is rather than guessed at
+    assert settings.ts_geo_station_distance_for("precipitation_height", "every other tuesday") == 20.0
+
+
+def test_settings_geo_station_distance_factors_name_every_resolution() -> None:
+    """Test that no resolution falls through to the unscaled default.
+
+    The default exists for a name from outside the vocabulary, not for a resolution the table
+    forgot: a resolution left out would hold a heterogeneous parameter to the hourly radius at
+    every interval, which is a fifth too wide at `10_minutes` and half as wide as it should be at
+    `daily`, and nothing about the result would say so.
+    """
+    assert set(_STATION_DISTANCE_RESOLUTION_FACTORS) == {resolution.value for resolution in Resolution}
 
 
 def test_settings_geo_station_distance_for_stops_widening_past_a_day() -> None:


### PR DESCRIPTION
## Description

`Resolution.UNDEFINED` and `Period.UNDEFINED` were what a source without a stated interval was served under. The last of those went when WSV and Hubeau started reporting the interval each station records at, and neither has been declared by a provider since — all networks with a metadata model name only the eleven real resolutions and four real periods.

Left in, they were not inert:

- `undefined` was still accepted as a key of `ts_geo_station_distance_resolution_factors`, whose keys are validated against `Resolution` and which is the one place in `src/` where the enum is read as a closed vocabulary. It was a setting that could be written and never read.
- `Resolution.UNDEFINED` had no `Frequency` member of its own name, which is how `create_date_range` looks the interval up, so anything that had reached it would have raised a `KeyError` rather than being served coarsely.

`PeriodType` goes with `Period.UNDEFINED`, the only thing that read it, as `ResolutionType` went with `Resolution.DYNAMIC`. `Frequency.MINUTE_2` goes too, having named a resolution that never existed, the way `MINUTE_60` did.

The app restates the resolutions as a TypeScript union, and it had drifted both ways: still offering `undefined` and `dynamic`, and never having gained `6_minutes`, which Meteo-France has been served under all along.

**Breaking:** `periods="undefined"` now raises `InvalidEnumerationError` where it used to parse and then match no dataset. That is the one visible change.

Four tests now hold the vocabulary and its restatements together — every member is declared by some provider, `Frequency` answers for every resolution and for nothing else, the radius factors name every resolution, and the app's union matches. Each fails on the code before this commit, and each failure names what drifted.

The second commit makes the last of those four run: `test_the_app_names_the_same_resolutions` reads `app/shared/types/api.ts`, which was in neither the Tests nor the Coverage path filters, so a PR editing only that file — exactly the drift the test exists to catch — would have triggered neither workflow and the guard would have been inert. The file joins all four filter lists, and the comment stating which app entries the suite reads is widened with it.

Rebased onto `main` after the phenology network landed; the vocabulary test still holds, `annual` being a resolution other networks already declare.

## Type of change

- [ ] Bug fix
- [ ] New feature / provider
- [x] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] Tests added or updated
- [x] `uv run poe format` passed
- [ ] Remote/slow tests verified if network code was touched — no network code touched
- [x] App changes tested locally (if applicable) — `pnpm lint`, `pnpm typecheck` and `pnpm test:ci` (248 tests) all clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vb79GWaKFu2ACYFdwHJD6W)_
