### PR TITLE
fix(ci): deploy to Coolify with POST, which is the only method it still answers

### DIFF
--- a/.github/workflows/docker-publish-app.yml
+++ b/.github/workflows/docker-publish-app.yml
@@ -276,6 +276,6 @@ jobs:
 
       - name: Deploy to Coolify
         run: |
-          curl --fail --request GET \
+          curl --fail --request POST \
             --header "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
             'https://coolify.eobs.org/api/v1/deploy?uuid=${{ secrets.COOLIFY_APP_UUID }}&force=false'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -189,6 +189,6 @@ jobs:
 
       - name: Deploy to Coolify
         run: |
-          curl --fail --request GET \
+          curl --fail --request POST \
             --header "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
             'https://coolify.eobs.org/api/v1/deploy?uuid=${{ secrets.COOLIFY_BACKEND_UUID }}&force=false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- CI: the Coolify deploy step has failed on every run since 2026-08-17, so no release or nightly
+  has reached the live deployment since. Coolify moved `/api/v1/deploy` from GET to POST and left
+  the GET route pointing at a stub that answers `405 This endpoint has changed to a POST request.`,
+  which `curl --fail` turned into an exit 22 after the images had already been built and pushed.
+  Both deploy calls now use POST. The images were never the problem -- every run pushed its
+  manifest and passed `Inspect image` before dying on the last step
+
 ## [0.135.0] - 2026-08-31
 
 ### Added

--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -16,6 +16,15 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[Build]` The Coolify deploy step has failed on every run since 2026-08-17, so no release or
+  nightly has reached the live app since -- which is why a published version could sit in GHCR
+  while the running site stayed on the one before it. Coolify moved `/api/v1/deploy` from GET to
+  POST and left the GET route answering `405 This endpoint has changed to a POST request.`, which
+  `curl --fail` turned into an exit 22 after the image had already been built and pushed. The
+  deploy call now uses POST
+
 ## [0.14.0] - 2026-08-31
 
 ### Added


### PR DESCRIPTION
## Description

The Coolify deploy step has failed on **every** run since 2026-08-17 — ten nightlies plus both the 0.134.0 and 0.135.0 releases — so nothing has reached the live deployment in two weeks. That is why a freshly published version can sit in GHCR while the running site stays on the one before it.

**The images were never the problem.** Every run built both architectures, pushed its manifest and passed `Inspect image`; it died on the last step of the job, after all the work was done:

```
success  Create manifest list and push
success  Inspect image
failure  Deploy to Coolify      ← curl: (22) The requested URL returned error: 405
```

## Cause

Coolify moved `/api/v1/deploy` from GET to POST and kept the GET route as a deliberate stub:

```php
Route::get('/deploy',  [OtherController::class, 'post_required'])
Route::post('/deploy', [DeployController::class, 'deploy'])
```

`post_required` answers `405 This endpoint has changed to a POST request.` with an `Allow: POST` header — exactly the 405 in the logs — and `curl --fail` turns that into exit 22.

The request was authenticated and the uuid was right; only the verb was wrong. A 401/403 would have meant the token, a 404 the uuid; 405 is specifically the method.

## Fix

`--request GET` → `--request POST` in both `docker-publish.yml` and `docker-publish-app.yml`.

The query string is left alone: the handler reads `uuid` and `force` through Laravel's `$request->input()`, which takes them from the query string on a POST just as it did on a GET.

## Verification

Last green deploy was 2026-08-16; the first 405 was 2026-08-17, with no repo-side change to the step in between — the workflow line was last touched 2026-07-02. Cause confirmed against Coolify's own `routes/api.php` and `OtherController::post_required` rather than guessed from the status code. `zizmor` reports no findings on either workflow, both files still parse as YAML, and the changelog/citation guards pass.

Cannot be verified end to end from a PR: the deploy step is skipped on pull requests by design, and the token is a repository secret. The proof will be the first nightly, or a manual `workflow_dispatch` after merge.

## Type of change

- [x] Bug fix
- [ ] New feature / provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [x] CI / tooling

## Checklist

- [x] Tests added or updated — not testable in CI; the step is PR-skipped and needs the live token
- [x] `uv run poe format` passed
- [x] Remote/slow tests verified if network code was touched — no source code touched
- [x] App changes tested locally (if applicable) — n/a, workflow and changelog only

## Note

`.github/RELEASE_STRATEGY.md` still describes deployment as Railway auto-deploy and says the backend is "currently `0.117.0`" with the app having "no version". All three are stale — the workflows deploy to Coolify. Left alone here to keep this PR to the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vb79GWaKFu2ACYFdwHJD6W)_
