### PR TITLE
fix(app): stop suspending the page behind an awaited useFetch

### DIFF
--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -18,6 +18,15 @@ Types of changes:
 
 ### Fixed
 
+- `[App]` Every page rendered nothing at all -- not even its own headings -- until the backend
+  answered, most visibly on the Explorer. `useFetch` was awaited at the top level of `app.vue`,
+  of the parameter selection and of the glossary page; with server-side rendering off, an async
+  `setup()` suspends the surrounding boundary, so the version request blanked the whole app and
+  the coverage request blanked whichever page asked for it. None of the three is awaited now: the
+  page renders immediately, the provider and network selects show as loading while coverage is in
+  flight, and the glossary's own loading state -- which the await had made unreachable -- appears
+  again. The Explorer only showed this on a cold load, since a coverage answer already in the
+  cache resolved the await at once
 - `[Build]` The Coolify deploy step has failed on every run since 2026-08-17, so no release or
   nightly has reached the live app since -- which is why a published version could sit in GHCR
   while the running site stayed on the one before it. Coolify moved `/api/v1/deploy` from GET to

--- a/app/app/app.vue
+++ b/app/app/app.vue
@@ -16,9 +16,19 @@ const uiLocale = computed(() => (locale.value === 'de' ? uiDe : uiEn))
 const route = useRoute()
 const isWidget = computed(() => route.path.startsWith('/widget'))
 
-const { data: versionData } = await useFetch<{ version: string }>('/api/version')
+// Deliberately not awaited. A top-level `await` in the root component makes its setup async, and
+// with `ssr: false` that suspends the entire app -- header, page and footer -- behind this one
+// request, so every cold load stared at an empty screen until the backend answered. The footer
+// simply has nothing to show for the backend until the answer lands.
+const { data: versionData, status: versionStatus } = useFetch<{ version: string }>('/api/version')
 
-const backendVersion = computed(() => versionData.value?.version ?? 'unknown')
+const backendVersion = computed(() => {
+  const version = versionData.value?.version
+  if (version)
+    return `v${version}`
+  // still in flight is not the same as answered-but-unusable, and only the latter is "unknown"
+  return versionStatus.value === 'pending' ? '…' : 'unknown'
+})
 const appVersion = pkg.version || 'unknown'
 
 // The same four statements the home page spells out, as icons here: the footer is on every page,
@@ -261,7 +271,7 @@ const items = computed<NavigationMenuItem[]>(() =>
         <div class="text-xs text-gray-400 dark:text-gray-600">
           <span class="text-green-600 dark:text-green-400 font-medium">App</span> {{ appVersion === 'unknown' ? appVersion : `v${appVersion}` }}
           <span class="mx-1">|</span>
-          <span class="text-blue-600 dark:text-blue-400 font-medium">Backend</span> {{ backendVersion === 'unknown' ? backendVersion : `v${backendVersion}` }}
+          <span class="text-blue-600 dark:text-blue-400 font-medium">Backend</span> {{ backendVersion }}
         </div>
         <!-- Two rows by kind rather than one list of six. In one row the values statements sat in
              the same register as the links, separated by the same pipe, and the separators -- flex

--- a/app/app/components/ParameterSelection.vue
+++ b/app/app/components/ParameterSelection.vue
@@ -34,7 +34,16 @@ const parameters = ref<string[]>([])
 const isInitializing = ref(true)
 
 // fetch coverage data
-const { data: coverage } = await useFetch<CoverageResponse>('/api/coverage')
+//
+// Deliberately not awaited. A top-level `await` makes this component's setup async, and with
+// `ssr: false` the nearest Suspense boundary is the page itself -- so the Explorer rendered
+// nothing at all, not even its own headings, until the backend had answered this request. The
+// selects render empty-and-loading instead, and `initializeFromProps()` waits for the answer.
+const { data: coverage, status: coverageStatus } = useFetch<CoverageResponse>('/api/coverage')
+// Nothing derived from `coverage` means anything until the request has settled: an empty answer
+// and an answer that has not arrived yet are indistinguishable in the data, but not to a reader.
+const coverageSettled = computed(() => coverageStatus.value === 'success' || coverageStatus.value === 'error')
+const coveragePending = computed(() => !coverageSettled.value)
 
 // A provider/network is available when it needs no auth, or when auth credentials are present and valid.
 const isAvailable = (n: { auth: boolean, configured: boolean, valid: boolean }) => !n.auth || (n.configured && n.valid)
@@ -90,7 +99,7 @@ const networkItems = computed(() => {
 })
 
 // provider-network coverage
-const { data: providerNetworkCoverage, pending: networkCoveragePending, refresh: refreshProviderNetworkCoverage } = await useFetch<ProviderNetworkCoverageResponse>(
+const { data: providerNetworkCoverage, pending: networkCoveragePending, refresh: refreshProviderNetworkCoverage } = useFetch<ProviderNetworkCoverageResponse>(
   '/api/coverage',
   {
     query: computed(() => ({
@@ -239,10 +248,23 @@ async function initializeFromProps() {
   emitUpdate()
 }
 
-// Run initialization on mount
-onMounted(() => {
+// Initialization needs the coverage answer -- every validation step above reads it -- and that is
+// no longer awaited in setup, so mount alone is too early. An error settles it too: initialization
+// then falls through to the "nothing valid to restore" branch, exactly as it did when a failed
+// fetch left `coverage` null.
+//
+// Not an `immediate` watcher, which would run this during setup: the answer can already be cached
+// (both /explorer and /history mount this component against the same `useFetch` key), and
+// `emitUpdate()` firing mid-render mutates the parent's state while it is still rendering.
+let initializationStarted = false
+function initializeWhenCoverageSettled() {
+  if (initializationStarted || !coverageSettled.value)
+    return
+  initializationStarted = true
   initializeFromProps()
-})
+}
+onMounted(initializeWhenCoverageSettled)
+watch(coverageSettled, initializeWhenCoverageSettled)
 
 // watch to reset provider and network
 watch(provider, () => {
@@ -337,8 +359,10 @@ watch([provider, network, resolution, dataset, parameters, dateRequired], () => 
         </h2>
       </div>
     </template>
+    <!-- only once coverage has settled: while the request is out every provider looks unavailable,
+         and flashing "not available from this backend" on each cold load is worse than silence -->
     <UAlert
-      v-if="restrictProvider && !restrictedProviderAvailable"
+      v-if="coverageSettled && restrictProvider && !restrictedProviderAvailable"
       color="error"
       variant="subtle"
       :title="t('parameterSelection.providerRestrictionUnavailable', { provider: restrictProvider })"
@@ -346,7 +370,7 @@ watch([provider, network, resolution, dataset, parameters, dateRequired], () => 
       class="mx-6 mt-4"
     />
     <UAlert
-      v-else-if="restrictNetwork && !restrictedNetworkAvailable"
+      v-else-if="coverageSettled && restrictNetwork && !restrictedNetworkAvailable"
       color="error"
       variant="subtle"
       :title="t('parameterSelection.networkRestrictionUnavailable', { network: restrictNetwork })"
@@ -355,10 +379,10 @@ watch([provider, network, resolution, dataset, parameters, dateRequired], () => 
     />
     <UContainer class="flex flex-col gap-4">
       <UFormField :label="t('parameterSelection.providerLabel')">
-        <USelect v-model="provider" :items="providerItems" :placeholder="t('parameterSelection.selectProvider')" :disabled="!!restrictProvider" class="w-full" :class="{ 'needs-input': activeField === 'provider' }" />
+        <USelect v-model="provider" :items="providerItems" :placeholder="t('parameterSelection.selectProvider')" :disabled="!!restrictProvider || coveragePending" :loading="coveragePending" class="w-full" :class="{ 'needs-input': activeField === 'provider' }" />
       </UFormField>
       <UFormField :label="t('parameterSelection.networkLabel')">
-        <USelect v-model="network" :items="networkItems" :placeholder="t('parameterSelection.selectNetwork')" :disabled="!provider || !!restrictNetwork" class="w-full" :class="{ 'needs-input': activeField === 'network' }" />
+        <USelect v-model="network" :items="networkItems" :placeholder="t('parameterSelection.selectNetwork')" :disabled="!provider || !!restrictNetwork || coveragePending" :loading="coveragePending" class="w-full" :class="{ 'needs-input': activeField === 'network' }" />
       </UFormField>
       <UFormField :label="t('parameterSelection.resolutionLabel')" :help="resolutionDescription">
         <USelect v-model="resolution" :items="resolutionItems" :placeholder="t('parameterSelection.selectResolution')" :disabled="!network || networkCoveragePending" class="w-full" :class="{ 'needs-input': activeField === 'resolution' }" />

--- a/app/app/pages/glossary.vue
+++ b/app/app/pages/glossary.vue
@@ -12,7 +12,11 @@ const collator = computed(() => new Intl.Collator(locale.value, { numeric: true 
 
 // the whole vocabulary in one call -- around 500 entries, small enough to filter in the browser
 // and it saves a round trip per keystroke
-const { data: glossary, pending } = await useFetch<GlossaryEntry[]>('/api/glossary')
+//
+// Not awaited: a top-level `await` makes this page's setup async, and with `ssr: false` that
+// suspends the page behind the request, so the loading state below could never be seen -- the
+// route simply showed nothing until the answer arrived.
+const { data: glossary, pending } = useFetch<GlossaryEntry[]>('/api/glossary')
 
 const search = ref('')
 const unitType = ref<string | undefined>(undefined)

--- a/app/tests/nuxt/components/ParameterSelection.test.ts
+++ b/app/tests/nuxt/components/ParameterSelection.test.ts
@@ -3,6 +3,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { clearNuxtData } from '#app'
 import { ParameterSelection } from '#components'
 
+// The component starts its /api/coverage request without awaiting it in setup -- awaiting would
+// suspend the whole page behind it -- so mountSuspended() now returns before the answer lands.
+// Anything that reads what coverage feeds has to wait for initialization to finish first.
+async function mountReady(props: Record<string, unknown>) {
+  const wrapper = await mountSuspended(ParameterSelection, { props })
+  await vi.waitFor(() => expect((wrapper.vm as any).isInitializing).toBe(false), { timeout: 5000 })
+  return wrapper
+}
+
 describe('parameterSelection Component', () => {
   beforeEach(() => {
     globalThis.fetch = vi.fn()
@@ -12,15 +21,31 @@ describe('parameterSelection Component', () => {
     clearNuxtData()
   })
 
+  it('renders itself while /api/coverage is still out', async () => {
+    // The regression this guards: the coverage request used to be awaited at the top level of
+    // setup, which with `ssr: false` suspended the whole page -- the Explorer showed nothing at
+    // all, not even its own headings, until the backend answered. A request that never settles
+    // makes that visible.
+    vi.mocked(globalThis.fetch).mockReturnValue(new Promise(() => {}) as Promise<Response>)
+
+    const wrapper = await mountSuspended(ParameterSelection, {
+      props: { modelValue: {}, restrictProvider: 'dwd' },
+    })
+
+    expect(wrapper.text()).toContain('Select Parameters')
+    expect((wrapper.vm as any).coveragePending).toBe(true)
+    // An unanswered request is not an answer of "no such provider": while it is out, every
+    // restriction looks unavailable, and the alert must not flash on each cold load.
+    expect(wrapper.text()).not.toContain('is not available from this backend')
+  })
+
   it('renders the component', async () => {
     vi.mocked(globalThis.fetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ dwd: ['observation'] }), { status: 200 }),
     )
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {},
-      },
+    const wrapper = await mountReady({
+      modelValue: {},
     })
 
     expect(wrapper.exists()).toBe(true)
@@ -32,10 +57,8 @@ describe('parameterSelection Component', () => {
       new Response(JSON.stringify({ dwd: ['observation'] }), { status: 200 }),
     )
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {},
-      },
+    const wrapper = await mountReady({
+      modelValue: {},
     })
 
     const selects = wrapper.findAllComponents({ name: 'USelect' })
@@ -47,15 +70,13 @@ describe('parameterSelection Component', () => {
       new Response(JSON.stringify({ dwd: ['observation'] }), { status: 200 }),
     )
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {
-          provider: 'dwd',
-          network: 'observation',
-          resolution: 'daily',
-          dataset: 'climate_summary',
-          parameters: ['temperature_air_max_200'],
-        },
+    const wrapper = await mountReady({
+      modelValue: {
+        provider: 'dwd',
+        network: 'observation',
+        resolution: 'daily',
+        dataset: 'climate_summary',
+        parameters: ['temperature_air_max_200'],
       },
     })
 
@@ -79,10 +100,8 @@ describe('parameterSelection Component', () => {
       parameters: ['temperature_air_max_200'],
     }
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: initialValue,
-      },
+    const wrapper = await mountReady({
+      modelValue: initialValue,
     })
 
     expect(wrapper.exists()).toBe(true)
@@ -96,15 +115,13 @@ describe('parameterSelection Component', () => {
       new Response(JSON.stringify({ dwd: ['observation'], noaa: ['ghcn'] }), { status: 200 }),
     )
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {
-          provider: 'dwd',
-          network: 'observation',
-          resolution: 'daily',
-          dataset: 'climate_summary',
-          parameters: ['temperature_air_max_200'],
-        },
+    const wrapper = await mountReady({
+      modelValue: {
+        provider: 'dwd',
+        network: 'observation',
+        resolution: 'daily',
+        dataset: 'climate_summary',
+        parameters: ['temperature_air_max_200'],
       },
     })
 
@@ -124,15 +141,13 @@ describe('parameterSelection Component', () => {
       new Response(JSON.stringify({ dwd: ['observation'] }), { status: 200 }),
     )
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {
-          provider: 'dwd',
-          network: 'observation',
-          resolution: 'daily',
-          dataset: 'climate_summary',
-          parameters: [],
-        },
+    const wrapper = await mountReady({
+      modelValue: {
+        provider: 'dwd',
+        network: 'observation',
+        resolution: 'daily',
+        dataset: 'climate_summary',
+        parameters: [],
       },
     })
 
@@ -144,11 +159,9 @@ describe('parameterSelection Component', () => {
   it('restricts the provider select to restrictProvider', async () => {
     registerEndpoint('/api/coverage', () => ({ dwd: { observation: {} }, noaa: { ghcn: {} } }))
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {},
-        restrictProvider: 'dwd',
-      },
+    const wrapper = await mountReady({
+      modelValue: {},
+      restrictProvider: 'dwd',
     })
 
     const vm = wrapper.vm as any
@@ -162,11 +175,9 @@ describe('parameterSelection Component', () => {
   it('restricts the network select to restrictNetwork', async () => {
     registerEndpoint('/api/coverage', () => ({ dwd: { observation: {}, mosmix: {} } }))
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: { provider: 'dwd' },
-        restrictNetwork: 'observation',
-      },
+    const wrapper = await mountReady({
+      modelValue: { provider: 'dwd' },
+      restrictNetwork: 'observation',
     })
 
     const vm = wrapper.vm as any
@@ -178,11 +189,9 @@ describe('parameterSelection Component', () => {
   it('does not fall back to the unrestricted provider list when restrictProvider does not exist', async () => {
     registerEndpoint('/api/coverage', () => ({ noaa: { ghcn: {} } }))
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {},
-        restrictProvider: 'dwd',
-      },
+    const wrapper = await mountReady({
+      modelValue: {},
+      restrictProvider: 'dwd',
     })
 
     const vm = wrapper.vm as any
@@ -196,12 +205,10 @@ describe('parameterSelection Component', () => {
   it('does not fall back to the unrestricted network list when restrictNetwork does not exist', async () => {
     registerEndpoint('/api/coverage', () => ({ dwd: { mosmix: {} } }))
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {},
-        restrictProvider: 'dwd',
-        restrictNetwork: 'observation',
-      },
+    const wrapper = await mountReady({
+      modelValue: {},
+      restrictProvider: 'dwd',
+      restrictNetwork: 'observation',
     })
 
     const vm = wrapper.vm as any
@@ -215,18 +222,16 @@ describe('parameterSelection Component', () => {
   it('overrides a mismatched initial provider/network with the restricted values', async () => {
     registerEndpoint('/api/coverage', () => ({ dwd: { observation: {} }, noaa: { ghcn: {} } }))
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {
-          provider: 'noaa',
-          network: 'ghcn',
-          resolution: 'daily',
-          dataset: 'foo',
-          parameters: ['bar'],
-        },
-        restrictProvider: 'dwd',
-        restrictNetwork: 'observation',
+    const wrapper = await mountReady({
+      modelValue: {
+        provider: 'noaa',
+        network: 'ghcn',
+        resolution: 'daily',
+        dataset: 'foo',
+        parameters: ['bar'],
       },
+      restrictProvider: 'dwd',
+      restrictNetwork: 'observation',
     })
 
     const vm = wrapper.vm as any
@@ -256,15 +261,13 @@ describe('parameterSelection Component', () => {
         ),
       )
 
-    const wrapper = await mountSuspended(ParameterSelection, {
-      props: {
-        modelValue: {
-          provider: 'dwd',
-          network: 'observation',
-          resolution: 'daily',
-          dataset: 'climate_summary',
-          parameters: ['temperature_air_max_200'],
-        },
+    const wrapper = await mountReady({
+      modelValue: {
+        provider: 'dwd',
+        network: 'observation',
+        resolution: 'daily',
+        dataset: 'climate_summary',
+        parameters: ['temperature_air_max_200'],
       },
     })
 

--- a/app/tests/nuxt/pages/explorer.test.ts
+++ b/app/tests/nuxt/pages/explorer.test.ts
@@ -3,6 +3,7 @@ import { getQuery } from 'h3'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { UApp } from '#components'
+import ParameterSelection from '~/components/ParameterSelection.vue'
 import ExplorerPage from '~/pages/explorer.vue'
 
 // DataViewer's copy-to-clipboard buttons use UTooltip, which needs a
@@ -79,9 +80,13 @@ describe('explorer Page', () => {
     const wrapper = await mountSuspended(ExplorerWithApp, { attachTo: document.body })
     const vm = wrapper.findComponent(ExplorerPage).vm as any
 
-    // Let ParameterSelection's async initialization settle before driving it
-    // externally -- otherwise its own emitUpdate() races and clobbers these.
-    await new Promise(resolve => setTimeout(resolve, 100))
+    // Let ParameterSelection's initialization settle before driving it externally -- otherwise its
+    // own emitUpdate() races and clobbers these. It no longer awaits /api/coverage in setup, so
+    // that window now spans the whole round trip and is too long to sleep through blindly.
+    await vi.waitFor(
+      () => expect((wrapper.findComponent(ParameterSelection).vm as any).isInitializing).toBe(false),
+      { timeout: 5000 },
+    )
     await wrapper.vm.$nextTick()
 
     vm.parameterSelectionState.selection.resolution = 'daily'

--- a/app/tests/nuxt/pages/glossary.test.ts
+++ b/app/tests/nuxt/pages/glossary.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { clearNuxtData } from '#app'
 import GlossaryPage from '~/pages/glossary.vue'
 
@@ -26,22 +26,31 @@ const entries = [
 let served: typeof entries = entries
 registerEndpoint('/api/glossary', () => served)
 
+// The page no longer awaits `/api/glossary` in setup -- awaiting suspended the whole route and
+// made its own loading state unreachable -- so mountSuspended() returns while the request is still
+// out. Every assertion here is about what the answer renders, so wait for it.
+async function mountGlossary() {
+  const wrapper = await mountSuspended(GlossaryPage)
+  await vi.waitFor(() => expect((wrapper.vm as any).pending).toBe(false), { timeout: 5000 })
+  return wrapper
+}
+
 describe('glossary Page', () => {
   it('renders the page', async () => {
     served = entries
-    const wrapper = await mountSuspended(GlossaryPage)
+    const wrapper = await mountGlossary()
     expect(wrapper.exists()).toBe(true)
   })
 
   it('displays the glossary heading', async () => {
     served = entries
-    const wrapper = await mountSuspended(GlossaryPage)
+    const wrapper = await mountGlossary()
     expect(wrapper.text()).toContain('Glossary')
   })
 
   it('shows each parameter with its description and unit', async () => {
     served = entries
-    const wrapper = await mountSuspended(GlossaryPage)
+    const wrapper = await mountGlossary()
     const text = wrapper.text()
 
     // the description is what the page exists for -- it comes from the backend, per parameter
@@ -54,7 +63,7 @@ describe('glossary Page', () => {
 
   it('reports how much of the vocabulary is shown', async () => {
     served = entries
-    const wrapper = await mountSuspended(GlossaryPage)
+    const wrapper = await mountGlossary()
     expect(wrapper.text()).toContain('2 of 2 parameters')
   })
 
@@ -62,7 +71,7 @@ describe('glossary Page', () => {
     // `useFetch` caches by url, so the payload from the mounts above would be reused otherwise
     clearNuxtData()
     served = []
-    const wrapper = await mountSuspended(GlossaryPage)
+    const wrapper = await mountGlossary()
     expect(wrapper.text()).toContain('No parameter matches your search.')
   })
 
@@ -74,7 +83,7 @@ describe('glossary Page', () => {
     served = [...entries].reverse()
     expect(served.map(entry => entry.name)).toEqual(['sunshine_duration', 'temperature_air_mean_2m'])
 
-    const wrapper = await mountSuspended(GlossaryPage)
+    const wrapper = await mountGlossary()
     const shown = (wrapper.vm as any).entries.map((entry: { name: string }) => entry.name)
     expect(shown).toEqual(['temperature_air_mean_2m', 'sunshine_duration'])
   })
@@ -91,7 +100,7 @@ describe('glossary Page', () => {
       unit_symbol: 'J/cm²',
       description: 'Global radiation.',
     }]
-    const wrapper = await mountSuspended(GlossaryPage)
+    const wrapper = await mountGlossary()
     // the options live in a popover that is not rendered until the select opens, so what the select
     // is handed is what gets checked
     const labels = ((wrapper.vm as any).unitTypeItems as { label: string }[]).map(item => item.label)

--- a/app/tests/nuxt/pages/history.test.ts
+++ b/app/tests/nuxt/pages/history.test.ts
@@ -1,7 +1,21 @@
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
 import { getQuery } from 'h3'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ParameterSelection from '~/components/ParameterSelection.vue'
 import HistoryPage from '~/pages/history.vue'
+
+// ParameterSelection fires its /api/coverage request without awaiting it in setup, so mounting no
+// longer implies it has restored provider/network. Driving `paramSel` before that has settled
+// would be clobbered by the component's own initial emit. The page's own `paramSel.provider` is
+// no signal here -- it starts out as 'dwd' -- so this waits on the child's initialization flag.
+async function mountHistory(options?: Record<string, unknown>) {
+  const wrapper = await mountSuspended(HistoryPage, options)
+  await vi.waitFor(
+    () => expect((wrapper.findComponent(ParameterSelection).vm as any).isInitializing).toBe(false),
+    { timeout: 5000 },
+  )
+  return wrapper
+}
 
 describe('history Page', () => {
   beforeEach(() => {
@@ -16,17 +30,17 @@ describe('history Page', () => {
   })
 
   it('renders the page', async () => {
-    const wrapper = await mountSuspended(HistoryPage)
+    const wrapper = await mountHistory()
     expect(wrapper.exists()).toBe(true)
   })
 
   it('displays the station history heading', async () => {
-    const wrapper = await mountSuspended(HistoryPage)
+    const wrapper = await mountHistory()
     expect(wrapper.text()).toContain('Station history')
   })
 
   it('restricts provider/network to dwd/observation', async () => {
-    const wrapper = await mountSuspended(HistoryPage)
+    const wrapper = await mountHistory()
     const vm = wrapper.vm as any
 
     expect(vm.paramSel.provider).toBe('dwd')
@@ -34,17 +48,17 @@ describe('history Page', () => {
   })
 
   it('prompts to select resolution/dataset before station selection', async () => {
-    const wrapper = await mountSuspended(HistoryPage)
+    const wrapper = await mountHistory()
     expect(wrapper.text()).toContain('Please select resolution and dataset first')
   })
 
   it('shows the history sections selector', async () => {
-    const wrapper = await mountSuspended(HistoryPage)
+    const wrapper = await mountHistory()
     expect(wrapper.text()).toContain('History sections')
   })
 
   it('disables fetching until resolution, dataset and a station are selected', async () => {
-    const wrapper = await mountSuspended(HistoryPage)
+    const wrapper = await mountHistory()
     const vm = wrapper.vm as any
 
     expect(vm.canFetch).toBe(false)
@@ -60,12 +74,12 @@ describe('history Page', () => {
   })
 
   it('shows an empty-results hint before any query has run', async () => {
-    const wrapper = await mountSuspended(HistoryPage)
+    const wrapper = await mountHistory()
     expect(wrapper.text()).toContain('No histories loaded')
   })
 
   it('clear() resets fetched history data', async () => {
-    const wrapper = await mountSuspended(HistoryPage)
+    const wrapper = await mountHistory()
     const vm = wrapper.vm as any
 
     vm.data = { histories: [{ name: { station: [{ station_name: 'Foo' }] } }] }
@@ -78,7 +92,7 @@ describe('history Page', () => {
   })
 
   it('clicking the about toggle reveals the explanatory text', async () => {
-    const wrapper = await mountSuspended(HistoryPage, { attachTo: document.body })
+    const wrapper = await mountHistory({ attachTo: document.body })
     expect(wrapper.text()).not.toContain('captures the administrative')
 
     const aboutButton = wrapper.findAll('button').find(b => b.text().includes('About station history'))
@@ -98,18 +112,15 @@ describe('history Page', () => {
       ],
     }))
 
-    const wrapper = await mountSuspended(HistoryPage, { attachTo: document.body })
+    const wrapper = await mountHistory({ attachTo: document.body })
     const vm = wrapper.vm as any
 
-    // Let ParameterSelection's async initialization settle before driving it
-    // externally -- otherwise its own emitUpdate() races and clobbers these.
-    await new Promise(resolve => setTimeout(resolve, 100))
-    await wrapper.vm.$nextTick()
-
+    // mountHistory() already waited for ParameterSelection's initialization, whose own emitUpdate()
+    // would otherwise clobber what is set here. Resolution and dataset go first and get a tick of
+    // their own: each has a watcher that clears the station selection, so a station set in the
+    // same tick would be wiped again.
     vm.paramSel.resolution = 'daily'
     vm.paramSel.dataset = 'climate_summary'
-    await wrapper.vm.$nextTick()
-    await new Promise(resolve => setTimeout(resolve, 50))
     await wrapper.vm.$nextTick()
 
     vm.stationSelectionState.selection.stations = [{ station_id: '00001', name: 'Test' }]
@@ -118,10 +129,9 @@ describe('history Page', () => {
 
     const runButton = wrapper.findAll('button').find(b => b.text() === 'Show')
     await runButton!.trigger('click')
-    await new Promise(resolve => setTimeout(resolve, 50))
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.text()).toContain('Station ID: 00001')
+    // Waiting on the rendered result rather than on a fixed sleep: under a parallel test run no
+    // sleep short enough to be worth having is reliably long enough.
+    await vi.waitFor(() => expect(wrapper.text()).toContain('Station ID: 00001'), { timeout: 5000 })
 
     const nameHistoryButton = wrapper.findAll('button').find(b => b.text().includes('Name history'))
     await nameHistoryButton!.trigger('click')


### PR DESCRIPTION
## Description

The Explorer sometimes showed nothing at all — not even its own headings — before any content appeared. With `ssr: false`, an async `<script setup>` suspends the nearest Suspense boundary, so a top-level `await useFetch` blocks rendering until the backend answers. Three places did it:

- `app/app/app.vue` — `await useFetch('/api/version')` in the **root** component, so every route blanked until the version request returned.
- `app/app/components/ParameterSelection.vue` — `await useFetch('/api/coverage')`, blanking whichever page mounts it (Explorer, History).
- `app/app/pages/glossary.vue` — `await useFetch('/api/glossary')`, which made the page's own `pending` loading state unreachable.

"Sometimes" on the Explorer was the cache: once `/api/coverage` had been answered in a session, the await resolved instantly, so it only showed on a cold load or a slow backend.

None of the three is awaited now:

- `ParameterSelection` initializes from the URL when the coverage request *settles* — success or error, so a failed fetch still falls through to the same "nothing valid to restore" branch it did before — rather than on mount, which is now too early. The provider and network selects render disabled with a spinner while it is in flight.
- The provider/network restriction alerts wait for the same signal. While the request is out, every provider looks unavailable, and flashing *"The configured provider "dwd" is not available from this backend."* on each cold load of `/history` is worse than silence.
- `backendVersion` shows `…` while pending; `unknown` is now reserved for a settled-but-unusable answer.

Tests could no longer take `mountSuspended()` as proof the fetch had landed, so they wait on the component's own `isInitializing` flag. The history and explorer suites drove their pages after a fixed sleep that used to cover only initialization and now spans the whole round trip; the history "clicking Show" test additionally kept its two-phase setup, since the resolution and dataset watchers clear the station selection a tick later. New regression test: with a `/api/coverage` that never settles, the component still renders its headings and shows no restriction alert.

## Type of change

- [x] Bug fix
- [ ] New feature / provider
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] Tests added or updated
- [ ] `uv run poe format` passed — no Python touched
- [ ] Remote/slow tests verified if network code was touched — n/a
- [x] App changes tested locally (`pnpm lint`, `pnpm typecheck`, `pnpm test:ci` — 249 passed, suite run repeatedly to check for flakes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vb79GWaKFu2ACYFdwHJD6W
