### PR TITLE
fix(tests): stop the radar PE timerange test failing on the first of a month

### DIFF
--- a/tests/provider/dwd/radar/test_api_historic.py
+++ b/tests/provider/dwd/radar/test_api_historic.py
@@ -616,7 +616,9 @@ def test_radar_request_site_historic_pe_timerange(default_settings: Settings, fm
     if fmt == DwdRadarDataFormat.BINARY:
         buffer = results[0].data
         payload = buffer.getvalue()
-        month_year = dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None).strftime("%m%y")
+        # from the requested date, not from now: the request is for yesterday, so on the first of
+        # a month the two are in different months and the header would never match
+        month_year = request.start_date.strftime("%m%y")
         header = (
             f"PE......10132{month_year}BY ....VS 1LV12  "
             "1.0  2.0  3.0  4.0  5.0  6.0  7.0  8.0  9.0 10.0 11.0 12.0"


### PR DESCRIPTION
## Summary

`test_radar_request_site_historic_pe_timerange` requests **yesterday** at this time, then asserts the BINARY payload's header carries the month-year taken from **`now`**. On the first of a month those are two different months, so the header built for the assertion can never match the data the test itself asked for.

It fires today (2026-09-01) on every PR and on `main`, from CI at 05:49 UTC:

```
expected  PE......10132 0926 …   ← from now()          = September
actual    PE3118291013 2 0826 …  ← the 31 Aug data the request asked for
```

Re-running does not help: it fails for the whole of the 1st and starts passing by itself on the 2nd. This is what took every Python matrix job and `coverage` red on #1886, whose own suites all pass.

## Change

The month-year now comes from `request.start_date`, the date of the data — which is what the two sibling assertions in this same file (lines 479 and 948) already do.

```python
# from the requested date, not from now: the request is for yesterday, so on the first of
# a month the two are in different months and the header would never match
month_year = request.start_date.strftime("%m%y")
```

`tests/provider/dwd/radar/test_api_latest.py:33` builds its header from `now` in the same way, but for the *latest* product, where the two agree except in the first minutes of a month. Left alone rather than changed speculatively.

## Testing

Run on 2026-09-01, the date that exposes the bug:

- before: `1 failed, 1 passed` (the BINARY parametrization)
- after: `2 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vb79GWaKFu2ACYFdwHJD6W
