### PR TITLE
fix(model): say what did not match instead of dropping the parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,29 @@ Types of changes:
   real daily total in a unit of ~0.636 MJ/m2 per count that matches nothing the converter knows.
   Sum the hourly column for a daily total
 
+### Changed
+
+- Parameter parsing: a parameter the provider does not have is now logged as a warning naming what
+  did not match -- resolution, dataset or parameter -- with the closest name as a "did you mean"
+  and the names that would have matched, where it used to be an `info` line saying only that the
+  parameter was not found. Half a request silently resolving to less data than was asked for is
+  otherwise invisible. `NoParametersFoundError` names the request and the provider too
+- Parameter parsing: the parts of a parameter must be strings. A tuple mixing in an enum member,
+  `(Resolution.DAILY, "kl")`, now raises a `TypeError` naming the accepted forms instead of an
+  `AttributeError` from deep inside the parser
+- Lookups on the metadata models (`metadata["daily"]["kl"]`, `metadata.daily.kl`) match the
+  source's own name case-insensitively, as looking a parameter up by its `name_original` already
+  did in a request, and suggest the closest name when nothing matches
+
 ### Fixed
 
+- Parameter parsing: parameters requested more than once -- a dataset and one of its parameters,
+  or the same dataset twice -- are returned once instead of being queried and returned per mention
+- Parameter parsing: an iterator of parameters no longer parses as empty. It was consumed by the
+  checks that tell `("daily", "kl")` apart from `["daily/kl", "daily/solar"]`
+- Parameter parsing: a quality flag requested by name (`daily/kl/quality_wind`) says that quality
+  flags come back in the `quality` column next to their parameter, where it used to be dropped as
+  if it did not exist. Requesting one as a `ParameterModel` was dropped the same way
 - CI: the Coolify deploy step has failed on every run since 2026-08-17, so no release or nightly
   has reached the live deployment since. Coolify moved `/api/v1/deploy` from GET to POST and left
   the GET route pointing at a stub that answers `405 This endpoint has changed to a POST request.`,

--- a/src/wetterdienst/model/metadata.py
+++ b/src/wetterdienst/model/metadata.py
@@ -4,10 +4,11 @@
 
 from __future__ import annotations
 
+import difflib
 import logging
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, SkipValidation, field_validator
 from pydantic_extra_types.timezone_name import (
@@ -32,6 +33,57 @@ POSSIBLE_SEPARATORS = ("/", ".", ":")
 
 # for any provider that does not publish their data under a dedicated dataset name
 DATASET_NAME_DEFAULT = "data"
+
+# how close a typo has to be before it is offered as "did you mean"
+_SUGGESTION_CUTOFF = 0.6
+
+_EXPECTED_PARAMETER = (
+    "a 'resolution/dataset' or 'resolution/dataset/parameter' string, a tuple of its parts, "
+    "a DatasetModel or a ParameterModel"
+)
+
+
+# any of the three models that carry a canonical and a source name and are looked up by either
+_NamedModel = TypeVar("_NamedModel", "ResolutionModel", "DatasetModel", "ParameterModel")
+
+
+def _names(model: _NamedModel) -> tuple[str, ...]:
+    """All lowercase names a model may be addressed by.
+
+    That is the canonical name and the source's own name, plus for a resolution the name of the
+    ``Resolution`` enum member ("minute_1" next to "1_minute"), which is what a user reading the
+    enum rather than the docs is likely to type.
+    """
+    names = (model.name.lower(), model.name_original.lower())
+    if isinstance(model, ResolutionModel):
+        return (*names, model.value.name.lower())
+    return names
+
+
+def _find(models: Iterable[_NamedModel], item: str) -> _NamedModel | None:
+    """Find a model by any of its names, case-insensitively, or return None."""
+    item_search = item.strip().lower()
+    for model in models:
+        if item_search in _names(model):
+            return model
+    return None
+
+
+def _not_found(kind: str, item: str, models: Iterable[_NamedModel]) -> str:
+    """Build the message for a name that no model matched.
+
+    Names a close match where there is one, because the common failure is a typo or a name taken
+    from another provider, and the available-names list alone leaves the user to spot the
+    difference themselves.
+    """
+    models = list(models)
+    candidates = sorted({name for model in models for name in _names(model)})
+    close = difflib.get_close_matches(str(item).strip().lower(), candidates, n=1, cutoff=_SUGGESTION_CUTOFF)
+    suggestion = f" Did you mean '{close[0]}'?" if close else ""
+    available = ", ".join(
+        f"{model.name}/{model.name_original}" if model.name != model.name_original else model.name for model in models
+    )
+    return f"'{item}'.{suggestion} Available {kind}: {available}"
 
 
 class ParameterModel(BaseModel):  # noqa: PLW1641
@@ -124,32 +176,17 @@ class DatasetModel(BaseModel):  # noqa: PLW1641
         """Get a parameter by name."""
         if isinstance(item, int):
             return self.parameters[item]
-        item_search = item.strip().lower()
-        for parameter in self.parameters:
-            if item_search in (parameter.name, parameter.name_original):
-                return parameter
-        available_parameters = [
-            f"{parameter.name}/{parameter.name_original}"
-            if parameter.name != parameter.name_original
-            else parameter.name
-            for parameter in self.parameters
-        ]
-        msg = f"'{item}'. Available parameters: {', '.join(available_parameters)}"
-        raise KeyError(msg)
+        parameter = _find(self.parameters, item)
+        if parameter is None:
+            raise KeyError(_not_found("parameters", item, self.parameters))
+        return parameter
 
     def __getattr__(self, item: str) -> ParameterModel:
         """Get a parameter by name."""
-        for parameter in self.parameters:
-            if item in (parameter.name, parameter.name_original):
-                return parameter
-        available_parameters = [
-            f"{parameter.name}/{parameter.name_original}"
-            if parameter.name != parameter.name_original
-            else parameter.name
-            for parameter in self.parameters
-        ]
-        msg = f"'{item}'. Available parameters: {', '.join(available_parameters)}"
-        raise AttributeError(msg)
+        parameter = _find(self.parameters, item)
+        if parameter is None:
+            raise AttributeError(_not_found("parameters", item, self.parameters))
+        return parameter
 
     def __iter__(self) -> Iterator[ParameterModel]:  # ty: ignore[invalid-method-override]
         """Iterate over all parameters."""
@@ -193,29 +230,17 @@ class ResolutionModel(BaseModel):
         """Get a dataset by name."""
         if isinstance(item, int):
             return self.datasets[item]
-        item_search = item.strip().lower()
-        for dataset in self.datasets:
-            if item_search in (dataset.name, dataset.name_original):
-                return dataset
-        available_datasets = [
-            f"{dataset.name}/{dataset.name_original}" if dataset.name != dataset.name_original else dataset.name
-            for dataset in self.datasets
-        ]
-        msg = f"'{item}'. Available datasets: {', '.join(available_datasets)}"
-        raise KeyError(msg)
+        dataset = _find(self.datasets, item)
+        if dataset is None:
+            raise KeyError(_not_found("datasets", item, self.datasets))
+        return dataset
 
     def __getattr__(self, item: str) -> DatasetModel:
         """Get a dataset by name."""
-        item_search = item.strip().lower()
-        for dataset in self.datasets:
-            if item_search in (dataset.name, dataset.name_original):
-                return dataset
-        available_datasets = [
-            f"{dataset.name}/{dataset.name_original}" if dataset.name != dataset.name_original else dataset.name
-            for dataset in self.datasets
-        ]
-        msg = f"'{item}'. Available datasets: {', '.join(available_datasets)}"
-        raise AttributeError(msg)
+        dataset = _find(self.datasets, item)
+        if dataset is None:
+            raise AttributeError(_not_found("datasets", item, self.datasets))
+        return dataset
 
     def __iter__(self) -> Iterator[DatasetModel]:  # ty: ignore[invalid-method-override]
         """Iterate over all datasets."""
@@ -240,59 +265,53 @@ class MetadataModel(BaseModel):
         """Get a resolution by name."""
         if isinstance(item, int):
             return self.resolutions[item]
-        item_search = item.strip().lower()
-        for resolution in self.resolutions:
-            if item_search in (resolution.name, resolution.name_original, resolution.value.name.lower()):
-                return resolution
-        available_resolutions = [
-            f"{resolution.name}/{resolution.name_original}"
-            if resolution.name != resolution.name_original
-            else resolution.name
-            for resolution in self.resolutions
-        ]
-        msg = f"'{item}'. Available resolutions: {', '.join(available_resolutions)}"
-        raise KeyError(msg)
+        resolution = _find(self.resolutions, item)
+        if resolution is None:
+            raise KeyError(_not_found("resolutions", item, self.resolutions))
+        return resolution
 
     def __getattr__(self, item: str) -> ResolutionModel:
         """Get a resolution by name.
 
         Alternatively, this still finds any other attribute that is not a resolution.
         """
-        item_search = item.strip().lower()
-        for resolution in self.resolutions:
-            if item_search in (resolution.name, resolution.name_original, resolution.value.name.lower()):
-                return resolution
-        return super().__getattr__(item)  # ty: ignore[unresolved-attribute]
+        resolution = _find(self.resolutions, item)
+        if resolution is None:
+            return super().__getattr__(item)  # ty: ignore[unresolved-attribute]
+        return resolution
 
     def __iter__(self) -> Iterator[ResolutionModel]:  # ty: ignore[invalid-method-override]
         """Iterate over all resolutions."""
         return iter(self.resolutions)
 
     def search_parameter(self, parameter_search: ParameterSearch) -> list[ParameterModel]:
-        """Search for a parameter in the metadata."""
-        for resolution in self:
-            if (
-                resolution.name == parameter_search.resolution
-                or resolution.name_original.lower() == parameter_search.resolution
-                or resolution.value.name.lower() == parameter_search.resolution
-            ):
-                break
-        else:
-            raise KeyError(parameter_search.resolution)
-        for dataset in resolution:
-            if dataset.name == parameter_search.dataset or dataset.name_original.lower() == parameter_search.dataset:
-                break
-        else:
-            raise KeyError(parameter_search.dataset)
+        """Search for a parameter in the metadata.
+
+        Raises a ``KeyError`` naming the part that did not match -- resolution, dataset or
+        parameter -- with the names that would have matched, so a caller that drops the request
+        can say why it dropped it.
+        """
+        resolution = _find(self.resolutions, parameter_search.resolution)
+        if resolution is None:
+            raise KeyError(_not_found("resolutions", parameter_search.resolution, self.resolutions))
+        dataset = _find(resolution.datasets, parameter_search.dataset)
+        if dataset is None:
+            raise KeyError(_not_found("datasets", parameter_search.dataset, resolution.datasets))
         if not parameter_search.parameter:
+            # iterating the dataset leaves out its quality flags, see DatasetModel.__iter__
             return [*dataset]
-        for parameter in dataset:
-            if (
-                parameter.name == parameter_search.parameter
-                or parameter.name_original.lower() == parameter_search.parameter
-            ):
-                return [parameter]
-        raise KeyError(parameter_search.parameter)
+        # searched over all parameters rather than over the dataset's iterator, so that a quality
+        # flag is answered with the explanation below instead of with "no such parameter"
+        parameter = _find(dataset.parameters, parameter_search.parameter)
+        if parameter is None:
+            raise KeyError(_not_found("parameters", parameter_search.parameter, dataset))
+        if parameter.name.startswith("quality"):
+            msg = (
+                f"'{parameter_search.parameter}' is a quality flag. Quality flags are returned in the "
+                f"'quality' column next to the parameter they belong to and cannot be requested on their own."
+            )
+            raise KeyError(msg)
+        return [parameter]
 
 
 def build_metadata_model(metadata: dict, name: str) -> MetadataModel:
@@ -370,29 +389,31 @@ class ParameterSearch:
             return ParameterSearch(value.resolution.name, value.name)
         if isinstance(value, ParameterModel):
             return ParameterSearch(value.dataset.resolution.name, value.dataset.name, value.name)
-        parameter = None
         if isinstance(value, str):
-            if all(value.count(sep) == 0 for sep in POSSIBLE_SEPARATORS):
-                msg = (
-                    f"expected 'resolution/dataset' or 'resolution/dataset/parameter' "
-                    f"(separator any of {POSSIBLE_SEPARATORS})"
-                )
-                raise ValueError(msg)
+            normalized = value
             for sep in POSSIBLE_SEPARATORS:
-                if sep in value:
-                    value = value.replace(sep, "/")
-            value = value.split("/")
-        try:
-            resolution, dataset, parameter = value
-        except ValueError as e:
-            try:
-                resolution, dataset = value
-            except ValueError as inner_e:
-                raise inner_e from e
-        resolution = resolution and resolution.strip().lower()
-        dataset = dataset and dataset.strip().lower()
-        parameter = parameter and parameter.strip().lower()
-        return ParameterSearch(resolution, dataset, parameter)
+                normalized = normalized.replace(sep, "/")
+            parts = normalized.split("/")
+        elif isinstance(value, Iterable):
+            parts = list(value)
+        else:
+            msg = f"expected {_EXPECTED_PARAMETER}, got {type(value).__name__}"
+            raise TypeError(msg)
+        # the parts are names, so an enum member mixed into a tuple -- (Resolution.DAILY, "kl") --
+        # is rejected here, naming the accepted forms, rather than searched for and not found
+        for part in parts:
+            if not isinstance(part, str):
+                msg = f"{value!r}: expected the parts as strings, got {type(part).__name__} '{part}'"
+                raise TypeError(msg)
+        parts = [part.strip().lower() for part in parts]
+        if len(parts) not in (2, 3) or not all(parts):
+            msg = (
+                f"{value!r}: expected 'resolution/dataset' or 'resolution/dataset/parameter' "
+                f"(separator any of {POSSIBLE_SEPARATORS}), or the same as a tuple of its parts"
+            )
+            raise ValueError(msg)
+        parameter = parts[2] if len(parts) == 3 else None
+        return ParameterSearch(parts[0], parts[1], parameter)
 
     def concat(self) -> str:
         """Concatenate resolution, dataset and parameter with '/'."""
@@ -400,26 +421,52 @@ class ParameterSearch:
 
 
 def parse_parameters(parameters: _PARAMETER_TYPE, metadata: MetadataModel) -> list[ParameterModel]:
-    """Parse parameters, either from string or tuple or MetadataModel or sequence of those."""
+    """Parse one parameter or a sequence of them into the provider's parameter models.
+
+    A parameter the provider does not have, or one that is not shaped like a parameter at all, is
+    not fatal on its own -- the other parameters are still resolved and returned -- but it is
+    logged as a warning naming the reason, because silently returning less data than was asked for
+    is otherwise invisible. Only a request where nothing at all resolves fails, which the caller
+    raises. A part that is not a string is a ``TypeError`` and does propagate: it says the caller
+    passed the wrong kind of object rather than misspelled a name.
+    """
     if isinstance(parameters, str | DatasetModel | ParameterModel):
         # "daily/climate_summary" -> ["daily/climate_summary"]
-        parameters = [
-            parameters,
-        ]
-    elif (
-        isinstance(parameters, Iterable)
-        and all(isinstance(p, str) for p in parameters)
-        and all(all(sep not in p for sep in POSSIBLE_SEPARATORS) for p in parameters)
-    ):
-        # ("daily", "climate_summary") -> [("daily", "climate_summary")]
-        parameters = [  # ty: ignore[invalid-assignment]
-            parameters,
-        ]
+        parameters = [parameters]
+    elif isinstance(parameters, Iterable):
+        # materialized first: the check below would otherwise exhaust an iterator
+        parameters = list(parameters)
+        if parameters and all(
+            isinstance(p, str) and all(sep not in p for sep in POSSIBLE_SEPARATORS) for p in parameters
+        ):
+            # ("daily", "climate_summary") -> [("daily", "climate_summary")]
+            parameters = [parameters]  # ty: ignore[invalid-assignment]
+    else:
+        msg = f"expected {_EXPECTED_PARAMETER}, or a sequence of those, got {type(parameters).__name__}"
+        raise TypeError(msg)
     parameters_found = []
+    seen = set()
     for parameter in parameters:
-        parameter_search = ParameterSearch.parse(parameter)
         try:
-            parameters_found.extend(metadata.search_parameter(parameter_search))
-        except KeyError:
-            log.info(f"{parameter_search.concat()} not found in {metadata.__name__}")
+            parameter_search = ParameterSearch.parse(parameter)
+            found = metadata.search_parameter(parameter_search)
+        except ValueError as e:
+            # malformed, e.g. a trailing separator -- skipped like an unknown name, so that one
+            # bad entry does not take the parameters around it down with it
+            log.warning(f"{parameter!r} could not be parsed as a parameter: {e.args[0]}")
+            continue
+        except KeyError as e:
+            log.warning(f"{parameter_search.concat()} not found in {metadata.__name__}: {e.args[0]}")
+            continue
+        for parameter_found in found:
+            # requests commonly overlap e.g. a dataset and one of its parameters, which would
+            # otherwise be queried and returned twice
+            key = (
+                parameter_found.dataset.resolution.name,
+                parameter_found.dataset.name,
+                parameter_found.name,
+            )
+            if key not in seen:
+                seen.add(key)
+                parameters_found.append(parameter_found)
     return parameters_found

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -60,7 +60,7 @@ EARTH_RADIUS_KM = 6371
 # types
 # either of
 # str: "daily/kl" or "daily/kl/temperature_air_mean_2m"  # noqa: ERA001
-# tuple: ("daily", "kl") or ("daily", "kl", "temperature_air_mean_2m")  # noqa: ERA001
+# tuple of strings: ("daily", "kl") or ("daily", "kl", "temperature_air_mean_2m")
 # Parameter: DwdObservationMetadata.daily.kl.temperature_air_mean_2m or DwdObservationMetadata["daily"]["kl"]["temperature_air_mean_2m"]  # noqa: E501, ERA001
 _PARAMETER_TYPE_SINGULAR = str | tuple[str, str] | tuple[str, str, str] | ParameterModel | DatasetModel
 _PARAMETER_TYPE = _PARAMETER_TYPE_SINGULAR | Sequence[_PARAMETER_TYPE_SINGULAR]
@@ -98,10 +98,13 @@ class TimeseriesRequest:
         # Convert timestamps
         self.start_date, self.end_date = self.convert_timestamps(self.start_date, self.end_date)
         # Parse parameters
-        if self.parameters:
-            self.parameters = parse_parameters(self.parameters, self.metadata)  # type: list[ParameterModel]
+        requested = self.parameters
+        if requested:
+            self.parameters = parse_parameters(requested, self.metadata)  # type: list[ParameterModel]
         if not self.parameters:
-            msg = "No valid parameters could be parsed from given argument"
+            # the warnings parse_parameters logged say per parameter what was wrong with it, but
+            # they are only visible to whoever configured logging, so name the request here too
+            msg = f"No valid parameters could be parsed from {requested!r} for {self.metadata.__name__}"
             raise NoParametersFoundError(msg)
 
     # Columns that should be contained within any stations information

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -104,7 +104,7 @@ class TimeseriesRequest:
         if not self.parameters:
             # the warnings parse_parameters logged say per parameter what was wrong with it, but
             # they are only visible to whoever configured logging, so name the request here too
-            msg = f"No valid parameters could be parsed from {requested!r} for {self.metadata.__name__}"
+            msg = f"No valid parameters could be parsed from {requested!r} for {type(self).__name__}"
             raise NoParametersFoundError(msg)
 
     # Columns that should be contained within any stations information

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from abc import abstractmethod
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
 from hashlib import sha256
 from typing import TYPE_CHECKING, ClassVar
@@ -99,6 +99,10 @@ class TimeseriesRequest:
         self.start_date, self.end_date = self.convert_timestamps(self.start_date, self.end_date)
         # Parse parameters
         requested = self.parameters
+        if isinstance(requested, Iterator):
+            # parse_parameters consumes an iterator, so keep the values for the message below,
+            # which would otherwise render the exhausted iterator rather than what was asked for
+            requested = list(requested)
         if requested:
             self.parameters = parse_parameters(requested, self.metadata)  # type: list[ParameterModel]
         if not self.parameters:

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field, field_validator
 # is one; model/result.py imports it from here for the same reason
 from typing_extensions import TypedDict
 
-from wetterdienst.exceptions import InvalidTimeIntervalError, StartDateEndDateError
+from wetterdienst.exceptions import InvalidTimeIntervalError, NoParametersFoundError, StartDateEndDateError
 from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.unit_type import UnitType  # noqa: TC001, needed at runtime by FastAPI
 from wetterdienst.model.metadata import parse_parameters
@@ -826,6 +826,11 @@ def _get_stations_request(
             start_date = parse_date(date)
 
     parameters = parse_parameters(request.parameters, api.metadata)
+    if not parameters:
+        # raised here rather than left to the request, which would only see the empty list this
+        # resolved to and could not name what was asked for
+        msg = f"No valid parameters could be parsed from {request.parameters!r} for {api.metadata.__name__}"
+        raise NoParametersFoundError(msg)
 
     any_date_required = any(parameter.dataset.date_required for parameter in parameters)
     if any_date_required and (not start_date or not end_date) and not isinstance(request, StationsRequest):

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -829,7 +829,7 @@ def _get_stations_request(
     if not parameters:
         # raised here rather than left to the request, which would only see the empty list this
         # resolved to and could not name what was asked for
-        msg = f"No valid parameters could be parsed from {request.parameters!r} for {api.metadata.__name__}"
+        msg = f"No valid parameters could be parsed from {request.parameters!r} for {api.__name__}"
         raise NoParametersFoundError(msg)
 
     any_date_required = any(parameter.dataset.date_required for parameter in parameters)

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -119,6 +119,15 @@ def test_api_no_valid_parameters(default_settings: Settings) -> None:
         )
 
 
+def test_api_no_valid_parameters_from_iterator(default_settings: Settings) -> None:
+    """Test that the message names the values an iterator held, not the iterator it consumed."""
+    with pytest.raises(
+        NoParametersFoundError,
+        match=re.escape("No valid parameters could be parsed from ['daily/abc'] for DwdObservationRequest"),
+    ):
+        DwdObservationRequest(parameters=iter(["daily/abc"]), settings=default_settings)
+
+
 def test_api_partly_valid_parameters(default_settings: Settings, caplog: pytest.LogCaptureFixture) -> None:
     """Test that invalid parameters are ignored."""
     request = DwdObservationRequest(

--- a/tests/core/test_api.py
+++ b/tests/core/test_api.py
@@ -2,6 +2,7 @@
 # Distributed under the MIT License. See LICENSE for more info.
 """Tests for DWD observation API."""
 
+import re
 from typing import Literal
 
 import pytest
@@ -101,8 +102,15 @@ def test_api_drop_nulls(default_settings: Settings) -> None:
 
 
 def test_api_no_valid_parameters(default_settings: Settings) -> None:
-    """Test that an error is raised when no valid parameters are found."""
-    with pytest.raises(NoParametersFoundError):
+    """Test that an error is raised when no valid parameters are found.
+
+    The message names the concrete request, not the abstract base, so it says which provider and
+    network the parameters were looked for in.
+    """
+    with pytest.raises(
+        NoParametersFoundError,
+        match=re.escape("No valid parameters could be parsed from [('daily', 'abc')] for DwdObservationRequest"),
+    ):
         DwdObservationRequest(
             parameters=[
                 ("daily", "abc"),

--- a/tests/model/test_metadata_model.py
+++ b/tests/model/test_metadata_model.py
@@ -2,8 +2,11 @@
 # Distributed under the MIT License. See LICENSE for more info.
 """Tests for metadata models."""
 
+import re
+
 import pytest
 
+from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.model.metadata import ParameterModel, ParameterSearch, parse_parameters
 from wetterdienst.provider.dwd.observation.metadata import DwdObservationMetadata
 
@@ -98,3 +101,96 @@ def test_parameter_search(value: str | ParameterModel, expected: ParameterModel)
 def test_parse_parameters(value: str | ParameterModel, expected: ParameterModel) -> None:
     """Test parsing of parameters."""
     assert parse_parameters(value, DwdObservationMetadata) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "error", "message"),
+    [
+        # too few, too many or empty parts
+        ("daily", ValueError, "expected 'resolution/dataset'"),
+        ("a/b/c/d", ValueError, "expected 'resolution/dataset'"),
+        (("daily",), ValueError, "expected 'resolution/dataset'"),
+        ("daily/", ValueError, "expected 'resolution/dataset'"),
+        # parts that are not names
+        (("daily", 1), TypeError, "expected the parts as strings, got int '1'"),
+        ((Resolution.DAILY, "climate_summary"), TypeError, "expected the parts as strings, got Resolution"),
+        (Resolution.DAILY, TypeError, "got Resolution"),
+    ],
+)
+def test_parameter_search_invalid(value: str | tuple, error: type[Exception], message: str) -> None:
+    """Test that a malformed parameter says what shape was expected instead of failing to unpack."""
+    with pytest.raises(error, match=re.escape(message)):
+        ParameterSearch.parse(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "message"),
+    [
+        ("dayly/kl", "'dayly'. Did you mean 'daily'? Available resolutions:"),
+        ("daily/klx", "'klx'. Did you mean 'kl'? Available datasets:"),
+        (
+            "daily/kl/temperature_air_mean_200",
+            "'temperature_air_mean_200'. Did you mean 'temperature_air_mean_2m'? Available parameters:",
+        ),
+        ("daily/kl/quality_wind", "'quality_wind' is a quality flag."),
+    ],
+)
+def test_parse_parameters_not_found(value: str, message: str, caplog: pytest.LogCaptureFixture) -> None:
+    """Test that a parameter that cannot be resolved is warned about with the reason."""
+    assert parse_parameters(value, DwdObservationMetadata) == []
+    assert message in caplog.text
+    assert caplog.records[0].levelname == "WARNING"
+
+
+def test_parse_parameters_deduplicated() -> None:
+    """Test that a parameter requested twice, directly and via its dataset, is only returned once."""
+    parameters = parse_parameters(
+        ["daily/climate_summary", "daily/kl", "daily/kl/temperature_air_mean_2m"],
+        DwdObservationMetadata,
+    )
+    assert parameters == [*DwdObservationMetadata.daily.climate_summary]
+
+
+def test_parse_parameters_iterator() -> None:
+    """Test that an iterator is not exhausted by the checks that classify the argument."""
+    parameters = parse_parameters(iter(["daily/kl/temperature_air_mean_2m"]), DwdObservationMetadata)
+    assert parameters == [DwdObservationMetadata.daily.climate_summary.temperature_air_mean_2m]
+
+
+def test_parse_parameters_wrong_type() -> None:
+    """Test that a parameter of an unsupported type is named as such."""
+    with pytest.raises(TypeError, match="got int"):
+        parse_parameters(1, DwdObservationMetadata)
+    with pytest.raises(TypeError, match="expected the parts as strings, got Resolution"):
+        parse_parameters([(Resolution.DAILY, "climate_summary")], DwdObservationMetadata)
+
+
+@pytest.mark.parametrize(
+    "item",
+    ["climate_summary", "CLIMATE_SUMMARY", "kl", "KL", " kl "],
+)
+def test_lookup_case_insensitive(item: str) -> None:
+    """Test that item and attribute lookup accept either name in any case."""
+    assert DwdObservationMetadata.daily[item] == DwdObservationMetadata.daily.climate_summary
+    assert getattr(DwdObservationMetadata.daily, item) == DwdObservationMetadata.daily.climate_summary
+
+
+@pytest.mark.parametrize(
+    "lookup", [lambda: DwdObservationMetadata.daily["klx"], lambda: DwdObservationMetadata.daily.klx]
+)
+def test_lookup_suggests(lookup: object) -> None:
+    """Test that a failed lookup suggests the closest name."""
+    with pytest.raises((KeyError, AttributeError), match="Did you mean 'kl'"):
+        lookup()
+
+
+def test_parse_parameters_malformed_is_skipped(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that a malformed parameter is skipped like an unknown one, not raised to the caller.
+
+    A trailing separator is easy to produce from CLI or REST input and used to be answered with
+    the whole dataset; taking the parameters listed next to it down with it would be worse than
+    either.
+    """
+    parameters = parse_parameters(["daily/kl/", "daily/solar"], DwdObservationMetadata)
+    assert parameters == [*DwdObservationMetadata.daily.solar]
+    assert "'daily/kl/' could not be parsed as a parameter" in caplog.text

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -602,6 +602,22 @@ def test_values_dwd_no_station(client: TestClient) -> None:
     )
 
 
+def test_values_dwd_no_valid_parameters(client: TestClient) -> None:
+    """Test that a parameter the provider does not have is answered with the request it was asked of."""
+    response = client.get(
+        "/api/values",
+        params={
+            "provider": "dwd",
+            "network": "observation",
+            "parameters": "daily/abc",
+            "station": "00011",
+        },
+    )
+    assert response.status_code == 400
+    assert "No valid parameters could be parsed from" in response.text
+    assert "DwdObservationRequest" in response.text
+
+
 @pytest.mark.remote
 @pytest.mark.sql
 def test_values_dwd_sql_tabular(client: TestClient) -> None:


### PR DESCRIPTION
## Why

A parameter the provider does not have was logged as one `info` line saying only that it was not found, and then left out of the request. If the rest of the request resolved, you got a smaller dataframe and no visible sign why:

```python
DwdObservationRequest(parameters=["daily/kl", "daily/kl/temperature_air_mean_200"])
# INFO: daily/kl/temperature_air_mean_200 not found in DwdObservationMetadata
```

Reviewing that path turned up five more defects of the same kind, all silent.

## What changed

**Every failed lookup says what missed.** Resolution, dataset or parameter, with the closest name and the names that would have matched, at warning level:

```
WARNING: daily/kl/temperature_air_mean_200 not found in DwdObservationMetadata:
  'temperature_air_mean_200'. Did you mean 'temperature_air_mean_2m'?
  Available parameters: wind_gust_max/fx, wind_speed/fm, …
```

`NoParametersFoundError` names the request and the provider too. The REST/CLI/MCP path raises it from `_get_stations_request`, where the parameters as the caller wrote them are still in hand — left to the request it could only see the empty list they resolved to, and `restapi.py` turns it into a 400 with that message.

**One lookup helper behind all of it.** `_find`/`_not_found` now back all six `__getitem__`/`__getattr__` methods and `search_parameter`, dropping six copies of the same message building (~60 lines) and settling two disagreements between them:

- the source's own name is matched case-insensitively everywhere, as a request string already did — `dataset["W"]` worked for WSV, `dataset["w"]` did not
- a quality flag requested by name says quality flags come back in the `quality` column next to their parameter, instead of being dropped as if it did not exist. A `ParameterModel` taken straight from the metadata model round-tripped to `[]` before

**Four more fixes:**

- parameters requested twice — a dataset and one of its parameters — are returned once instead of queried and returned per mention (`["daily/kl", "daily/kl/temperature_air_mean_2m"]` returned 15 parameters for a 14-parameter dataset)
- an iterator of parameters no longer parses as empty; it was consumed by the checks that tell `("daily", "kl")` apart from `["daily/kl", "daily/solar"]`
- the parts of a parameter must be strings, so `(Resolution.DAILY, "kl")` is a `TypeError` naming the accepted forms rather than an `AttributeError` from inside the parser. Tuples themselves stay
- a malformed entry such as a trailing separator is skipped with a warning like an unknown name, so one bad entry does not take the parameters listed next to it down with it

## Not changed

Partial resolution stays non-fatal — `["daily/kl", "daily/typo"]` still returns `kl` and warns — since `tests/core/test_api.py::test_api_partly_valid_parameters` asserts that contract. Happy to make a typo hard-fail instead if you'd rather.

A `name_original` containing a separator still cannot be addressed by path (DWD's `climate_indices/kl` dataset, POI's `sea/water_temperature`); the canonical names work, and the new error now says so explicitly rather than failing silently.

## Testing

- 19 new tests in `tests/model/test_metadata_model.py`: suggestions, dedup, iterators, enum rejection, malformed-skip, case-insensitive lookup
- full offline suite (`-m "not remote"`) green apart from two remote flakes — `opendata.dwd.de` refusing the connection and a 404 on the urban-wind history file; the CLI and interpolation failures seen in isolated runs are the same DWD throttling and pass on rerun
- `poe typecheck`, `poe lint`, `poe format` clean
- all 31 shipped provider metadata models scanned for the two hazards the new lookup could introduce — duplicate canonical names within a dataset, and case-insensitive collisions between one model's `name` and another's `name_original`. Zero of either

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vb79GWaKFu2ACYFdwHJD6W