### PR TITLE
fix(model): reject misspelled metadata keys and report the real validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Types of changes:
 - Lookups on the metadata models (`metadata["daily"]["kl"]`, `metadata.daily.kl`) match the
   source's own name case-insensitively, as looking a parameter up by its `name_original` already
   did in a request, and suggest the closest name when nothing matches
+- Provider metadata: `MetadataModel` carries the name it was built with as a `name` field, where
+  it used to be stashed on the model's `__name__`. Read `DwdObservationMetadata.name` instead of
+  `DwdObservationMetadata.__name__`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ Types of changes:
 - Parameter parsing: a quality flag requested by name (`daily/kl/quality_wind`) says that quality
   flags come back in the `quality` column next to their parameter, where it used to be dropped as
   if it did not exist. Requesting one as a `ParameterModel` was dropped the same way
+- Provider metadata: a misspelled key in a metadata declaration is rejected instead of dropped.
+  Only `ParameterModel` forbade extra keys, so `date_requiered` or `grupped` anywhere else was
+  silently ignored and the declaration fell back to a default -- a dataset quietly inheriting its
+  resolution's `date_required`. Every existing declaration passes unchanged
+- Provider metadata: an invalid `periods` or `date_required` on a resolution is reported as the
+  validation error it is, naming the value that is wrong, where the validator that cascades those
+  two fields down to the datasets used to turn it into a bare `KeyError('periods')`
 - CI: the Coolify deploy step has failed on every run since 2026-08-17, so no release or nightly
   has reached the live deployment since. Coolify moved `/api/v1/deploy` from GET to POST and left
   the GET route pointing at a stub that answers `405 This endpoint has changed to a POST request.`,

--- a/src/wetterdienst/model/metadata.py
+++ b/src/wetterdienst/model/metadata.py
@@ -216,7 +216,17 @@ class ResolutionModel(BaseModel):
         Reads the two cascading fields with ``get``: a field that failed its own validation is not
         in ``validation_info.data`` at all, and indexing it would replace pydantic's report of what
         was actually wrong -- an unknown period, say -- with a bare ``KeyError('periods')``.
+
+        A dataset that would have inherited such a field is then left out rather than validated:
+        it would otherwise be reported as missing a field it deliberately omits, once per dataset
+        -- 110 times over for one mistyped period in a `DwdPhenologyMetadata` resolution -- burying
+        the one error that is real. A dataset declaring the field itself is validated as usual, so
+        anything else wrong with it is still reported.
         """
+        if "periods" not in validation_info.data:
+            v = [dataset for dataset in v if dataset.get("periods")]
+        if "date_required" not in validation_info.data:
+            v = [dataset for dataset in v if dataset.get("date_required") is not None]
         periods = validation_info.data.get("periods")
         date_required = validation_info.data.get("date_required")
         if periods:
@@ -338,7 +348,14 @@ def build_metadata_model(metadata: dict, name: str) -> MetadataModel:
     carried. A description a provider module already declares wins, since that is a transcription of
     the source's own wording and is only kept where it says at least as much as the curated text.
     ``DERIVED_DESCRIPTIONS`` fills only what no source supplies at all.
+
+    ``name`` becomes ``MetadataModel.name``. A declaration cannot set it itself: it is the one
+    top-level key ``extra="forbid"`` does not reject, and it is a plausible one to write next to
+    ``name_short``, ``name_english`` and ``name_local``, where it would be silently overwritten.
     """
+    if "name" in metadata:
+        msg = f"{name}: 'name' is the name the model is built with and cannot be declared"
+        raise ValueError(msg)
     from wetterdienst.metadata.source_descriptions import (  # noqa: PLC0415
         DATASET_DESCRIPTIONS,
         DERIVED_DESCRIPTIONS,

--- a/src/wetterdienst/model/metadata.py
+++ b/src/wetterdienst/model/metadata.py
@@ -142,6 +142,8 @@ class ParameterModel(BaseModel):  # noqa: PLW1641
 class DatasetModel(BaseModel):  # noqa: PLW1641
     """Dataset model for a provider."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     name_original: str
     grouped: bool  # if parameters are grouped together e.g. in one file
@@ -196,6 +198,8 @@ class DatasetModel(BaseModel):  # noqa: PLW1641
 class ResolutionModel(BaseModel):
     """Resolution model for a provider."""
 
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     name_original: str
     value: Resolution = Field(alias="name", exclude=True, repr=False)  # this is just to make the code more readable
@@ -207,9 +211,14 @@ class ResolutionModel(BaseModel):
     @field_validator("datasets", mode="before")
     @classmethod
     def validate_datasets(cls, v: list[dict], validation_info: ValidationInfo) -> list[DatasetModel]:
-        """Validate datasets and set resolution for each dataset."""
-        periods = validation_info.data["periods"]
-        date_required = validation_info.data["date_required"]
+        """Validate datasets and set resolution for each dataset.
+
+        Reads the two cascading fields with ``get``: a field that failed its own validation is not
+        in ``validation_info.data`` at all, and indexing it would replace pydantic's report of what
+        was actually wrong -- an unknown period, say -- with a bare ``KeyError('periods')``.
+        """
+        periods = validation_info.data.get("periods")
+        date_required = validation_info.data.get("date_required")
         if periods:
             for dataset in v:
                 if not dataset.get("periods"):
@@ -250,6 +259,13 @@ class ResolutionModel(BaseModel):
 class MetadataModel(BaseModel):
     """Metadata model for a provider."""
 
+    model_config = ConfigDict(extra="forbid")
+
+    # the name the declaration is bound to, e.g. "DwdObservationMetadata", set by
+    # `build_metadata_model`. Unlike the three provider names below it is a name of ours, so it
+    # identifies the provider in messages about a request that could not be resolved against it
+    # but stays out of the serialized metadata.
+    name: str = Field(default="", exclude=True, repr=False)
     name_short: str
     name_english: str
     name_local: str
@@ -343,6 +359,7 @@ def build_metadata_model(metadata: dict, name: str) -> MetadataModel:
     # its monthly ones minus humidity, so annual read "Monthly mean temperature".
     metadata = {
         **metadata,
+        "name": name,
         "resolutions": [
             {
                 **resolution,
@@ -369,9 +386,7 @@ def build_metadata_model(metadata: dict, name: str) -> MetadataModel:
             for resolution in metadata["resolutions"]
         ],
     }
-    validated = MetadataModel.model_validate(metadata)
-    validated.__name__ = name  # ty: ignore[unresolved-attribute]
-    return validated
+    return MetadataModel.model_validate(metadata)
 
 
 @dataclass
@@ -456,7 +471,7 @@ def parse_parameters(parameters: _PARAMETER_TYPE, metadata: MetadataModel) -> li
             log.warning(f"{parameter!r} could not be parsed as a parameter: {e.args[0]}")
             continue
         except KeyError as e:
-            log.warning(f"{parameter_search.concat()} not found in {metadata.__name__}: {e.args[0]}")
+            log.warning(f"{parameter_search.concat()} not found in {metadata.name}: {e.args[0]}")
             continue
         for parameter_found in found:
             # requests commonly overlap e.g. a dataset and one of its parameters, which would

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -367,10 +367,31 @@ def test_metadata_model_reports_the_invalid_period() -> None:
     `validate_datasets` cascades the resolution's `periods` down to its datasets. Reading that
     field by index used to turn any error in it into `KeyError('periods')`, because pydantic drops
     a field that failed validation from the data the next validator sees.
+
+    The datasets that would have inherited it are left out of the report rather than each adding a
+    `Field required` of its own, which for a resolution the size of `DwdPhenologyMetadata`'s would
+    bury the real error under 110 misleading ones.
     """
     metadata = _minimal_metadata()
-    metadata["resolutions"][0]["periods"] = ["histerical"]
-    with pytest.raises(ValidationError, match="histerical"):
+    resolution = metadata["resolutions"][0]
+    resolution["periods"] = ["histerical"]
+    resolution["datasets"].append({**resolution["datasets"][0], "name": "other", "name_original": "other"})
+    with pytest.raises(ValidationError, match="histerical") as excinfo:
+        build_metadata_model(metadata, "ExampleMetadata")
+
+    assert excinfo.value.error_count() == 1
+
+
+def test_metadata_model_rejects_a_declared_name() -> None:
+    """Test that a declaration cannot set the name the model is built with.
+
+    `build_metadata_model` injects it, so a declaration setting it would have it silently
+    overwritten -- the one top-level key `extra="forbid"` cannot catch, and a plausible one to
+    write next to `name_short`, `name_english` and `name_local`.
+    """
+    metadata = _minimal_metadata()
+    metadata["name"] = "example"
+    with pytest.raises(ValueError, match="cannot be declared"):
         build_metadata_model(metadata, "ExampleMetadata")
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,7 +19,7 @@ from wetterdienst.metadata.parameter_table import PARAMETER_TABLE, PARAMETERS
 from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.metadata.unit_type import UnitType
-from wetterdienst.model.metadata import ParameterModel
+from wetterdienst.model.metadata import ParameterModel, build_metadata_model
 from wetterdienst.model.unit import UnitConverter
 from wetterdienst.provider.aemet.observation import AemetObservationMetadata, AemetObservationRequest
 from wetterdienst.provider.chmi.observation import ChmiObservationMetadata, ChmiObservationRequest
@@ -302,6 +302,90 @@ def test_parameter_model_unit_type_unknown_name() -> None:
         _ = parameter.unit_type
 
 
+def _minimal_metadata() -> dict:
+    """Build the smallest metadata declaration that validates, for the model tests below."""
+    return {
+        "name_short": "Example",
+        "name_english": "Example Weather Service",
+        "name_local": "Beispiel",
+        "country": "Germany",
+        "copyright": "© Example",
+        "url": "https://example.com",
+        "kind": "observation",
+        "timezone": "Europe/Berlin",
+        "resolutions": [
+            {
+                "name": "daily",
+                "name_original": "daily",
+                "periods": ["historical"],
+                "date_required": False,
+                "datasets": [
+                    {
+                        "name": "data",
+                        "name_original": "data",
+                        "grouped": True,
+                        "parameters": [
+                            {
+                                "name": "temperature_air_mean_2m",
+                                "name_original": "tt",
+                                "unit": "degree_celsius",
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("level", "key"),
+    [
+        ("metadata", "kindd"),
+        ("resolution", "date_requiered"),
+        ("dataset", "grupped"),
+    ],
+)
+def test_metadata_model_rejects_unknown_keys(level: str, key: str) -> None:
+    """Test that a misspelled key is rejected rather than dropped, at every level of the model.
+
+    Only `ParameterModel` used to forbid extra keys. Everywhere else a typo was silently ignored
+    and the declaration then fell back to a default -- a `date_requiered` dataset quietly inherits
+    the resolution's `date_required`, which is the sort of drift no test would catch.
+    """
+    metadata = _minimal_metadata()
+    resolution = metadata["resolutions"][0]
+    target = {"metadata": metadata, "resolution": resolution, "dataset": resolution["datasets"][0]}[level]
+    target[key] = True
+    with pytest.raises(ValidationError, match=key):
+        build_metadata_model(metadata, "ExampleMetadata")
+
+
+def test_metadata_model_reports_the_invalid_period() -> None:
+    """Test that an unknown period is reported as such, rather than as a missing field.
+
+    `validate_datasets` cascades the resolution's `periods` down to its datasets. Reading that
+    field by index used to turn any error in it into `KeyError('periods')`, because pydantic drops
+    a field that failed validation from the data the next validator sees.
+    """
+    metadata = _minimal_metadata()
+    metadata["resolutions"][0]["periods"] = ["histerical"]
+    with pytest.raises(ValidationError, match="histerical"):
+        build_metadata_model(metadata, "ExampleMetadata")
+
+
+def test_metadata_model_name() -> None:
+    """Test that the name a metadata model is built with is readable and stays out of the dump.
+
+    It names the provider in messages about parameters that could not be resolved against it. It
+    is the name of the declaration rather than one of the provider's own names, so it is excluded
+    from the serialized metadata.
+    """
+    metadata = build_metadata_model(_minimal_metadata(), "ExampleMetadata")
+    assert metadata.name == "ExampleMetadata"
+    assert "name" not in metadata.model_dump()
+
+
 @pytest.mark.parametrize(
     "metadata",
     ALL_METADATA,
@@ -318,7 +402,7 @@ def test_metadata_parameter_table(unit_converter_unit_type_units: dict, metadata
         for dataset in resolution:
             # iterate dataset.parameters rather than dataset, to cover quality parameters too
             for parameter in dataset.parameters:
-                site = f"{metadata.__name__} {resolution.name}/{dataset.name}/{parameter.name}"
+                site = f"{metadata.name} {resolution.name}/{dataset.name}/{parameter.name}"
                 canonical = PARAMETERS.get(parameter.name)
                 assert canonical, f"{site}: not a canonical parameter name"
                 # the source's unit must be a unit of the quantity this parameter measures
@@ -980,7 +1064,7 @@ def test_source_descriptions_reach_the_metadata() -> None:
                 for dataset in resolution
                 for parameter in dataset.parameters
             }
-            unknown.extend(sorted(set(SOURCE_DESCRIPTIONS.get(metadata.__name__, {})) - declared))
+            unknown.extend(sorted(set(SOURCE_DESCRIPTIONS.get(metadata.name, {})) - declared))
     assert not unknown, f"descriptions for parameters that no longer exist: {unknown[:5]}"
 
     parameter = DwdObservationRequest.metadata["10_minutes"]["solar"]["radiation_global"]
@@ -1023,8 +1107,8 @@ def test_source_descriptions_reach_the_parameter_they_name() -> None:
                 continue
             # a derived description only fills a gap, never displaces one the source wrote
             expected = {
-                **DERIVED_DESCRIPTIONS.get(metadata.__name__, {}),
-                **SOURCE_DESCRIPTIONS.get(metadata.__name__, {}),
+                **DERIVED_DESCRIPTIONS.get(metadata.name, {}),
+                **SOURCE_DESCRIPTIONS.get(metadata.name, {}),
             }
             for resolution in metadata:
                 for dataset in resolution:
@@ -1032,7 +1116,7 @@ def test_source_descriptions_reach_the_parameter_they_name() -> None:
                         key = (resolution.name, dataset.name, parameter.name_original)
                         if key in expected and parameter.description != expected[key]:
                             wrong.append(
-                                f"{metadata.__name__} {'/'.join(key)}: "
+                                f"{metadata.name} {'/'.join(key)}: "
                                 f"got {parameter.description!r}, expected {expected[key]!r}",
                             )
     assert not wrong, "\n".join(wrong[:10])


### PR DESCRIPTION
Three sharp edges in `model/metadata.py`, none of which a provider declaration could see going wrong. Found while reviewing whether pydantic is still the right tool for the metadata layer — it is (it is already a hard dependency via `pydantic-settings`, and validating a provider's declaration costs 0.2–1.7 ms against 261 ms to import the module it lives in), but these three were worth fixing.

### The validator masked the error it was reporting

`validate_datasets` read the two fields it cascades down to the datasets by index. A field that fails its own validation is not in `validation_info.data` at all, so

```python
"periods": ["histerical"]
```

surfaced as `KeyError: 'periods'` from inside the validator instead of pydantic's report of the value that is actually wrong. Read with `get` now, so the `ValidationError` names `histerical`.

### A misspelled key was silently dropped

Only `ParameterModel` set `extra="forbid"`. Everywhere else a typo — a dataset's `date_requiered`, a resolution's `grupped` — was ignored and the declaration then fell back to a default, which for `date_required` means quietly inheriting the resolution's. That is the sort of drift no test catches.

`extra="forbid"` on `DatasetModel`, `ResolutionModel` and `MetadataModel`. All 33 provider/network declarations pass unchanged.

### `__name__` was not a field

The name a metadata object is built with was stashed as `validated.__name__`, which only works because pydantic routes dunder names past its field machinery, and carried a `ty` ignore to say so. It is a declared field now — `exclude=True, repr=False`, injected by `build_metadata_model` alongside the descriptions — so it is typed, stays out of `model_dump()`, and survives a copy. Its one consumer (the "not found in ..." warning in `parse_parameters`) and the test sites read `metadata.name`.

### Tests

`test_metadata_model_rejects_unknown_keys` (parametrized over all three levels), `test_metadata_model_reports_the_invalid_period`, `test_metadata_model_name`.

`poe format` and `poe typecheck` clean; `tests/test_api.py tests/model tests/metadata` 344 passed and `tests/ui tests/core tests/util tests/test_io.py` 213 passed with remote tests deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BMmz23eRedUH9VTYaMQzV