### PR TITLE
fix(model): correct the ranked station walk, its geo callers and dataset grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,8 +86,16 @@ Types of changes:
   so any gap shifted every station after it onto its neighbour's location
 - Values: a request that collected nothing returns an empty frame carrying its columns rather than
   one with no columns at all, which wrote an empty file where a header was meant and raised
-  `ColumnNotFoundError` from `get_column("date")`. Having no data for the constraints given is an
-  ordinary outcome, so it is no longer logged with an exception traceback either
+  `ColumnNotFoundError` from `get_column("date")`. The columns are the ones a populated frame
+  would have had, dataset prefixes and all, in whichever shape was asked for. Having no data for
+  the constraints given is an ordinary outcome, so it is no longer logged with an exception
+  traceback either
+- Values: a ranked request no longer reads the whole provider to answer for a window that predates
+  it. A station returning nothing inside the window rightly does not count towards `rank`, but
+  then nothing bounded the walk either, so a window no station covers read every station there is.
+  A station the index says began after the window ended is now skipped without being downloaded.
+  Only that direction is read from the index: a station still reporting carries an `end_date` a
+  little behind the readings it can already answer for
 - Values: a dataset named more than once in a request -- interleaved with another, as in
   `["daily/kl/temperature_air_mean_2m", "daily/more_precip/precipitation_height",
   "daily/kl/precipitation_height"]` -- is fetched and parsed once instead of once per run of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,26 @@ Types of changes:
   which `curl --fail` turned into an exit 22 after the images had already been built and pushed.
   Both deploy calls now use POST. The images were never the problem -- every run pushed its
   manifest and passed `Inspect image` before dying on the last step
+- Ranked station values: a station whose record lies entirely outside the requested window no
+  longer counts against the station count of `filter_by_rank`. It was checked for data before the
+  window was cut and never again after, so it spent one of the ranked slots on an empty frame and
+  the walk stopped short of the stations that do cover the window -- a request for a window only
+  the more distant stations reach came back with nothing, which reads exactly like no data
+  existing at all
+- Interpolation and summarization: the values of one station are no longer read together with
+  another station's coordinates and distance. Both walks paired the distance-sorted stations frame
+  against the values generator by position, but that frame carries a row per station *and* dataset
+  while the generator yields one result per station and passes over those that returned nothing,
+  so any gap shifted every station after it onto its neighbour's location
+- Values: a request that collected nothing returns an empty frame carrying its columns rather than
+  one with no columns at all, which wrote an empty file where a header was meant and raised
+  `ColumnNotFoundError` from `get_column("date")`. Having no data for the constraints given is an
+  ordinary outcome, so it is no longer logged with an exception traceback either
+- Values: a dataset named more than once in a request -- interleaved with another, as in
+  `["daily/kl/temperature_air_mean_2m", "daily/more_precip/precipitation_height",
+  "daily/kl/precipitation_height"]` -- is fetched and parsed once instead of once per run of
+  consecutive mentions. The station index of NOAA GHCN, Geosphere and MeteoSwiss gained a
+  duplicate row per station the same way
 
 ## [0.135.0] - 2026-08-31
 

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -80,11 +80,20 @@ def request_stations(
     # yields only the stations that returned data inside the requested window, so any station it
     # passes over shifts a positional pairing by one and every station after it is then read with
     # the coordinates and distance of its neighbour
-    stations_by_id = {station["station_id"]: station for station in df_stations_ranked.iter_rows(named=True)}
+    # one row per station, the nearest: the ranked frame carries a row per station *and* dataset,
+    # so a multi-dataset request has several rows for one station, each with the coordinates and
+    # distance its own dataset's meta index reported. `query()` yields one result per station, and
+    # the row that answers for it is the closest one rather than whichever happened to sort last
+    stations_by_id = {
+        station["station_id"]: station
+        for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
+            named=True,
+        )
+    }
     tqdm_out = TqdmToLogger(log, level=logging.INFO)
     for result in tqdm(
         stations_ranked.values.query(),
-        total=len(df_stations_ranked),
+        total=len(stations_by_id),
         desc="querying stations for interpolation",
         unit="station",
         file=tqdm_out,

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -76,14 +76,20 @@ def request_stations(
     )
     stations_ranked = request.filter_by_distance(latlon=(latitude, longitude), distance=max_interp_distance)
     df_stations_ranked = stations_ranked.df
+    # looked up by station id rather than zipped against the ranked frame positionally: `query()`
+    # yields only the stations that returned data inside the requested window, so any station it
+    # passes over shifts a positional pairing by one and every station after it is then read with
+    # the coordinates and distance of its neighbour
+    stations_by_id = {station["station_id"]: station for station in df_stations_ranked.iter_rows(named=True)}
     tqdm_out = TqdmToLogger(log, level=logging.INFO)
-    for station, result in tqdm(
-        zip(df_stations_ranked.iter_rows(named=True), stations_ranked.values.query(), strict=False),
+    for result in tqdm(
+        stations_ranked.values.query(),
         total=len(df_stations_ranked),
         desc="querying stations for interpolation",
         unit="station",
         file=tqdm_out,
     ):
+        station = stations_by_id[result.df.get_column("station_id")[0]]
         valid_station_groups_exists = not get_valid_station_groups(stations_dict, utm_x, utm_y).empty()
         # check if all parameters found enough stations and the stations build a valid station group
         if len(param_dict) > 0 and all(param.finished for param in param_dict.values()) and valid_station_groups_exists:

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -60,11 +60,20 @@ def request_stations(request: TimeseriesRequest, latitude: float, longitude: flo
     # yields only the stations that returned data inside the requested window, so any station it
     # passes over shifts a positional pairing by one and every station after it is then read with
     # the coordinates and distance of its neighbour
-    stations_by_id = {station["station_id"]: station for station in df_stations_ranked.iter_rows(named=True)}
+    # one row per station, the nearest: the ranked frame carries a row per station *and* dataset,
+    # so a multi-dataset request has several rows for one station, each with the coordinates and
+    # distance its own dataset's meta index reported. `query()` yields one result per station, and
+    # the row that answers for it is the closest one rather than whichever happened to sort last
+    stations_by_id = {
+        station["station_id"]: station
+        for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
+            named=True,
+        )
+    }
     tqdm_out = TqdmToLogger(log, level=logging.INFO)
     for result in tqdm(
         stations_ranked.values.query(),
-        total=len(df_stations_ranked),
+        total=len(stations_by_id),
         desc="querying stations for summary",
         unit="station",
         file=tqdm_out,

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -56,14 +56,20 @@ def request_stations(request: TimeseriesRequest, latitude: float, longitude: flo
     )
     stations_ranked = request.filter_by_distance(latlon=(latitude, longitude), distance=distance)
     df_stations_ranked = stations_ranked.df
+    # looked up by station id rather than zipped against the ranked frame positionally: `query()`
+    # yields only the stations that returned data inside the requested window, so any station it
+    # passes over shifts a positional pairing by one and every station after it is then read with
+    # the coordinates and distance of its neighbour
+    stations_by_id = {station["station_id"]: station for station in df_stations_ranked.iter_rows(named=True)}
     tqdm_out = TqdmToLogger(log, level=logging.INFO)
-    for station, result in tqdm(
-        zip(df_stations_ranked.iter_rows(named=True), stations_ranked.values.query(), strict=False),
+    for result in tqdm(
+        stations_ranked.values.query(),
         total=len(df_stations_ranked),
         desc="querying stations for summary",
         unit="station",
         file=tqdm_out,
     ):
+        station = stations_by_id[result.df.get_column("station_id")[0]]
         # check if all parameters found enough stations and the stations build a valid station group
         if len(param_dict) > 0 and all(param.finished for param in param_dict.values()):
             break

--- a/src/wetterdienst/model/metadata.py
+++ b/src/wetterdienst/model/metadata.py
@@ -502,3 +502,28 @@ def parse_parameters(parameters: _PARAMETER_TYPE, metadata: MetadataModel) -> li
                 seen.add(key)
                 parameters_found.append(parameter_found)
     return parameters_found
+
+
+def group_parameters_by_dataset(
+    parameters: Iterable[ParameterModel],
+) -> list[tuple[DatasetModel, list[ParameterModel]]]:
+    """Group parameters by the dataset they belong to, in order of first appearance.
+
+    Not ``itertools.groupby``, which only groups *consecutive* items: ``parse_parameters`` keeps
+    the order the caller asked in, so datasets interleaved across parameters -- say
+    ``[daily/kl/temperature_air_mean_2m, daily/more_precip/..., daily/kl/precipitation_height]`` --
+    produce one group per run rather than one per dataset. Downstream that means a dataset fetched
+    and parsed once per run instead of once, and, where the groups build a stations frame, one
+    duplicated station row per extra run.
+
+    Keyed on the resolution and dataset names rather than on the model, which defines ``__eq__``
+    without ``__hash__`` and is therefore unhashable.
+    """
+    groups: dict[tuple[str, str], tuple[DatasetModel, list[ParameterModel]]] = {}
+    for parameter in parameters:
+        dataset = parameter.dataset
+        key = (dataset.resolution.name, dataset.name)
+        if key not in groups:
+            groups[key] = (dataset, [])
+        groups[key][1].append(parameter)
+    return list(groups.values())

--- a/src/wetterdienst/model/values.py
+++ b/src/wetterdienst/model/values.py
@@ -60,6 +60,18 @@ class TimeseriesValues(ABC):
 
     # Fields for type coercion, needed for separation from fields with actual data
     # that have to be parsed differently when having data in tabular form
+    # the long form every provider returns, before `_widen_df` reshapes it. Declared once so that
+    # a frame can be built in it without going through the shape-dependent property below
+    _long_fields: ClassVar = {
+        "station_id": pl.String,
+        "resolution": pl.String,
+        "dataset": pl.String,
+        "parameter": pl.String,
+        "date": pl.Datetime(time_zone="UTC"),
+        "value": pl.Float64,
+        "quality": pl.Float64,
+    }
+
     @property
     def _meta_fields(self) -> dict[str, Any]:
         """Get metadata fields for the DataFrame."""
@@ -70,15 +82,7 @@ class TimeseriesValues(ABC):
                 "dataset": pl.String,
                 "date": pl.Datetime(time_zone="UTC"),
             }
-        return {
-            "station_id": pl.String,
-            "resolution": pl.String,
-            "dataset": pl.String,
-            "parameter": pl.String,
-            "date": pl.Datetime(time_zone="UTC"),
-            "value": pl.Float64,
-            "quality": pl.Float64,
-        }
+        return dict(self._long_fields)
 
     def _get_timezone_from_station(self, station_id: str) -> str:
         """Get timezone information for explicit station.
@@ -176,6 +180,8 @@ class TimeseriesValues(ABC):
             if self.stations_counter == self.sr.rank:
                 break
             station_id = cast("str", station_id)
+            if self._begins_after_window(df_station_meta):
+                continue
             available_datasets = self._get_available_datasets(df_station_meta)
             # Collect data for this station
             df = self._filter_by_window(self._collect_station_data(station_id, available_datasets))
@@ -212,6 +218,25 @@ class TimeseriesValues(ABC):
             self.stations_collected.append(station_id)
             yield ValuesResult(stations=self.sr, values=self, df=df)
 
+    def _begins_after_window(self, df_station_meta: pl.DataFrame) -> bool:
+        """Whether the station index already says this station started after the window ended.
+
+        Asked of the index rather than of the data, because nothing else bounds the walk once a
+        station that returns nothing inside the window no longer counts towards ``rank``: a ranked
+        request for a window that predates the whole network used to stop after ``rank`` stations
+        and would otherwise download every station there is to reach the same answer.
+
+        Only this one direction is read. A ``start_date`` is a historical fact and does not move,
+        while an ``end_date`` lags on a station that is still reporting -- the index is written
+        before the day it describes is over -- so ruling a station out for having stopped too
+        early would drop live stations from a request for recent data. A bound the provider did
+        not publish, as the forecast networks do not, states nothing either way.
+        """
+        if not self.sr.end_date or "start_date" not in df_station_meta.columns:
+            return False
+        start_date = cast("dt.datetime | None", df_station_meta.get_column("start_date").min())
+        return start_date is not None and start_date > self.sr.end_date
+
     def _filter_by_window(self, df: pl.DataFrame) -> pl.DataFrame:
         """Cut a station's frame down to the window the request asked for, if it named one.
 
@@ -234,11 +259,19 @@ class TimeseriesValues(ABC):
         Shaped like a collected one would have been, so that the empty case differs from the
         populated case only in having no rows: wide for ``ts_shape="wide"``, where ``_widen_df``
         names the parameter columns from the request rather than from data it does not have.
+
+        Built in the long form and then reshaped, exactly as a collected frame is, rather than in
+        the shape asked for: `_widen_df` reads the `parameter` column that the wide form no longer
+        has, and a wide request spanning two datasets raised `ColumnNotFoundError` from inside it.
+
+        The metadata columns stay strings here. `Enum` categories are taken from the values in the
+        frame, and a frame with no rows has none to take, which leaves an `Enum([])` that says
+        less than the string it replaces and reads oddly on a schema anyone may print.
         """
-        df = pl.DataFrame(schema=self._meta_fields)
+        df = pl.DataFrame(schema=self._long_fields)
         if not self.sr.settings.ts_tidy:
             df = self._widen_df(df=df)
-        return self._cast_metadata_to_enum(df)
+        return df
 
     def _get_available_datasets(self, df: pl.DataFrame) -> list[DatasetModel]:
         """Extract available datasets for the station."""
@@ -395,6 +428,11 @@ class TimeseriesValues(ABC):
         else:
             for parameter in self.sr.parameters:
                 parameter_name = parameter.name_original if not self.sr.settings.ts_humanize else parameter.name
+                # prefixed on the same condition as the populated branch above, so that an empty
+                # frame carries the column names a populated one would have rather than the
+                # unprefixed names it used to, which named no column the request could produce
+                if len(datasets) > 1:
+                    parameter_name = f"{parameter.dataset.name}_{parameter_name}"
                 parameter_quality = f"qn_{parameter_name}"
                 df_wide = df_wide.with_columns(
                     pl.lit(None, pl.Float64).alias(parameter_name),

--- a/src/wetterdienst/model/values.py
+++ b/src/wetterdienst/model/values.py
@@ -228,6 +228,18 @@ class TimeseriesValues(ABC):
             ),
         )
 
+    def _empty_values_df(self) -> pl.DataFrame:
+        """Build the frame a request that collected nothing returns, carrying its schema.
+
+        Shaped like a collected one would have been, so that the empty case differs from the
+        populated case only in having no rows: wide for ``ts_shape="wide"``, where ``_widen_df``
+        names the parameter columns from the request rather than from data it does not have.
+        """
+        df = pl.DataFrame(schema=self._meta_fields)
+        if not self.sr.settings.ts_tidy:
+            df = self._widen_df(df=df)
+        return self._cast_metadata_to_enum(df)
+
     def _get_available_datasets(self, df: pl.DataFrame) -> list[DatasetModel]:
         """Extract available datasets for the station."""
         resolution_dataset_pairs = (
@@ -400,11 +412,16 @@ class TimeseriesValues(ABC):
         for result in tqdm(self.query(), total=len(self.sr.station_id), file=tqdm_out):
             data.append(result.df)
 
-        try:
-            df = pl.concat(data, how="diagonal")
-        except ValueError:
-            log.exception("No data available for given constraints")
-            return ValuesResult(stations=self.sr, values=self, df=pl.DataFrame())
+        if not data:
+            # an ordinary outcome -- no station covered the requested window -- rather than an
+            # error, so it is logged as one and does not print a traceback. The frame still carries
+            # its schema: a caller writes it out as a header row, asks it for a column or
+            # concatenates it against a populated frame, and none of that survives a frame with no
+            # columns at all
+            log.info("No data available for given constraints")
+            return ValuesResult(stations=self.sr, values=self, df=self._empty_values_df())
+
+        df = pl.concat(data, how="diagonal")
 
         # store the low-cardinality metadata columns as Enum to reduce the memory footprint of the
         # aggregated result; done once here on the full frame, with categories from the actual data

--- a/src/wetterdienst/model/values.py
+++ b/src/wetterdienst/model/values.py
@@ -9,7 +9,6 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from itertools import groupby
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 import polars as pl
@@ -17,13 +16,14 @@ from tqdm import tqdm
 from tzfpy import get_tz
 
 from wetterdienst.metadata.resolution import count_readings, reading_interval
+from wetterdienst.model.metadata import group_parameters_by_dataset
 from wetterdienst.model.result import StationsResult, ValuesResult
 from wetterdienst.model.unit import UnitConverter
 from wetterdienst.util.logging import TqdmToLogger
 
 if TYPE_CHECKING:
     import datetime as dt
-    from collections.abc import Callable, Iterable, Iterator
+    from collections.abc import Callable, Iterable, Iterator, Sequence
 
     from wetterdienst.model.metadata import DatasetModel, ParameterModel
 
@@ -178,18 +178,14 @@ class TimeseriesValues(ABC):
             station_id = cast("str", station_id)
             available_datasets = self._get_available_datasets(df_station_meta)
             # Collect data for this station
-            df = self._collect_station_data(station_id, available_datasets)
-            # Skip if no data found
+            df = self._filter_by_window(self._collect_station_data(station_id, available_datasets))
+            # judged after the window has been cut, not before it: a station whose record lies
+            # entirely outside the requested window returned data, but none that was asked for.
+            # Counting it as collected spent one of `filter_by_rank`'s slots on an empty frame, so
+            # the ranked walk stopped short of the stations that do cover the window and the
+            # request came back with nothing
             if df.is_empty():
                 continue
-            if self.sr.start_date:
-                df = df.filter(
-                    pl.col("date").is_between(
-                        self.sr.start_date,
-                        self.sr.end_date,
-                        closed="both",
-                    ),
-                )
             if self.sr.settings.ts_skip_empty:
                 percentage = self._get_actual_percentage(df=df)
                 if percentage < self.sr.settings.ts_skip_threshold:
@@ -216,6 +212,22 @@ class TimeseriesValues(ABC):
             self.stations_collected.append(station_id)
             yield ValuesResult(stations=self.sr, values=self, df=df)
 
+    def _filter_by_window(self, df: pl.DataFrame) -> pl.DataFrame:
+        """Cut a station's frame down to the window the request asked for, if it named one.
+
+        A frame with nothing in it is handed back untouched: a station that delivered no data at
+        all comes back as a bare frame with no ``date`` column to filter on.
+        """
+        if not self.sr.start_date or df.is_empty():
+            return df
+        return df.filter(
+            pl.col("date").is_between(
+                self.sr.start_date,
+                self.sr.end_date,
+                closed="both",
+            ),
+        )
+
     def _get_available_datasets(self, df: pl.DataFrame) -> list[DatasetModel]:
         """Extract available datasets for the station."""
         resolution_dataset_pairs = (
@@ -231,8 +243,8 @@ class TimeseriesValues(ABC):
         # self.sr.stations.parameters is parsed at runtime to a list[ParameterModel],
         # but the static type of the attribute is a union of input forms. Cast here so
         # the typechecker understands we iterate ParameterModel instances.
-        for dataset, parameters in groupby(
-            cast("Iterable[ParameterModel]", self.sr.stations.parameters), key=lambda x: x.dataset
+        for dataset, parameters in group_parameters_by_dataset(
+            cast("Iterable[ParameterModel]", self.sr.stations.parameters),
         ):
             if dataset not in available_datasets:
                 continue
@@ -242,7 +254,7 @@ class TimeseriesValues(ABC):
         return pl.concat(data) if data else pl.DataFrame()
 
     def _process_dataset(
-        self, station_id: str, dataset: DatasetModel, parameters: Iterator[ParameterModel]
+        self, station_id: str, dataset: DatasetModel, parameters: Sequence[ParameterModel]
     ) -> pl.DataFrame:
         """Process data for a specific dataset."""
         if dataset.grouped:

--- a/src/wetterdienst/provider/geosphere/observation/api.py
+++ b/src/wetterdienst/provider/geosphere/observation/api.py
@@ -8,7 +8,6 @@ import datetime as dt
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from itertools import groupby
 from typing import TYPE_CHECKING, ClassVar
 from zoneinfo import ZoneInfo
 
@@ -16,12 +15,15 @@ import polars as pl
 
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.resolution import Resolution
+from wetterdienst.model.metadata import group_parameters_by_dataset
 from wetterdienst.model.request import TimeseriesRequest
 from wetterdienst.model.values import TimeseriesValues
 from wetterdienst.provider.geosphere.observation.metadata import GeosphereObservationMetadata
 from wetterdienst.util.network import download_file
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from wetterdienst.model.metadata import ParameterModel
     from wetterdienst.settings import Settings
 
@@ -141,7 +143,7 @@ class GeosphereObservationRequest(TimeseriesRequest):
 
         settings = cast("Settings", self.settings)
         data = []
-        for dataset, _ in groupby(self.parameters, key=lambda x: x.dataset):
+        for dataset, _ in group_parameters_by_dataset(cast("Iterable[ParameterModel]", self.parameters)):
             url = self._endpoint.format(dataset=dataset.name_original)
             file = download_file(
                 url=url,

--- a/src/wetterdienst/provider/meteoswiss/observation/api.py
+++ b/src/wetterdienst/provider/meteoswiss/observation/api.py
@@ -8,18 +8,20 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from itertools import groupby
 from typing import TYPE_CHECKING, ClassVar, cast
 
 import polars as pl
 
 from wetterdienst.metadata.cache import CacheExpiry
+from wetterdienst.model.metadata import group_parameters_by_dataset
 from wetterdienst.model.request import TimeseriesRequest
 from wetterdienst.model.values import TimeseriesValues
 from wetterdienst.provider.meteoswiss.observation.metadata import MeteoswissObservationMetadata
 from wetterdienst.util.network import download_file
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from wetterdienst.model.metadata import DatasetModel, ParameterModel
     from wetterdienst.settings import Settings
 
@@ -374,7 +376,7 @@ class MeteoswissObservationRequest(TimeseriesRequest):
             .alias("start_date"),
         )
         data = []
-        for dataset, _ in groupby(self.parameters, key=lambda x: x.dataset):
+        for dataset, _ in group_parameters_by_dataset(cast("Iterable[ParameterModel]", self.parameters)):
             data.append(
                 df.with_columns(
                     pl.lit(dataset.resolution.name, dtype=pl.String).alias("resolution"),

--- a/src/wetterdienst/provider/noaa/ghcn/api.py
+++ b/src/wetterdienst/provider/noaa/ghcn/api.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from itertools import groupby
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -14,6 +13,7 @@ import polars.selectors as cs
 
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.resolution import Resolution
+from wetterdienst.model.metadata import group_parameters_by_dataset
 from wetterdienst.model.request import TimeseriesRequest
 from wetterdienst.model.values import TimeseriesValues
 from wetterdienst.provider.noaa.ghcn.metadata import (
@@ -24,7 +24,9 @@ from wetterdienst.util.network import download_file
 from wetterdienst.util.polars_util import read_fwf_from_df
 
 if TYPE_CHECKING:
-    from wetterdienst.model.metadata import DatasetModel
+    from collections.abc import Iterable
+
+    from wetterdienst.model.metadata import DatasetModel, ParameterModel
     from wetterdienst.settings import Settings
 
 log = logging.getLogger(__name__)
@@ -192,8 +194,10 @@ class NoaaGhcnRequest(TimeseriesRequest):
     _values = NoaaGhcnValues
 
     def _all(self) -> pl.LazyFrame:
+        from typing import cast  # noqa: PLC0415
+
         data = []
-        for dataset, _ in groupby(self.parameters, key=lambda x: x.dataset):
+        for dataset, _ in group_parameters_by_dataset(cast("Iterable[ParameterModel]", self.parameters)):
             if dataset.resolution.value == Resolution.HOURLY:
                 data.append(self._create_metaindex_for_ghcn_hourly())
             elif dataset.resolution.value == Resolution.DAILY:

--- a/tests/model/test_metadata_model.py
+++ b/tests/model/test_metadata_model.py
@@ -7,7 +7,12 @@ import re
 import pytest
 
 from wetterdienst.metadata.resolution import Resolution
-from wetterdienst.model.metadata import ParameterModel, ParameterSearch, parse_parameters
+from wetterdienst.model.metadata import (
+    ParameterModel,
+    ParameterSearch,
+    group_parameters_by_dataset,
+    parse_parameters,
+)
 from wetterdienst.provider.dwd.observation.metadata import DwdObservationMetadata
 
 
@@ -194,3 +199,27 @@ def test_parse_parameters_malformed_is_skipped(caplog: pytest.LogCaptureFixture)
     parameters = parse_parameters(["daily/kl/", "daily/solar"], DwdObservationMetadata)
     assert parameters == [*DwdObservationMetadata.daily.solar]
     assert "'daily/kl/' could not be parsed as a parameter" in caplog.text
+
+
+def test_group_parameters_by_dataset_groups_a_dataset_asked_for_twice() -> None:
+    """A dataset interleaved with another must form one group, not one per run.
+
+    ``parse_parameters`` keeps the order the caller asked in, so ``itertools.groupby`` -- which
+    only groups consecutive items -- split ``climate_summary`` into two groups here. Downstream
+    that fetched and parsed it twice, and put a duplicate station row in the frames built from it.
+    """
+    parameters = parse_parameters(
+        [
+            "daily/kl/temperature_air_mean_2m",
+            "daily/more_precip/precipitation_height",
+            "daily/kl/precipitation_height",
+        ],
+        DwdObservationMetadata,
+    )
+
+    groups = group_parameters_by_dataset(parameters)
+
+    assert [(dataset.name, [parameter.name for parameter in grouped]) for dataset, grouped in groups] == [
+        ("climate_summary", ["temperature_air_mean_2m", "precipitation_height"]),
+        ("precipitation_more", ["precipitation_height"]),
+    ]

--- a/tests/model/test_values.py
+++ b/tests/model/test_values.py
@@ -479,36 +479,51 @@ def _stub_dwd_daily(
     station_ids: list[str],
     data_year_by_station: dict[str, int],
     monkeypatch: pytest.MonkeyPatch,
+    datasets: list[str] | None = None,
+    collected: list[str] | None = None,
+    index_start: dt.datetime | None = None,
+    index_end: dt.datetime | None = None,
 ) -> None:
-    """Stand in for DWD's station index and data files, so the walk can be exercised offline."""
+    """Stand in for DWD's station index and data files, so the walk can be exercised offline.
+
+    The index range defaults wide enough to cover any window a test asks for, so that what the
+    index says and what the files hold can be varied independently -- a station whose published
+    range covers a window it has no readings in is the ordinary case, not a contradiction.
+    """
     utc = ZoneInfo("UTC")
+    datasets = datasets or ["climate_summary"]
+    rows = [(station_id, dataset) for station_id in station_ids for dataset in datasets]
     df_stations = pl.DataFrame(
         {
-            "resolution": ["daily"] * len(station_ids),
-            "dataset": ["climate_summary"] * len(station_ids),
-            "station_id": station_ids,
-            "start_date": [dt.datetime(1990, 1, 1, tzinfo=utc)] * len(station_ids),
-            "end_date": [dt.datetime(2020, 1, 1, tzinfo=utc)] * len(station_ids),
+            "resolution": ["daily"] * len(rows),
+            "dataset": [dataset for _, dataset in rows],
+            "station_id": [station_id for station_id, _ in rows],
+            "start_date": [index_start or dt.datetime(1900, 1, 1, tzinfo=utc)] * len(rows),
+            "end_date": [index_end or dt.datetime(2030, 1, 1, tzinfo=utc)] * len(rows),
             # spread along a meridian so the distance ranking follows the list order
-            "latitude": [50.0 + index / 10 for index in range(len(station_ids))],
-            "longitude": [8.0] * len(station_ids),
-            "height": [100.0] * len(station_ids),
-            "name": station_ids,
-            "state": ["x"] * len(station_ids),
+            "latitude": [50.0 + station_ids.index(station_id) / 10 for station_id, _ in rows],
+            "longitude": [8.0] * len(rows),
+            "height": [100.0] * len(rows),
+            "name": [station_id for station_id, _ in rows],
+            "state": ["x"] * len(rows),
         },
     )
     monkeypatch.setattr(DwdObservationRequest, "_all", lambda self: df_stations.lazy())  # noqa: ARG005
 
     def collect(self, station_id: str, parameter_or_dataset) -> pl.DataFrame:  # noqa: ANN001, ARG001
+        if collected is not None:
+            collected.append(station_id)
         year = data_year_by_station[station_id]
+        dataset = getattr(parameter_or_dataset, "dataset", parameter_or_dataset)
+        names = [parameter.name_original for parameter in dataset]
         return pl.DataFrame(
             {
-                "date": [dt.datetime(year, 1, day, tzinfo=utc) for day in range(1, 4)],
-                "parameter": ["tmk"] * 3,
-                "value": [1.0] * 3,
-                "quality": [1.0] * 3,
-                "resolution": ["daily"] * 3,
-                "dataset": ["climate_summary"] * 3,
+                "date": [dt.datetime(year, 1, day, tzinfo=utc) for day in range(1, 4) for _ in names],
+                "parameter": names * 3,
+                "value": [1.0] * (3 * len(names)),
+                "quality": [1.0] * (3 * len(names)),
+                "resolution": ["daily"] * (3 * len(names)),
+                "dataset": [dataset.name] * (3 * len(names)),
             },
         )
 
@@ -561,3 +576,88 @@ def test_a_request_that_collects_nothing_keeps_its_schema(monkeypatch: pytest.Mo
     # a header rather than an empty file, and a column that can still be asked for
     assert df.write_csv() == "station_id,resolution,dataset,parameter,date,value,quality\n"
     assert df.get_column("date").is_empty()
+
+
+def test_wide_empty_result_matches_the_shape_of_a_populated_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wide request spanning two datasets returns the columns it would have, not an error.
+
+    ``_widen_df`` reads the ``parameter`` column, which the wide form does not have, so building
+    the empty frame in the shape asked for raised ``ColumnNotFoundError`` from inside it.
+    """
+    _stub_dwd_daily(
+        station_ids=["00001"],
+        data_year_by_station={"00001": 1990},
+        monkeypatch=monkeypatch,
+        datasets=["climate_summary", "precipitation_more"],
+    )
+    parameters = ["daily/kl/temperature_air_mean_2m", "daily/more_precip/precipitation_height"]
+    settings = {"ts_shape": "wide"}
+
+    empty = (
+        DwdObservationRequest(parameters=parameters, start_date="1930-01-01", end_date="1930-12-31", settings=settings)
+        .filter_by_station_id("00001")
+        .values.all()
+        .df
+    )
+    populated = (
+        DwdObservationRequest(parameters=parameters, start_date="1990-01-01", end_date="1990-12-31", settings=settings)
+        .filter_by_station_id("00001")
+        .values.all()
+        .df
+    )
+
+    assert empty.is_empty()
+    assert not populated.is_empty()
+    # including the dataset prefix the populated frame carries, which the empty one used to omit
+    assert empty.columns == populated.columns
+    assert "climate_summary_temperature_air_mean_2m" in empty.columns
+
+
+def test_a_station_that_started_after_the_window_is_not_downloaded(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The index answers for a window a station cannot cover, so the walk stays bounded.
+
+    Nothing bounds the ranked walk once a station returning nothing inside the window no longer
+    counts towards ``rank``, so it would otherwise read every station in the provider.
+    """
+    station_ids = [f"{index:05d}" for index in range(1, 21)]
+    _stub_dwd_daily(
+        station_ids=station_ids,
+        data_year_by_station=dict.fromkeys(station_ids, 1990),
+        monkeypatch=monkeypatch,
+        collected=(collected := []),
+        index_start=dt.datetime(1990, 1, 1, tzinfo=ZoneInfo("UTC")),
+    )
+    request = DwdObservationRequest(
+        parameters=[("daily", "climate_summary", "temperature_air_mean_2m")],
+        start_date="1930-01-01",
+        end_date="1930-12-31",
+    )
+
+    request.filter_by_rank(latlon=(50.0, 8.0), rank=5).values.all()
+
+    # the stub's stations all start in 1990, so the index alone rules the 1930 window out
+    assert collected == []
+
+
+def test_a_station_still_reporting_is_not_ruled_out_by_a_lagging_end_date(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the start of a record rules a window out; an `end_date` lags on a live station.
+
+    A station index is written before the day it describes is over, so a station that is still
+    reporting carries an `end_date` a little behind the readings it can already answer for.
+    """
+    _stub_dwd_daily(
+        station_ids=["00001"],
+        data_year_by_station={"00001": 2020},
+        monkeypatch=monkeypatch,
+        # the index stops a year before the window, but the station does have the readings
+        index_end=dt.datetime(2019, 1, 1, tzinfo=ZoneInfo("UTC")),
+    )
+    request = DwdObservationRequest(
+        parameters=[("daily", "climate_summary", "temperature_air_mean_2m")],
+        start_date="2020-01-01",
+        end_date="2020-12-31",
+    )
+
+    df = request.filter_by_station_id("00001").values.all().df
+
+    assert df.height == 3

--- a/tests/model/test_values.py
+++ b/tests/model/test_values.py
@@ -472,3 +472,92 @@ def test_actual_percentage_matches_a_parameter_name_in_the_provider_own_casing()
     )
 
     assert _percentage(values, df) == 1.0
+
+
+def _stub_dwd_daily(
+    *,
+    station_ids: list[str],
+    data_year_by_station: dict[str, int],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stand in for DWD's station index and data files, so the walk can be exercised offline."""
+    utc = ZoneInfo("UTC")
+    df_stations = pl.DataFrame(
+        {
+            "resolution": ["daily"] * len(station_ids),
+            "dataset": ["climate_summary"] * len(station_ids),
+            "station_id": station_ids,
+            "start_date": [dt.datetime(1990, 1, 1, tzinfo=utc)] * len(station_ids),
+            "end_date": [dt.datetime(2020, 1, 1, tzinfo=utc)] * len(station_ids),
+            # spread along a meridian so the distance ranking follows the list order
+            "latitude": [50.0 + index / 10 for index in range(len(station_ids))],
+            "longitude": [8.0] * len(station_ids),
+            "height": [100.0] * len(station_ids),
+            "name": station_ids,
+            "state": ["x"] * len(station_ids),
+        },
+    )
+    monkeypatch.setattr(DwdObservationRequest, "_all", lambda self: df_stations.lazy())  # noqa: ARG005
+
+    def collect(self, station_id: str, parameter_or_dataset) -> pl.DataFrame:  # noqa: ANN001, ARG001
+        year = data_year_by_station[station_id]
+        return pl.DataFrame(
+            {
+                "date": [dt.datetime(year, 1, day, tzinfo=utc) for day in range(1, 4)],
+                "parameter": ["tmk"] * 3,
+                "value": [1.0] * 3,
+                "quality": [1.0] * 3,
+                "resolution": ["daily"] * 3,
+                "dataset": ["climate_summary"] * 3,
+            },
+        )
+
+    monkeypatch.setattr(DwdObservationValues, "_collect_station_parameter_or_dataset", collect)
+
+
+def test_rank_is_not_spent_on_a_station_whose_data_misses_the_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A station with no reading inside the window must not consume one of ``rank``'s slots.
+
+    The two nearest stations hold data, but only outside the requested window; the third does
+    cover it. Counting the near two as collected stopped the ranked walk before the third and
+    returned nothing at all.
+    """
+    _stub_dwd_daily(
+        station_ids=["00001", "00002", "00003"],
+        data_year_by_station={"00001": 1990, "00002": 1990, "00003": 1930},
+        monkeypatch=monkeypatch,
+    )
+    request = DwdObservationRequest(
+        parameters=[("daily", "climate_summary", "temperature_air_mean_2m")],
+        start_date="1930-01-01",
+        end_date="1930-12-31",
+    )
+
+    values = request.filter_by_rank(latlon=(50.0, 8.0), rank=2).values
+    df = values.all().df
+
+    assert values.stations_collected == ["00003"]
+    assert df.get_column("station_id").unique().to_list() == ["00003"]
+    assert df.height == 3
+
+
+def test_a_request_that_collects_nothing_keeps_its_schema(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty result is still shaped like a populated one, so it can be written or read from."""
+    _stub_dwd_daily(
+        station_ids=["00001"],
+        data_year_by_station={"00001": 1990},
+        monkeypatch=monkeypatch,
+    )
+    request = DwdObservationRequest(
+        parameters=[("daily", "climate_summary", "temperature_air_mean_2m")],
+        start_date="1930-01-01",
+        end_date="1930-12-31",
+    )
+
+    df = request.filter_by_station_id("00001").values.all().df
+
+    assert df.is_empty()
+    assert df.columns == ["station_id", "resolution", "dataset", "parameter", "date", "value", "quality"]
+    # a header rather than an empty file, and a column that can still be asked for
+    assert df.write_csv() == "station_id,resolution,dataset,parameter,date,value,quality\n"
+    assert df.get_column("date").is_empty()


### PR DESCRIPTION
Bugs found while reviewing `TimeseriesRequest` / `TimeseriesValues`, the caller fixes they force, and tests for all of it. Four commits; every claim below was reproduced before being fixed.

## 1. A station outside the requested window spent a rank slot

`TimeseriesValues.query` checked a station's frame for emptiness *before* cutting it down to the requested window, and never again after. A station whose record lies entirely outside that window therefore counted as collected and was yielded as an empty frame — which spends one of `filter_by_rank`'s slots. The ranked walk then stopped short of the stations that do cover the window and the request came back with nothing, indistinguishable to the caller from "no data exists".

This contradicts `filter_by_rank`'s own docstring: *"Value collection walks the distance-sorted stations and stops once `rank` stations that returned anything have been consumed."* `ts_skip_empty` masked it, but that defaults to `False`.

| | `stations_collected` | rows |
|---|---|---|
| before | `['00001', '00002']` | 0 |
| after | `['00003']` | 3 |

The window filter moves into `_filter_by_window`, which hands back a frame with no data untouched — a station that delivered nothing has no `date` column to filter on.

## 2. `core/interpolate.py` and `core/summarize.py` paired stations positionally

Both zipped the distance-sorted stations frame against the `query()` generator:

```python
zip(df_stations_ranked.iter_rows(named=True), stations_ranked.values.query(), strict=False)
```

`query()` has always been free to pass a station over, so this was already fragile; fix 1 makes it pass over more of them. A skipped station shifts every station after it onto its neighbour's coordinates and distance, and `strict=False` drops the trailing result silently.

Confirmed against live DWD data (`hourly/precipitation`, 2022-01-01..20, 25 km around 52.8/12.9) — the ranked frame held five stations, `query()` yielded four:

```
ranked  : ['02733', '03552', '00096', '05825', '03205']
yielded : ['02733',          '00096', '05825', '03205']
   02733 -> 02733   OK
   03552 -> 00096   <<< MISALIGNED
   00096 -> 05825   <<< MISALIGNED
   05825 -> 03205   <<< MISALIGNED
```

So `03552`'s location was being read together with `00096`'s values, and `03205` was dropped entirely. Both call sites now look the station up by id.

The ranked frame carries a row per station **and dataset**, each with the coordinates that dataset's meta index reported, so the lookup is deduplicated to the nearest row per station rather than whichever sorts last. That also gives the progress bar the station count it means, instead of the inflated station×dataset one.

## 3. `itertools.groupby` produced one group per run, not per dataset

`groupby` only groups *consecutive* items, but `parse_parameters` keeps the order the caller asked in. So `[daily/kl/temperature_air_mean_2m, daily/more_precip/precipitation_height, daily/kl/precipitation_height]` produced three groups over two datasets.

- `_collect_station_data` — fetched and parsed `climate_summary` twice (verified: 2 collect calls → 1, all three parameters still returned).
- `_all()` in NOAA GHCN, Geosphere and MeteoSwiss — put a **duplicate station row** in the stations frame per extra run.

All four now share `group_parameters_by_dataset`, keyed on the resolution and dataset names (the model defines `__eq__` without `__hash__`, so it is unhashable) and preserving first-appearance order. Météo-France had already fixed this inline in its own `_all`; that copy is left as it is, so the rule now lives in three places and is worth consolidating in a follow-up.

## 4. The empty-result path (fixes 4a–4c came out of review of this PR)

Fix 1 meant a request where no station covers the window reaches `all()` with nothing to concatenate. On `main` that already returned a frame with **no columns at all** whenever no station yielded anything — it writes an empty file where a header was meant, and `get_column("date")` raises `ColumnNotFoundError`. `_empty_values_df` now rebuilds the frame the request would have produced, and the branch logs an info line rather than an exception traceback, this being an ordinary outcome.

Three defects in that first attempt, all caught in review and fixed here:

**4a.** It built the frame in the shape asked for and handed it to `_widen_df`, which reads the `parameter` column the wide form does not have. A wide request naming two datasets over an uncovered window raised `ColumnNotFoundError` out of `.all()` — a crash where there had been a quiet empty frame. It is now built in the long form and reshaped, exactly as a collected frame is.

**4b.** `_widen_df`'s empty branch named its parameter columns without the dataset prefix its populated branch applies, so the empty frame of a multi-dataset request named no column that request could produce. Both branches now prefix on the same condition; empty and populated frames come out with equal columns in either shape.

**4c.** The metadata columns are no longer cast to `Enum` on an empty frame — categories come from the values present, and with no rows that leaves an `Enum([])`. Note this does **not** make the frame concatenable with a populated one: two *populated* results already are not, since each takes its categories from its own data. That claim was dropped from the changelog rather than repaired.

## 5. Fix 1 also removed the only bound on the ranked walk

The walk stops on `rank` stations that returned something; a station returning nothing inside the window rightly no longer counts, and then nothing bounded it. A window no station covers therefore read **every station in the provider** — 50 of 50 for `rank=5` in the offline probe, and a thousand-plus files against real DWD.

A station the index says began after the window ended is now skipped without being downloaded, which takes that probe to 0. Only that direction is read: a station still reporting carries an `end_date` a little behind the readings it can already answer for, so ruling one out for having stopped too early would drop live stations from a request for recent data. The forecast networks (`dwd/mosmix`, `dwd/dmo`, `dwd/poi`) publish neither bound and are untouched.

## Tests

Six offline tests using a stubbed station index and collector — no network. The stub varies what the index publishes independently of what the files hold, since a station whose published range covers a window it has no readings in is the ordinary case.

- `test_rank_is_not_spent_on_a_station_whose_data_misses_the_window`
- `test_a_request_that_collects_nothing_keeps_its_schema`
- `test_wide_empty_result_matches_the_shape_of_a_populated_one`
- `test_a_station_that_started_after_the_window_is_not_downloaded`
- `test_a_station_still_reporting_is_not_ruled_out_by_a_lagging_end_date`
- `test_group_parameters_by_dataset_groups_a_dataset_asked_for_twice`

Each was run against the code it describes, not only against the fix: the rank test fails on `main`; the schema test fails on commit 1; the wide-crash and unbounded-walk tests fail on commit 2.

## Verification

- `poe format`, `poe lint`, `poe typecheck` — clean.
- `pytest -m "not remote"` — **900 passed**.

### `tests/core/test_interpolation.py` (remote, hits live DWD) — resolved on CI

Local runs were heavily throttled by opendata.dwd.de (30s stalls, `stamina` retries, hard download failures, 444s for two tests) and produced a failure set that changed between runs. CI settles it: **every interpolation and summary test passes**, including the two that failed locally.

| test | local | CI |
|---|---|---|
| `test_interpolation_increased_station_distance` | fixed by this PR | ✅ |
| `test_interpolation_precipitation_height_minute_10` | passes | ✅ |
| `test_interpolation_sunshine_duration_daily` | flaky (empty station list) | ✅ |
| `test_interpolation_temperature_air_mean_2m_hourly_by_coords` | drifting value, fails on `main` too | ✅ |
| `test_provider_dwd_mosmix` | `FSTimeoutError` / `StopIteration` | ✅ |

Full matrix green on Python 3.10–3.14 across ubuntu, macos and windows, plus coverage, minimum dependency versions, E2E, CodeQL, lint, typecheck and docs. The one red job, `Python 3.14 on ubuntu-latest`, is `tests/test_api.py::test_api_eaufrance_hubeau` failing with `FileNotFoundError` on a live Hubeau API URL — an unrelated provider being unreachable, with 1433 passed alongside it.

### Noticed, not fixed (pre-existing, out of scope)

`filter_by_distance` on an empty station index calls `filter_by_rank(latlon, 0)` and surfaces as `ValueError: 'rank' has to be at least 1.`, which says nothing about the real cause — the provider returned no stations. Worth a clearer error in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01148A4dug6LTPkgqcoZjRqx
