### PR TITLE
feat(model)!: resolve periods against the metadata on every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ Types of changes:
   than the provider-wide set it used to be. `TimeseriesRequest.available_periods()` reports the
   provider's periods; the per-provider `_available_periods` class attributes it replaces were an
   exact copy of what the metadata already said
+- Periods: narrowing the periods of a provider that does not read its data per period -- SMHI,
+  MeteoSwiss, met.no Frost and Meteo-France observation declare datasets with more than one period
+  but fetch all of them by design -- is logged as a warning saying the request was not narrowed,
+  rather than answered with everything in silence
 
 ### Fixed
 
@@ -117,6 +121,12 @@ Types of changes:
   CLI's `--periods` and the REST API's `periods` were dropped for every provider but DWD
   observation, derived and phenology -- including met.no Frost, whose datasets are published under
   both `historical` and `recent`
+- Periods: a period derived from `start_date`/`end_date` is checked against the datasets like a
+  requested one is. An interval reaching into today derives `now`, which `daily/kl` has no release
+  for, and the request then read no station index at all -- `DwdObservationRequest` for today's
+  `daily/kl` reported *no stations*, where asking for `periods="now"` outright raises for the same
+  datasets. Where the interval reaches past the newest release a dataset has, that release answers
+  for it
 - Periods: an explicit period is answered for a dataset published under a single one. The CLI and
   REST API forwarded `periods` only when some requested dataset had more than one, so asking DWD
   derived for `historical` on `monthly/climate_correction_factor` -- a `recent`-only dataset --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,16 @@ Types of changes:
 - Provider metadata: `MetadataModel` carries the name it was built with as a `name` field, where
   it used to be stashed on the model's `__name__`. Read `DwdObservationMetadata.name` instead of
   `DwdObservationMetadata.__name__`
+- Periods: `periods` is an argument of every request rather than of the three that hand-rolled it,
+  and is resolved against the periods the requested datasets declare in the metadata. A dataset
+  published under a single period has nothing to choose between, so asking for that period is
+  answered and asking for another one raises `NoPeriodsFoundError` naming what is available.
+  Left out, the periods are still derived from `start_date`/`end_date` where the provider has a
+  release schedule to derive them from -- DWD observation and DWD phenology -- and are otherwise
+  every period the requested datasets publish, which for a request naming one dataset is narrower
+  than the provider-wide set it used to be. `TimeseriesRequest.available_periods()` reports the
+  provider's periods; the per-provider `_available_periods` class attributes it replaces were an
+  exact copy of what the metadata already said
 
 ### Fixed
 
@@ -96,6 +106,22 @@ Types of changes:
   A station the index says began after the window ended is now skipped without being downloaded.
   Only that direction is read from the index: a station still reporting carries an `end_date` a
   little behind the readings it can already answer for
+- Periods: a period no requested dataset publishes is no longer silently turned into *every*
+  period. `DwdObservationRequest(parameters=["daily/kl"], periods="future")` intersected the
+  request with the available periods, and the empty result then read as "no periods requested", so
+  asking for a period that does not exist returned more data than asking for one that does. It
+  raises `NoPeriodsFoundError` now, and a period dropped from a request that keeps others is
+  logged as a warning naming it
+- Periods: `periods` reaches providers that never accepted the argument. It was a per-provider
+  constructor field, so `NoaaGhcnRequest(..., periods="historical")` was a `TypeError`, and the
+  CLI's `--periods` and the REST API's `periods` were dropped for every provider but DWD
+  observation, derived and phenology -- including met.no Frost, whose datasets are published under
+  both `historical` and `recent`
+- Periods: an explicit period is answered for a dataset published under a single one. The CLI and
+  REST API forwarded `periods` only when some requested dataset had more than one, so asking DWD
+  derived for `historical` on `monthly/climate_correction_factor` -- a `recent`-only dataset --
+  read every period the provider has instead of reporting that the dataset has no historical
+  release
 - Values: a dataset named more than once in a request -- interleaved with another, as in
   `["daily/kl/temperature_air_mean_2m", "daily/more_precip/precipitation_height",
   "daily/kl/precipitation_height"]` -- is fetched and parsed once instead of once per run of

--- a/docs/usage/python-api.md
+++ b/docs/usage/python-api.md
@@ -138,8 +138,11 @@ DwdObservationRequest(
 )
 ```
 
-For some weather service one can select which period of the data is request with ``periods``.
-Valid periods are ``historical``, ``recent`` and ``now``. ``periods`` can be given as a list or a single value.
+Every request takes ``periods``, the release the data is read from. Valid periods are
+``historical``, ``recent``, ``now`` and ``future``, and which of them a dataset is published under
+is part of its metadata. A dataset published under a single period has nothing to choose between,
+so asking for another one is an error naming the periods it does have, rather than a request that
+quietly reads all of them. ``periods`` can be given as a list or a single value.
 The value can be a string, the enumeration value or the enumeration name e.g.
 
 - by using the exact enumeration e.g.
@@ -160,9 +163,11 @@ Period.HISTORICAL
 "historical" or "HISTORICAL"
 ```
 
-If a weather service has periods, the period argument typically can be used as replacement
-for the start_date and end_date arguments. In case both arguments are given they are used
-as a filter for the data.
+The period argument typically can be used as replacement for the start_date and end_date
+arguments. In case both arguments are given they are used as a filter for the data. Left out, the
+periods are derived from ``start_date``/``end_date`` where the provider publishes on a release
+schedule that says which period holds which years -- DWD observation and DWD phenology do -- and
+are otherwise every period the requested datasets publish.
 
 Regarding the definition of requested parameters:
 

--- a/src/wetterdienst/exceptions.py
+++ b/src/wetterdienst/exceptions.py
@@ -11,6 +11,10 @@ class NoParametersFoundError(ValueError):
     """Raised when no parameters are found."""
 
 
+class NoPeriodsFoundError(ValueError):
+    """Raised when none of the requested periods is published for the requested datasets."""
+
+
 class MetaFileNotFoundError(FileNotFoundError):
     """Raised when a meta file is not found."""
 

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import datetime as dt
 import logging
 from abc import abstractmethod
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
 from hashlib import sha256
 from typing import TYPE_CHECKING, ClassVar
@@ -22,10 +22,12 @@ from rapidfuzz import utils as fuzz_utils
 
 from wetterdienst.exceptions import (
     NoParametersFoundError,
+    NoPeriodsFoundError,
     StartDateEndDateError,
     StationNotFoundError,
 )
 from wetterdienst.metadata.parameter_table import INTERPOLATABLE_PARAMETERS
+from wetterdienst.metadata.period import Period
 from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.model.metadata import (
     DatasetModel,
@@ -41,6 +43,7 @@ from wetterdienst.model.result import (
     SummarizedValuesResult,
 )
 from wetterdienst.settings import Settings
+from wetterdienst.util.enumeration import parse_enumeration_from_template
 from wetterdienst.util.python import to_list
 
 try:
@@ -65,6 +68,17 @@ EARTH_RADIUS_KM = 6371
 _PARAMETER_TYPE_SINGULAR = str | tuple[str, str] | tuple[str, str, str] | ParameterModel | DatasetModel
 _PARAMETER_TYPE = _PARAMETER_TYPE_SINGULAR | Sequence[_PARAMETER_TYPE_SINGULAR]
 _DATETIME_TYPE = str | dt.datetime | None
+# either of
+# str: "recent"  # noqa: ERA001
+# Period: Period.RECENT  # noqa: ERA001
+# an iterable of either: ["historical", "recent"] or {Period.HISTORICAL, Period.RECENT}
+_PERIOD_TYPE_SINGULAR = str | Period
+_PERIODS_TYPE = _PERIOD_TYPE_SINGULAR | Iterable[_PERIOD_TYPE_SINGULAR] | None
+
+
+def _format_periods(periods: Iterable[Period]) -> str:
+    """Name periods the way they are requested, oldest first."""
+    return ", ".join(period.value for period in sorted(periods))
 
 
 @dataclass
@@ -84,6 +98,11 @@ class TimeseriesRequest:
     start_date: _DATETIME_TYPE = None
     end_date: _DATETIME_TYPE = None
     settings: Settings | dict = field(default_factory=Settings)
+    # The periods to read. Every provider publishes its datasets under one or more of them, so this
+    # is accepted everywhere and resolved in __post_init__ to the set actually served -- see
+    # `_resolve_periods`. A dataset published under a single period has nothing to choose between;
+    # asking for another one is an error rather than a silently widened request.
+    periods: _PERIODS_TYPE = None
 
     def __post_init__(self) -> None:
         """Post init method to validate the settings and convert the timestamps."""
@@ -110,6 +129,9 @@ class TimeseriesRequest:
             # they are only visible to whoever configured logging, so name the request here too
             msg = f"No valid parameters could be parsed from {requested!r} for {type(self).__name__}"
             raise NoParametersFoundError(msg)
+        # Has to follow the parameters, which say which datasets -- and so which periods -- were
+        # asked for, and the timestamps, which a provider may derive the periods from
+        self.periods = self._resolve_periods(self.periods)
 
     # Columns that should be contained within any stations information
     _base_columns: ClassVar = (
@@ -129,6 +151,60 @@ class TimeseriesRequest:
     # quantity rather than of a request -- see `CanonicalParameter.interpolation`. Kept here as a
     # class attribute because that is where callers look for it.
     interpolatable_parameters: ClassVar = INTERPOLATABLE_PARAMETERS
+
+    @classmethod
+    def available_periods(cls) -> set[Period]:
+        """Periods the provider publishes, across all of its datasets."""
+        return {period for resolution in cls.metadata for dataset in resolution for period in dataset.periods}
+
+    @property
+    def published_periods(self) -> set[Period]:
+        """Periods published for the datasets this request resolved to."""
+        return {
+            period
+            for parameter in self.parameters
+            if isinstance(parameter, ParameterModel)
+            for period in parameter.dataset.periods
+        }
+
+    def _get_periods(self) -> set[Period] | None:
+        """Derive the periods from the requested interval.
+
+        ``None`` -- the default -- means the provider has no release schedule to derive them from,
+        so the request falls back to every period its datasets publish. A provider that does know
+        one returns the periods the interval reaches, which may legitimately be empty for an
+        interval no period covers; see ``DwdObservationRequest._get_periods``.
+        """
+        return None
+
+    def _resolve_periods(self, periods: _PERIODS_TYPE) -> set[Period]:
+        """Resolve the requested periods against the ones the requested datasets publish.
+
+        A period that is not published is dropped with a warning naming it, and if that leaves
+        nothing the request fails -- it used to fall back to *every* period, so asking for one that
+        does not exist quietly returned more data than asking for a valid one.
+        """
+        published = self.published_periods
+        if periods:
+            requested = {parse_enumeration_from_template(period, Period) for period in to_list(periods)}
+            served = requested & published
+            if not served:
+                msg = (
+                    f"None of the periods {_format_periods(requested)} is published for the datasets requested "
+                    f"from {type(self).__name__}. Available periods: {_format_periods(published)}"
+                )
+                raise NoPeriodsFoundError(msg)
+            if dropped := requested - served:
+                log.warning(
+                    f"Periods {_format_periods(dropped)} are not published for the datasets requested from "
+                    f"{type(self).__name__} and are skipped. Available periods: {_format_periods(published)}",
+                )
+            return served
+        if self.start_date is not None:
+            derived = self._get_periods()
+            if derived is not None:
+                return derived
+        return published
 
     @staticmethod
     def _parse_station_id(series: pl.Series) -> pl.Series:

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -152,6 +152,13 @@ class TimeseriesRequest:
     # class attribute because that is where callers look for it.
     interpolatable_parameters: ClassVar = INTERPOLATABLE_PARAMETERS
 
+    # Whether the values implementation reads `self.periods` to decide which source to fetch. Only
+    # a diagnostic: a provider that leaves it False still validates periods, it just cannot narrow
+    # what it reads by them, and says so instead of accepting the argument and ignoring it. Getting
+    # it wrong costs a spurious warning, never a dropped argument -- which is what the per-provider
+    # `periods` field it replaces used to cost.
+    _selects_by_period: ClassVar[bool] = False
+
     @classmethod
     def available_periods(cls) -> set[Period]:
         """Periods the provider publishes, across all of its datasets."""
@@ -199,11 +206,24 @@ class TimeseriesRequest:
                     f"Periods {_format_periods(dropped)} are not published for the datasets requested from "
                     f"{type(self).__name__} and are skipped. Available periods: {_format_periods(published)}",
                 )
+            if served != published and not self._selects_by_period:
+                log.warning(
+                    f"{type(self).__name__} does not read its data per period, so asking for "
+                    f"{_format_periods(served)} does not narrow what is returned: every period the requested "
+                    f"datasets publish ({_format_periods(published)}) is read.",
+                )
             return served
         if self.start_date is not None:
             derived = self._get_periods()
             if derived is not None:
-                return derived
+                # The derived periods have to pass the same check as the requested ones, or a
+                # request lands on a period its datasets do not publish: an interval reaching into
+                # today derives `now`, which `daily/kl` has no release for, and the request then
+                # read no station index at all and reported no stations rather than no data. Where
+                # the interval reaches past the newest release a dataset has, that release is what
+                # holds whatever it can answer with, so fall back to it rather than to every period
+                # -- which would pull the whole historical archive for a query about today.
+                return derived & published or {max(published)}
         return published
 
     @staticmethod

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -216,6 +216,11 @@ class TimeseriesRequest:
         if self.start_date is not None:
             derived = self._get_periods()
             if derived is not None:
+                if not derived:
+                    # The interval reaches no release at all -- a window in the future. There is
+                    # nothing to read and nothing to fall back to, so the request stays empty
+                    # rather than downloading a period that cannot hold it
+                    return derived
                 # The derived periods have to pass the same check as the requested ones, or a
                 # request lands on a period its datasets do not publish: an interval reaching into
                 # today derives `now`, which `daily/kl` has no release for, and the request then

--- a/src/wetterdienst/provider/dwd/derived/api.py
+++ b/src/wetterdienst/provider/dwd/derived/api.py
@@ -16,7 +16,6 @@ from zoneinfo import ZoneInfo
 
 import polars as pl
 
-from wetterdienst import Period
 from wetterdienst.metadata.cache import CacheExpiry
 from wetterdienst.metadata.resolution import Resolution
 from wetterdienst.model.metadata import DatasetModel, ParameterModel
@@ -30,13 +29,10 @@ from wetterdienst.provider.dwd.derived.fileindex import (
 from wetterdienst.provider.dwd.derived.metadata import TECHNICAL_DATASETS, DwdDerivedMetadata
 from wetterdienst.provider.dwd.derived.metaindex import create_meta_index_for_climate_derived
 from wetterdienst.provider.dwd.derived.parser import parse_climate_derived_data
-from wetterdienst.util.enumeration import parse_enumeration_from_template
 from wetterdienst.util.network import File, download_file, list_remote_files_fsspec
-from wetterdienst.util.python import to_list
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
-
+    from wetterdienst import Period
     from wetterdienst.settings import Settings
 
 
@@ -644,8 +640,6 @@ class DwdDerivedRequest(TimeseriesRequest):
 
     metadata = DwdDerivedMetadata
     _values = DwdDerivedValues
-    _available_periods: ClassVar = {Period.HISTORICAL, Period.RECENT}
-    periods: str | Period | set[Period] | None = None
 
     @staticmethod
     def _process_dataframe_to_expected_format(
@@ -672,34 +666,6 @@ class DwdDerivedRequest(TimeseriesRequest):
         )
 
         return stations_data.sort(by=["station_id"])
-
-    def __post_init__(self) -> None:
-        """Post init method."""
-        super().__post_init__()
-
-        self.periods = self._parse_period(self.periods)
-        if not self.periods:
-            self.periods = self._available_periods
-
-    def _parse_period(
-        self,
-        period: str | Period | Iterable[str | Period] | None,
-    ) -> set[Period] | None:
-        """Parse period from string or Period enumeration.
-
-        :param period: Input value for the period
-        :return: Parsed period
-        """
-        if not period:
-            return None
-        periods_parsed = {
-            parse_enumeration_from_template(
-                enum_=p,
-                intermediate=Period,
-            )
-            for p in to_list(period)
-        }
-        return periods_parsed & self._available_periods or None
 
     def _all(self) -> pl.LazyFrame:
         """Fetch station data for the given request.

--- a/src/wetterdienst/provider/dwd/derived/api.py
+++ b/src/wetterdienst/provider/dwd/derived/api.py
@@ -682,8 +682,14 @@ class DwdDerivedRequest(TimeseriesRequest):
                 datasets.append(parameter.dataset)
         stations = []
         for dataset in datasets:
+            # An empty period set means the interval reaches no release at all; the stations
+            # themselves do not depend on that, so discovery reads every period the dataset has
+            # and the values stay empty, rather than the request reporting no stations
             periods = set(dataset.periods) & cast("set[Period]", self.periods) if self.periods else dataset.periods
-            for period in reversed(list(periods)):
+            # newest period first, so the `keep="first"` below settles a station on the most current
+            # of its descriptions. Period is orderable; `reversed(list(...))` over a set left the
+            # winner to the set's own iteration order, which varies from one interpreter run to the next
+            for period in sorted(periods, reverse=True):
                 df = create_meta_index_for_climate_derived(dataset, settings)
                 df = self._process_dataframe_to_expected_format(df, dataset)
                 file_index = create_file_index_for_climate_derived(dataset, period, settings)

--- a/src/wetterdienst/provider/dwd/derived/api.py
+++ b/src/wetterdienst/provider/dwd/derived/api.py
@@ -640,6 +640,7 @@ class DwdDerivedRequest(TimeseriesRequest):
 
     metadata = DwdDerivedMetadata
     _values = DwdDerivedValues
+    _selects_by_period = True
 
     @staticmethod
     def _process_dataframe_to_expected_format(

--- a/src/wetterdienst/provider/dwd/observation/api.py
+++ b/src/wetterdienst/provider/dwd/observation/api.py
@@ -9,7 +9,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from zoneinfo import ZoneInfo
 
 import polars as pl
@@ -581,8 +581,6 @@ class DwdObservationRequest(TimeseriesRequest):
     # Use cast to satisfy the static typechecker which expects instances of those types.
     _values = cast("TimeseriesValues", DwdObservationValues)
     _history = cast("TimeseriesHistory", DwdObservationHistory)
-    _available_periods: ClassVar = {Period.HISTORICAL, Period.RECENT, Period.NOW}
-    periods: str | Period | set[Period] | None = None
 
     @property
     def interval(self) -> Interval | None:
@@ -630,12 +628,12 @@ class DwdObservationRequest(TimeseriesRequest):
         now_begin = now_end.replace(hour=0, minute=0, second=0) - dt.timedelta(days=1)
         return portion.closed(now_begin, now_end)
 
-    def _get_periods(self) -> set[Period]:
+    def _get_periods(self) -> set[Period] | None:
         """Get periods based on the interval of the request."""
         periods = set()
         interval = self.interval
         if interval is None:
-            return periods
+            return None
         if interval.overlaps(self._historical_interval):
             periods.add(Period.HISTORICAL)
         if interval.overlaps(self._recent_interval):
@@ -647,27 +645,6 @@ class DwdObservationRequest(TimeseriesRequest):
     @staticmethod
     def _parse_station_id(series: pl.Series) -> pl.Series:
         return series.cast(pl.String).str.pad_start(5, "0")
-
-    def _parse_period(self, period: str | Period | set[Period] | None) -> set[Period] | None:
-        """Parse period from string or Period enumeration."""
-        if not period:
-            return None
-        periods_parsed = set()
-        periods_parsed.update(parse_enumeration_from_template(p, Period) for p in to_list(period))
-        return periods_parsed & self._available_periods or None
-
-    def __post_init__(self) -> None:
-        """Post init method."""
-        super().__post_init__()
-
-        self.periods = self._parse_period(self.periods)
-        # Has to follow the super call as start date and end date are required for getting
-        # automated periods from overlapping intervals
-        if not self.periods:
-            if self.start_date:
-                self.periods = self._get_periods()
-            else:
-                self.periods = self._available_periods
 
     def filter_by_station_id(
         self,
@@ -703,7 +680,7 @@ class DwdObservationRequest(TimeseriesRequest):
             raise KeyError(msg)
         dataset = DwdObservationMetadata.search_parameter(parameter_template)[0].dataset
         period_enum = parse_enumeration_from_template(period, Period)
-        if period_enum not in dataset.periods or period_enum not in cls._available_periods:
+        if period_enum not in dataset.periods:
             msg = f"Period {period_enum} not available for dataset {dataset}"
             raise ValueError(msg)
         url = _build_url_from_dataset_and_period(dataset, period_enum)

--- a/src/wetterdienst/provider/dwd/observation/api.py
+++ b/src/wetterdienst/provider/dwd/observation/api.py
@@ -581,6 +581,7 @@ class DwdObservationRequest(TimeseriesRequest):
     # Use cast to satisfy the static typechecker which expects instances of those types.
     _values = cast("TimeseriesValues", DwdObservationValues)
     _history = cast("TimeseriesHistory", DwdObservationHistory)
+    _selects_by_period = True
 
     @property
     def interval(self) -> Interval | None:

--- a/src/wetterdienst/provider/dwd/observation/api.py
+++ b/src/wetterdienst/provider/dwd/observation/api.py
@@ -726,6 +726,9 @@ class DwdObservationRequest(TimeseriesRequest):
                 datasets.append(parameter.dataset)
         stations = []
         for dataset in datasets:
+            # An empty period set means the interval reaches no release at all; the stations
+            # themselves do not depend on that, so discovery reads every period the dataset has
+            # and the values stay empty, rather than the request reporting no stations
             periods = set(dataset.periods) & cast("set[Period]", self.periods) if self.periods else dataset.periods
             # newest period first, so the `keep="first"` below settles a station on the most current
             # of its descriptions. Period is orderable; iterating the set directly left the winner

--- a/src/wetterdienst/provider/dwd/phenology/api.py
+++ b/src/wetterdienst/provider/dwd/phenology/api.py
@@ -187,8 +187,15 @@ def _periods_for(requested: set[Period] | None, dataset: DatasetModel) -> set[Pe
     record lives in the recent file, back to 2018 for `annual_currant_all_varieties` and 2021 for
     `annual_beet`. Intersecting would have left those years unreachable by any date range -- the
     request returned nothing at all rather than the rows it asked for.
+
+    The exception is a request that resolved to no period at all: that says its interval reaches
+    no release, so there is nothing to read and nothing to widen to.
     """
     published = set(dataset.periods)
+    if requested is not None and not requested:
+        # the interval reaches no release at all -- see `TimeseriesRequest._get_periods`. Reading
+        # the files anyway would download a whole network's records to filter them all away
+        return set()
     return (requested or published) & published or published
 
 

--- a/src/wetterdienst/provider/dwd/phenology/api.py
+++ b/src/wetterdienst/provider/dwd/phenology/api.py
@@ -21,7 +21,7 @@ import datetime as dt
 import logging
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, cast
 from zoneinfo import ZoneInfo
 
 import polars as pl
@@ -37,9 +37,7 @@ from wetterdienst.provider.dwd.phenology.metadata import (
     DWD_PHENOLOGY_PATHS,
     DwdPhenologyMetadata,
 )
-from wetterdienst.util.enumeration import parse_enumeration_from_template
 from wetterdienst.util.network import download_file, list_remote_files_fsspec
-from wetterdienst.util.python import to_list
 
 if TYPE_CHECKING:
     from portion import Interval
@@ -282,28 +280,10 @@ class DwdPhenologyRequest(TimeseriesRequest):
 
     metadata = DwdPhenologyMetadata
     _values = cast("TimeseriesValues", DwdPhenologyValues)
-    _available_periods: ClassVar = {Period.HISTORICAL, Period.RECENT}
-    periods: str | Period | set[Period] | None = None
 
     @staticmethod
     def _parse_station_id(series: pl.Series) -> pl.Series:
         return series.cast(pl.String).str.pad_start(5, "0")
-
-    def _parse_period(self, period: str | Period | set[Period] | None) -> set[Period] | None:
-        """Parse period from string or Period enumeration."""
-        if not period:
-            return None
-        periods_parsed = set()
-        periods_parsed.update(parse_enumeration_from_template(p, Period) for p in to_list(period))
-        return periods_parsed & self._available_periods or None
-
-    def __post_init__(self) -> None:
-        """Post init method."""
-        super().__post_init__()
-        self.periods = self._parse_period(self.periods)
-        # has to follow the super call, which is where start_date and end_date are converted
-        if not self.periods:
-            self.periods = self._get_periods() if self.start_date else self._available_periods
 
     @property
     def interval(self) -> Interval | None:
@@ -316,11 +296,11 @@ class DwdPhenologyRequest(TimeseriesRequest):
             cast("dt.datetime", self.end_date).astimezone(timezone),
         )
 
-    def _get_periods(self) -> set[Period]:
+    def _get_periods(self) -> set[Period] | None:
         """Choose the periods that can hold the requested interval."""
         interval = self.interval
         if interval is None:
-            return set()
+            return None
         now_local = dt.datetime.now(ZoneInfo(self.metadata.timezone))
         year_start = now_local.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
         historical = portion.closed(dt.datetime(1678, 1, 1, tzinfo=year_start.tzinfo), year_start)

--- a/src/wetterdienst/provider/dwd/phenology/api.py
+++ b/src/wetterdienst/provider/dwd/phenology/api.py
@@ -280,6 +280,7 @@ class DwdPhenologyRequest(TimeseriesRequest):
 
     metadata = DwdPhenologyMetadata
     _values = cast("TimeseriesValues", DwdPhenologyValues)
+    _selects_by_period = True
 
     @staticmethod
     def _parse_station_id(series: pl.Series) -> pl.Series:

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -146,7 +146,8 @@ def station_options_core(command: click.Command) -> click.Command:
             type=str,
             help=(
                 "Dataset periods to query (comma-separated). "
-                "Inferred automatically when --date is used. "
+                "Inferred automatically when --date is used, else every period the requested "
+                "datasets publish. A period they are not published under is rejected. "
                 "Examples: historical, recent, now"
             ),
         ),

--- a/src/wetterdienst/ui/core.py
+++ b/src/wetterdienst/ui/core.py
@@ -63,7 +63,11 @@ _ParametersField = Annotated[
 ]
 _PeriodsField = Annotated[
     list[str] | None,
-    Field(description="Dataset periods: 'historical', 'recent' and/or 'now'. Inferred from the date when omitted."),
+    Field(
+        description="Dataset periods: 'historical', 'recent', 'now' and/or 'future'. A period the "
+        "requested datasets are not published under is rejected. Inferred from the date when "
+        "omitted, else every period those datasets publish.",
+    ),
 ]
 _LeadTimeField = Annotated[
     Literal["short", "long"] | None,
@@ -837,15 +841,14 @@ def _get_stations_request(
         msg = "Start and end date required for single period datasets"
         raise StartDateEndDateError(msg)
 
-    any_multiple_period_dataset = any(len(parameter.dataset.periods) > 1 for parameter in parameters)
-
     kwargs: dict[str, Any] = {
         "parameters": parameters,
         "start_date": start_date,
         "end_date": end_date,
+        # every request takes periods and validates them against what its datasets publish, so pass
+        # them through rather than deciding here which provider is allowed to hear about them
+        "periods": getattr(request, "periods", None),
     }
-    if any_multiple_period_dataset and "periods" in getattr(api, "__dataclass_fields__", {}):
-        kwargs["periods"] = getattr(request, "periods", None)
 
     if issubclass(api, (DwdMosmixRequest, DwdDmoRequest)) and (issue := getattr(request, "issue", None)) is not None:
         kwargs["issue"] = issue

--- a/src/wetterdienst/ui/mcp.py
+++ b/src/wetterdienst/ui/mcp.py
@@ -69,7 +69,10 @@ measurement. Prefer the single-measurement form to keep responses small. Paramet
 snake_case; `coverage(provider="dwd", network="observation", datasets="climate_summary")` lists them. \
 Its answer is keyed by resolution, then `datasets`, then each dataset's `parameters`, and every one \
 of those three levels carries a `description` saying what the source means by it.
-- periods: "recent" (roughly the last 1.5 years) is the usual choice; "historical" for older data.
+- periods: leave it out unless the provider splits its record into releases. dwd/observation does \
+-- "recent" is roughly the last 1.5 years, "historical" reaches further back -- as do dwd/derived and \
+dwd/phenology. Most other providers publish everything under a single period, and asking for one \
+their datasets do not have is an error, not a narrower answer.
 - Handy DWD datasets: daily/kl (= climate_summary: temperature, precipitation, wind, sunshine), \
 hourly/air_temperature, hourly/precipitation.
 

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -509,8 +509,10 @@ def values(
     Requires provider, network, parameters and a station selection. Use parameters as
     "resolution/dataset/parameter" (e.g. "daily/climate_summary/temperature_air_mean_2m") to keep
     the response small, and `station` with an id from `stations` (e.g. station="01975"). `periods`
-    is usually "recent". The response `values` array is sorted by date; the most recent reading for
-    a parameter is the last item with that parameter. Do not re-request in other formats.
+    is optional and provider-specific -- "recent" for dwd/observation, while a provider that
+    publishes under a single period rejects any other one. The response `values` array is sorted by
+    date; the most recent reading for a parameter is the last item with that parameter. Do not
+    re-request in other formats.
     """
     set_logging_level(debug=request.debug)
 

--- a/tests/model/test_request.py
+++ b/tests/model/test_request.py
@@ -421,3 +421,39 @@ def test_available_periods_reads_the_metadata() -> None:
     assert DwdObservationRequest.available_periods() == {
         period for resolution in DwdObservationMetadata for dataset in resolution for period in dataset.periods
     }
+
+
+def test_periods_derived_from_dates_stay_within_what_is_published(default_settings: Settings) -> None:
+    """Periods derived from the dates are checked against the datasets like requested ones are.
+
+    An interval reaching into today derives `now`, which `daily/kl` has no release for. The derived
+    set was returned unchecked, so the request read no station index at all and reported no stations
+    -- while asking for `periods="now"` outright raises for the very same datasets. Where the
+    interval reaches past the newest release a dataset has, that release answers for it.
+    """
+    now = dt.datetime.now(tz=ZoneInfo("UTC"))
+    request = DwdObservationRequest(
+        parameters=["daily/kl"],
+        start_date=now,
+        end_date=now,
+        settings=default_settings,
+    )
+    assert request.periods == {Period.RECENT}
+
+
+def test_periods_on_a_provider_that_does_not_read_them_warns(default_settings: Settings, caplog) -> None:  # noqa: ANN001
+    """Narrowing the periods of a provider that cannot narrow what it reads says so.
+
+    SMHI publishes `hourly/data` under both historical and recent but reads both of its upstream
+    files by design, so the argument is validated and then makes no difference. Accepting it in
+    silence would answer a narrowed request with everything.
+    """
+    from wetterdienst.provider.smhi.observation import SmhiObservationRequest  # noqa: PLC0415
+
+    request = SmhiObservationRequest(parameters=["hourly/data"], periods="historical", settings=default_settings)
+    assert request.periods == {Period.HISTORICAL}
+    assert "does not read its data per period" in caplog.text
+    caplog.clear()
+    # the three that do read them stay quiet
+    DwdObservationRequest(parameters=["daily/kl"], periods="recent", settings=default_settings)
+    assert "does not read its data per period" not in caplog.text

--- a/tests/model/test_request.py
+++ b/tests/model/test_request.py
@@ -360,3 +360,64 @@ def test_dwd_observation_multiple_datasets(default_settings: Settings) -> None:
         {"count": 151743, "dataset": "precipitation", "resolution": "hourly", "station_id": "01050"},
         {"count": 27568, "dataset": "precipitation", "resolution": "hourly", "station_id": "19140"},
     ]
+
+
+def test_periods_default_to_what_the_requested_datasets_publish(default_settings: Settings) -> None:
+    """Without a period the request reads every period the requested datasets publish.
+
+    Not every period the *provider* publishes: `monthly/climate_correction_factor` is released
+    under `recent` only, so a request for it must not go looking for a historical release too.
+    """
+    from wetterdienst.provider.dwd.derived import DwdDerivedRequest  # noqa: PLC0415
+
+    request = DwdDerivedRequest(parameters=["monthly/climate_correction_factor"], settings=default_settings)
+    assert request.periods == {Period.RECENT}
+    request = DwdDerivedRequest(parameters=["monthly/soil"], settings=default_settings)
+    assert request.periods == {Period.HISTORICAL, Period.RECENT}
+
+
+def test_periods_unpublished_period_raises(default_settings: Settings) -> None:
+    """A period none of the requested datasets publishes fails, naming what is available.
+
+    It used to be dropped by an intersection whose empty result then read as "nothing requested",
+    so asking for a period that does not exist quietly returned *every* period instead.
+    """
+    from wetterdienst.exceptions import NoPeriodsFoundError  # noqa: PLC0415
+
+    with pytest.raises(NoPeriodsFoundError, match="None of the periods future is published"):
+        DwdObservationRequest(parameters=["daily/kl"], periods="future", settings=default_settings)
+
+
+def test_periods_partly_unpublished_period_warns(default_settings: Settings, caplog) -> None:  # noqa: ANN001
+    """A period the requested datasets do not publish is skipped with a warning, not silently."""
+    request = DwdObservationRequest(
+        parameters=["daily/kl"],
+        periods=["recent", "now"],
+        settings=default_settings,
+    )
+    assert request.periods == {Period.RECENT}
+    assert "Periods now are not published" in caplog.text
+
+
+def test_periods_on_a_request_without_a_choice(default_settings: Settings) -> None:
+    """Every request takes periods, including the providers that publish under a single one.
+
+    `NoaaGhcnRequest` has no period to choose between, but used to raise `TypeError: unexpected
+    keyword argument 'periods'` rather than accept the one it does publish -- which meant the CLI
+    and REST API dropped `periods` for such a provider instead of answering it.
+    """
+    from wetterdienst.exceptions import NoPeriodsFoundError  # noqa: PLC0415
+    from wetterdienst.provider.noaa.ghcn import NoaaGhcnRequest  # noqa: PLC0415
+
+    request = NoaaGhcnRequest(parameters=["daily/data"], periods="historical", settings=default_settings)
+    assert request.periods == {Period.HISTORICAL}
+    with pytest.raises(NoPeriodsFoundError, match="Available periods: historical"):
+        NoaaGhcnRequest(parameters=["daily/data"], periods="now", settings=default_settings)
+
+
+def test_available_periods_reads_the_metadata() -> None:
+    """`available_periods` is derived from the metadata, not a hand-maintained class attribute."""
+    assert DwdObservationRequest.available_periods() == {Period.HISTORICAL, Period.RECENT, Period.NOW}
+    assert DwdObservationRequest.available_periods() == {
+        period for resolution in DwdObservationMetadata for dataset in resolution for period in dataset.periods
+    }

--- a/tests/provider/dwd/observation/test_api_data.py
+++ b/tests/provider/dwd/observation/test_api_data.py
@@ -110,9 +110,14 @@ def test_request_period_historical_recent(default_settings: Settings) -> None:
 
 
 def test_request_period_historical_recent_now(default_settings: Settings) -> None:
-    """Test for historical, recent and now period."""
+    """Test for historical, recent and now period.
+
+    `10_minutes/temperature_air` rather than `daily/climate_summary` because the periods derived
+    from an interval are checked against the ones the dataset publishes, and climate_summary has
+    no `now` release -- see `test_request_period_now_narrows_to_what_the_dataset_publishes`.
+    """
     request = DwdObservationRequest(
-        parameters=[("daily", "climate_summary")],
+        parameters=[("10_minutes", "temperature_air")],
         start_date="1971-01-01",
         end_date=dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None),
         settings=default_settings,
@@ -128,7 +133,7 @@ def test_request_period_historical_recent_now(default_settings: Settings) -> Non
 def test_request_period_recent_now(default_settings: Settings) -> None:
     """Test for recent and now period."""
     request = DwdObservationRequest(
-        parameters=[("daily", "climate_summary")],
+        parameters=[("10_minutes", "temperature_air")],
         start_date=dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None) - dt.timedelta(hours=2),
         settings=default_settings,
     )
@@ -139,7 +144,7 @@ def test_request_period_recent_now(default_settings: Settings) -> None:
 def test_request_period_now(default_settings: Settings) -> None:
     """Test for now period."""
     request = DwdObservationRequest(
-        parameters=[("daily", "climate_summary")],
+        parameters=[("10_minutes", "temperature_air")],
         start_date=dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None) - dt.timedelta(hours=2),
         settings=default_settings,
     )
@@ -150,7 +155,7 @@ def test_request_period_now(default_settings: Settings) -> None:
 def test_request_period_now_fixed_date(default_settings: Settings) -> None:
     """Test for now period with fixed date."""
     request = DwdObservationRequest(
-        parameters=[("daily", "climate_summary")],
+        parameters=[("10_minutes", "temperature_air")],
         start_date=dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None) - dt.timedelta(hours=2),
         settings=default_settings,
     )
@@ -160,15 +165,36 @@ def test_request_period_now_fixed_date(default_settings: Settings) -> None:
 def test_request_period_now_previous_hour(default_settings: Settings) -> None:
     """Test for now period with previous hour."""
     request = DwdObservationRequest(
-        parameters=[("daily", "climate_summary")],
+        parameters=[("10_minutes", "temperature_air")],
         start_date=dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None) - dt.timedelta(hours=1),
         settings=default_settings,
     )
     assert Period.NOW in request.periods
 
 
+@freeze_time(dt.datetime(2022, 1, 29, 2, 30, tzinfo=ZoneInfo("Europe/Berlin")))
+def test_request_period_now_narrows_to_what_the_dataset_publishes(default_settings: Settings) -> None:
+    """An interval reaching into today reads the newest release the dataset actually has.
+
+    `daily/climate_summary` is published as historical and recent only. The derived `now` used to
+    stand, so the request carried a period the dataset has no release for and read no station index
+    at all -- `.all()` reported no stations, where asking for `periods="now"` outright raises for
+    the same datasets.
+    """
+    request = DwdObservationRequest(
+        parameters=[("daily", "climate_summary")],
+        start_date=dt.datetime.now(ZoneInfo("UTC")).replace(tzinfo=None) - dt.timedelta(hours=2),
+        settings=default_settings,
+    )
+    assert request.periods == {Period.RECENT}
+
+
 def test_request_period_empty(default_settings: Settings) -> None:
-    """Test for empty periods."""
+    """Test for empty periods.
+
+    An interval reaching no release at all has nothing to read and nothing to fall back to, so it
+    stays empty rather than being widened to the dataset's newest release.
+    """
     # No period (for example in future)
     request = DwdObservationRequest(
         parameters=[("daily", "climate_summary")],

--- a/tests/provider/dwd/phenology/test_api.py
+++ b/tests/provider/dwd/phenology/test_api.py
@@ -209,13 +209,16 @@ def test_periods_from_dates() -> None:
     assert old.periods == {Period.HISTORICAL}
 
 
-def test_single_period_dataset_ignores_the_derived_period() -> None:
-    """A dataset published in one period only is read whatever period the dates imply.
+def test_single_period_dataset_reads_the_period_it_is_published_under() -> None:
+    """A dataset published in one period only is read from it whatever period the dates imply.
 
     Periods derived from a date range assume `recent` holds the last few years. The two datasets
     with no historical release at all break that assumption -- their whole record lives in the
-    recent file, back to 2018 and 2021 -- so intersecting the derived period with the published
-    one left those years unreachable by any date range, and the request returned nothing.
+    recent file, back to 2018 and 2021 -- so leaving those years to a derived `historical` would
+    make them unreachable by any date range, and the request returned nothing. The request now
+    resolves to the period the dataset actually publishes rather than reporting one it does not
+    have and leaving `_periods_for` to repair it per dataset, which it still does for a request
+    naming datasets with different periods.
     """
     request = DwdPhenologyRequest(
         parameters=[("annual", "annual_beet")],
@@ -225,7 +228,7 @@ def test_single_period_dataset_ignores_the_derived_period() -> None:
     dataset = DwdPhenologyMetadata["annual"]["annual_beet"]
     assert dataset.periods == [Period.RECENT]
     # the dates imply historical, which this dataset does not publish
-    assert request.periods == {Period.HISTORICAL}
+    assert request.periods == {Period.RECENT}
     assert _periods_for(request.periods, dataset) == {Period.RECENT}
 
 

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -1276,23 +1276,58 @@ def test_get_stations_request_date_required_dataset_does_not_raise_for_stations_
     assert stations_request is not None
 
 
-def test_get_stations_request_no_periods_kwarg_for_providers_without_periods_field() -> None:
-    """_get_stations_request must not pass `periods` kwarg to providers that lack the field.
+def test_get_stations_request_passes_periods_to_every_provider() -> None:
+    """The periods a caller asked for reach the request, whichever provider serves it.
 
-    MetNoFrostRequest has multi-period datasets (historical + recent) but no `periods`
-    constructor argument. Previously this caused TypeError when building the request.
+    `periods` used to be a per-provider constructor argument, so `_get_stations_request` had to
+    check for the field before passing it -- and MetnoFrostRequest, whose datasets are published
+    under both historical and recent, had no way to hear the choice at all. It is a field of
+    `TimeseriesRequest` now, validated against what the requested datasets publish.
     """
-    from wetterdienst import Wetterdienst  # noqa: PLC0415
+    from wetterdienst import Period, Wetterdienst  # noqa: PLC0415
     from wetterdienst.provider.metno.frost.api import MetnoFrostRequest  # noqa: PLC0415
     from wetterdienst.settings import Settings  # noqa: PLC0415
     from wetterdienst.ui.core import StationsRequest, _get_stations_request  # noqa: PLC0415
 
     api = Wetterdienst("metno", "frost")
     settings = Settings(auth={"metno_frost": "fake-client-id"})
-    request = StationsRequest(provider="metno", network="frost", parameters=["hourly/data"])
+    request = StationsRequest(provider="metno", network="frost", parameters=["hourly/data"], periods="recent")
 
     stations_request = _get_stations_request(api=api, request=request, date=None, settings=settings)
     assert isinstance(stations_request, MetnoFrostRequest)
+    assert stations_request.periods == {Period.RECENT}
+
+
+def test_get_stations_request_periods_on_a_single_period_dataset() -> None:
+    """An explicit period is answered even when the dataset publishes only one.
+
+    `_get_stations_request` forwarded `periods` only when some requested dataset had more than one,
+    so for `monthly/climate_correction_factor` -- released under `recent` alone -- a caller asking
+    for `historical` was silently given every period the provider has instead of an error.
+    """
+    from wetterdienst import Period, Wetterdienst  # noqa: PLC0415
+    from wetterdienst.exceptions import NoPeriodsFoundError  # noqa: PLC0415
+    from wetterdienst.settings import Settings  # noqa: PLC0415
+    from wetterdienst.ui.core import StationsRequest, _get_stations_request  # noqa: PLC0415
+
+    api = Wetterdienst("dwd", "derived")
+    settings = Settings()
+    request = StationsRequest(
+        provider="dwd",
+        network="derived",
+        parameters=["monthly/climate_correction_factor"],
+        periods="recent",
+    )
+    assert _get_stations_request(api=api, request=request, date=None, settings=settings).periods == {Period.RECENT}
+
+    request = StationsRequest(
+        provider="dwd",
+        network="derived",
+        parameters=["monthly/climate_correction_factor"],
+        periods="historical",
+    )
+    with pytest.raises(NoPeriodsFoundError, match="Available periods: recent"):
+        _get_stations_request(api=api, request=request, date=None, settings=settings)
 
 
 @pytest.mark.parametrize("schema_name", ["_Station", "_OgcFeatureProperties"])


### PR DESCRIPTION
Continues the review of the general API. `periods` was the last request argument that each provider carried its own copy of, and the copies disagreed with the metadata that already says which periods a dataset is published under. Four defects, every one reproduced before being fixed.

## 1. An unavailable period returned *more* data, not an error

Each of the three implementations ended in `periods_parsed & self._available_periods or None`, and `__post_init__` read that `None` as "nothing requested" and filled in every available period:

```python
DwdObservationRequest(parameters=["daily/kl"], periods="future").periods
# {<Period.HISTORICAL>, <Period.RECENT>, <Period.NOW>}
```

So asking for a period that does not exist read three periods where asking for a valid one reads one. It raises now, naming what the requested datasets do publish:

```
NoPeriodsFoundError: None of the periods future is published for the datasets requested from
DwdObservationRequest. Available periods: historical, recent
```

A period dropped from a request that keeps others (`periods=["recent", "now"]` on `daily/kl`) is logged as a warning naming it, rather than disappearing.

## 2. `periods` never reached most providers

It was a per-provider constructor field — DWD observation, derived and phenology had it, the other 28 request classes did not:

```python
NoaaGhcnRequest(parameters=["daily/data"], periods="historical")
# TypeError: NoaaGhcnRequest.__init__() got an unexpected keyword argument 'periods'
```

Through the CLI and REST API the same thing was silent, because `_get_stations_request` checked `"periods" in getattr(api, "__dataclass_fields__", {})` before passing it. met.no Frost publishes `hourly/data` under both `historical` and `recent` and had no way to hear the choice at all — the sniffing existed precisely to stop that TypeError, and `tests/ui/test_restapi.py` pinned it.

## 3. An explicit period was dropped for a single-period dataset

The same call site only forwarded `periods` when `any(len(parameter.dataset.periods) > 1 ...)`. DWD derived's `monthly/climate_correction_factor` is released under `recent` alone, so:

| `periods=historical` on `monthly/climate_correction_factor` | result |
|---|---|
| before | `{historical, recent}` — the choice dropped, the default widened |
| after | `NoPeriodsFoundError: ... Available periods: recent` |

## 4. `_available_periods` duplicated the metadata

A hand-maintained `ClassVar` per provider, verified byte-identical to the union of `dataset.periods` in all three:

```
dwd/observation: _available_periods=['historical', 'now', 'recent'] metadata_union=['historical', 'now', 'recent']
dwd/derived:     _available_periods=['historical', 'recent']        metadata_union=['historical', 'recent']
dwd/phenology:   _available_periods=['historical', 'recent']        metadata_union=['historical', 'recent']
```

Gone, along with three copies of `_parse_period`. `TimeseriesRequest.available_periods()` reads the metadata instead.

## What it looks like now

`periods` is a field of `TimeseriesRequest`, resolved in `__post_init__` after the parameters — which say which datasets, and so which periods, were asked for:

- explicit periods ∩ the requested datasets' published periods; empty raises, partial warns
- else `_get_periods()` when `start_date` is set, the provider hook for deriving periods from the requested interval. It returns `None` by default, meaning "no release schedule to derive from"; DWD observation and phenology override it. `None` and `set()` differ on purpose — an empty set is a real answer (an interval no period covers reads nothing) and must not be widened back to everything
- else every period the requested datasets publish

## Why not a `PeriodExtension` mixin

A mixin models "some requests have periods", and that is false: `periods` is a required field of `DatasetModel`, so every dataset of every provider has at least one. What varies is arity, not presence. Opt-in is also what caused defects 2 and 3 — a provider whose author forgets to mix it in loses the argument silently, which is exactly what happened to met.no Frost. The genuinely provider-specific part is already an extension point (`_get_periods`).

`issue` / `lead_time` are the honest candidates for that pattern — not universal, no metadata backing, and still special-cased in `ui/core.py` via `issubclass`. Left for a follow-up.

## Breaking

- a period none of the requested datasets publishes raises instead of being replaced by all of them
- the default is the requested datasets' periods rather than the provider's, which is narrower for a request naming one dataset (`monthly/climate_correction_factor` → `{recent}`, not `{historical, recent}`)
- `periods` is a base field, so it precedes `issue` and `lead_time` positionally for DWD MOSMIX/DMO. No caller in the repo constructs a request positionally

## Tests

`test_periods_default_to_what_the_requested_datasets_publish`, `test_periods_unpublished_period_raises`, `test_periods_partly_unpublished_period_warns`, `test_periods_on_a_request_without_a_choice`, `test_available_periods_reads_the_metadata`; the restapi test that pinned the sniffing is rewritten as `test_get_stations_request_passes_periods_to_every_provider` and joined by `test_get_stations_request_periods_on_a_single_period_dataset`.

`poe format` and `poe typecheck` clean. Full suite with remote deselected: 898 passed, 8 failed — all DWD network flakes (connection refused to `opendata.dwd.de`, missing `.kmz` files), each passing in isolation, and the set rotates between runs. The history tests among them pin `Period.HISTORICAL` and never read `stations.periods`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BMmz23eRedUH9VTYaMQzV