### PR TITLE
fix(model): answer an empty interpolation, and label a plot with the unit it shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ Types of changes:
 
 ### Fixed
 
+- Interpolation and summarization: a result that came back with no rows is a feature collection
+  with no values rather than an `OutOfBoundsError`. The feature's id was read out of the frame's
+  first row, so a point and window no station covers -- an ordinary outcome, and one the REST API
+  serves as `format=geojson` -- raised `gather indices are out of bounds` from `to_geojson` and
+  `to_ogc_feature_collection`, where `to_dict` on the same result answered fine. The id belongs to
+  the point rather than to any row: it is the name beside it hashed, which is how the
+  interpolation builds it in the first place
+- Plots: a parameter is labelled with the unit its values are actually written in. The label
+  mapping was keyed on the canonical parameter name alone, while a frame carries `name_original`
+  unless `ts_humanize` is on, so nothing matched and the label repeated the name -- `sd_10
+  (sd_10)`. The symbol was also always the target unit's, though `ts_convert_units=False` leaves
+  the values as the source published them: `10_minutes/solar/sunshine_duration` comes in hours and
+  was labelled seconds, a factor of 3600 between the number and its unit. Both affected the value,
+  interpolation and summary plots, and the images exported from them
+
 - Dates: a date string covers everything it names instead of only the instant it starts with.
   `2020-05` is the month of May, `2020` the year, and `2020-05-01` a whole day -- which for
   anything measured more often than daily is 24 hours of readings rather than the one at midnight.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,11 @@ Types of changes:
   unless `ts_humanize` is on, so nothing matched and the label repeated the name -- `sd_10
   (sd_10)`. The symbol was also always the target unit's, though `ts_convert_units=False` leaves
   the values as the source published them: `10_minutes/solar/sunshine_duration` comes in hours and
-  was labelled seconds, a factor of 3600 between the number and its unit. Both affected the value,
-  interpolation and summary plots, and the images exported from them
-
+  was labelled seconds, a factor of 3600 between the number and its unit. The mapping is keyed by
+  resolution and dataset as well as name, since a canonical name is only unique within its dataset
+  -- DWD publishes `sunshine_duration` in hours at 10 minutes and in minutes at an hour, and one
+  would otherwise have labelled the other. Both affected the value, interpolation and summary
+  plots, and the images exported from them
 - Dates: a date string covers everything it names instead of only the instant it starts with.
   `2020-05` is the month of May, `2020` the year, and `2020-05-01` a whole day -- which for
   anything measured more often than daily is 24 hours of readings rather than the one at midnight.

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -9,7 +9,6 @@ import logging
 from abc import abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field
-from hashlib import sha256
 from typing import TYPE_CHECKING, ClassVar
 from zoneinfo import ZoneInfo
 
@@ -42,6 +41,7 @@ from wetterdienst.model.result import (
     StationsResult,
     SummarizedValuesResult,
 )
+from wetterdienst.model.util import create_station_id_from_string
 from wetterdienst.settings import Settings
 from wetterdienst.util.enumeration import parse_enumeration_from_template
 from wetterdienst.util.python import to_list
@@ -708,7 +708,7 @@ class TimeseriesRequest:
         lat, lon = latlon
         lat, lon = float(lat), float(lon)
         df_interpolated = get_interpolated_df(self, lat, lon)
-        station_id = self._create_station_id_from_string(f"interpolation({lat:.4f},{lon:.4f})")
+        station_id = create_station_id_from_string(f"interpolation({lat:.4f},{lon:.4f})")
         df_interpolated = df_interpolated.select(
             pl.lit(station_id).alias("station_id"),
             pl.col("resolution"),
@@ -762,7 +762,7 @@ class TimeseriesRequest:
         lat, lon = latlon
         lat, lon = float(lat), float(lon)
         summarized_values = get_summarized_df(self, lat, lon)
-        station_id = self._create_station_id_from_string(f"summary({lat:.4f},{lon:.4f})")
+        station_id = create_station_id_from_string(f"summary({lat:.4f},{lon:.4f})")
         summarized_values = summarized_values.select(
             pl.lit(station_id).alias("station_id"),
             pl.col("resolution"),
@@ -811,11 +811,3 @@ class TimeseriesRequest:
             msg = f"no station found for {station_id}"
             raise StationNotFoundError(msg) from e
         return lat, lon
-
-    @staticmethod
-    def _create_station_id_from_string(string: str) -> str:
-        """Create station id from string.
-
-        Used for interpolation and summarization data
-        """
-        return sha256(string.encode("utf-8")).hexdigest()[:8]

--- a/src/wetterdienst/model/result.py
+++ b/src/wetterdienst/model/result.py
@@ -14,7 +14,7 @@ import polars as pl
 from typing_extensions import NotRequired, TypedDict
 
 from wetterdienst.io.export import ExportMixin
-from wetterdienst.model.util import filter_by_date
+from wetterdienst.model.util import create_station_id_from_string, filter_by_date
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from wetterdienst.model.history import History, TimeseriesHistory
     from wetterdienst.model.metadata import ParameterModel
     from wetterdienst.model.request import TimeseriesRequest
+    from wetterdienst.model.unit import UnitConverter
     from wetterdienst.model.values import TimeseriesValues
     from wetterdienst.provider.dwd.dmo import DwdDmoRequest
     from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
@@ -473,6 +474,28 @@ class _ValuesResult(ExportMixin):
             indent = None
         return json.dumps(self.to_dict(with_metadata=with_metadata, with_stations=with_stations), indent=indent)
 
+    def _unit_symbols(self, unit_converter: UnitConverter) -> dict[str, str]:
+        """Map every parameter name a frame can carry to the symbol its values are written in.
+
+        Two things the plots used to get wrong. The frame carries `name_original` unless
+        `ts_humanize` is on, while the mapping was keyed on the canonical name alone, so nothing
+        matched and the label read `tmk (tmk)` -- the name where the unit belongs. And the symbol
+        was always the target unit's, though `ts_convert_units=False` leaves the values in the unit
+        the source published them in: `10_minutes/solar/sunshine_duration` came back in hours under
+        a label saying seconds.
+        """
+        convert_units = self.stations.settings.ts_convert_units
+        symbols = {}
+        for parameter in self.stations.parameters:
+            unit = (
+                unit_converter.targets[parameter.unit_type]
+                if convert_units
+                else unit_converter.get_unit(parameter.unit, parameter.unit_type)
+            )
+            symbols[parameter.name] = unit.symbol
+            symbols[parameter.name_original] = unit.symbol
+        return symbols
+
     def filter_by_date(self, date: str) -> pl.DataFrame:
         """Filter values by date or date interval and return a new DataFrame.
 
@@ -590,10 +613,7 @@ class ValuesResult(_ValuesResult):
         if df.is_empty():
             return go.Figure()
         # create unit mapping for title
-        units = {
-            parameter.name: self.values.unit_converter.targets[parameter.unit_type].symbol
-            for parameter in self.values.sr.parameters
-        }
+        units = self._unit_symbols(self.values.unit_converter)
         # used for subplots
         n = df.select(["resolution", "dataset", "parameter"]).n_unique()
         # used for name
@@ -766,7 +786,9 @@ class InterpolatedValuesResult(_ValuesResult):
         feature = {
             "type": "Feature",
             "properties": {
-                "id": self.df.get_column("station_id").gather(0).item(),
+                # the id of the point, which is this name hashed -- read out of the frame, it took
+                # a result that came back with no rows down with an out-of-bounds gather
+                "id": create_station_id_from_string(name),
                 "name": name,
             },
             "geometry": {
@@ -805,10 +827,7 @@ class InterpolatedValuesResult(_ValuesResult):
         if df.is_empty():
             return go.Figure()
         # create unit mapping for title
-        units = {
-            parameter.name: self.stations.values.unit_converter.targets[parameter.unit_type].symbol
-            for parameter in self.stations.parameters
-        }
+        units = self._unit_symbols(self.stations.values.unit_converter)
         # used for subplots
         n = df.select(["dataset", "parameter"]).n_unique()
         # used for name
@@ -968,7 +987,9 @@ class SummarizedValuesResult(_ValuesResult):
         feature = {
             "type": "Feature",
             "properties": {
-                "id": self.df.get_column("station_id").gather(0).item(),
+                # the id of the point, which is this name hashed -- read out of the frame, it took
+                # a result that came back with no rows down with an out-of-bounds gather
+                "id": create_station_id_from_string(name),
                 "name": name,
             },
             "geometry": {
@@ -1007,10 +1028,7 @@ class SummarizedValuesResult(_ValuesResult):
         if df.is_empty():
             return go.Figure()
         # create unit mapping for title
-        units = {
-            parameter.name: self.stations.values.unit_converter.targets[parameter.unit_type].symbol
-            for parameter in self.stations.parameters
-        }
+        units = self._unit_symbols(self.stations.values.unit_converter)
         # used for subplots
         n = df.select(["dataset", "parameter"]).n_unique()
         # used for name

--- a/src/wetterdienst/model/result.py
+++ b/src/wetterdienst/model/result.py
@@ -475,7 +475,12 @@ class _ValuesResult(ExportMixin):
         return json.dumps(self.to_dict(with_metadata=with_metadata, with_stations=with_stations), indent=indent)
 
     def _unit_symbols(self, unit_converter: UnitConverter) -> dict[str, str]:
-        """Map every parameter name a frame can carry to the symbol its values are written in.
+        """Map every parameter a frame can carry to the symbol its values are written in.
+
+        Keyed the way `_unit_symbol_key` reads a frame, by resolution and dataset as well as name.
+        A canonical name is only unique within its dataset -- `sunshine_duration` is published by
+        DWD in hours at 10 minutes and in minutes at an hour -- so keying on the name alone let one
+        of them label the other, which is the mislabel this method exists to prevent.
 
         Two things the plots used to get wrong. The frame carries `name_original` unless
         `ts_humanize` is on, while the mapping was keyed on the canonical name alone, so nothing
@@ -492,9 +497,27 @@ class _ValuesResult(ExportMixin):
                 if convert_units
                 else unit_converter.get_unit(parameter.unit, parameter.unit_type)
             )
-            symbols[parameter.name] = unit.symbol
-            symbols[parameter.name_original] = unit.symbol
+            resolution = parameter.dataset.resolution.name
+            dataset = parameter.dataset.name
+            # either naming, since which one the frame carries depends on `ts_humanize`
+            symbols[f"{resolution}/{dataset}/{parameter.name}"] = unit.symbol
+            symbols[f"{resolution}/{dataset}/{parameter.name_original}"] = unit.symbol
         return symbols
+
+    @staticmethod
+    def _unit_symbol_key() -> pl.Expr:
+        """Read the key of `_unit_symbols` off a frame.
+
+        The metadata columns come back as Enum in aggregated results, which concat_str will not
+        take, hence the casts.
+        """
+        return pl.concat_str(
+            pl.col("resolution").cast(pl.String),
+            pl.lit("/"),
+            pl.col("dataset").cast(pl.String),
+            pl.lit("/"),
+            pl.col("parameter").cast(pl.String),
+        )
 
     def filter_by_date(self, date: str) -> pl.DataFrame:
         """Filter values by date or date interval and return a new DataFrame.
@@ -624,9 +647,7 @@ class ValuesResult(_ValuesResult):
             pl.concat_str(
                 pl.col("parameter"),
                 pl.lit(" ("),
-                # parameter may be Enum in aggregated value results; cast to String so the unit
-                # symbols (which are not Enum categories) can be substituted in
-                pl.col("parameter").cast(pl.String).replace(units),
+                self._unit_symbol_key().replace(units),
                 pl.lit(")"),
             ).alias("parameter"),
         )
@@ -838,9 +859,7 @@ class InterpolatedValuesResult(_ValuesResult):
             pl.concat_str(
                 pl.col("parameter"),
                 pl.lit(" ("),
-                # parameter may be Enum in aggregated value results; cast to String so the unit
-                # symbols (which are not Enum categories) can be substituted in
-                pl.col("parameter").cast(pl.String).replace(units),
+                self._unit_symbol_key().replace(units),
                 pl.lit(")"),
             ).alias("parameter"),
             pl.col("taken_station_ids").list.join(",").alias("taken_station_ids"),
@@ -1039,9 +1058,7 @@ class SummarizedValuesResult(_ValuesResult):
             pl.concat_str(
                 pl.col("parameter"),
                 pl.lit(" ("),
-                # parameter may be Enum in aggregated value results; cast to String so the unit
-                # symbols (which are not Enum categories) can be substituted in
-                pl.col("parameter").cast(pl.String).replace(units),
+                self._unit_symbol_key().replace(units),
                 pl.lit(")"),
             ).alias("parameter"),
         )

--- a/src/wetterdienst/model/unit.py
+++ b/src/wetterdienst/model/unit.py
@@ -313,19 +313,34 @@ class UnitConverter:
             ("degree_fahrenheit_hour", "degree_kelvin_hour"): lambda x: 5 / 9 * x,
         }
 
+    def get_unit(self, name: str, unit_type: str) -> Unit:
+        """Get the unit of a type by name, for its symbol.
+
+        Args:
+            name: Name of the unit, as a parameter declares it
+            unit_type: Type of the unit the name belongs to
+
+        Returns:
+            The unit, carrying the symbol it is written with
+
+        """
+        if unit_type not in self.units:
+            msg = f"Unit type {unit_type} not supported"
+            raise ValueError(msg)
+        unit = next((unit for unit in self.units[unit_type] if unit.name == name), None)
+        if not unit:
+            supported_units = ",".join(unit.name for unit in self.units[unit_type])
+            msg = f"Unit {name} not supported for type {unit_type}. Supported units are: {supported_units}"
+            raise ValueError(msg)
+        return unit
+
     def update_targets(self, targets: dict[str, str]) -> None:
         """Update the target units for each unit type."""
         for key, value in targets.items():
             if key not in self.targets:
                 msg = f"Unit type {key} not supported"
                 raise ValueError(msg)
-            # find the unit with the given name
-            unit = next((unit for unit in self.units[key] if unit.name == value), None)
-            if not unit:
-                supported_units = ",".join(unit.name for unit in self.units[key])
-                msg = f"Unit {value} not supported for type {key}. Supported units are: {supported_units}"
-                raise ValueError(msg)
-            self.targets[key] = unit
+            self.targets[key] = self.get_unit(value, key)
 
     def _get_lambda(self, unit: str, unit_target: str) -> Callable[[Any], Any]:
         if unit == unit_target:

--- a/src/wetterdienst/model/util.py
+++ b/src/wetterdienst/model/util.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from hashlib import sha256
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -21,6 +22,23 @@ except ImportError:
     pass
 else:
     MonkeyPatch.patch_fromisoformat()
+
+
+def create_station_id_from_string(string: str) -> str:
+    """Create a station id from a string.
+
+    The id of an interpolated or summarized result, which stands for a point rather than a station.
+    It is derived from the point alone, so it can be given for a result that came back with no rows
+    just as well as for one that did.
+
+    Args:
+        string: The name of the point, as the result reports it
+
+    Returns:
+        The id of the point
+
+    """
+    return sha256(string.encode("utf-8")).hexdigest()[:8]
 
 
 def create_date_range(date: str, resolution: Resolution) -> tuple[dt.datetime | None, dt.datetime | None]:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -552,7 +552,9 @@ def test_interpolated_values_to_ogc_feature_collection(
     assert data.keys() == {"data"}
     assert data["data"]["features"][0] == {
         "geometry": {"coordinates": [2.3456, 1.2345], "type": "Point"},
-        "properties": {"id": "abc", "name": "interpolation(1.2345,2.3456)"},
+        # the id is the name hashed, as the interpolation itself builds it -- not read out of the
+        # frame, whose station_id is a placeholder here
+        "properties": {"id": "ea536c83", "name": "interpolation(1.2345,2.3456)"},
         "stations": [
             {
                 "resolution": "daily",
@@ -653,7 +655,7 @@ def test_summarized_values_to_ogc_feature_collection(
     assert data.keys() == {"data"}
     assert data["data"]["features"][0] == {
         "geometry": {"coordinates": [2.3456, 1.2345], "type": "Point"},
-        "properties": {"id": "abc", "name": "summary(1.2345,2.3456)"},
+        "properties": {"id": "875cac86", "name": "summary(1.2345,2.3456)"},
         "stations": [
             {
                 "resolution": "daily",
@@ -717,6 +719,83 @@ def test_filter_by_date_interval(df_values: pl.DataFrame) -> None:
     assert not df.is_empty()
     df = filter_by_date(df, date="2020")
     assert not df.is_empty()
+
+
+@pytest.mark.parametrize(
+    ("result_class", "name", "expected_id"),
+    [
+        (InterpolatedValuesResult, "interpolation(1.2345,2.3456)", "ea536c83"),
+        (SummarizedValuesResult, "summary(1.2345,2.3456)", "875cac86"),
+    ],
+)
+def test_interpolated_or_summarized_ogc_feature_collection_without_values(
+    result_class: type,
+    name: str,
+    expected_id: str,
+    df_interpolated_values: pl.DataFrame,
+    df_summarized_values: pl.DataFrame,
+    stations_result_mock: StationsResult,
+) -> None:
+    """A result that came back with no rows is a feature collection with no values.
+
+    The feature's id was read out of the frame, so an interpolation or summary over a window no
+    station covers -- an ordinary outcome, and one the REST API serves as `format=geojson` --
+    raised `OutOfBoundsError: gather indices are out of bounds` instead of answering. The id
+    belongs to the point rather than to any row, and is the name beside it hashed.
+    """
+    df = df_interpolated_values if result_class is InterpolatedValuesResult else df_summarized_values
+    data = result_class(
+        stations=stations_result_mock, df=df.clear(), latlon=(1.2345, 2.3456)
+    ).to_ogc_feature_collection()
+    feature = data["data"]["features"][0]
+    assert feature["properties"] == {"id": expected_id, "name": name}
+    assert feature["values"] == []
+
+
+@pytest.mark.parametrize(
+    ("settings_kwargs", "parameter_in_frame", "expected"),
+    [
+        ({}, "sunshine_duration", "sunshine_duration (s)"),
+        ({"ts_humanize": False}, "sd_10", "sd_10 (s)"),
+        ({"ts_convert_units": False}, "sunshine_duration", "sunshine_duration (h)"),
+        ({"ts_humanize": False, "ts_convert_units": False}, "sd_10", "sd_10 (h)"),
+    ],
+)
+def test_values_plot_labels_the_unit_the_values_carry(
+    settings_kwargs: dict,
+    parameter_in_frame: str,
+    expected: str,
+) -> None:
+    """A plot labels a parameter with the unit its values are actually written in.
+
+    Two ways that went wrong. The label mapping was keyed on the canonical parameter name alone,
+    while a frame carries `name_original` unless `ts_humanize` is on, so nothing matched and the
+    label repeated the name: `sd_10 (sd_10)`. And the symbol was always the target unit's, though
+    `ts_convert_units=False` leaves the values as the source published them -- sunshine duration
+    comes in hours and was labelled seconds, a factor of 3600 between the number and its unit.
+    """
+    request = DwdObservationRequest(
+        parameters=["10_minutes/solar/sunshine_duration"],
+        settings=Settings(**settings_kwargs),
+    )
+    stations = StationsResult(
+        stations=request,
+        df=pl.DataFrame(),
+        df_all=pl.DataFrame(),
+        stations_filter=StationsFilter.ALL,
+    )
+    df = pl.DataFrame(
+        {
+            "station_id": ["01048"],
+            "resolution": ["10_minutes"],
+            "dataset": ["solar"],
+            "parameter": [parameter_in_frame],
+            "date": [dt.datetime(2020, 1, 1, tzinfo=ZoneInfo("UTC"))],
+            "value": [1.0],
+        },
+    )
+    figure = ValuesResult(stations=stations, values=stations.values, df=df).to_plot()
+    assert [annotation.text for annotation in figure.layout.annotations] == [expected]
 
 
 @pytest.fixture

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -794,8 +794,44 @@ def test_values_plot_labels_the_unit_the_values_carry(
             "value": [1.0],
         },
     )
+    pytest.importorskip("plotly")
     figure = ValuesResult(stations=stations, values=stations.values, df=df).to_plot()
     assert [annotation.text for annotation in figure.layout.annotations] == [expected]
+
+
+def test_values_plot_labels_one_name_published_in_two_units() -> None:
+    """A canonical name is only unique within its dataset, and the label follows the dataset.
+
+    DWD publishes `sunshine_duration` in hours at 10 minutes and in minutes at an hour. Keyed on
+    the name alone, one of them labelled the other -- and left unconverted, that is a factor of 60
+    between the number and its unit.
+    """
+    pytest.importorskip("plotly")
+    request = DwdObservationRequest(
+        parameters=["10_minutes/solar/sunshine_duration", "hourly/sun/sunshine_duration"],
+        settings=Settings(ts_convert_units=False),
+    )
+    stations = StationsResult(
+        stations=request,
+        df=pl.DataFrame(),
+        df_all=pl.DataFrame(),
+        stations_filter=StationsFilter.ALL,
+    )
+    df = pl.DataFrame(
+        {
+            "station_id": ["01048", "01048"],
+            "resolution": ["10_minutes", "hourly"],
+            "dataset": ["solar", "sun"],
+            "parameter": ["sunshine_duration", "sunshine_duration"],
+            "date": [dt.datetime(2020, 1, 1, tzinfo=ZoneInfo("UTC"))] * 2,
+            "value": [1.0, 2.0],
+        },
+    )
+    figure = ValuesResult(stations=stations, values=stations.values, df=df).to_plot()
+    assert sorted(annotation.text for annotation in figure.layout.annotations) == [
+        "10_minutes<br>solar<br>sunshine_duration (h)",
+        "hourly<br>sun<br>sunshine_duration (min)",
+    ]
 
 
 @pytest.fixture


### PR DESCRIPTION
Next module in the general-API sweep: `model/result.py`, the export and serialisation layer, which had not been through it. Three defects, each reproduced before being fixed.

## 1. An empty interpolation or summary crashed its own geojson export

```python
result = request.interpolate(latlon=(50.0, 8.9))   # a window no station covers -> 0 rows
result.to_dict()                                    # {"values": []}
result.to_ogc_feature_collection()                  # OutOfBoundsError: gather indices are out of bounds
```

The feature's id came from `self.df.get_column("station_id").gather(0).item()`, which assumes a row. `to_dict` on the same result answers fine, and the REST API serves this path as `format=geojson`, so a point and window with no data — an ordinary outcome, as #1890 argued for values — was a 500 rather than a feature collection with no values.

The id belongs to the point, not to any row. It is `sha256("interpolation({lat:.4f},{lon:.4f})")[:8]`, which is exactly the string the method already computes two lines further down as the feature's `name`, and exactly how `TimeseriesRequest.interpolate` fills that column to begin with. Computing it from the name is therefore identical for every populated result and defined for an empty one:

| | id from the frame | id from the name |
|---|---|---|
| `interpolation(48.2156,8.9784)` | `6754d04d` | `6754d04d` |
| `summary(48.2156,8.9784)` | `a87291a8` | `a87291a8` |

Those are the values `tests/ui/cli/test_cli_interpolate.py` and `test_cli_summarize.py` already assert against live data, so the derivation is pinned by tests that predate this change.

`_create_station_id_from_string` moves off `TimeseriesRequest` into `model/util.py` as `create_station_id_from_string`, since the result layer needs it and cannot import the request layer.

## 2. Plots labelled a parameter with its own name instead of a unit

The label mapping was keyed on the canonical parameter name, but a frame carries `name_original` unless `ts_humanize` is on, so nothing matched and `replace` left the name in place of the symbol:

```
ts_humanize=False   ->   sd_10 (sd_10)
```

## 3. Plots labelled the target unit even when nothing had been converted

The symbol was always `unit_converter.targets[...]`, while `ts_convert_units=False` leaves the values in the unit the source published them in. 29 DWD parameters have a source unit that differs from the target, so this is not a corner:

```
10_minutes/solar/sunshine_duration, ts_convert_units=False
  values: hours          label: (s)          # a factor of 3600 between the number and its unit
```

Both label defects sat in three copies of the same block — `ValuesResult`, `InterpolatedValuesResult`, `SummarizedValuesResult` — which now share one `_unit_symbols` helper that maps both namings of a parameter and picks the symbol according to `ts_convert_units`. The lookup it needs is a `get_unit` on `UnitConverter`; `update_targets` reuses it in place of the inline scan it carried.

## Tests

`test_interpolated_or_summarized_ogc_feature_collection_without_values`, parametrized over both result classes, and `test_values_plot_labels_the_unit_the_values_carry`, which renders through `to_plot` and asserts the annotation text across all four `ts_humanize`/`ts_convert_units` combinations:

| humanize | convert | label |
|---|---|---|
| on | on | `sunshine_duration (s)` |
| off | on | `sd_10 (s)` |
| on | off | `sunshine_duration (h)` |
| off | off | `sd_10 (h)` |

The two existing OGC tests asserted `"id": "abc"` — the fixture's placeholder station id, which real results never carry — and now assert the derived id, with a comment saying why it no longer echoes the frame.

`poe format` and `poe typecheck` clean; `tests/test_io.py tests/model tests/core/test_summary.py` 261 passed with remote deselected. The remote `tests/ui` and `tests/core` suites are running locally as well — those hold the live-data interpolation and summary geojson tests that pin the ids above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BMmz23eRedUH9VTYaMQzV