### PR TITLE
fix(units): derive the mile and the knot from what they are defined as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,11 @@ Types of changes:
 
 ### Fixed
 
-- Unit conversion: the mile, the nautical mile and the knot are derived from the metres they are
-  defined as, rather than from decimals rounded to four figures. `1.609` put kilometre to mile
-  0.0214% away from the metre-to-mile route, `1.151` did the same to the two miles, and `1.944`
-  left knots to metres per second 0.0080% from what its own kilometres-per-hour route gives -- so
+- Unit conversion: the mile and the knot are derived from the metres they are defined as, rather
+  than from decimals rounded to four figures. `1.609` put kilometre to mile 0.0214% away from the
+  metre-to-mile route, `1.151` did the same to the mile and the nautical mile -- the nautical mile
+  itself was already exact against metres and kilometres, and only its ratio to the mile moves --
+  and `1.944` left knots to metres per second 0.0080% from its kilometres-per-hour route, so
   the same quantity converted differently depending on which unit its source published. That last
   one is on real data: the Met Office publishes wind in knots and the speed target is metres per
   second, so every one of its wind speeds carried the error. A round trip hid all three, both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- Unit conversion: the mile, the nautical mile and the knot are derived from the metres they are
+  defined as, rather than from decimals rounded to four figures. `1.609` put kilometre to mile
+  0.0214% away from the metre-to-mile route, `1.151` did the same to the two miles, and `1.944`
+  left knots to metres per second 0.0080% from what its own kilometres-per-hour route gives -- so
+  the same quantity converted differently depending on which unit its source published. That last
+  one is on real data: the Met Office publishes wind in knots and the speed target is metres per
+  second, so every one of its wind speeds carried the error. A round trip hid all three, both
+  directions sharing the rounding, so the tests now check that a conversion agrees whichever route
+  it takes
+
 ## [0.136.0] - 2026-09-04
 
 ### Added

--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -16,6 +16,13 @@ Types of changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- `[Meteogram]` Wind barbs convert metres per second to knots the way the API does, a knot being a
+  nautical mile -- 1852 m exactly -- per hour. Rounded to `1.944`, a speed sitting within 0.008% of
+  a barb boundary or of the 2.5 kt calm threshold could be drawn as the next barb up from the one
+  the value warrants
+
 ## [0.15.0] - 2026-09-04
 
 ### Added

--- a/app/app/components/Meteogram.vue
+++ b/app/app/components/Meteogram.vue
@@ -512,7 +512,9 @@ function updateOverlaySize() {
 function drawBarb(ctx: CanvasRenderingContext2D, px: number, py: number, dirFrom: number, speed: number) {
   // Standard meteorological wind barbs: speed encoded in knots
   // Pennant = 50 kt, full barb = 10 kt, half barb = 5 kt
-  const kt = speed * 1.944
+  // A knot is a nautical mile -- 1852 m exactly -- per hour, which is how the API converts it too;
+  // rounded to 1.944 a speed either side of a barb boundary could be drawn as the next barb up
+  const kt = (speed * 3600) / 1852
   const scale = compact.value ? 0.78 : 1.0
   const barbColor = isDark.value ? '#f4f4f5' : '#0f172a'
   ctx.strokeStyle = barbColor

--- a/src/wetterdienst/model/unit.py
+++ b/src/wetterdienst/model/unit.py
@@ -7,6 +7,19 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+# The mile and the nautical mile are defined in metres exactly, and the knot as one nautical mile
+# per hour. Deriving the factors from these keeps a conversion the same whichever unit a source
+# publishes: rounded to `1.609`, `1.151` and `1.944`, kilometre to mile came out 0.0214% away from
+# metre to mile, and knots to metres per second -- which every Met Office wind speed passes through
+# -- 0.0080% away from the value its own kilometres-per-hour route gives.
+_METERS_PER_MILE = 1609.344
+_METERS_PER_NAUTICAL_MILE = 1852.0
+_KILOMETERS_PER_MILE = _METERS_PER_MILE / 1000
+_KILOMETERS_PER_NAUTICAL_MILE = _METERS_PER_NAUTICAL_MILE / 1000
+_MILES_PER_NAUTICAL_MILE = _METERS_PER_NAUTICAL_MILE / _METERS_PER_MILE
+# one knot is one nautical mile per hour, so metres per second follow from the hour
+_METERS_PER_SECOND_PER_KNOT = _METERS_PER_NAUTICAL_MILE / 3600
+
 
 @dataclass
 class Unit:
@@ -241,18 +254,18 @@ class UnitConverter:
             ("kilometer", "millimeter"): lambda x: x * 1000000,
             ("kilometer", "centimeter"): lambda x: x * 100000,
             ("kilometer", "meter"): lambda x: x * 1000,
-            ("kilometer", "mile"): lambda x: x / 1.609,
-            ("kilometer", "nautical_mile"): lambda x: x / 1.852,
+            ("kilometer", "mile"): lambda x: x / _KILOMETERS_PER_MILE,
+            ("kilometer", "nautical_mile"): lambda x: x / _KILOMETERS_PER_NAUTICAL_MILE,
             ("nautical_mile", "millimeter"): lambda x: x * 1852000,
             ("nautical_mile", "centimeter"): lambda x: x * 185200,
             ("nautical_mile", "meter"): lambda x: x * 1852,
-            ("nautical_mile", "kilometer"): lambda x: x * 1.852,
-            ("nautical_mile", "mile"): lambda x: x * 1.151,
+            ("nautical_mile", "kilometer"): lambda x: x * _KILOMETERS_PER_NAUTICAL_MILE,
+            ("nautical_mile", "mile"): lambda x: x * _MILES_PER_NAUTICAL_MILE,
             ("mile", "millimeter"): lambda x: x * 1609344,
             ("mile", "centimeter"): lambda x: x * 160934.4,
             ("mile", "meter"): lambda x: x * 1609.344,
-            ("mile", "kilometer"): lambda x: x * 1.609,
-            ("mile", "nautical_mile"): lambda x: x / 1.151,
+            ("mile", "kilometer"): lambda x: x * _KILOMETERS_PER_MILE,
+            ("mile", "nautical_mile"): lambda x: x / _MILES_PER_NAUTICAL_MILE,
             # precipitation
             ("millimeter", "liter_per_square_meter"): lambda x: x,
             ("liter_per_square_meter", "millimeter"): lambda x: x,
@@ -268,17 +281,17 @@ class UnitConverter:
             ("kilopascal", "hectopascal"): lambda x: x * 10,
             # speed
             ("meter_per_second", "kilometer_per_hour"): lambda x: x * 3.6,
-            ("meter_per_second", "knots"): lambda x: x * 1.944,
+            ("meter_per_second", "knots"): lambda x: x / _METERS_PER_SECOND_PER_KNOT,
             ("meter_per_second", "beaufort"): lambda x: (x / 0.836) ** (2 / 3),
             ("kilometer_per_hour", "meter_per_second"): lambda x: x / 3.6,
-            ("kilometer_per_hour", "knots"): lambda x: x / 1.852,
+            ("kilometer_per_hour", "knots"): lambda x: x / _KILOMETERS_PER_NAUTICAL_MILE,
             ("kilometer_per_hour", "beaufort"): lambda x: (x / 3.6 / 0.836) ** (2 / 3),
-            ("knots", "meter_per_second"): lambda x: x / 1.944,
-            ("knots", "kilometer_per_hour"): lambda x: x * 1.852,
-            ("knots", "beaufort"): lambda x: (x / 1.944 / 0.836) ** (2 / 3),
+            ("knots", "meter_per_second"): lambda x: x * _METERS_PER_SECOND_PER_KNOT,
+            ("knots", "kilometer_per_hour"): lambda x: x * _KILOMETERS_PER_NAUTICAL_MILE,
+            ("knots", "beaufort"): lambda x: (x * _METERS_PER_SECOND_PER_KNOT / 0.836) ** (2 / 3),
             ("beaufort", "meter_per_second"): lambda x: 0.836 * (x ** (3 / 2)),
             ("beaufort", "kilometer_per_hour"): lambda x: 0.836 * (x ** (3 / 2)) * 3.6,
-            ("beaufort", "knots"): lambda x: 0.836 * (x ** (3 / 2)) * 1.944,
+            ("beaufort", "knots"): lambda x: 0.836 * (x ** (3 / 2)) / _METERS_PER_SECOND_PER_KNOT,
             # temperature
             ("degree_kelvin", "degree_celsius"): lambda x: x - 273.15,
             ("degree_kelvin", "degree_fahrenheit"): lambda x: (x - 273.15) * 9 / 5 + 32,

--- a/tests/model/test_unit.py
+++ b/tests/model/test_unit.py
@@ -2,6 +2,8 @@
 # Distributed under the MIT License. See LICENSE for more info.
 """Tests for unit conversion."""
 
+from itertools import permutations
+
 import pytest
 
 from wetterdienst.model.unit import UnitConverter
@@ -145,12 +147,12 @@ def test_unit_converter_lambda_dimensionless(unit_converter: UnitConverter) -> N
         ("meter", "centimeter", 0.42, 42),
         # length_long
         ("kilometer", "kilometer", 42, 42),
-        ("kilometer", "mile", 42, 26.10316967060286),
+        ("kilometer", "mile", 42, 26.097590073968025),
         ("kilometer", "nautical_mile", 42, 22.67818574514039),
-        ("mile", "kilometer", 42, 67.578),
-        ("mile", "nautical_mile", 42, 36.490008688097305),
+        ("mile", "kilometer", 42, 67.592448),
+        ("mile", "nautical_mile", 42, 36.49700215982721),
         ("nautical_mile", "kilometer", 42, 77.784),
-        ("nautical_mile", "mile", 42, 48.342),
+        ("nautical_mile", "mile", 42, 48.332736816988785),
         # precipitation
         ("millimeter", "millimeter", 42, 42),
         ("millimeter", "liter_per_square_meter", 42, 42),
@@ -166,17 +168,17 @@ def test_unit_converter_lambda_dimensionless(unit_converter: UnitConverter) -> N
         # speed
         ("meter_per_second", "meter_per_second", 42, 42),
         ("meter_per_second", "kilometer_per_hour", 1, 3.6),
-        ("meter_per_second", "knots", 1, 1.944),
+        ("meter_per_second", "knots", 1, 1.9438444924406046),
         ("meter_per_second", "beaufort", 4.2, 2.9333373265075173),
         ("kilometer_per_hour", "meter_per_second", 42, 11.666666666666666),
         ("kilometer_per_hour", "knots", 42, 22.67818574514039),
         ("kilometer_per_hour", "beaufort", 15.12, 2.933337326507517),
-        ("knots", "meter_per_second", 42, 21.60493827160494),
+        ("knots", "meter_per_second", 42, 21.60666666666667),
         ("knots", "kilometer_per_hour", 42, 77.784),
-        ("knots", "beaufort", 4.2, 1.8832060248217928),
+        ("knots", "beaufort", 4.2, 1.8833064611373287),
         ("beaufort", "meter_per_second", 12, 34.75186740306195),
         ("beaufort", "kilometer_per_hour", 12, 125.10672265102302),
-        ("beaufort", "knots", 12, 67.55763023155244),
+        ("beaufort", "knots", 12, 67.55222605346815),
         # temperature
         ("degree_celsius", "degree_celsius", 42, 42),
         ("degree_celsius", "degree_fahrenheit", 42, 107.6),
@@ -264,3 +266,45 @@ def test_unit_converter__get_lambda_invalid(unit_converter: UnitConverter) -> No
         unit_converter._get_lambda("invalid", "degree_fahrenheit")  # noqa: SLF001
     with pytest.raises(ValueError, match="Conversion from degree_kelvin to invalid not supported"):
         unit_converter._get_lambda("degree_kelvin", "invalid")  # noqa: SLF001
+
+
+def test_conversions_agree_whichever_route_they_take() -> None:
+    """Converting a to c directly gives what converting a to b to c gives.
+
+    A conversion table is only consistent if its factors are, and rounded ones are not: `1.609` for
+    the kilometre-to-mile ratio put kilometre-to-mile 0.0214% away from the metre-to-mile route,
+    `1.151` did the same to the two miles, and `1.944` for the knot -- which every Met Office wind
+    speed passes through, the source publishing knots and the target being metres per second --
+    left knots-to-metres-per-second 0.0080% from its own kilometres-per-hour route. A round trip
+    hid all three, since both directions carried the same rounding.
+    """
+    unit_converter = UnitConverter()
+    for units in unit_converter.units.values():
+        names = [unit.name for unit in units]
+        for first, second, third in permutations(names, 3):
+            lambdas = unit_converter.lambdas
+            if not all(pair in lambdas for pair in ((first, second), (second, third), (first, third))):
+                continue
+            direct = lambdas[(first, third)](100.0)
+            via = lambdas[(second, third)](lambdas[(first, second)](100.0))
+            assert direct == pytest.approx(via, rel=1e-9), (
+                f"{first} -> {third} disagrees with {first} -> {second} -> {third}"
+            )
+
+
+def test_every_pair_of_units_of_a_type_converts() -> None:
+    """Every unit of a type converts to every other, which a target override relies on."""
+    unit_converter = UnitConverter()
+    for unit_type, units in unit_converter.units.items():
+        for source, target in permutations([unit.name for unit in units], 2):
+            assert (source, target) in unit_converter.lambdas, f"{unit_type}: {source} -> {target}"
+
+
+def test_converting_to_a_unit_and_back_returns_the_value() -> None:
+    """A value converted to another unit and back is the value it started as."""
+    unit_converter = UnitConverter()
+    for units in unit_converter.units.values():
+        for source, target in permutations([unit.name for unit in units], 2):
+            forth = unit_converter.lambdas[(source, target)]
+            back = unit_converter.lambdas[(target, source)]
+            assert back(forth(100.0)) == pytest.approx(100.0, rel=1e-9), f"{source} -> {target} -> {source}"


### PR DESCRIPTION
Next module in the general-API sweep: `model/unit.py`, which every value in the library passes through.

## How it was found

The conversion table is 130-odd hand-written lambdas, so rather than read them I checked the three properties it should have. Completeness and round-trip were clean; **transitivity was not**:

```
[length_short] kilometer->mile = 62.150404 but kilometer->meter->mile = 62.137119   (0.0214% off)
[length_short] mile->nautical_mile = 86.880973 but mile->meter->nautical_mile = 86.897624   (0.0192% off)
[speed]        knots->meter_per_second = 51.440329 but knots->kilometer_per_hour->meter_per_second = 51.444444   (0.0080% off)
```

131 violations in total, every one tracing to a rounded constant: `1.609` for the kilometre-to-mile ratio (exact: 1.609344), `1.151` for the two miles (exact: 1.150779…), `1.944` for the knot (exact: 1.943844…). The metre-based pairs beside them already used the exact figures, which is why the routes disagree.

A round trip hid all three, because both directions carried the same rounding — `mile -> kilometer -> mile` is exact to the last bit while both legs are 0.02% wrong.

## Why it matters on real data

`knots -> meter_per_second` is not a hypothetical override. The Met Office publishes wind speed in knots and the default target for `speed` is metres per second, so **every Met Office wind speed** was converted with the rounded factor. ECCC, NOAA GHCN and DWD POI publish visibility in kilometres, which reaches the mile factors through `ts_unit_targets`.

The absolute error is small — 0.008% on a wind speed is far inside the instrument's own accuracy — but it is systematic, it is free to remove, and a conversion table whose answer depends on the route is wrong in a way that will bite the next person who adds a unit.

## What changed

The mile and the nautical mile are defined in metres exactly, and the knot is one nautical mile per hour, so the factors are derived from those definitions and named for what they are:

```python
_METERS_PER_MILE = 1609.344
_METERS_PER_NAUTICAL_MILE = 1852.0
_MILES_PER_NAUTICAL_MILE = _METERS_PER_NAUTICAL_MILE / _METERS_PER_MILE
_METERS_PER_SECOND_PER_KNOT = _METERS_PER_NAUTICAL_MILE / 3600
```

Twelve lambdas now read off those instead of carrying their own decimal. Transitivity violations: **131 → 0**.

## Tests

Three properties, checked across the whole table rather than at hand-picked points — this is the part that outlives the fix:

- `test_conversions_agree_whichever_route_they_take` — a to c equals a to b to c, for every triple of every type
- `test_every_pair_of_units_of_a_type_converts` — every ordered pair has a lambda, which a `ts_unit_targets` override relies on
- `test_converting_to_a_unit_and_back_returns_the_value` — round trip, which was already clean and stays a guard

Eight expectations in the existing table encoded the rounded results (`42 mi -> 67.578 km`, now `67.592448`; `1 m/s -> 1.944 kn`, now `1.9438444924406046`) and are updated. No provider test pins a converted value from these units — the Met Office tests assert what its parser produces, before conversion.

`poe format` and `poe typecheck` clean; `tests/model tests/test_api.py` 341 passed with remote deselected, the one failure being a DWD connection error unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BMmz23eRedUH9VTYaMQzV