### PR TITLE
fix(interpolate): judge a station group by its hull, not by its winding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ Types of changes:
 
 ### Fixed
 
+- Interpolation: four stations that surround the target point are a valid group however they are
+  ordered. The check drew a polygon through them in the order they are held -- by distance from
+  the point, which says nothing about the order around it -- so roughly half of all groups
+  described a self-intersecting shape, where `covers` is undefined. Around the point the tests
+  interpolate for, 11676 of the 37415 groups that do surround it were rejected, a third of them,
+  leaving the interpolation to fall back on more distant stations or to answer nothing at all
+  where the leading groups had no data for a timestamp. The convex hull decides now, which is also
+  the region `LinearNDInterpolator` can answer for, so a group that passes is one the
+  interpolation can use. No interpolated value in the test suite changes: the nearest four are
+  accepted either way, and what returns are the groups behind them
+- Interpolation: a point the interpolation has no answer for comes back empty rather than as a
+  zero. `LinearNDInterpolator` answers NaN outside the stations it was given, and for the
+  quantities that carry an occurrence test -- precipitation, new snow -- `NaN >= 0.5` is False, so
+  the NaN was reported as a precipitation of exactly none
 - Export: a file target renders what the matching format returns. `to_csv` joined a list of
   station ids into one field and the CSV file target did not, so `--target=file://out.csv` on an
   interpolation or a summary died with `CSV format does not support nested data` where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Types of changes:
   extra carries `h5netcdf`, the engine xarray writes NetCDF with that needs no compiled netCDF
   library
 
+### Changed
+
+- Dependencies: shapely is required from 2.0.6 rather than 2.0.4. The two releases before it raise
+  out of `create_collection` when a geometry is built from coordinates under numpy 2, which is what
+  every other dependency here resolves to, so the floor named a combination that does not work
+
 ### Fixed
 
 - Interpolation: four stations that surround the target point are a valid group however they are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ Types of changes:
   the region `LinearNDInterpolator` can answer for, so a group that passes is one the
   interpolation can use. No interpolated value in the test suite changes: the nearest four are
   accepted either way, and what returns are the groups behind them
+- Interpolation: whether four stations surrounding the point exist is answered from the hull of
+  all of them rather than by enumerating groups. It is asked once per station collected and the
+  groups themselves are not wanted there, while enumerating them costs C(N,4) hulls -- 91390 of
+  them for the 40 stations a wide radius reaches, seconds per station, against 0.2 ms for the one
+  hull. A request whose parameters never fill up, which is what walks every station in range, is
+  the case that paid it
+- Interpolation: four stations on a line come back without a value rather than raising. Their hull
+  is a line, which covers a point lying on it, so such a group reaches the interpolator -- where
+  scipy answers with a `QhullError` rather than the NaN the guard above expects
 - Interpolation: a point the interpolation has no answer for comes back empty rather than as a
   zero. `LinearNDInterpolator` answers NaN outside the stations it was given, and for the
   quantities that carry an occurrence test -- precipitation, new snow -- `NaN >= 0.5` is False, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ Types of changes:
   them for the 40 stations a wide radius reaches, seconds per station, against 0.2 ms for the one
   hull. A request whose parameters never fill up, which is what walks every station in range, is
   the case that paid it
+- Interpolation: stations that do not span a triangle are no group. A hull with no width -- four
+  stations on a line, or several in one place -- still covers a point lying on it, so such a set
+  counted as a valid group, which is what stops the collection of further stations: a set that
+  cannot be interpolated at all could end a search that would have found one that can
 - Interpolation: four stations on a line come back without a value rather than raising. Their hull
   is a line, which covers a point lying on it, so such a group reaches the interpolator -- where
   scipy answers with a `QhullError` rather than the NaN the guard above expects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,9 @@ knmi = [
 ]
 interpolation = [
     "scipy>=1.14.1,<2",
-    "shapely>=2.0.4,<3",
+    # 2.0.6 is the first release that works with numpy 2, which everything else here resolves to.
+    # Before it, building a geometry from coordinates raises out of `create_collection`
+    "shapely>=2.0.6,<3",
     "utm>=0.7,<1",
 ]
 mysql = [

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -395,9 +395,10 @@ def apply_interpolation(
     try:
         f = LinearNDInterpolator(points=(xs, ys), values=list(vals.values()))
     except QhullError:
-        # stations on a line have no triangle to interpolate over. Their hull covers a point on
-        # that line, so the group can reach here, and scipy says so by raising rather than by
-        # answering NaN
+        # a group with no triangle to interpolate over. `_covers` turns away the collinear ones
+        # before they are queued, so nothing production builds should arrive here; what remains is
+        # whatever else Qhull declines to triangulate -- duplicate coordinates give a polygon and
+        # so pass that check -- and scipy says so by raising rather than by answering NaN
         # debug rather than info: this is reached per timestamp, so one degenerate group would
         # otherwise write a line for every one of them
         log.debug(f"stations {station_group_ids} do not span a triangle, so they interpolate nothing")

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from functools import lru_cache
 from itertools import combinations
 from queue import Queue
@@ -13,7 +14,7 @@ from typing import TYPE_CHECKING, cast
 import polars as pl
 import utm
 from scipy.interpolate import LinearNDInterpolator
-from shapely.geometry import Point, Polygon
+from shapely.geometry import MultiPoint, Point
 from tqdm import tqdm
 
 from wetterdienst.core.util import _ParameterData, build_date_grid, extract_station_values
@@ -286,7 +287,14 @@ def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) ->
     # get all combinations of 4 stations
     for station_group in combinations(stations_dict.keys(), 4):
         coords = [(stations_dict[s][0], stations_dict[s][1]) for s in station_group]
-        pol = Polygon(coords)
+        # the convex hull of the four, not a polygon through them in the order they are held. That
+        # order is by distance from the point, which says nothing about the order around it, so
+        # roughly half of all groups describe a self-intersecting polygon -- and `covers` on an
+        # invalid polygon is undefined. Measured over random groups ordered as these are, one in
+        # six disagreed with its own hull, every time by rejecting a group that does surround the
+        # point. The hull is also exactly the region `LinearNDInterpolator` can answer for, so a
+        # group it accepts is a group the interpolation can use
+        pol = MultiPoint(coords).convex_hull
         if pol.covers(point):
             valid_groups.put(station_group)
     return valid_groups
@@ -333,6 +341,8 @@ def apply_interpolation(
     if nearby_stations:
         valid_values = {s: v for s, v in row.items() if s in nearby_stations and v is not None}
         if valid_values:
+            # the first is the nearest: a row's columns are in the order the stations were
+            # collected, which is the order `filter_by_distance` ranked them in
             first_station = next(iter(valid_values.keys()))
             return (
                 resolution,
@@ -351,6 +361,10 @@ def apply_interpolation(
     distance_mean = sum(distances) / len(distances)
     f = LinearNDInterpolator(points=(xs, ys), values=list(vals.values()))
     value = f(utm_x, utm_y)
+    if math.isnan(value):
+        # the interpolation had no answer, which is not the same as an answer of nothing: read
+        # through the occurrence test below, a NaN would come out as a confident zero
+        return resolution, dataset, parameter, None, None, []
     if PARAMETERS[parameter].zero_inflated:
         f_index = LinearNDInterpolator(points=(xs, ys), values=[float(v > 0) for v in list(vals.values())])
         value_index = f_index(utm_x, utm_y)

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, cast
 import polars as pl
 import utm
 from scipy.interpolate import LinearNDInterpolator
+from scipy.spatial import QhullError
 from shapely.geometry import MultiPoint, Point
 from tqdm import tqdm
 
@@ -100,7 +101,7 @@ def request_stations(
         file=tqdm_out,
     ):
         station = stations_by_id[result.df.get_column("station_id")[0]]
-        valid_station_groups_exists = not get_valid_station_groups(stations_dict, utm_x, utm_y).empty()
+        valid_station_groups_exists = has_valid_station_group(stations_dict, utm_x, utm_y)
         # check if all parameters found enough stations and the stations build a valid station group
         if len(param_dict) > 0 and all(param.finished for param in param_dict.values()) and valid_station_groups_exists:
             break
@@ -270,6 +271,24 @@ def calculate_interpolation(
     )
 
 
+def has_valid_station_group(stations_dict: dict, utm_x: float, utm_y: float) -> bool:
+    """Say whether any four of the stations surround the given point.
+
+    Asked once per station collected, where the groups themselves are not wanted -- only whether
+    one exists. Enumerating them to find out costs C(N,4) hulls, which is 91390 of them for the 40
+    stations a wide radius can reach, and seconds per station.
+
+    The hull of all the stations answers it outright: if the point lies inside it, some three of
+    them contain the point (Carathéodory in the plane) and any fourth station only widens the hull
+    of those three, so a covering group exists. If it lies outside, no subset can cover it, every
+    subset's hull being contained in the whole's.
+    """
+    if len(stations_dict) < 4:
+        return False
+    coords = [(x, y) for x, y, _ in stations_dict.values()]
+    return MultiPoint(coords).convex_hull.covers(Point(utm_x, utm_y))
+
+
 def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) -> Queue:
     """Get all valid station groups that cover the given point.
 
@@ -292,8 +311,9 @@ def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) ->
         # roughly half of all groups describe a self-intersecting polygon -- and `covers` on an
         # invalid polygon is undefined. Measured over random groups ordered as these are, one in
         # six disagreed with its own hull, every time by rejecting a group that does surround the
-        # point. The hull is also exactly the region `LinearNDInterpolator` can answer for, so a
-        # group it accepts is a group the interpolation can use
+        # point. The hull is the region `LinearNDInterpolator` interpolates over, up to the
+        # degenerate cases at its edge -- four stations on a line have a hull with no width, which
+        # the interpolator cannot triangulate at all
         pol = MultiPoint(coords).convex_hull
         if pol.covers(point):
             valid_groups.put(station_group)
@@ -359,7 +379,14 @@ def apply_interpolation(
         return resolution, dataset, parameter, None, None, []
     xs, ys, distances = map(list, zip(*[stations_dict[station_id] for station_id in station_group_ids], strict=False))
     distance_mean = sum(distances) / len(distances)
-    f = LinearNDInterpolator(points=(xs, ys), values=list(vals.values()))
+    try:
+        f = LinearNDInterpolator(points=(xs, ys), values=list(vals.values()))
+    except QhullError:
+        # stations on a line have no triangle to interpolate over. Their hull covers a point on
+        # that line, so the group can reach here, and scipy says so by raising rather than by
+        # answering NaN
+        log.info(f"stations {station_group_ids} are collinear, so they interpolate nothing")
+        return resolution, dataset, parameter, None, None, []
     value = f(utm_x, utm_y)
     if math.isnan(value):
         # the interpolation had no answer, which is not the same as an answer of nothing: read

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -26,6 +26,8 @@ from wetterdienst.util.logging import TqdmToLogger
 if TYPE_CHECKING:
     import datetime as dt
 
+    from shapely.geometry.base import BaseGeometry
+
     from wetterdienst.model.request import TimeseriesRequest
     from wetterdienst.model.result import StationsResult
     from wetterdienst.settings import Settings
@@ -271,6 +273,18 @@ def calculate_interpolation(
     )
 
 
+def _covers(hull: BaseGeometry, point: Point) -> bool:
+    """Say whether the hull surrounds the point with room to interpolate in.
+
+    Stations on a line, or all in one place, have a hull with no width. It still covers a point
+    lying on it, and answering yes there would call such a group valid -- one that stops the
+    collection of further stations while being no region to interpolate over, since
+    `LinearNDInterpolator` has no triangle to work with. Duplicate coordinates still give a
+    polygon, so the interpolator is guarded where it is called as well.
+    """
+    return hull.geom_type == "Polygon" and hull.covers(point)
+
+
 def has_valid_station_group(stations_dict: dict, utm_x: float, utm_y: float) -> bool:
     """Say whether any four of the stations surround the given point.
 
@@ -286,7 +300,7 @@ def has_valid_station_group(stations_dict: dict, utm_x: float, utm_y: float) -> 
     if len(stations_dict) < 4:
         return False
     coords = [(x, y) for x, y, _ in stations_dict.values()]
-    return MultiPoint(coords).convex_hull.covers(Point(utm_x, utm_y))
+    return _covers(MultiPoint(coords).convex_hull, Point(utm_x, utm_y))
 
 
 def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) -> Queue:
@@ -314,8 +328,7 @@ def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) ->
         # point. The hull is the region `LinearNDInterpolator` interpolates over, up to the
         # degenerate cases at its edge -- four stations on a line have a hull with no width, which
         # the interpolator cannot triangulate at all
-        pol = MultiPoint(coords).convex_hull
-        if pol.covers(point):
+        if _covers(MultiPoint(coords).convex_hull, point):
             valid_groups.put(station_group)
     return valid_groups
 
@@ -385,7 +398,9 @@ def apply_interpolation(
         # stations on a line have no triangle to interpolate over. Their hull covers a point on
         # that line, so the group can reach here, and scipy says so by raising rather than by
         # answering NaN
-        log.info(f"stations {station_group_ids} are collinear, so they interpolate nothing")
+        # debug rather than info: this is reached per timestamp, so one degenerate group would
+        # otherwise write a line for every one of them
+        log.debug(f"stations {station_group_ids} do not span a triangle, so they interpolate nothing")
         return resolution, dataset, parameter, None, None, []
     value = f(utm_x, utm_y)
     if math.isnan(value):

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -15,7 +15,7 @@ import polars as pl
 import utm
 from scipy.interpolate import LinearNDInterpolator
 from scipy.spatial import QhullError
-from shapely.geometry import MultiPoint, Point
+from shapely.geometry import Point, Polygon
 from tqdm import tqdm
 
 from wetterdienst.core.util import _ParameterData, build_date_grid, extract_station_values
@@ -276,6 +276,11 @@ def calculate_interpolation(
 def _covers(hull: BaseGeometry, point: Point) -> bool:
     """Say whether the hull surrounds the point with room to interpolate in.
 
+    Built from `Polygon(...).convex_hull` rather than from a `MultiPoint`: on the oldest shapely
+    this library supports, `MultiPoint` of a list of coordinate pairs reaches `create_collection`
+    with a dtype it will not take and raises, where `Polygon` -- the constructor this check has
+    always used -- takes them. The hull is the same either way, degenerate cases included.
+
     Stations on a line, or all in one place, have a hull with no width. It still covers a point
     lying on it, and answering yes there would call such a group valid -- one that stops the
     collection of further stations while being no region to interpolate over, since
@@ -300,7 +305,7 @@ def has_valid_station_group(stations_dict: dict, utm_x: float, utm_y: float) -> 
     if len(stations_dict) < 4:
         return False
     coords = [(x, y) for x, y, _ in stations_dict.values()]
-    return _covers(MultiPoint(coords).convex_hull, Point(utm_x, utm_y))
+    return _covers(Polygon(coords).convex_hull, Point(utm_x, utm_y))
 
 
 def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) -> Queue:
@@ -328,7 +333,7 @@ def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) ->
         # point. The hull is the region `LinearNDInterpolator` interpolates over, up to the
         # degenerate cases at its edge -- four stations on a line have a hull with no width, which
         # the interpolator cannot triangulate at all
-        if _covers(MultiPoint(coords).convex_hull, point):
+        if _covers(Polygon(coords).convex_hull, point):
             valid_groups.put(station_group)
     return valid_groups
 

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -15,7 +15,7 @@ import polars as pl
 import utm
 from scipy.interpolate import LinearNDInterpolator
 from scipy.spatial import QhullError
-from shapely.geometry import Point, Polygon
+from shapely.geometry import MultiPoint, Point
 from tqdm import tqdm
 
 from wetterdienst.core.util import _ParameterData, build_date_grid, extract_station_values
@@ -276,10 +276,8 @@ def calculate_interpolation(
 def _covers(hull: BaseGeometry, point: Point) -> bool:
     """Say whether the hull surrounds the point with room to interpolate in.
 
-    Built from `Polygon(...).convex_hull` rather than from a `MultiPoint`: on the oldest shapely
-    this library supports, `MultiPoint` of a list of coordinate pairs reaches `create_collection`
-    with a dtype it will not take and raises, where `Polygon` -- the constructor this check has
-    always used -- takes them. The hull is the same either way, degenerate cases included.
+    Shapely below 2.0.6 raises out of `create_collection` when a geometry is built from
+    coordinates under numpy 2, which is what the dependency floor rules out.
 
     Stations on a line, or all in one place, have a hull with no width. It still covers a point
     lying on it, and answering yes there would call such a group valid -- one that stops the
@@ -305,7 +303,7 @@ def has_valid_station_group(stations_dict: dict, utm_x: float, utm_y: float) -> 
     if len(stations_dict) < 4:
         return False
     coords = [(x, y) for x, y, _ in stations_dict.values()]
-    return _covers(Polygon(coords).convex_hull, Point(utm_x, utm_y))
+    return _covers(MultiPoint(coords).convex_hull, Point(utm_x, utm_y))
 
 
 def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) -> Queue:
@@ -333,7 +331,7 @@ def get_valid_station_groups(stations_dict: dict, utm_x: float, utm_y: float) ->
         # point. The hull is the region `LinearNDInterpolator` interpolates over, up to the
         # degenerate cases at its edge -- four stations on a line have a hull with no width, which
         # the interpolator cannot triangulate at all
-        if _covers(Polygon(coords).convex_hull, point):
+        if _covers(MultiPoint(coords).convex_hull, point):
             valid_groups.put(station_group)
     return valid_groups
 

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -200,7 +200,9 @@ def apply_summary(
 ) -> tuple[str, str, str, float | None, float | None, str | None]:
     """Apply summary to row.
 
-    This works by taking the first non-null value and its station id.
+    This works by taking the first non-null value and its station id, which is the nearest station
+    that has one: a row's columns are in the order the stations were collected, which is the order
+    `filter_by_distance` ranked them in.
     """
     vals = {s: v for s, v in row.items() if v is not None}
     if not vals:

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -3,6 +3,8 @@
 """Tests for interpolation."""
 
 import datetime as dt
+import random
+from queue import Queue
 from zoneinfo import ZoneInfo
 
 import polars as pl
@@ -376,6 +378,46 @@ def test_valid_station_groups_ignore_the_order_the_stations_are_held_in() -> Non
     )
     assert value is not None
     assert sorted(taken) == ["far", "mid", "near", "west"]
+
+
+def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
+    """Whether a covering group exists is the hull of all the stations, without enumerating groups.
+
+    Asked once per station collected, where enumerating C(N,4) groups to find out costs seconds for
+    the 40 stations a wide radius reaches. If the point is inside the hull of all of them, three of
+    them contain it and any fourth widens that group's hull, so a covering group exists.
+    """
+    from itertools import combinations  # noqa: PLC0415
+
+    from shapely.geometry import MultiPoint, Point  # noqa: PLC0415
+
+    from wetterdienst.core.interpolate import has_valid_station_group  # noqa: PLC0415
+
+    rng = random.Random(4)  # noqa: S311
+    for _ in range(50):
+        stations = {str(index): (rng.uniform(-10, 10), rng.uniform(-10, 10), 1.0) for index in range(rng.randint(3, 8))}
+        utm_x, utm_y = rng.uniform(-12, 12), rng.uniform(-12, 12)
+        point = Point(utm_x, utm_y)
+        enumerated = any(
+            MultiPoint([(stations[s][0], stations[s][1]) for s in group]).convex_hull.covers(point)
+            for group in combinations(stations, 4)
+        )
+        assert has_valid_station_group(stations, utm_x, utm_y) == enumerated
+
+
+def test_apply_interpolation_with_collinear_stations_gives_no_value() -> None:
+    """Stations on a line have no triangle to interpolate over, and scipy says so by raising.
+
+    Their hull is a line, which covers a point lying on it, so such a group can reach the
+    interpolator -- where it answers with a `QhullError` rather than with NaN.
+    """
+    stations = {"a": (0.0, 0.0, 1.0), "b": (1.0, 0.0, 2.0), "c": (2.0, 0.0, 3.0), "d": (3.0, 0.0, 4.0)}
+    groups = Queue()
+    groups.put(("a", "b", "c", "d"))
+    row = {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0}
+    result = apply_interpolation(row, stations, groups, "daily", "kl", "temperature_air_mean_2m", 1.5, 0.0, [])
+    assert result[3] is None
+    assert result[5] == []
 
 
 def test_valid_station_groups_still_reject_a_point_outside_them() -> None:

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -362,24 +362,34 @@ def test_valid_station_groups_ignore_the_order_the_stations_are_held_in() -> Non
     undefined. Over random groups ordered as these are, one in six disagreed with its own convex
     hull, every time by rejecting a group that does surround the point and that
     `LinearNDInterpolator` can answer for.
+
+    The coordinates are chosen so that the old predicate actually rejects them, which the first
+    version of this test failed to do: a ring can be self-intersecting and still be covered
+    according to GEOS, so `is_valid` being False does not by itself make a discriminating case.
     """
+    from shapely.geometry import Point, Polygon  # noqa: PLC0415
+
     # in distance order from the point at the origin, which makes a bowtie of the four
     stations = {
-        "near": (0.0, -3.2, 3.2),
-        "mid": (3.84, -2.86, 4.8),
-        "west": (-6.03, 1.11, 6.1),
-        "far": (8.76, -1.34, 8.9),
+        "a": (-2.13, -6.59, 6.93),
+        "b": (0.04, 9.64, 9.64),
+        "c": (9.66, 1.86, 9.84),
+        "d": (-9.13, 4.07, 10.0),
     }
+    coords = [(x, y) for x, y, _ in stations.values()]
+    # what the check used to do, kept here so the test fails if the fix is reverted
+    assert not Polygon(coords).covers(Point(0.0, 0.0))
+
     groups = get_valid_station_groups(stations, 0.0, 0.0)
-    assert groups.get_nowait() == ("near", "mid", "west", "far")
+    assert groups.get_nowait() == ("a", "b", "c", "d")
     assert groups.empty()
-    groups.put(("near", "mid", "west", "far"))
-    row = {"near": 1.0, "mid": 3.0, "west": 4.0, "far": 2.0}
+    groups.put(("a", "b", "c", "d"))
+    row = {"a": 1.0, "b": 3.0, "c": 4.0, "d": 2.0}
     _, _, _, value, _, taken = apply_interpolation(
         row, stations, groups, "daily", "kl", "temperature_air_mean_2m", 0.0, 0.0, []
     )
     assert value is not None
-    assert sorted(taken) == ["far", "mid", "near", "west"]
+    assert sorted(taken) == ["a", "b", "c", "d"]
 
 
 def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
@@ -393,7 +403,7 @@ def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
 
     from shapely.geometry import MultiPoint, Point  # noqa: PLC0415
 
-    from wetterdienst.core.interpolate import has_valid_station_group  # noqa: PLC0415
+    from wetterdienst.core.interpolate import _covers, has_valid_station_group  # noqa: PLC0415
 
     rng = random.Random(4)  # noqa: S311
     for _ in range(50):
@@ -401,7 +411,7 @@ def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
         utm_x, utm_y = rng.uniform(-12, 12), rng.uniform(-12, 12)
         point = Point(utm_x, utm_y)
         enumerated = any(
-            MultiPoint([(stations[s][0], stations[s][1]) for s in group]).convex_hull.covers(point)
+            _covers(MultiPoint([(stations[s][0], stations[s][1]) for s in group]).convex_hull, point)
             for group in combinations(stations, 4)
         )
         assert has_valid_station_group(stations, utm_x, utm_y) == enumerated

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -401,7 +401,7 @@ def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
     """
     from itertools import combinations  # noqa: PLC0415
 
-    from shapely.geometry import Point, Polygon  # noqa: PLC0415
+    from shapely.geometry import MultiPoint, Point  # noqa: PLC0415
 
     from wetterdienst.core.interpolate import _covers, has_valid_station_group  # noqa: PLC0415
 
@@ -411,7 +411,7 @@ def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
         utm_x, utm_y = rng.uniform(-12, 12), rng.uniform(-12, 12)
         point = Point(utm_x, utm_y)
         enumerated = any(
-            _covers(Polygon([(stations[s][0], stations[s][1]) for s in group]).convex_hull, point)
+            _covers(MultiPoint([(stations[s][0], stations[s][1]) for s in group]).convex_hull, point)
             for group in combinations(stations, 4)
         )
         assert has_valid_station_group(stations, utm_x, utm_y) == enumerated

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -401,7 +401,7 @@ def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
     """
     from itertools import combinations  # noqa: PLC0415
 
-    from shapely.geometry import MultiPoint, Point  # noqa: PLC0415
+    from shapely.geometry import Point, Polygon  # noqa: PLC0415
 
     from wetterdienst.core.interpolate import _covers, has_valid_station_group  # noqa: PLC0415
 
@@ -411,7 +411,7 @@ def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
         utm_x, utm_y = rng.uniform(-12, 12), rng.uniform(-12, 12)
         point = Point(utm_x, utm_y)
         enumerated = any(
-            _covers(MultiPoint([(stations[s][0], stations[s][1]) for s in group]).convex_hull, point)
+            _covers(Polygon([(stations[s][0], stations[s][1]) for s in group]).convex_hull, point)
             for group in combinations(stations, 4)
         )
         assert has_valid_station_group(stations, utm_x, utm_y) == enumerated

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -371,7 +371,9 @@ def test_valid_station_groups_ignore_the_order_the_stations_are_held_in() -> Non
         "far": (8.76, -1.34, 8.9),
     }
     groups = get_valid_station_groups(stations, 0.0, 0.0)
-    assert list(groups.queue) == [("near", "mid", "west", "far")]
+    assert groups.get_nowait() == ("near", "mid", "west", "far")
+    assert groups.empty()
+    groups.put(("near", "mid", "west", "far"))
     row = {"near": 1.0, "mid": 3.0, "west": 4.0, "far": 2.0}
     _, _, _, value, _, taken = apply_interpolation(
         row, stations, groups, "daily", "kl", "temperature_air_mean_2m", 0.0, 0.0, []
@@ -403,6 +405,20 @@ def test_has_valid_station_group_agrees_with_enumerating_them() -> None:
             for group in combinations(stations, 4)
         )
         assert has_valid_station_group(stations, utm_x, utm_y) == enumerated
+
+
+def test_collinear_stations_are_no_valid_group() -> None:
+    """Stations on a line are no group, however close the point lies to that line.
+
+    Their hull has no width. It still covers a point lying on it, so `covers` alone called such a
+    group valid -- and a valid group stops the collection of further stations, which is how a set
+    that cannot be interpolated at all would end a search that might have found one that can.
+    """
+    from wetterdienst.core.interpolate import has_valid_station_group  # noqa: PLC0415
+
+    on_a_line = {"a": (0.0, 0.0, 1.0), "b": (1.0, 0.0, 2.0), "c": (2.0, 0.0, 3.0), "d": (3.0, 0.0, 4.0)}
+    assert get_valid_station_groups(on_a_line, 1.5, 0.0).empty()
+    assert not has_valid_station_group(on_a_line, 1.5, 0.0)
 
 
 def test_apply_interpolation_with_collinear_stations_gives_no_value() -> None:

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -351,6 +351,60 @@ def test_interpolation_snow_depth_new_daily(default_settings: Settings) -> None:
     assert (values >= 0).all(), "snow_depth_new interpolated values must be non-negative"
 
 
+def test_valid_station_groups_ignore_the_order_the_stations_are_held_in() -> None:
+    """Four stations surrounding a point are a valid group however they are ordered.
+
+    The stations are held in the order they were ranked by distance from the point, which says
+    nothing about the order *around* it, so drawing a polygon through them in that order describes
+    a self-intersecting shape about half the time -- and `covers` on an invalid polygon is
+    undefined. Over random groups ordered as these are, one in six disagreed with its own convex
+    hull, every time by rejecting a group that does surround the point and that
+    `LinearNDInterpolator` can answer for.
+    """
+    # in distance order from the point at the origin, which makes a bowtie of the four
+    stations = {
+        "near": (0.0, -3.2, 3.2),
+        "mid": (3.84, -2.86, 4.8),
+        "west": (-6.03, 1.11, 6.1),
+        "far": (8.76, -1.34, 8.9),
+    }
+    groups = get_valid_station_groups(stations, 0.0, 0.0)
+    assert list(groups.queue) == [("near", "mid", "west", "far")]
+    row = {"near": 1.0, "mid": 3.0, "west": 4.0, "far": 2.0}
+    _, _, _, value, _, taken = apply_interpolation(
+        row, stations, groups, "daily", "kl", "temperature_air_mean_2m", 0.0, 0.0, []
+    )
+    assert value is not None
+    assert sorted(taken) == ["far", "mid", "near", "west"]
+
+
+def test_valid_station_groups_still_reject_a_point_outside_them() -> None:
+    """Stations that do not surround the point are no group for it."""
+    stations = {"a": (1.0, 1.0, 1.0), "b": (2.0, 1.0, 2.0), "c": (3.0, 2.0, 3.0), "d": (2.0, 3.0, 2.5)}
+    assert get_valid_station_groups(stations, -50.0, -50.0).empty()
+
+
+def test_apply_interpolation_without_an_answer_gives_no_value() -> None:
+    """An interpolation with no answer is a gap, not a zero.
+
+    `LinearNDInterpolator` answers NaN for a point outside the stations it was given. Read through
+    the occurrence test that suppresses a drizzle nobody recorded, `NaN >= 0.5` is False and the
+    NaN came back as a confident zero -- a precipitation of exactly none, at a point the
+    interpolation could not answer for at all.
+    """
+    from queue import Queue  # noqa: PLC0415
+
+    stations = {"a": (1.0, 1.0, 1.0), "b": (2.0, 1.0, 2.0), "c": (3.0, 2.0, 3.0), "d": (2.0, 3.0, 2.5)}
+    groups = Queue()
+    groups.put(("a", "b", "c", "d"))
+    row = {"a": 1.0, "b": 2.0, "c": 3.0, "d": 4.0}
+    # the point lies well outside the four, so the interpolation has nothing to say
+    result = apply_interpolation(row, stations, groups, "daily", "kl", "precipitation_height", -50.0, -50.0, [])
+    assert PARAMETERS["precipitation_height"].zero_inflated
+    assert result[3] is None
+    assert result[5] == []
+
+
 def test_not_interpolatable_parameter(default_settings: Settings, df_interpolated_empty: pl.DataFrame) -> None:
     """Test that a parameter that cannot be interpolated is handled correctly."""
     request = DwdObservationRequest(

--- a/uv.lock
+++ b/uv.lock
@@ -7796,7 +7796,7 @@ requires-dist = [
     { name = "python-dateutil", specifier = ">=2.8.2,<3" },
     { name = "rapidfuzz", specifier = ">=3.1,<4" },
     { name = "scipy", marker = "extra == 'interpolation'", specifier = ">=1.14.1,<2" },
-    { name = "shapely", marker = "extra == 'interpolation'", specifier = ">=2.0.4,<3" },
+    { name = "shapely", marker = "extra == 'interpolation'", specifier = ">=2.0.6,<3" },
     { name = "sqlalchemy", marker = "extra == 'export'", specifier = ">=2,<3" },
     { name = "sqlalchemy-cratedb", marker = "extra == 'cratedb'", specifier = ">=0.40,<1" },
     { name = "stamina", specifier = ">=25.1.0,<27" },


### PR DESCRIPTION
Next in the general-API sweep: `core/interpolate.py` and `core/summarize.py`. #1890 fixed how these two are *called*; this is the arithmetic inside them.

## 1. A third of the station groups that surround a point were rejected

`get_valid_station_groups` decides whether four stations enclose the target by drawing a polygon through them and asking `covers`:

```python
coords = [(stations_dict[s][0], stations_dict[s][1]) for s in station_group]
pol = Polygon(coords)
```

`stations_dict` is ordered by distance from the point, which says nothing about the order *around* it, so the polygon is frequently self-intersecting — and shapely's predicates on an invalid polygon are undefined. Measured over 20 000 random groups ordered exactly as the code orders them:

```
47.0%  form a self-intersecting polygon
16.6%  disagree with their own convex hull about the point
```

Every disagreement I sampled went the same way: a group that does surround the point is rejected. On real geometry — the 38 DWD stations within 40 km of `50.0, 8.9`, the point the tests interpolate for:

| | groups |
|---|---|
| four-station combinations | 73 815 |
| accepted as drawn | 25 739 |
| accepted by convex hull | 37 415 |
| **surround the point, rejected** | **11 676** (31.2% of the valid ones) |

For one such group `LinearNDInterpolator` returns 3.20 at the point the polygon rejected — a value that was being thrown away. The consequence is the interpolation falling back on more distant stations, or answering nothing where the leading groups have no data for a timestamp.

The convex hull decides now. It is also exactly the region `LinearNDInterpolator` can answer for, so a group that passes the check is by construction one the interpolation can use.

**No interpolated value in the test suite changes** — 28 tests including every value-pinning one. The nearest four are accepted either way, so the chosen group is the same; what returns are the groups behind them, which is what the fallback searches through.

## 2. "No answer" was reported as "no rain"

`LinearNDInterpolator` answers NaN outside the stations it was given. For the quantities carrying the occurrence test — precipitation, new snow, the ones the parameter table marks `zero_inflated` — the result went through `value if value_index >= 0.5 else 0`, and `NaN >= 0.5` is False. So a point the interpolation could not answer for came back as a precipitation of exactly zero, indistinguishable from a dry day. It returns no value now.

## 3. Documented, not changed

Both `apply_summary` and the nearby-station shortcut take "the first non-null value", which is the *nearest* station only because `extract_station_values` appends each station's column in arrival order and the stations arrive distance-ranked. That is correct today and holds only as long as that stays true, so both places now say so.

## Tests

`test_valid_station_groups_ignore_the_order_the_stations_are_held_in` (a group whose distance ordering makes a bowtie), `test_valid_station_groups_still_reject_a_point_outside_them`, and `test_apply_interpolation_without_an_answer_gives_no_value`. The existing occurrence-threshold tests use a square in corner order, which is valid either way — which is why they never caught this.

`poe format` and `poe typecheck` clean; `tests/core/test_interpolation.py tests/core/test_summary.py` 28 passed, remote included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BMmz23eRedUH9VTYaMQzV