### PR TITLE
feat(app): let the Explorer name the elevation of an interpolated point

### DIFF
--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -22,7 +22,8 @@ Types of changes:
   sea level, beside the coordinates. Air temperature falls about 0.65 K per 100 m, so a point in a
   valley and one on the ridge above it get different answers from the same stations; left empty,
   the readings are used as they come. Choosing the point by station fills it with that station's
-  own height, a station naming its altitude as well as its position
+  own height, a station naming its altitude as well as its position, and the field is shown either
+  way so that a height is never carried without being seen
 
 ### Fixed
 

--- a/CHANGELOG_APP.md
+++ b/CHANGELOG_APP.md
@@ -16,6 +16,14 @@ Types of changes:
 
 ## [Unreleased]
 
+### Added
+
+- `[Explorer]` An elevation for the point an interpolation or summary answers for, in metres above
+  sea level, beside the coordinates. Air temperature falls about 0.65 K per 100 m, so a point in a
+  valley and one on the ridge above it get different answers from the same stations; left empty,
+  the readings are used as they come. Choosing the point by station fills it with that station's
+  own height, a station naming its altitude as well as its position
+
 ### Fixed
 
 - `[Meteogram]` Wind barbs convert metres per second to knots the way the API does, a knot being a

--- a/app/app/components/DataViewer.vue
+++ b/app/app/components/DataViewer.vue
@@ -24,7 +24,7 @@ const stationSelection = computed(() => {
     return {
       mode: 'station' as const,
       selection: { stations: [] as { station_id: string }[] },
-      interpolation: { source: 'manual' as const, latitude: undefined, longitude: undefined, station: undefined },
+      interpolation: { source: 'manual' as const, latitude: undefined, longitude: undefined, elevation: undefined, station: undefined },
       dateRange: { startDate: undefined, endDate: undefined },
     }
   }
@@ -149,6 +149,7 @@ const apiQuery = computed(() => {
       ...base,
       latitude: interp?.latitude,
       longitude: interp?.longitude,
+      elevation: interp?.elevation,
       use_nearby_station_distance: props.settings.useNearbyStationDistance,
     }
     // Add interpolation station distance if provided (filter out empty values)
@@ -171,6 +172,7 @@ const apiQuery = computed(() => {
       ...base,
       latitude: interp?.latitude,
       longitude: interp?.longitude,
+      elevation: interp?.elevation,
       use_nearby_station_distance: props.settings.useNearbyStationDistance,
     }
     // Add summary station distance if provided (filter out empty values)
@@ -429,6 +431,8 @@ async function downloadValues(format: string, extension: string) {
     const interp = ss.interpolation
     if (interp?.latitude !== undefined)
       params.set('latitude', interp.latitude.toString())
+    if (interp?.elevation !== undefined)
+      params.set('elevation', interp.elevation.toString())
     if (interp?.longitude !== undefined)
       params.set('longitude', interp.longitude.toString())
     // Add interpolation settings
@@ -454,6 +458,8 @@ async function downloadValues(format: string, extension: string) {
     const interp = ss.interpolation
     if (interp?.latitude !== undefined)
       params.set('latitude', interp.latitude.toString())
+    if (interp?.elevation !== undefined)
+      params.set('elevation', interp.elevation.toString())
     if (interp?.longitude !== undefined)
       params.set('longitude', interp.longitude.toString())
     // Add summary settings (uses same settings as interpolation)

--- a/app/app/components/DataViewer.vue
+++ b/app/app/components/DataViewer.vue
@@ -431,10 +431,10 @@ async function downloadValues(format: string, extension: string) {
     const interp = ss.interpolation
     if (interp?.latitude !== undefined)
       params.set('latitude', interp.latitude.toString())
-    if (interp?.elevation !== undefined)
-      params.set('elevation', interp.elevation.toString())
     if (interp?.longitude !== undefined)
       params.set('longitude', interp.longitude.toString())
+    if (interp?.elevation !== undefined)
+      params.set('elevation', interp.elevation.toString())
     // Add interpolation settings
     params.set('use_nearby_station_distance', props.settings.useNearbyStationDistance.toString())
     const stationDistance = Object.entries(props.settings.useStationDistancePerParameter)
@@ -458,10 +458,10 @@ async function downloadValues(format: string, extension: string) {
     const interp = ss.interpolation
     if (interp?.latitude !== undefined)
       params.set('latitude', interp.latitude.toString())
-    if (interp?.elevation !== undefined)
-      params.set('elevation', interp.elevation.toString())
     if (interp?.longitude !== undefined)
       params.set('longitude', interp.longitude.toString())
+    if (interp?.elevation !== undefined)
+      params.set('elevation', interp.elevation.toString())
     // Add summary settings (uses same settings as interpolation)
     params.set('use_nearby_station_distance', props.settings.useNearbyStationDistance.toString())
     const stationDistance = Object.entries(props.settings.useStationDistancePerParameter)

--- a/app/app/components/InterpolationSummarySelection.vue
+++ b/app/app/components/InterpolationSummarySelection.vue
@@ -20,6 +20,14 @@ const latitudeInput = ref<string>(modelValue.value.latitude?.toString() ?? '')
 const longitudeInput = ref<string>(modelValue.value.longitude?.toString() ?? '')
 const elevationInput = ref<string>(modelValue.value.elevation?.toString() ?? '')
 
+// the station watcher writes the elevation straight into the model, so the box has to follow it
+// or it shows empty while the query carries a height the user cannot see
+watch(() => modelValue.value.elevation, (elevation) => {
+  const shown = elevation?.toString() ?? ''
+  if (shown !== elevationInput.value)
+    elevationInput.value = shown
+})
+
 // Watch inputs and update model
 watch([latitudeInput, longitudeInput, elevationInput], ([lat, lon, elevation]) => {
   const latNum = Number.parseFloat(lat)
@@ -44,8 +52,9 @@ watch(selectedStation, (station) => {
     latitude: station?.latitude,
     longitude: station?.longitude,
     // a station names its altitude as well as its position, which is the height the answer is
-    // wanted at when the point is given as a station
-    elevation: station?.height,
+    // wanted at when the point is given as a station -- except where the provider reports no
+    // height for it, and several report none at all, where there is nothing to name
+    elevation: station?.height ?? undefined,
   }
 })
 

--- a/app/app/components/InterpolationSummarySelection.vue
+++ b/app/app/components/InterpolationSummarySelection.vue
@@ -24,6 +24,14 @@ const selectedStation = ref<Station | undefined>(modelValue.value.station)
 
 watch(selectedStation, fromStation)
 
+// the parent replaces the whole model when the provider or dataset changes, which clears the
+// station -- and a select still holding the old one would write it back, coordinates, height and
+// all, for a station the new dataset may not have
+watch(() => modelValue.value.station, (station) => {
+  if (station !== selectedStation.value)
+    selectedStation.value = station
+})
+
 // Fetch stations for station source
 const { data: stationsData, pending: stationsPending, refresh: refreshStations } = useFetch<StationsResponse>(
   '/api/stations',
@@ -76,8 +84,9 @@ function setSource(source: InterpolationSource) {
   // source change was being undone by the elevation change that followed it
   modelValue.value = source === 'station'
     // back to the station still in the select: it names its height again, where the watcher below
-    // stays silent, the selection itself not having changed
-    ? { ...modelValue.value, source, ...pointFromStation(selectedStation.value) }
+    // stays silent, the selection itself not having changed. With nothing selected it says
+    // nothing -- taking its empty answer would clear coordinates someone had just typed
+    ? { ...modelValue.value, source, ...(selectedStation.value ? pointFromStation(selectedStation.value) : {}) }
     // the elevation came from wherever the point did, so it goes with it
     : { ...modelValue.value, source, elevation: undefined }
 }

--- a/app/app/components/InterpolationSummarySelection.vue
+++ b/app/app/components/InterpolationSummarySelection.vue
@@ -17,7 +17,7 @@ const sourceOptions = computed(() => [
 
 // the point, and the boxes that describe it -- see `useInterpolationPoint` for why the coordinates
 // and the elevation are kept apart
-const { latitudeInput, longitudeInput, elevationInput, fromStation, forgetPoint } = useInterpolationPoint(modelValue)
+const { latitudeInput, longitudeInput, elevationInput, fromStation, pointFromStation } = useInterpolationPoint(modelValue)
 
 // For station selection
 const selectedStation = ref<Station | undefined>(modelValue.value.station)
@@ -67,12 +67,19 @@ watch(() => props.parameterSelection, () => {
 }, { deep: true, immediate: true })
 
 function setSource(source: InterpolationSource) {
-  modelValue.value = {
-    ...modelValue.value,
-    source,
-  }
-  // the elevation came from wherever the point did, so it goes with it
-  forgetPoint()
+  // clicking the source already in use is not a change, and treating it as one dropped the height
+  // of a station that stayed selected -- the form unchanged on screen, the next answer
+  // uncorrected, which at 1000 m is six degrees of air temperature
+  if (source === modelValue.value.source)
+    return
+  // one assignment: a second write in the same tick spreads the model the first replaced, and the
+  // source change was being undone by the elevation change that followed it
+  modelValue.value = source === 'station'
+    // back to the station still in the select: it names its height again, where the watcher below
+    // stays silent, the selection itself not having changed
+    ? { ...modelValue.value, source, ...pointFromStation(selectedStation.value) }
+    // the elevation came from wherever the point did, so it goes with it
+    : { ...modelValue.value, source, elevation: undefined }
 }
 
 // Display coordinates

--- a/app/app/components/InterpolationSummarySelection.vue
+++ b/app/app/components/InterpolationSummarySelection.vue
@@ -15,56 +15,14 @@ const sourceOptions = computed(() => [
   { value: 'station' as InterpolationSource, label: t('interpolation.fromStation'), icon: 'i-lucide-map-pin' },
 ])
 
-// For manual input
-const latitudeInput = ref<string>(modelValue.value.latitude?.toString() ?? '')
-const longitudeInput = ref<string>(modelValue.value.longitude?.toString() ?? '')
-const elevationInput = ref<string>(modelValue.value.elevation?.toString() ?? '')
-
-// the station watcher writes the elevation straight into the model, so the box has to follow it
-// or it shows empty while the query carries a height the user cannot see
-watch(() => modelValue.value.elevation, (elevation) => {
-  const shown = elevation?.toString() ?? ''
-  if (shown !== elevationInput.value)
-    elevationInput.value = shown
-})
-
-// Watch inputs and update model. The coordinates and the elevation are watched apart: the boxes
-// above only hold what was typed into them, which in station mode is nothing, and writing all
-// three together let a station's elevation arriving here take the station's coordinates out with
-// it -- the source that fills them is the station, not these boxes
-watch([latitudeInput, longitudeInput], ([lat, lon]) => {
-  const latNum = Number.parseFloat(lat)
-  const lonNum = Number.parseFloat(lon)
-  modelValue.value = {
-    ...modelValue.value,
-    latitude: Number.isNaN(latNum) ? undefined : latNum,
-    longitude: Number.isNaN(lonNum) ? undefined : lonNum,
-  }
-})
-
-watch(elevationInput, (elevation) => {
-  const elevationNum = Number.parseFloat(elevation)
-  // optional: left empty, the readings are interpolated as they come
-  const parsed = Number.isNaN(elevationNum) ? undefined : elevationNum
-  if (parsed !== modelValue.value.elevation)
-    modelValue.value = { ...modelValue.value, elevation: parsed }
-})
+// the point, and the boxes that describe it -- see `useInterpolationPoint` for why the coordinates
+// and the elevation are kept apart
+const { latitudeInput, longitudeInput, elevationInput, fromStation } = useInterpolationPoint(modelValue)
 
 // For station selection
 const selectedStation = ref<Station | undefined>(modelValue.value.station)
 
-watch(selectedStation, (station) => {
-  modelValue.value = {
-    ...modelValue.value,
-    station,
-    latitude: station?.latitude,
-    longitude: station?.longitude,
-    // a station names its altitude as well as its position, which is the height the answer is
-    // wanted at when the point is given as a station -- except where the provider reports no
-    // height for it, and several report none at all, where there is nothing to name
-    elevation: station?.height ?? undefined,
-  }
-})
+watch(selectedStation, fromStation)
 
 // Fetch stations for station source
 const { data: stationsData, pending: stationsPending, refresh: refreshStations } = useFetch<StationsResponse>(

--- a/app/app/components/InterpolationSummarySelection.vue
+++ b/app/app/components/InterpolationSummarySelection.vue
@@ -18,15 +18,19 @@ const sourceOptions = computed(() => [
 // For manual input
 const latitudeInput = ref<string>(modelValue.value.latitude?.toString() ?? '')
 const longitudeInput = ref<string>(modelValue.value.longitude?.toString() ?? '')
+const elevationInput = ref<string>(modelValue.value.elevation?.toString() ?? '')
 
 // Watch inputs and update model
-watch([latitudeInput, longitudeInput], ([lat, lon]) => {
+watch([latitudeInput, longitudeInput, elevationInput], ([lat, lon, elevation]) => {
   const latNum = Number.parseFloat(lat)
   const lonNum = Number.parseFloat(lon)
+  const elevationNum = Number.parseFloat(elevation)
   modelValue.value = {
     ...modelValue.value,
     latitude: Number.isNaN(latNum) ? undefined : latNum,
     longitude: Number.isNaN(lonNum) ? undefined : lonNum,
+    // optional: left empty, the readings are interpolated as they come
+    elevation: Number.isNaN(elevationNum) ? undefined : elevationNum,
   }
 })
 
@@ -39,6 +43,9 @@ watch(selectedStation, (station) => {
     station,
     latitude: station?.latitude,
     longitude: station?.longitude,
+    // a station names its altitude as well as its position, which is the height the answer is
+    // wanted at when the point is given as a station
+    elevation: station?.height,
   }
 })
 
@@ -137,6 +144,15 @@ const displayCoords = computed(() => {
           placeholder="e.g. 13.4050"
           class="w-full"
           :class="{ 'needs-input': modelValue.longitude === undefined }"
+        />
+      </UFormField>
+      <UFormField :label="t('interpolation.elevation')" :hint="t('interpolation.elevationHint')" class="flex-1">
+        <UInput
+          v-model="elevationInput"
+          type="number"
+          step="1"
+          placeholder="e.g. 34"
+          class="w-full"
         />
       </UFormField>
     </div>

--- a/app/app/components/InterpolationSummarySelection.vue
+++ b/app/app/components/InterpolationSummarySelection.vue
@@ -17,7 +17,7 @@ const sourceOptions = computed(() => [
 
 // the point, and the boxes that describe it -- see `useInterpolationPoint` for why the coordinates
 // and the elevation are kept apart
-const { latitudeInput, longitudeInput, elevationInput, fromStation } = useInterpolationPoint(modelValue)
+const { latitudeInput, longitudeInput, elevationInput, fromStation, forgetPoint } = useInterpolationPoint(modelValue)
 
 // For station selection
 const selectedStation = ref<Station | undefined>(modelValue.value.station)
@@ -71,6 +71,8 @@ function setSource(source: InterpolationSource) {
     ...modelValue.value,
     source,
   }
+  // the elevation came from wherever the point did, so it goes with it
+  forgetPoint()
 }
 
 // Display coordinates

--- a/app/app/components/InterpolationSummarySelection.vue
+++ b/app/app/components/InterpolationSummarySelection.vue
@@ -28,18 +28,26 @@ watch(() => modelValue.value.elevation, (elevation) => {
     elevationInput.value = shown
 })
 
-// Watch inputs and update model
-watch([latitudeInput, longitudeInput, elevationInput], ([lat, lon, elevation]) => {
+// Watch inputs and update model. The coordinates and the elevation are watched apart: the boxes
+// above only hold what was typed into them, which in station mode is nothing, and writing all
+// three together let a station's elevation arriving here take the station's coordinates out with
+// it -- the source that fills them is the station, not these boxes
+watch([latitudeInput, longitudeInput], ([lat, lon]) => {
   const latNum = Number.parseFloat(lat)
   const lonNum = Number.parseFloat(lon)
-  const elevationNum = Number.parseFloat(elevation)
   modelValue.value = {
     ...modelValue.value,
     latitude: Number.isNaN(latNum) ? undefined : latNum,
     longitude: Number.isNaN(lonNum) ? undefined : lonNum,
-    // optional: left empty, the readings are interpolated as they come
-    elevation: Number.isNaN(elevationNum) ? undefined : elevationNum,
   }
+})
+
+watch(elevationInput, (elevation) => {
+  const elevationNum = Number.parseFloat(elevation)
+  // optional: left empty, the readings are interpolated as they come
+  const parsed = Number.isNaN(elevationNum) ? undefined : elevationNum
+  if (parsed !== modelValue.value.elevation)
+    modelValue.value = { ...modelValue.value, elevation: parsed }
 })
 
 // For station selection

--- a/app/app/components/InterpolationSummarySelection.vue
+++ b/app/app/components/InterpolationSummarySelection.vue
@@ -121,15 +121,6 @@ const displayCoords = computed(() => {
           :class="{ 'needs-input': modelValue.longitude === undefined }"
         />
       </UFormField>
-      <UFormField :label="t('interpolation.elevation')" :hint="t('interpolation.elevationHint')" class="flex-1">
-        <UInput
-          v-model="elevationInput"
-          type="number"
-          step="1"
-          placeholder="e.g. 34"
-          class="w-full"
-        />
-      </UFormField>
     </div>
 
     <div v-else>
@@ -149,6 +140,18 @@ const displayCoords = computed(() => {
         </div>
       </UFormField>
     </div>
+
+    <!-- part of the point whichever way the point was given: a station fills it with its own
+         height, and leaving it filled in silently is what drops the neighbours that have none -->
+    <UFormField :label="t('interpolation.elevation')" :hint="t('interpolation.elevationHint')">
+      <UInput
+        v-model="elevationInput"
+        type="number"
+        step="1"
+        placeholder="e.g. 34"
+        class="w-full"
+      />
+    </UFormField>
 
     <div v-if="displayCoords" class="text-sm text-gray-500">
       {{ t('interpolation.coords', { coords: displayCoords }) }}

--- a/app/app/composables/useInterpolationPoint.ts
+++ b/app/app/composables/useInterpolationPoint.ts
@@ -62,20 +62,30 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
   })
 
   /**
-   * Forget the point, the source having changed.
+   * Forget the elevation, and only that.
    *
-   * The elevation especially: filled from a station, it belongs to that station, and carrying it
-   * into a hand-typed point elsewhere reduces every reading to a height the point does not have
-   * -- a summit's 1000 m against a city at 34 m is six degrees of air temperature.
+   * Used where the elevation alone changes; a source change puts it into the one assignment that
+   * changes the source, two writes in a tick losing the first.
+   *
+   * Filled from a station it belongs to that station, and carrying it into a hand-typed point
+   * elsewhere reduces every reading to a height the point does not have -- a summit's 1000 m
+   * against a city at 34 m is six degrees of air temperature. The coordinates are left alone: they
+   * are what the manual boxes are about to describe.
    */
-  function forgetPoint() {
+  function forgetElevation() {
     modelValue.value = { ...modelValue.value, elevation: undefined }
   }
 
-  /** Take the point from a station: its position, and its altitude where the provider reports one. */
-  function fromStation(station: Station | undefined) {
-    modelValue.value = {
-      ...modelValue.value,
+  /**
+   * What a station says about the point: its position, and its altitude where the provider
+   * reports one.
+   *
+   * Given apart from the writing so that a caller changing something else at the same time can
+   * put both into one assignment -- two writes in a tick have the second spreading a model the
+   * first has already replaced, and the first is lost.
+   */
+  function pointFromStation(station: Station | undefined): Partial<InterpolationSelection> {
+    return {
       station,
       latitude: station?.latitude,
       longitude: station?.longitude,
@@ -83,5 +93,10 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
     }
   }
 
-  return { latitudeInput, longitudeInput, elevationInput, fromStation, forgetPoint }
+  /** Take the point from a station. */
+  function fromStation(station: Station | undefined) {
+    modelValue.value = { ...modelValue.value, ...pointFromStation(station) }
+  }
+
+  return { latitudeInput, longitudeInput, elevationInput, fromStation, pointFromStation, forgetElevation }
 }

--- a/app/app/composables/useInterpolationPoint.ts
+++ b/app/app/composables/useInterpolationPoint.ts
@@ -2,14 +2,6 @@ import type { Ref } from 'vue'
 import type { InterpolationSelection } from '~/types/station-selection-state.type'
 
 /**
- * Wire the point an interpolation or summary answers for to the boxes that describe it.
- *
- * Three values, filled from two places: the coordinates and the elevation are typed in manual
- * mode, while choosing a station writes all three at once. Keeping that straight is the whole of
- * this, and getting it wrong is quiet -- a query that carries a height the form does not show, or
- * a station whose coordinates are cleared by an elevation arriving after them.
- */
-/**
  * Read a box as the number it names, or nothing.
  *
  * Finite, not merely not-NaN: `1e400` parses to Infinity, which would travel into the model, into
@@ -20,6 +12,14 @@ function numberFromBox(value: string | number): number | undefined {
   return Number.isFinite(parsed) ? parsed : undefined
 }
 
+/**
+ * Wire the point an interpolation or summary answers for to the boxes that describe it.
+ *
+ * Three values, filled from two places: the coordinates and the elevation are typed in manual
+ * mode, while choosing a station writes all three at once. Keeping that straight is the whole of
+ * this, and getting it wrong is quiet -- a query that carries a height the form does not show, or
+ * a station whose coordinates are cleared by an elevation arriving after them.
+ */
 export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
   // `string`, which is what `UInput` declares its model to be -- though one of type number writes
   // a number back through it at runtime, so everything reading a box says which it wants rather
@@ -61,6 +61,17 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
       modelValue.value = { ...modelValue.value, elevation: parsed }
   })
 
+  /**
+   * Forget the point, the source having changed.
+   *
+   * The elevation especially: filled from a station, it belongs to that station, and carrying it
+   * into a hand-typed point elsewhere reduces every reading to a height the point does not have
+   * -- a summit's 1000 m against a city at 34 m is six degrees of air temperature.
+   */
+  function forgetPoint() {
+    modelValue.value = { ...modelValue.value, elevation: undefined }
+  }
+
   /** Take the point from a station: its position, and its altitude where the provider reports one. */
   function fromStation(station: Station | undefined) {
     modelValue.value = {
@@ -72,5 +83,5 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
     }
   }
 
-  return { latitudeInput, longitudeInput, elevationInput, fromStation }
+  return { latitudeInput, longitudeInput, elevationInput, fromStation, forgetPoint }
 }

--- a/app/app/composables/useInterpolationPoint.ts
+++ b/app/app/composables/useInterpolationPoint.ts
@@ -14,13 +14,18 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
   const longitudeInput = ref<string>(modelValue.value.longitude?.toString() ?? '')
   const elevationInput = ref<string>(modelValue.value.elevation?.toString() ?? '')
 
-  // choosing a station writes the elevation straight into the model, so the box follows it -- or
-  // it shows empty while the query carries a height the user cannot see
-  watch(() => modelValue.value.elevation, (elevation) => {
-    const shown = elevation?.toString() ?? ''
-    if (shown !== elevationInput.value)
-      elevationInput.value = shown
-  })
+  // choosing a station writes all three straight into the model, so the boxes follow it -- or they
+  // show empty while the query carries a point the user cannot see. All three, not the elevation
+  // alone: with the coordinate boxes left stale, typing one of them made the watcher below read
+  // the other box, still empty, and wipe a coordinate nobody had touched
+  function follow(box: Ref<string>, value: number | undefined) {
+    const shown = value?.toString() ?? ''
+    if (shown !== box.value)
+      box.value = shown
+  }
+  watch(() => modelValue.value.latitude, latitude => follow(latitudeInput, latitude))
+  watch(() => modelValue.value.longitude, longitude => follow(longitudeInput, longitude))
+  watch(() => modelValue.value.elevation, elevation => follow(elevationInput, elevation))
 
   // the coordinates and the elevation are watched apart. These boxes hold only what was typed into
   // them, which in station mode is nothing, so writing all three together let an elevation arriving

--- a/app/app/composables/useInterpolationPoint.ts
+++ b/app/app/composables/useInterpolationPoint.ts
@@ -1,0 +1,58 @@
+import type { Ref } from 'vue'
+import type { InterpolationSelection } from '~/types/station-selection-state.type'
+
+/**
+ * Wire the point an interpolation or summary answers for to the boxes that describe it.
+ *
+ * Three values, filled from two places: the coordinates and the elevation are typed in manual
+ * mode, while choosing a station writes all three at once. Keeping that straight is the whole of
+ * this, and getting it wrong is quiet -- a query that carries a height the form does not show, or
+ * a station whose coordinates are cleared by an elevation arriving after them.
+ */
+export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
+  const latitudeInput = ref<string>(modelValue.value.latitude?.toString() ?? '')
+  const longitudeInput = ref<string>(modelValue.value.longitude?.toString() ?? '')
+  const elevationInput = ref<string>(modelValue.value.elevation?.toString() ?? '')
+
+  // choosing a station writes the elevation straight into the model, so the box follows it -- or
+  // it shows empty while the query carries a height the user cannot see
+  watch(() => modelValue.value.elevation, (elevation) => {
+    const shown = elevation?.toString() ?? ''
+    if (shown !== elevationInput.value)
+      elevationInput.value = shown
+  })
+
+  // the coordinates and the elevation are watched apart. These boxes hold only what was typed into
+  // them, which in station mode is nothing, so writing all three together let an elevation arriving
+  // from a station take that station's coordinates out with it
+  watch([latitudeInput, longitudeInput], ([latitude, longitude]) => {
+    const latitudeNumber = Number.parseFloat(latitude)
+    const longitudeNumber = Number.parseFloat(longitude)
+    modelValue.value = {
+      ...modelValue.value,
+      latitude: Number.isNaN(latitudeNumber) ? undefined : latitudeNumber,
+      longitude: Number.isNaN(longitudeNumber) ? undefined : longitudeNumber,
+    }
+  })
+
+  watch(elevationInput, (elevation) => {
+    const elevationNumber = Number.parseFloat(elevation)
+    // optional: left empty, the readings are interpolated as they come
+    const parsed = Number.isNaN(elevationNumber) ? undefined : elevationNumber
+    if (parsed !== modelValue.value.elevation)
+      modelValue.value = { ...modelValue.value, elevation: parsed }
+  })
+
+  /** Take the point from a station: its position, and its altitude where the provider reports one. */
+  function fromStation(station: Station | undefined) {
+    modelValue.value = {
+      ...modelValue.value,
+      station,
+      latitude: station?.latitude,
+      longitude: station?.longitude,
+      elevation: station?.height ?? undefined,
+    }
+  }
+
+  return { latitudeInput, longitudeInput, elevationInput, fromStation }
+}

--- a/app/app/composables/useInterpolationPoint.ts
+++ b/app/app/composables/useInterpolationPoint.ts
@@ -9,7 +9,21 @@ import type { InterpolationSelection } from '~/types/station-selection-state.typ
  * this, and getting it wrong is quiet -- a query that carries a height the form does not show, or
  * a station whose coordinates are cleared by an elevation arriving after them.
  */
+/**
+ * Read a box as the number it names, or nothing.
+ *
+ * Finite, not merely not-NaN: `1e400` parses to Infinity, which would travel into the model, into
+ * a shared link, and on to an API that can give no answer for it.
+ */
+function numberFromBox(value: string | number): number | undefined {
+  const parsed = Number.parseFloat(String(value))
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
 export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
+  // `string`, which is what `UInput` declares its model to be -- though one of type number writes
+  // a number back through it at runtime, so everything reading a box says which it wants rather
+  // than trusting the annotation
   const latitudeInput = ref<string>(modelValue.value.latitude?.toString() ?? '')
   const longitudeInput = ref<string>(modelValue.value.longitude?.toString() ?? '')
   const elevationInput = ref<string>(modelValue.value.elevation?.toString() ?? '')
@@ -20,7 +34,9 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
   // the other box, still empty, and wipe a coordinate nobody had touched
   function follow(box: Ref<string>, value: number | undefined) {
     const shown = value?.toString() ?? ''
-    if (shown !== box.value)
+    // against the box as text: it may hold a number, and `'1000' !== 1000` would write on every
+    // change, each write firing the box's own watcher again
+    if (shown !== String(box.value))
       box.value = shown
   }
   watch(() => modelValue.value.latitude, latitude => follow(latitudeInput, latitude))
@@ -31,19 +47,16 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
   // them, which in station mode is nothing, so writing all three together let an elevation arriving
   // from a station take that station's coordinates out with it
   watch([latitudeInput, longitudeInput], ([latitude, longitude]) => {
-    const latitudeNumber = Number.parseFloat(latitude)
-    const longitudeNumber = Number.parseFloat(longitude)
     modelValue.value = {
       ...modelValue.value,
-      latitude: Number.isNaN(latitudeNumber) ? undefined : latitudeNumber,
-      longitude: Number.isNaN(longitudeNumber) ? undefined : longitudeNumber,
+      latitude: numberFromBox(latitude),
+      longitude: numberFromBox(longitude),
     }
   })
 
   watch(elevationInput, (elevation) => {
-    const elevationNumber = Number.parseFloat(elevation)
     // optional: left empty, the readings are interpolated as they come
-    const parsed = Number.isNaN(elevationNumber) ? undefined : elevationNumber
+    const parsed = numberFromBox(elevation)
     if (parsed !== modelValue.value.elevation)
       modelValue.value = { ...modelValue.value, elevation: parsed }
   })

--- a/app/app/composables/useInterpolationPoint.ts
+++ b/app/app/composables/useInterpolationPoint.ts
@@ -62,21 +62,6 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
   })
 
   /**
-   * Forget the elevation, and only that.
-   *
-   * Used where the elevation alone changes; a source change puts it into the one assignment that
-   * changes the source, two writes in a tick losing the first.
-   *
-   * Filled from a station it belongs to that station, and carrying it into a hand-typed point
-   * elsewhere reduces every reading to a height the point does not have -- a summit's 1000 m
-   * against a city at 34 m is six degrees of air temperature. The coordinates are left alone: they
-   * are what the manual boxes are about to describe.
-   */
-  function forgetElevation() {
-    modelValue.value = { ...modelValue.value, elevation: undefined }
-  }
-
-  /**
    * What a station says about the point: its position, and its altitude where the provider
    * reports one.
    *
@@ -98,5 +83,5 @@ export function useInterpolationPoint(modelValue: Ref<InterpolationSelection>) {
     modelValue.value = { ...modelValue.value, ...pointFromStation(station) }
   }
 
-  return { latitudeInput, longitudeInput, elevationInput, fromStation, pointFromStation, forgetElevation }
+  return { latitudeInput, longitudeInput, elevationInput, fromStation, pointFromStation }
 }

--- a/app/app/pages/explorer.vue
+++ b/app/app/pages/explorer.vue
@@ -138,10 +138,22 @@ function dataSettingsToQuery(settings: DataSettings): Record<string, string> {
 
 const showAbout = ref(false)
 const parameterSelectionState = ref<ParameterSelectionState>(fromQuery(route.query))
+function numberFromQuery(value: unknown): number | undefined {
+  const parsed = Number.parseFloat(String(value ?? ''))
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
 const stationSelectionState = ref<StationSelectionState>({
   mode: modeFromQuery(route.query),
   selection: { stations: [] },
-  interpolation: { source: (route.query.interpolationSource as 'manual' | 'station') || 'manual' },
+  interpolation: {
+    source: (route.query.interpolationSource as 'manual' | 'station') || 'manual',
+    // read back what `toQuery` writes, or a shared link reproduces a different answer than the
+    // one it was copied from
+    latitude: numberFromQuery(route.query.lat),
+    longitude: numberFromQuery(route.query.lon),
+    elevation: numberFromQuery(route.query.elevation),
+  },
   dateRange: {
     startDate: route.query.startDate?.toString(),
     endDate: route.query.endDate?.toString(),
@@ -231,6 +243,7 @@ watch(
   [
     parameterSelectionState,
     () => stationSelectionState.value.selection.stations,
+    () => stationSelectionState.value.interpolation,
     () => dataSettings.value.humanize,
     () => dataSettings.value.convertUnits,
     () => dataSettings.value.shape,
@@ -454,6 +467,7 @@ function fetchData() {
       : '',
     interpolationLat: ss.interpolation.latitude,
     interpolationLon: ss.interpolation.longitude,
+    interpolationElevation: ss.interpolation.elevation,
     startDate: ss.dateRange.startDate,
     endDate: ss.dateRange.endDate,
     settings: JSON.stringify(dataSettings.value),

--- a/app/app/pages/explorer.vue
+++ b/app/app/pages/explorer.vue
@@ -107,6 +107,8 @@ function toQuery(paramSel: ParameterSelectionState, stationSel: StationSelection
         q.lat = stationSel.interpolation.latitude.toString()
       if (stationSel.interpolation.longitude !== undefined)
         q.lon = stationSel.interpolation.longitude.toString()
+      if (stationSel.interpolation.elevation !== undefined)
+        q.elevation = stationSel.interpolation.elevation.toString()
     }
     else if (stationSel.interpolation.station) {
       q.interpolationStation = stationSel.interpolation.station.station_id
@@ -369,6 +371,7 @@ const lastFetchedParams = ref<{
   stations: string
   interpolationLat?: number
   interpolationLon?: number
+  interpolationElevation?: number
   startDate?: string
   endDate?: string
   settings: string
@@ -402,6 +405,7 @@ const canFetch = computed(() => {
         : '',
       interpolationLat: ss.interpolation.latitude,
       interpolationLon: ss.interpolation.longitude,
+      interpolationElevation: ss.interpolation.elevation,
       startDate: ss.dateRange.startDate,
       endDate: ss.dateRange.endDate,
       settings: JSON.stringify(dataSettings.value),
@@ -417,6 +421,7 @@ const canFetch = computed(() => {
         && currentParams.stations === lastFetchedParams.value.stations
         && currentParams.interpolationLat === lastFetchedParams.value.interpolationLat
         && currentParams.interpolationLon === lastFetchedParams.value.interpolationLon
+        && currentParams.interpolationElevation === lastFetchedParams.value.interpolationElevation
         && currentParams.startDate === lastFetchedParams.value.startDate
         && currentParams.endDate === lastFetchedParams.value.endDate
         && currentParams.settings === lastFetchedParams.value.settings

--- a/app/app/pages/explorer.vue
+++ b/app/app/pages/explorer.vue
@@ -139,8 +139,11 @@ function dataSettingsToQuery(settings: DataSettings): Record<string, string> {
 const showAbout = ref(false)
 const parameterSelectionState = ref<ParameterSelectionState>(fromQuery(route.query))
 function numberFromQuery(value: unknown): number | undefined {
-  const parsed = Number.parseFloat(String(value ?? ''))
-  return Number.isNaN(parsed) ? undefined : parsed
+  // a repeated key arrives as an array, and `1e400` parses to Infinity, which travels back into
+  // the URL and on to the API as a number no answer can be given for
+  const first = Array.isArray(value) ? value[0] : value
+  const parsed = Number.parseFloat(String(first ?? ''))
+  return Number.isFinite(parsed) ? parsed : undefined
 }
 
 const stationSelectionState = ref<StationSelectionState>({
@@ -148,8 +151,10 @@ const stationSelectionState = ref<StationSelectionState>({
   selection: { stations: [] },
   interpolation: {
     source: (route.query.interpolationSource as 'manual' | 'station') || 'manual',
-    // read back what `toQuery` writes, or a shared link reproduces a different answer than the
-    // one it was copied from
+    // read back what `toQuery` writes for a point given by coordinates, so a shared link
+    // reproduces the answer it was copied from. A point given by a station is written as an id
+    // and not restored -- the station itself has to be fetched before it can be selected, which
+    // `initialStationIds` does for station mode and nothing does for this one yet
     latitude: numberFromQuery(route.query.lat),
     longitude: numberFromQuery(route.query.lon),
     elevation: numberFromQuery(route.query.elevation),

--- a/app/app/pages/explorer.vue
+++ b/app/app/pages/explorer.vue
@@ -107,12 +107,14 @@ function toQuery(paramSel: ParameterSelectionState, stationSel: StationSelection
         q.lat = stationSel.interpolation.latitude.toString()
       if (stationSel.interpolation.longitude !== undefined)
         q.lon = stationSel.interpolation.longitude.toString()
-      if (stationSel.interpolation.elevation !== undefined)
-        q.elevation = stationSel.interpolation.elevation.toString()
     }
     else if (stationSel.interpolation.station) {
       q.interpolationStation = stationSel.interpolation.station.station_id
     }
+    // outside the branch: the box is shown for either source and sent for either, and a height
+    // the user typed over a station's is theirs rather than the station's
+    if (stationSel.interpolation.elevation !== undefined)
+      q.elevation = stationSel.interpolation.elevation.toString()
   }
   if (stationSel.dateRange.startDate)
     q.startDate = stationSel.dateRange.startDate

--- a/app/app/pages/explorer.vue
+++ b/app/app/pages/explorer.vue
@@ -112,7 +112,9 @@ function toQuery(paramSel: ParameterSelectionState, stationSel: StationSelection
       q.interpolationStation = stationSel.interpolation.station.station_id
     }
     // outside the branch: the box is shown for either source and sent for either, and a height
-    // the user typed over a station's is theirs rather than the station's
+    // the user typed over a station's is theirs rather than the station's. It survives the round
+    // trip only for a point given by coordinates: picking the station again names its own height,
+    // which is what choosing a station means
     if (stationSel.interpolation.elevation !== undefined)
       q.elevation = stationSel.interpolation.elevation.toString()
   }

--- a/app/app/types/station-selection-state.type.ts
+++ b/app/app/types/station-selection-state.type.ts
@@ -10,6 +10,11 @@ export interface InterpolationSelection {
   source: InterpolationSource
   latitude?: number
   longitude?: number
+  /**
+   * Metres above sea level. The backend brings each station's readings to this height before
+   * using them, for the quantities that fall with it -- air temperature, dew point.
+   */
+  elevation?: number
   station?: Station
 }
 

--- a/app/i18n/locales/cs.json
+++ b/app/i18n/locales/cs.json
@@ -512,6 +512,8 @@
     "fromStation": "Ze stanice",
     "latitude": "Zeměpisná šířka",
     "longitude": "Zeměpisná délka",
+    "elevation": "Nadmořská výška",
+    "elevationHint": "volitelné, m n. m.",
     "selectStationForCoords": "Vyberte stanici pro souřadnice",
     "selectStation": "Vyberte stanici",
     "loadingStations": "Načítání stanic …",

--- a/app/i18n/locales/da.json
+++ b/app/i18n/locales/da.json
@@ -512,6 +512,8 @@
     "fromStation": "Fra en station",
     "latitude": "Breddegrad",
     "longitude": "Længdegrad",
+    "elevation": "Højde",
+    "elevationHint": "valgfri, m over havet",
     "selectStationForCoords": "Vælg en station til koordinater",
     "selectStation": "Vælg en station",
     "loadingStations": "Indlæser stationer …",

--- a/app/i18n/locales/de-hh.json
+++ b/app/i18n/locales/de-hh.json
@@ -512,6 +512,8 @@
     "fromStation": "Von Station",
     "latitude": "Breitengrad",
     "longitude": "Längengrad",
+    "elevation": "Höhe",
+    "elevationHint": "optional, m över NN",
     "selectStationForCoords": "Station für Koordinaten auswählen",
     "selectStation": "Station auswählen",
     "loadingStations": "Stationen werden geladen …",

--- a/app/i18n/locales/de.json
+++ b/app/i18n/locales/de.json
@@ -512,6 +512,8 @@
     "fromStation": "Von Station",
     "latitude": "Breitengrad",
     "longitude": "Längengrad",
+    "elevation": "Höhe",
+    "elevationHint": "optional, m über NN",
     "selectStationForCoords": "Station für Koordinaten auswählen",
     "selectStation": "Station auswählen",
     "loadingStations": "Stationen werden geladen …",

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -512,6 +512,8 @@
     "fromStation": "From station",
     "latitude": "Latitude",
     "longitude": "Longitude",
+    "elevation": "Elevation",
+    "elevationHint": "optional, m above sea level",
     "selectStationForCoords": "Select station for coordinates",
     "selectStation": "Select a station",
     "loadingStations": "Loading stations …",

--- a/app/i18n/locales/es.json
+++ b/app/i18n/locales/es.json
@@ -512,6 +512,8 @@
     "fromStation": "Desde una estación",
     "latitude": "Latitud",
     "longitude": "Longitud",
+    "elevation": "Altitud",
+    "elevationHint": "opcional, m sobre el nivel del mar",
     "selectStationForCoords": "Seleccionar estación para las coordenadas",
     "selectStation": "Seleccionar una estación",
     "loadingStations": "Cargando estaciones …",

--- a/app/i18n/locales/fr.json
+++ b/app/i18n/locales/fr.json
@@ -512,6 +512,8 @@
     "fromStation": "Depuis une station",
     "latitude": "Latitude",
     "longitude": "Longitude",
+    "elevation": "Altitude",
+    "elevationHint": "facultatif, m au-dessus du niveau de la mer",
     "selectStationForCoords": "Sélectionner une station pour les coordonnées",
     "selectStation": "Sélectionner une station",
     "loadingStations": "Chargement des stations …",

--- a/app/i18n/locales/it.json
+++ b/app/i18n/locales/it.json
@@ -512,6 +512,8 @@
     "fromStation": "Da una stazione",
     "latitude": "Latitudine",
     "longitude": "Longitudine",
+    "elevation": "Altitudine",
+    "elevationHint": "opzionale, m sul livello del mare",
     "selectStationForCoords": "Seleziona una stazione per le coordinate",
     "selectStation": "Seleziona una stazione",
     "loadingStations": "Caricamento delle stazioni …",

--- a/app/i18n/locales/lb.json
+++ b/app/i18n/locales/lb.json
@@ -512,6 +512,8 @@
     "fromStation": "Vun enger Statioun",
     "latitude": "Breedegrad",
     "longitude": "Längegrad",
+    "elevation": "Héicht",
+    "elevationHint": "fakultativ, m iwwer dem Mier",
     "selectStationForCoords": "Wielt eng Statioun fir d'Koordinaten",
     "selectStation": "Wielt eng Statioun",
     "loadingStations": "Statioune ginn gelueden …",

--- a/app/i18n/locales/nl.json
+++ b/app/i18n/locales/nl.json
@@ -512,6 +512,8 @@
     "fromStation": "Vanaf een station",
     "latitude": "Breedtegraad",
     "longitude": "Lengtegraad",
+    "elevation": "Hoogte",
+    "elevationHint": "optioneel, m boven zeeniveau",
     "selectStationForCoords": "Selecteer een station voor de coördinaten",
     "selectStation": "Selecteer een station",
     "loadingStations": "Stations laden …",

--- a/app/i18n/locales/pl.json
+++ b/app/i18n/locales/pl.json
@@ -512,6 +512,8 @@
     "fromStation": "Ze stacji",
     "latitude": "Szerokość geograficzna",
     "longitude": "Długość geograficzna",
+    "elevation": "Wysokość",
+    "elevationHint": "opcjonalnie, m n.p.m.",
     "selectStationForCoords": "Wybierz stację dla współrzędnych",
     "selectStation": "Wybierz stację",
     "loadingStations": "Ładowanie stacji …",

--- a/app/shared/types/api.ts
+++ b/app/shared/types/api.ts
@@ -86,7 +86,8 @@ export interface Station {
   state: string
   latitude: number
   longitude: number
-  height: number
+  /** Null where the provider reports no height for the station, which for several is every one. */
+  height: number | null
   start_date?: string
   end_date?: string
 }
@@ -145,6 +146,8 @@ export interface InterpolateQuery {
   parameters: string
   latitude: number
   longitude: number
+  /** Metres above sea level; the readings are brought to it before being used. */
+  elevation?: number
   date?: string
   humanize?: boolean
   convert_units?: boolean
@@ -164,6 +167,8 @@ export interface SummarizeQuery {
   parameters: string
   latitude: number
   longitude: number
+  /** Metres above sea level; the readings are brought to it before being used. */
+  elevation?: number
   date?: string
   humanize?: boolean
   convert_units?: boolean

--- a/app/tests/nuxt/components/interpolation-summary-selection.test.ts
+++ b/app/tests/nuxt/components/interpolation-summary-selection.test.ts
@@ -1,4 +1,5 @@
 import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
+import { flushPromises } from '@vue/test-utils'
 import { describe, expect, it } from 'vitest'
 import { defineComponent, h, nextTick, ref } from 'vue'
 import InterpolationSummarySelection from '~/components/InterpolationSummarySelection.vue'
@@ -37,7 +38,8 @@ async function selection(source: 'manual' | 'station') {
       'onUpdate:modelValue': (value: Record<string, unknown>) => { model.value = value },
     }),
   }), { attachTo: document.body })
-  await new Promise(resolve => setTimeout(resolve, 20))
+  // the tests assign the station directly, so nothing waits on the station list
+  await flushPromises()
   const inner = wrapper.findComponent(InterpolationSummarySelection)
   return { wrapper, model, vm: inner.vm as any }
 }
@@ -61,6 +63,38 @@ describe('choosing the point an interpolation answers for', () => {
     vm.setSource('station')
     await settle()
     expect(model.value.elevation).toBe(1000)
+  })
+
+  it('keeps hand-typed coordinates when the station source has nothing to offer', async () => {
+    // clicking through to the station list and back was taking the empty answer of a select with
+    // nothing chosen in it, and clearing coordinates someone had just typed
+    const { model, vm } = await selection('manual')
+    vm.latitudeInput = '52.52'
+    vm.longitudeInput = '13.40'
+    await settle()
+    expect(model.value.latitude).toBe(52.52)
+
+    vm.setSource('station')
+    await settle()
+    vm.setSource('manual')
+    await settle()
+    expect(model.value.latitude).toBe(52.52)
+    expect(model.value.longitude).toBe(13.4)
+  })
+
+  it('lets go of a station the parent has cleared', async () => {
+    // a provider or dataset change replaces the whole model, and a select still holding the old
+    // station would write it back for a dataset that may not have it
+    const { model, vm } = await selection('station')
+    vm.selectedStation = feldberg
+    await settle()
+    expect(model.value.station).toBeTruthy()
+
+    model.value = { source: 'manual' }
+    await settle()
+    vm.setSource('station')
+    await settle()
+    expect(model.value.station).toBeUndefined()
   })
 
   it('names the station\'s height again on returning to it', async () => {

--- a/app/tests/nuxt/components/interpolation-summary-selection.test.ts
+++ b/app/tests/nuxt/components/interpolation-summary-selection.test.ts
@@ -1,0 +1,81 @@
+import { mountSuspended, registerEndpoint } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import InterpolationSummarySelection from '~/components/InterpolationSummarySelection.vue'
+
+const parameterSelection = {
+  provider: 'dwd',
+  network: 'observation',
+  resolution: 'daily' as const,
+  dataset: 'climate_summary',
+  parameters: ['temperature_air_mean_2m'],
+}
+
+const feldberg = {
+  station_id: '02290',
+  name: 'Feldberg',
+  state: 'Baden-Württemberg',
+  latitude: 47.9,
+  longitude: 8.0,
+  height: 1000,
+}
+
+registerEndpoint('/api/stations', () => ({ stations: [feldberg] }))
+
+/**
+ * Hold the model the way a parent does, so the component's writes come back to it.
+ *
+ * Through a ref rather than `setProps`, which lands a tick later and would have the component
+ * reading a model it has already written to.
+ */
+async function selection(source: 'manual' | 'station') {
+  const model = ref<Record<string, unknown>>({ source })
+  const wrapper = await mountSuspended(defineComponent({
+    setup: () => () => h(InterpolationSummarySelection as never, {
+      'parameterSelection': parameterSelection,
+      'modelValue': model.value,
+      'onUpdate:modelValue': (value: Record<string, unknown>) => { model.value = value },
+    }),
+  }), { attachTo: document.body })
+  await new Promise(resolve => setTimeout(resolve, 20))
+  const inner = wrapper.findComponent(InterpolationSummarySelection)
+  return { wrapper, model, vm: inner.vm as any }
+}
+
+/** The watchers settle over a few ticks, one feeding the next. */
+async function settle() {
+  for (let index = 0; index < 6; index++)
+    await nextTick()
+}
+
+describe('choosing the point an interpolation answers for', () => {
+  it('keeps the station\'s height when its own source button is clicked again', async () => {
+    // the button was treated as a change whichever source it named, so clicking the active one
+    // dropped the height of a station that stayed selected: nothing moved on screen and the next
+    // answer came back uncorrected, which at 1000 m is six degrees of air temperature
+    const { model, vm } = await selection('station')
+    vm.selectedStation = feldberg
+    await settle()
+    expect(model.value.elevation).toBe(1000)
+
+    vm.setSource('station')
+    await settle()
+    expect(model.value.elevation).toBe(1000)
+  })
+
+  it('names the station\'s height again on returning to it', async () => {
+    // the station never leaves the select, so its own watcher stays silent -- and the elevation
+    // would otherwise stay empty against a form showing the station and its coordinates
+    const { model, vm } = await selection('station')
+    vm.selectedStation = feldberg
+    await settle()
+
+    vm.setSource('manual')
+    await settle()
+    expect(model.value.elevation).toBeUndefined()
+
+    vm.setSource('station')
+    await settle()
+    expect(model.value.elevation).toBe(1000)
+  })
+})

--- a/app/tests/nuxt/composables/useInterpolationPoint.test.ts
+++ b/app/tests/nuxt/composables/useInterpolationPoint.test.ts
@@ -93,20 +93,6 @@ describe('the point an interpolation answers for', () => {
     expect(wrapper.vm.modelValue.longitude).toBe(8)
   })
 
-  it('forgets a station\'s height when the point is described afresh', async () => {
-    // pick a summit, then switch to typing coordinates: carrying its 1000 m into a city at 34 m
-    // reduces every reading to a height the point does not have, six degrees of air temperature
-    const wrapper = await mountSuspended(harness({ source: 'station' }))
-    wrapper.vm.fromStation(station as never)
-    await settle()
-    expect(wrapper.vm.modelValue.elevation).toBe(1000)
-
-    wrapper.vm.forgetElevation()
-    await settle()
-    expect(wrapper.vm.modelValue.elevation).toBeUndefined()
-    expect(wrapper.vm.elevationInput).toBe('')
-  })
-
   it('refuses a number no answer can be given for', async () => {
     // `1e400` parses to Infinity, which would travel into the model, into a shared link and on to
     // the API. The explorer's own query parser rejects it; the boxes have to agree

--- a/app/tests/nuxt/composables/useInterpolationPoint.test.ts
+++ b/app/tests/nuxt/composables/useInterpolationPoint.test.ts
@@ -1,0 +1,86 @@
+import type { InterpolationSelection } from '~/types/station-selection-state.type'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { useInterpolationPoint } from '~/composables/useInterpolationPoint'
+
+// Harness so the composable's watchers run inside a real setup context, as they do in the
+// selection component.
+function harness(initial: Partial<InterpolationSelection> = {}) {
+  return defineComponent({
+    setup() {
+      const modelValue = ref<InterpolationSelection>({ source: 'manual', ...initial })
+      return { modelValue, ...useInterpolationPoint(modelValue) }
+    },
+    render: () => h('div'),
+  })
+}
+
+/** The watchers settle over a few ticks, one feeding the next. */
+async function settle() {
+  for (let index = 0; index < 4; index++)
+    await nextTick()
+}
+
+const station = { station_id: '02290', name: 'Feldberg', state: '', latitude: 47.9, longitude: 8.0, height: 1000 }
+
+describe('the point an interpolation answers for', () => {
+  it('takes position and altitude from a chosen station', async () => {
+    const wrapper = await mountSuspended(harness({ source: 'station' }))
+    wrapper.vm.fromStation(station as never)
+    await settle()
+    expect(wrapper.vm.modelValue.latitude).toBe(47.9)
+    expect(wrapper.vm.modelValue.longitude).toBe(8.0)
+    expect(wrapper.vm.modelValue.elevation).toBe(1000)
+    // and the box shows it, rather than the query carrying a height the form does not
+    expect(wrapper.vm.elevationInput).toBe('1000')
+  })
+
+  it('keeps a station\'s coordinates when its elevation arrives', async () => {
+    // the elevation reaches the box through a watcher, which once fed the watcher that rebuilds
+    // the model from the manual boxes -- empty in station mode -- and cleared the coordinates,
+    // leaving the form unable to fetch at all
+    const wrapper = await mountSuspended(harness({ source: 'station' }))
+    wrapper.vm.fromStation(station as never)
+    await settle()
+    expect(wrapper.vm.modelValue.latitude).toBe(47.9)
+    expect(wrapper.vm.modelValue.longitude).toBe(8.0)
+  })
+
+  it('leaves the elevation unset for a station the provider gives no height for', async () => {
+    // FMI, IPMA, LHMT, the Environment Agency, WSV and IMGW's hydrology report none for any
+    // station; null is not undefined, and reached `.toString()` on the way to the query
+    const wrapper = await mountSuspended(harness({ source: 'station' }))
+    wrapper.vm.fromStation({ ...station, height: null } as never)
+    await settle()
+    expect(wrapper.vm.modelValue.elevation).toBeUndefined()
+    expect(wrapper.vm.elevationInput).toBe('')
+    expect(wrapper.vm.modelValue.latitude).toBe(47.9)
+  })
+
+  it('takes a typed elevation without disturbing the coordinates', async () => {
+    const wrapper = await mountSuspended(harness())
+    wrapper.vm.latitudeInput = '52.52'
+    wrapper.vm.longitudeInput = '13.40'
+    await settle()
+    wrapper.vm.elevationInput = '250'
+    await settle()
+    expect(wrapper.vm.modelValue).toMatchObject({ latitude: 52.52, longitude: 13.4, elevation: 250 })
+  })
+
+  it('leaves the elevation unset while its box is empty', async () => {
+    const wrapper = await mountSuspended(harness())
+    wrapper.vm.latitudeInput = '52.52'
+    wrapper.vm.longitudeInput = '13.40'
+    await settle()
+    // nothing typed: the readings are interpolated as they come
+    expect(wrapper.vm.modelValue.elevation).toBeUndefined()
+  })
+
+  it('clears the elevation when its box is emptied', async () => {
+    const wrapper = await mountSuspended(harness({ elevation: 250 }))
+    wrapper.vm.elevationInput = ''
+    await settle()
+    expect(wrapper.vm.modelValue.elevation).toBeUndefined()
+  })
+})

--- a/app/tests/nuxt/composables/useInterpolationPoint.test.ts
+++ b/app/tests/nuxt/composables/useInterpolationPoint.test.ts
@@ -93,6 +93,17 @@ describe('the point an interpolation answers for', () => {
     expect(wrapper.vm.modelValue.longitude).toBe(8)
   })
 
+  it('refuses a number no answer can be given for', async () => {
+    // `1e400` parses to Infinity, which would travel into the model, into a shared link and on to
+    // the API. The explorer's own query parser rejects it; the boxes have to agree
+    const wrapper = await mountSuspended(harness())
+    wrapper.vm.latitudeInput = '1e400'
+    wrapper.vm.elevationInput = '1e400'
+    await settle()
+    expect(wrapper.vm.modelValue.latitude).toBeUndefined()
+    expect(wrapper.vm.modelValue.elevation).toBeUndefined()
+  })
+
   it('clears the elevation when its box is emptied', async () => {
     const wrapper = await mountSuspended(harness({ elevation: 250 }))
     wrapper.vm.elevationInput = ''

--- a/app/tests/nuxt/composables/useInterpolationPoint.test.ts
+++ b/app/tests/nuxt/composables/useInterpolationPoint.test.ts
@@ -101,7 +101,7 @@ describe('the point an interpolation answers for', () => {
     await settle()
     expect(wrapper.vm.modelValue.elevation).toBe(1000)
 
-    wrapper.vm.forgetPoint()
+    wrapper.vm.forgetElevation()
     await settle()
     expect(wrapper.vm.modelValue.elevation).toBeUndefined()
     expect(wrapper.vm.elevationInput).toBe('')

--- a/app/tests/nuxt/composables/useInterpolationPoint.test.ts
+++ b/app/tests/nuxt/composables/useInterpolationPoint.test.ts
@@ -77,6 +77,22 @@ describe('the point an interpolation answers for', () => {
     expect(wrapper.vm.modelValue.elevation).toBeUndefined()
   })
 
+  it('shows a station\'s coordinates in the boxes, not only in the model', async () => {
+    // the boxes were seeded once at setup while the model was written by the station, so switching
+    // back to manual showed empty coordinates against a model that held them -- and typing one of
+    // them then read the other box, still empty, and wiped a coordinate nobody had touched
+    const wrapper = await mountSuspended(harness({ source: 'station' }))
+    wrapper.vm.fromStation(station as never)
+    await settle()
+    expect(wrapper.vm.latitudeInput).toBe('47.9')
+    expect(wrapper.vm.longitudeInput).toBe('8')
+
+    wrapper.vm.latitudeInput = '48'
+    await settle()
+    expect(wrapper.vm.modelValue.latitude).toBe(48)
+    expect(wrapper.vm.modelValue.longitude).toBe(8)
+  })
+
   it('clears the elevation when its box is emptied', async () => {
     const wrapper = await mountSuspended(harness({ elevation: 250 }))
     wrapper.vm.elevationInput = ''

--- a/app/tests/nuxt/composables/useInterpolationPoint.test.ts
+++ b/app/tests/nuxt/composables/useInterpolationPoint.test.ts
@@ -93,6 +93,20 @@ describe('the point an interpolation answers for', () => {
     expect(wrapper.vm.modelValue.longitude).toBe(8)
   })
 
+  it('forgets a station\'s height when the point is described afresh', async () => {
+    // pick a summit, then switch to typing coordinates: carrying its 1000 m into a city at 34 m
+    // reduces every reading to a height the point does not have, six degrees of air temperature
+    const wrapper = await mountSuspended(harness({ source: 'station' }))
+    wrapper.vm.fromStation(station as never)
+    await settle()
+    expect(wrapper.vm.modelValue.elevation).toBe(1000)
+
+    wrapper.vm.forgetPoint()
+    await settle()
+    expect(wrapper.vm.modelValue.elevation).toBeUndefined()
+    expect(wrapper.vm.elevationInput).toBe('')
+  })
+
   it('refuses a number no answer can be given for', async () => {
     // `1e400` parses to Infinity, which would travel into the model, into a shared link and on to
     // the API. The explorer's own query parser rejects it; the boxes have to agree


### PR DESCRIPTION
Follows #1898, which gave `interpolate` and `summarize` an elevation. The app had no way to say one, so the Explorer could not use the feature at all.

## Why it matters in the app

Air temperature falls about 0.65 K per 100 m. Interpolating stations at different altitudes as they come fits that vertical difference as though it were horizontal — around Garmisch the stations within 40 km span 630 m to 2956 m, which is 15 K, and even the flat country around Frankfurt spans 495 m, or 3.2 K.

## What changed

An **Elevation** field beside the latitude and longitude, optional: left empty nothing is corrected and the answer is what it was before. It goes out as `elevation` on `/api/interpolate` and `/api/summarize`, including in the URLs the export builds.

Choosing the point **by station** fills it with that station's own height — a station names its altitude as well as its position — which is also what the REST API does when a station names the point, so the two agree rather than the app silently getting the uncorrected answer for the same choice.

The `Station` type already carried `height`, so nothing new is fetched for it.

## Translations

Eleven locales, each in its own words rather than English with an accent:

| | label | hint |
|---|---|---|
| en | Elevation | optional, m above sea level |
| de | Höhe | optional, m über NN |
| cs | Nadmořská výška | volitelné, m n. m. |
| da | Højde | valgfri, m over havet |
| es | Altitud | opcional, m sobre el nivel del mar |
| fr | Altitude | facultatif, m au-dessus du niveau de la mer |
| it | Altitudine | opzionale, m sul livello del mare |
| lb | Héicht | fakultativ, m iwwer dem Mier |
| nl | Hoogte | optioneel, m boven zeeniveau |
| pl | Wysokość | opcjonalnie, m n.p.m. |

`de-hh` follows `de` for these, as it does for the other coordinate labels.

`pnpm lint` clean and `pnpm test:ci` 249 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BMmz23eRedUH9VTYaMQzV