### PR TITLE
feat(core): say why an elevation left nothing to answer with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,14 @@ Types of changes:
   share a station id. A station whose own height the provider does not report is left out of
   an answer about an elevation rather than contributing at its own altitude while its neighbours
   are moved -- thirteen providers have such stations, every one of FMI's, IPMA's and the
-  Environment Agency's among them. Where that leaves nothing to answer with, the request is
-  refused rather than answered empty: `NoStationsWithHeightError` names the parameters that lost
-  their stations and says that asking without an elevation gets them back, which the REST API
-  reports as a 400 and the CLI as a message rather than a traceback. A parameter emptied beside
-  one that still answered is a warning naming it, the rest of the result standing. Left out, the
+  Environment Agency's among them. Where that leaves nothing that can answer -- no station of
+  known height, or too few of them for the four an interpolation wants around the point -- the
+  request is refused rather than answered empty: `NoStationsWithHeightError` names the parameters
+  left unanswered and how to ask for the readings as they came, which the REST API reports as a
+  400 and the CLI as a message rather than a traceback. A parameter left unanswered beside one
+  that still answered is a warning naming it, the rest of the result standing. Whether a parameter
+  was answered is read off the finished frame rather than off the stations collected for it, those
+  being different questions. Left out, the
   elevation corrects nothing and the result is what it was before: an elevation taken from the
   interpolation itself cancels out of it exactly, so the correction is only possible when a caller
   says where the point is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,9 +40,14 @@ Types of changes:
   share a station id. A station whose own height the provider does not report is left out of
   an answer about an elevation rather than contributing at its own altitude while its neighbours
   are moved -- thirteen providers have such stations, every one of FMI's, IPMA's and the
-  Environment Agency's among them. Left out, nothing is corrected and the result is what it was
-  before: an elevation taken from the interpolation itself cancels out of it exactly, so the
-  correction is only possible when a caller says where the point is
+  Environment Agency's among them. Where that leaves nothing to answer with, the request is
+  refused rather than answered empty: `NoStationsWithHeightError` names the parameters that lost
+  their stations and says that asking without an elevation gets them back, which the REST API
+  reports as a 400 and the CLI as a message rather than a traceback. A parameter emptied beside
+  one that still answered is a warning naming it, the rest of the result standing. Left out, the
+  elevation corrects nothing and the result is what it was before: an elevation taken from the
+  interpolation itself cancels out of it exactly, so the correction is only possible when a caller
+  says where the point is
 - Parameter table: `lapse_rate` says how fast a quantity falls with height, in its own unit per
   metre, for the 17 air temperatures measured at 2 m and the dew point. Not for the 5 and 10 cm
   readings -- the grass minimum and its kin -- which are made in the air but governed by the
@@ -59,6 +64,10 @@ Types of changes:
   that fall with height to it. **This changes what those two calls return** where the stations
   drawn on stand at other altitudes -- for the reading uncorrected, pass the station's coordinates
   to `interpolate` or `summarize` instead
+
+- REST API: `/api/summarize` answers a window that ends before it starts with a 400 rather than a
+  404, as `/api/interpolate` already did. Both endpoints decide that from one place now, so the
+  status a failure carries no longer depends on which of the two it came through
 
 - Dependencies: shapely is required from 2.0.6 rather than 2.0.4. The two releases before it raise
   out of `create_collection` when a geometry is built from coordinates under numpy 2, which is what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,9 @@ Types of changes:
   400 and the CLI as a message rather than a traceback. A parameter left unanswered beside one
   that still answered is a warning naming it, the rest of the result standing. Whether a parameter
   was answered is read off the finished frame rather than off the stations collected for it, those
-  being different questions. Left out, the
+  being different questions -- and the exclusions are named as the reason only where the stations
+  they took would have made up what the calculation needs, a parameter that was short of stations
+  either way having failed on something an elevation has nothing to do with. Left out, the
   elevation corrects nothing and the result is what it was before: an elevation taken from the
   interpolation itself cancels out of it exactly, so the correction is only possible when a caller
   says where the point is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,12 +40,15 @@ Types of changes:
   share a station id. A station whose own height the provider does not report is left out of
   an answer about an elevation rather than contributing at its own altitude while its neighbours
   are moved -- thirteen providers have such stations, every one of FMI's, IPMA's and the
-  Environment Agency's among them. Where that leaves nothing that can answer -- no station of
-  known height, or too few of them for the four an interpolation wants around the point -- the
-  request is refused rather than answered empty: `NoStationsWithHeightError` names the parameters
-  left unanswered and how to ask for the readings as they came, which the REST API reports as a
-  400 and the CLI as a message rather than a traceback. A parameter left unanswered beside one
-  that still answered is a warning naming it, the rest of the result standing. Whether a parameter
+  Environment Agency's among them. Where that leaves a parameter with no station at all, the
+  request is refused rather than answered empty: `NoStationsWithHeightError` names it and how to
+  ask for the readings as they came, which the REST API reports as a 400 and the CLI as a message
+  rather than a traceback. Where every quantity asked for falls with height and no station near
+  the point reports one, that is settled off the station list without downloading a reading. A
+  parameter that kept some stations and still answered nothing is named in the log instead, the
+  rest of the result standing: whether the stations it lost would have completed the four an
+  interpolation wants is not something a count can say, and the readings that are there stay with
+  the caller. Whether a parameter
   was answered is read off the finished frame rather than off the stations collected for it, those
   being different questions -- and the exclusions are named as the reason only where the stations
   they took would have made up what the calculation needs, a parameter that was short of stations

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -141,6 +141,13 @@ measured in or on the ground, nor pressure, which falls exponentially rather tha
 station whose own height the provider does not report is left out of an answer about an elevation
 rather than contributing at its own altitude while its neighbours are moved.
 
+Where that leaves nothing to answer with — every station of a few providers reports no height,
+FMI's, IPMA's and the Environment Agency's among them — the request is refused rather than answered
+empty: `NoStationsWithHeightError` names the parameters that lost their stations and says that
+asking without an elevation gets them back. A parameter emptied beside one that still answered is
+a warning in the log instead, the rest of the result standing. Over the REST API both endpoints
+report it as a 400.
+
 Left out, nothing is corrected. The elevation cannot be taken from the stations themselves: one
 derived from the same linear interpolation cancels out of the correction exactly, leaving the
 result unchanged, so it has to come from the caller.

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -141,22 +141,22 @@ measured in or on the ground, nor pressure, which falls exponentially rather tha
 station whose own height the provider does not report is left out of an answer about an elevation
 rather than contributing at its own altitude while its neighbours are moved.
 
-Where that leaves nothing that can answer — every station of a few providers reports no height,
-FMI's, IPMA's and the Environment Agency's among them, and an interpolation wants four of known
-height that surround the point — the request is refused rather than answered empty:
-`NoStationsWithHeightError` names the parameters that took no station at all. Where every quantity
-asked for falls with height and not one station near the point reports one, that is settled off the
-station list alone, without downloading a single reading -- nothing there can be brought to another
-height whatever it holds. Ask for such a quantity beside one that does not fall with height, and
-the readings are fetched for the second, the first being named in the log once the answer is in.
+Where that leaves a parameter with no station at all — every station of a few providers reports no
+height, FMI's, IPMA's and the Environment Agency's among them — the request is refused rather than
+answered empty, and `NoStationsWithHeightError` names it. Where every quantity asked for falls with
+height and no station near the point reports one, that much is settled off the station list alone,
+without downloading a reading; ask for such a quantity beside one that does not fall with height
+and the readings are fetched for the second, the first being named once the answer is in.
 
-A parameter that kept some stations and still came back null is named in the log rather than
-raised: whether the stations it lost would have completed the four an interpolation wants is not
-something the count can say, and the readings that are there stay with the caller either way. Asking by coordinates and
-without an elevation takes each station's readings as they came; a request named by a station id
-answers at that station's own height, so it has no form that asks about no height at all. A
-parameter left unanswered beside one that still answered is a warning in the log instead, the rest
-of the result standing. Over the REST API both endpoints report the refusal as a 400.
+A parameter that kept some stations and still answered nothing is named in the log rather than
+raised. Whether the stations it lost would have completed the four an interpolation wants is not
+something a count can say — they may not have surrounded the point either — and the readings that
+are there stay with the caller either way.
+
+Asking by coordinates and without an elevation takes each station's readings as they came. A
+request named by a station id answers at that station's own height, so it has no form that asks
+about no height at all: pass the station's coordinates to `interpolate` for that. Over the REST API
+both endpoints report the refusal as a 400, and the CLI prints it without a traceback.
 
 Left out, nothing is corrected. The elevation cannot be taken from the stations themselves: one
 derived from the same linear interpolation cancels out of the correction exactly, leaving the

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -144,8 +144,8 @@ rather than contributing at its own altitude while its neighbours are moved.
 Where that leaves a parameter with no station at all — every station of a few providers reports no
 height, FMI's, IPMA's and the Environment Agency's among them — the request is refused rather than
 answered empty, and `NoStationsWithHeightError` names it. Where every quantity asked for falls with
-height and no station near the point reports one, that much is settled off the station list alone,
-without downloading a reading; ask for such a quantity beside one that does not fall with height
+height and enough stations stand near the point that their heights would have mattered, none of
+them reporting one, that much is settled off the station list alone, without downloading a reading; ask for such a quantity beside one that does not fall with height
 and the readings are fetched for the second, the first being named once the answer is in.
 
 A parameter that kept some stations and still answered nothing is named in the log rather than

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -144,7 +144,9 @@ rather than contributing at its own altitude while its neighbours are moved.
 Where that leaves nothing that can answer — every station of a few providers reports no height,
 FMI's, IPMA's and the Environment Agency's among them, and an interpolation wants four of known
 height that surround the point — the request is refused rather than answered empty:
-`NoStationsWithHeightError` names the parameters left unanswered. Asking by coordinates and
+`NoStationsWithHeightError` names the parameters left unanswered. Where not one station near the
+point reports a height, the request is refused off the station list alone, without downloading a
+single reading -- nothing there can be brought to another height whatever it holds. Asking by coordinates and
 without an elevation takes each station's readings as they came; a request named by a station id
 answers at that station's own height, so it has no form that asks about no height at all. A
 parameter left unanswered beside one that still answered is a warning in the log instead, the rest

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -144,9 +144,10 @@ rather than contributing at its own altitude while its neighbours are moved.
 Where that leaves a parameter with no station at all — every station of a few providers reports no
 height, FMI's, IPMA's and the Environment Agency's among them — the request is refused rather than
 answered empty, and `NoStationsWithHeightError` names it. Where every quantity asked for falls with
-height and enough stations stand near the point that their heights would have mattered, none of
-them reporting one, that much is settled off the station list alone, without downloading a reading; ask for such a quantity beside one that does not fall with height
-and the readings are fetched for the second, the first being named once the answer is in.
+height, enough stations stand near the point for their heights to have mattered, and none of
+them reports one, that much is settled off the station list alone, without downloading a
+reading. Ask for such a quantity beside one that does not fall with height and the readings are
+fetched for the second, the first being named once the answer is in.
 
 A parameter that kept some stations and still answered nothing is named in the log rather than
 raised. Whether the stations it lost would have completed the four an interpolation wants is not

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -141,12 +141,14 @@ measured in or on the ground, nor pressure, which falls exponentially rather tha
 station whose own height the provider does not report is left out of an answer about an elevation
 rather than contributing at its own altitude while its neighbours are moved.
 
-Where that leaves nothing to answer with — every station of a few providers reports no height,
-FMI's, IPMA's and the Environment Agency's among them — the request is refused rather than answered
-empty: `NoStationsWithHeightError` names the parameters that lost their stations and says that
-asking without an elevation gets them back. A parameter emptied beside one that still answered is
-a warning in the log instead, the rest of the result standing. Over the REST API both endpoints
-report it as a 400.
+Where that leaves nothing that can answer — every station of a few providers reports no height,
+FMI's, IPMA's and the Environment Agency's among them, and an interpolation wants four of known
+height that surround the point — the request is refused rather than answered empty:
+`NoStationsWithHeightError` names the parameters left unanswered. Asking by coordinates and
+without an elevation takes each station's readings as they came; a request named by a station id
+answers at that station's own height, so it has no form that asks about no height at all. A
+parameter left unanswered beside one that still answered is a warning in the log instead, the rest
+of the result standing. Over the REST API both endpoints report the refusal as a 400.
 
 Left out, nothing is corrected. The elevation cannot be taken from the stations themselves: one
 derived from the same linear interpolation cancels out of the correction exactly, leaving the

--- a/docs/usage/interpolation.md
+++ b/docs/usage/interpolation.md
@@ -144,9 +144,15 @@ rather than contributing at its own altitude while its neighbours are moved.
 Where that leaves nothing that can answer — every station of a few providers reports no height,
 FMI's, IPMA's and the Environment Agency's among them, and an interpolation wants four of known
 height that surround the point — the request is refused rather than answered empty:
-`NoStationsWithHeightError` names the parameters left unanswered. Where not one station near the
-point reports a height, the request is refused off the station list alone, without downloading a
-single reading -- nothing there can be brought to another height whatever it holds. Asking by coordinates and
+`NoStationsWithHeightError` names the parameters that took no station at all. Where every quantity
+asked for falls with height and not one station near the point reports one, that is settled off the
+station list alone, without downloading a single reading -- nothing there can be brought to another
+height whatever it holds. Ask for such a quantity beside one that does not fall with height, and
+the readings are fetched for the second, the first being named in the log once the answer is in.
+
+A parameter that kept some stations and still came back null is named in the log rather than
+raised: whether the stations it lost would have completed the four an interpolation wants is not
+something the count can say, and the readings that are there stay with the caller either way. Asking by coordinates and
 without an elevation takes each station's readings as they came; a request named by a station id
 answers at that station's own height, so it has no form that asks about no height at all. A
 parameter left unanswered beside one that still answered is a warning in the log instead, the rest

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -19,13 +19,16 @@ from shapely.geometry import MultiPoint, Point
 from tqdm import tqdm
 
 from wetterdienst.core.util import (
+    StationsInReach,
     can_answer_at_height,
     collection_is_done,
+    count_stations_in_reach,
     extract_station_values,
     lapse_rate_for,
     open_parameter_data,
     reduce_to_height,
     report_height_exclusions,
+    unanswerable_at_height,
 )
 from wetterdienst.metadata.parameter_table import PARAMETERS
 from wetterdienst.model.metadata import ParameterModel
@@ -68,7 +71,7 @@ def get_interpolated_df(
     """
     utm_x, utm_y, _, _ = utm.from_latlon(latitude, longitude)
     settings = cast("Settings", request.settings)
-    stations_dict, param_dict, dropped_for_height = request_stations(
+    stations_dict, param_dict, dropped_for_height, counts = request_stations(
         request,
         latitude,
         longitude,
@@ -79,7 +82,14 @@ def get_interpolated_df(
     df = calculate_interpolation(utm_x, utm_y, stations_dict, param_dict, settings.ts_geo_use_nearby_station_distance)
     # after the frame is built, not before: a parameter the exclusions left with three stations
     # holds columns and still interpolates to nothing, and only the frame knows that
-    report_height_exclusions(df, param_dict, dropped_for_height, elevation, stations_needed=STATIONS_NEEDED)
+    report_height_exclusions(
+        df,
+        param_dict,
+        dropped_for_height,
+        counts,
+        elevation,
+        stations_needed=STATIONS_NEEDED,
+    )
     return df
 
 
@@ -90,7 +100,7 @@ def request_stations(
     utm_x: float,
     utm_y: float,
     elevation: float | None = None,
-) -> tuple[dict, dict, set[tuple[str, str, str]]]:
+) -> tuple[dict, dict, set[tuple[str, str, str]], dict[tuple[str, str, str], StationsInReach]]:
     """Request the stations for the interpolation.
 
     Args:
@@ -102,8 +112,8 @@ def request_stations(
         elevation: elevation of the point in metres, to bring each station's readings to
 
     Returns:
-        the stations dict, the parameter dict, and the parameters that lost a station for
-        having no height of its own
+        the stations dict, the parameter dict, the parameters that lost a station for having
+        no height of its own, and what each parameter had in reach to begin with
 
     """
     param_dict = {}
@@ -125,9 +135,14 @@ def request_stations(
     # so a multi-dataset request has several rows for one station, each with the coordinates and
     # distance its own dataset's meta index reported. `query()` yields one result per station, and
     # the row that answers for it is the closest one rather than whichever happened to sort last
-    # asked once: a provider that reports no height for any station has nothing for the walk to
-    # hold out for, and every one of FMI's, IPMA's and the Environment Agency's stations is such
-    heights_in_reach = df_stations_ranked.get_column("height").null_count() < df_stations_ranked.height
+    # counted once, off the ranking, before a single value is downloaded: what each parameter has
+    # in its own radius, and how much of that reports a height
+    counts = count_stations_in_reach(df_stations_ranked, request.parameters, settings)
+    unanswerable = unanswerable_at_height(counts, elevation)
+    if unanswerable and unanswerable == set(counts):
+        # no station in reach can be brought to the height asked about, and every parameter wants
+        # to be: there is nothing a download could add, so the report speaks for the whole request
+        return stations_dict, param_dict, unanswerable, counts
     stations_by_id = {
         station["station_id"]: station
         for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
@@ -145,10 +160,7 @@ def request_stations(
         station = stations_by_id[result.df.get_column("station_id")[0]]
         valid_station_groups_exists = has_valid_station_group(stations_dict, utm_x, utm_y)
         # check if all parameters found enough stations and the stations build a valid station group
-        if (
-            collection_is_done(param_dict, dropped_for_height, heights_in_reach=heights_in_reach)
-            and valid_station_groups_exists
-        ):
+        if collection_is_done(param_dict, dropped_for_height - unanswerable) and valid_station_groups_exists:
             break
         if result.df.drop_nulls("value").is_empty():
             continue
@@ -169,7 +181,7 @@ def request_stations(
         if contributed:
             utm_x_station, utm_y_station = utm.from_latlon(station["latitude"], station["longitude"])[:2]
             stations_dict[station["station_id"]] = (utm_x_station, utm_y_station, station["distance"])
-    return stations_dict, param_dict, dropped_for_height
+    return stations_dict, param_dict, dropped_for_height, counts
 
 
 def apply_station_values_per_parameter(

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -24,6 +24,7 @@ from wetterdienst.core.util import (
     lapse_rate_for,
     open_parameter_data,
     reduce_to_height,
+    report_height_exclusions,
 )
 from wetterdienst.metadata.parameter_table import PARAMETERS
 from wetterdienst.model.metadata import ParameterModel
@@ -85,6 +86,7 @@ def request_stations(
     """
     param_dict = {}
     stations_dict = {}
+    dropped_for_height: set[tuple[str, str, str]] = set()
     settings = cast("Settings", request.settings)
     max_interp_distance = max(
         settings.ts_geo_station_distance_for(parameter.name, parameter.dataset.resolution.name)
@@ -128,6 +130,7 @@ def request_stations(
             param_dict,
             station,
             elevation,
+            dropped_for_height=dropped_for_height,
             valid_station_groups_exists=valid_station_groups_exists,
         )
         # only a station that gave something is one of the stations the interpolation has: the hull
@@ -138,6 +141,7 @@ def request_stations(
         if contributed:
             utm_x_station, utm_y_station = utm.from_latlon(station["latitude"], station["longitude"])[:2]
             stations_dict[station["station_id"]] = (utm_x_station, utm_y_station, station["distance"])
+    report_height_exclusions(param_dict, dropped_for_height, elevation)
     return stations_dict, param_dict
 
 
@@ -148,6 +152,7 @@ def apply_station_values_per_parameter(
     station: dict,
     elevation: float | None = None,
     *,
+    dropped_for_height: set[tuple[str, str, str]],
     valid_station_groups_exists: bool,
 ) -> bool:
     """Apply the station values to the parameter data.
@@ -158,6 +163,7 @@ def apply_station_values_per_parameter(
         param_dict: dict containing the parameter data
         station: dict containing the station data
         elevation: elevation of the point in metres, to bring each station's readings to
+        dropped_for_height: the parameters that lost a station for having no height
         min_gain_of_value_pairs: minimum gain of value pairs to add a station
         num_additional_stations: number of additional stations to add if the gain is not reached
         valid_station_groups_exists: bool indicating if valid station groups exist
@@ -204,6 +210,9 @@ def apply_station_values_per_parameter(
                 f"station {station['station_id']} has no height, so it says nothing about "
                 f"{parameter.name} at {elevation} m and is left out",
             )
+            # noted, not only logged: where this empties a parameter the caller is owed the
+            # reason, and a log line is the one place a caller cannot read it from
+            dropped_for_height.add(param_key)
             continue
         # cast, not parsed: the request declares its dates as `str | datetime | None` because
         # that is what a caller may hand it, and resolves them to datetimes in `__post_init__`

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -132,7 +132,7 @@ def request_stations(
     # counted once, off the ranking, before a single value is downloaded: what each parameter has
     # in its own radius, and how much of that reports a height
     counts = count_stations_in_reach(df_stations_ranked, request.parameters, settings)
-    unanswerable = unanswerable_at_height(counts, elevation)
+    unanswerable = unanswerable_at_height(counts, elevation, STATIONS_NEEDED)
     if unanswerable and unanswerable == set(counts):
         # every parameter asked for falls with height and not one station in reach reports one:
         # true of the request whatever the stations hold, so it is said without downloading them

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -20,6 +20,7 @@ from tqdm import tqdm
 
 from wetterdienst.core.util import (
     can_answer_at_height,
+    collection_is_done,
     extract_station_values,
     lapse_rate_for,
     open_parameter_data,
@@ -58,8 +59,19 @@ def get_interpolated_df(
     """Get the interpolated DataFrame for the given request and location."""
     utm_x, utm_y, _, _ = utm.from_latlon(latitude, longitude)
     settings = cast("Settings", request.settings)
-    stations_dict, param_dict = request_stations(request, latitude, longitude, utm_x, utm_y, elevation)
-    return calculate_interpolation(utm_x, utm_y, stations_dict, param_dict, settings.ts_geo_use_nearby_station_distance)
+    stations_dict, param_dict, dropped_for_height = request_stations(
+        request,
+        latitude,
+        longitude,
+        utm_x,
+        utm_y,
+        elevation,
+    )
+    df = calculate_interpolation(utm_x, utm_y, stations_dict, param_dict, settings.ts_geo_use_nearby_station_distance)
+    # after the frame is built, not before: a parameter the exclusions left with three stations
+    # holds columns and still interpolates to nothing, and only the frame knows that
+    report_height_exclusions(df, dropped_for_height, elevation)
+    return df
 
 
 def request_stations(
@@ -69,7 +81,7 @@ def request_stations(
     utm_x: float,
     utm_y: float,
     elevation: float | None = None,
-) -> tuple[dict, dict]:
+) -> tuple[dict, dict, set[tuple[str, str, str]]]:
     """Request the stations for the interpolation.
 
     Args:
@@ -81,7 +93,8 @@ def request_stations(
         elevation: elevation of the point in metres, to bring each station's readings to
 
     Returns:
-        tuple containing the stations dict and the parameter dict
+        the stations dict, the parameter dict, and the parameters that lost a station for
+        having no height of its own
 
     """
     param_dict = {}
@@ -120,7 +133,7 @@ def request_stations(
         station = stations_by_id[result.df.get_column("station_id")[0]]
         valid_station_groups_exists = has_valid_station_group(stations_dict, utm_x, utm_y)
         # check if all parameters found enough stations and the stations build a valid station group
-        if len(param_dict) > 0 and all(param.finished for param in param_dict.values()) and valid_station_groups_exists:
+        if collection_is_done(param_dict, dropped_for_height) and valid_station_groups_exists:
             break
         if result.df.drop_nulls("value").is_empty():
             continue
@@ -141,8 +154,7 @@ def request_stations(
         if contributed:
             utm_x_station, utm_y_station = utm.from_latlon(station["latitude"], station["longitude"])[:2]
             stations_dict[station["station_id"]] = (utm_x_station, utm_y_station, station["distance"])
-    report_height_exclusions(param_dict, dropped_for_height, elevation)
-    return stations_dict, param_dict
+    return stations_dict, param_dict, dropped_for_height
 
 
 def apply_station_values_per_parameter(

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -137,6 +137,12 @@ def request_stations(
     # so a multi-dataset request has several rows for one station, each with the coordinates and
     # distance its own dataset's meta index reported. `query()` yields one result per station, and
     # the row that answers for it is the closest one rather than whichever happened to sort last
+    stations_by_id = {
+        station["station_id"]: station
+        for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
+            named=True,
+        )
+    }
     # counted once, off the ranking, before a single value is downloaded: what each parameter has
     # in its own radius, and how much of that reports a height
     counts = count_stations_in_reach(
@@ -150,12 +156,6 @@ def request_stations(
         # every parameter asked for falls with height and not one station in reach reports one:
         # true of the request whatever the stations hold, so it is said without downloading them
         raise no_height_in_reach_error(unanswerable, elevation)
-    stations_by_id = {
-        station["station_id"]: station
-        for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
-            named=True,
-        )
-    }
     tqdm_out = TqdmToLogger(log, level=logging.INFO)
     for result in tqdm(
         stations_ranked.values.query(),

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -19,13 +19,13 @@ from shapely.geometry import MultiPoint, Point
 from tqdm import tqdm
 
 from wetterdienst.core.util import (
-    StationsInReach,
     can_answer_at_height,
     collection_is_done,
     count_stations_in_reach,
     extract_station_values,
     lapse_rate_for,
     open_parameter_data,
+    parameters_still_in_reach,
     reduce_to_height,
     report_height_exclusions,
     unanswerable_at_height,
@@ -71,7 +71,7 @@ def get_interpolated_df(
     """
     utm_x, utm_y, _, _ = utm.from_latlon(latitude, longitude)
     settings = cast("Settings", request.settings)
-    stations_dict, param_dict, dropped_for_height, counts = request_stations(
+    stations_dict, param_dict, dropped_for_height = request_stations(
         request,
         latitude,
         longitude,
@@ -82,14 +82,7 @@ def get_interpolated_df(
     df = calculate_interpolation(utm_x, utm_y, stations_dict, param_dict, settings.ts_geo_use_nearby_station_distance)
     # after the frame is built, not before: a parameter the exclusions left with three stations
     # holds columns and still interpolates to nothing, and only the frame knows that
-    report_height_exclusions(
-        df,
-        param_dict,
-        dropped_for_height,
-        counts,
-        elevation,
-        stations_needed=STATIONS_NEEDED,
-    )
+    report_height_exclusions(df, param_dict, dropped_for_height, elevation, stations_needed=STATIONS_NEEDED)
     return df
 
 
@@ -100,7 +93,7 @@ def request_stations(
     utm_x: float,
     utm_y: float,
     elevation: float | None = None,
-) -> tuple[dict, dict, set[tuple[str, str, str]], dict[tuple[str, str, str], StationsInReach]]:
+) -> tuple[dict, dict, dict[tuple[str, str, str], int]]:
     """Request the stations for the interpolation.
 
     Args:
@@ -112,13 +105,13 @@ def request_stations(
         elevation: elevation of the point in metres, to bring each station's readings to
 
     Returns:
-        the stations dict, the parameter dict, the parameters that lost a station for having
-        no height of its own, and what each parameter had in reach to begin with
+        the stations dict, the parameter dict, and how many stations each parameter lost for
+        having no height of its own
 
     """
     param_dict = {}
     stations_dict = {}
-    dropped_for_height: set[tuple[str, str, str]] = set()
+    dropped_for_height: dict[tuple[str, str, str], int] = {}
     settings = cast("Settings", request.settings)
     max_interp_distance = max(
         settings.ts_geo_station_distance_for(parameter.name, parameter.dataset.resolution.name)
@@ -142,7 +135,7 @@ def request_stations(
     if unanswerable and unanswerable == set(counts):
         # no station in reach can be brought to the height asked about, and every parameter wants
         # to be: there is nothing a download could add, so the report speaks for the whole request
-        return stations_dict, param_dict, unanswerable, counts
+        return stations_dict, param_dict, {key: counts[key].total for key in unanswerable}
     stations_by_id = {
         station["station_id"]: station
         for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
@@ -160,7 +153,12 @@ def request_stations(
         station = stations_by_id[result.df.get_column("station_id")[0]]
         valid_station_groups_exists = has_valid_station_group(stations_dict, utm_x, utm_y)
         # check if all parameters found enough stations and the stations build a valid station group
-        if collection_is_done(param_dict, dropped_for_height - unanswerable) and valid_station_groups_exists:
+        if (
+            collection_is_done(
+                param_dict, dropped_for_height.keys() & parameters_still_in_reach(counts, station["distance"])
+            )
+            and valid_station_groups_exists
+        ):
             break
         if result.df.drop_nulls("value").is_empty():
             continue
@@ -181,7 +179,7 @@ def request_stations(
         if contributed:
             utm_x_station, utm_y_station = utm.from_latlon(station["latitude"], station["longitude"])[:2]
             stations_dict[station["station_id"]] = (utm_x_station, utm_y_station, station["distance"])
-    return stations_dict, param_dict, dropped_for_height, counts
+    return stations_dict, param_dict, dropped_for_height
 
 
 def apply_station_values_per_parameter(
@@ -191,7 +189,7 @@ def apply_station_values_per_parameter(
     station: dict,
     elevation: float | None = None,
     *,
-    dropped_for_height: set[tuple[str, str, str]],
+    dropped_for_height: dict[tuple[str, str, str], int],
     valid_station_groups_exists: bool,
 ) -> bool:
     """Apply the station values to the parameter data.
@@ -202,7 +200,7 @@ def apply_station_values_per_parameter(
         param_dict: dict containing the parameter data
         station: dict containing the station data
         elevation: elevation of the point in metres, to bring each station's readings to
-        dropped_for_height: the parameters that lost a station for having no height
+        dropped_for_height: how many stations each parameter lost for having no height
         min_gain_of_value_pairs: minimum gain of value pairs to add a station
         num_additional_stations: number of additional stations to add if the gain is not reached
         valid_station_groups_exists: bool indicating if valid station groups exist
@@ -251,7 +249,7 @@ def apply_station_values_per_parameter(
             )
             # noted, not only logged: where this empties a parameter the caller is owed the
             # reason, and a log line is the one place a caller cannot read it from
-            dropped_for_height.add(param_key)
+            dropped_for_height[param_key] = dropped_for_height.get(param_key, 0) + 1
             continue
         # cast, not parsed: the request declares its dates as `str | datetime | None` because
         # that is what a caller may hand it, and resolves them to datetimes in `__post_init__`

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -24,6 +24,7 @@ from wetterdienst.core.util import (
     count_stations_in_reach,
     extract_station_values,
     lapse_rate_for,
+    no_height_in_reach_error,
     open_parameter_data,
     parameters_still_in_reach,
     reduce_to_height,
@@ -133,9 +134,9 @@ def request_stations(
     counts = count_stations_in_reach(df_stations_ranked, request.parameters, settings)
     unanswerable = unanswerable_at_height(counts, elevation)
     if unanswerable and unanswerable == set(counts):
-        # no station in reach can be brought to the height asked about, and every parameter wants
-        # to be: there is nothing a download could add, so the report speaks for the whole request
-        return stations_dict, param_dict, {key: counts[key].total for key in unanswerable}
+        # every parameter asked for falls with height and not one station in reach reports one:
+        # true of the request whatever the stations hold, so it is said without downloading them
+        raise no_height_in_reach_error(unanswerable, elevation)
     stations_by_id = {
         station["station_id"]: station
         for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -19,6 +19,7 @@ from shapely.geometry import MultiPoint, Point
 from tqdm import tqdm
 
 from wetterdienst.core.util import (
+    DroppedForHeight,
     can_answer_at_height,
     collection_is_done,
     count_stations_in_reach,
@@ -83,7 +84,14 @@ def get_interpolated_df(
     df = calculate_interpolation(utm_x, utm_y, stations_dict, param_dict, settings.ts_geo_use_nearby_station_distance)
     # after the frame is built, not before: a parameter the exclusions left with three stations
     # holds columns and still interpolates to nothing, and only the frame knows that
-    report_height_exclusions(df, param_dict, dropped_for_height, elevation, stations_needed=STATIONS_NEEDED)
+    report_height_exclusions(
+        df,
+        param_dict,
+        dropped_for_height,
+        elevation,
+        stations_needed=STATIONS_NEEDED,
+        nearby_station_distance=settings.ts_geo_use_nearby_station_distance,
+    )
     return df
 
 
@@ -94,7 +102,7 @@ def request_stations(
     utm_x: float,
     utm_y: float,
     elevation: float | None = None,
-) -> tuple[dict, dict, dict[tuple[str, str, str], int]]:
+) -> tuple[dict, dict, dict[tuple[str, str, str], DroppedForHeight]]:
     """Request the stations for the interpolation.
 
     Args:
@@ -112,7 +120,7 @@ def request_stations(
     """
     param_dict = {}
     stations_dict = {}
-    dropped_for_height: dict[tuple[str, str, str], int] = {}
+    dropped_for_height: dict[tuple[str, str, str], DroppedForHeight] = {}
     settings = cast("Settings", request.settings)
     max_interp_distance = max(
         settings.ts_geo_station_distance_for(parameter.name, parameter.dataset.resolution.name)
@@ -195,7 +203,7 @@ def apply_station_values_per_parameter(
     station: dict,
     elevation: float | None = None,
     *,
-    dropped_for_height: dict[tuple[str, str, str], int],
+    dropped_for_height: dict[tuple[str, str, str], DroppedForHeight],
     valid_station_groups_exists: bool,
 ) -> bool:
     """Apply the station values to the parameter data.
@@ -255,7 +263,11 @@ def apply_station_values_per_parameter(
             )
             # noted, not only logged: where this empties a parameter the caller is owed the
             # reason, and a log line is the one place a caller cannot read it from
-            dropped_for_height[param_key] = dropped_for_height.get(param_key, 0) + 1
+            lost = dropped_for_height.get(param_key)
+            dropped_for_height[param_key] = DroppedForHeight(
+                count=lost.count + 1 if lost else 1,
+                nearest=min(lost.nearest, station["distance"]) if lost else station["distance"],
+            )
             continue
         # cast, not parsed: the request declares its dates as `str | datetime | None` because
         # that is what a caller may hand it, and resolves them to datetimes in `__post_init__`

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -42,6 +42,9 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# what `apply_interpolation` wants before it can answer: four stations that surround the point
+STATIONS_NEEDED = 4
+
 # Occurrence thresholding is applied to the quantities the canonical parameter table marks
 # `zero_inflated`: linear interpolation between a station that recorded rain and one that recorded
 # none produces a spurious small positive, a drizzle that fell nowhere. We suppress those by also
@@ -56,7 +59,13 @@ def get_interpolated_df(
     longitude: float,
     elevation: float | None = None,
 ) -> pl.DataFrame:
-    """Get the interpolated DataFrame for the given request and location."""
+    """Get the interpolated DataFrame for the given request and location.
+
+    Raises:
+        NoStationsWithHeightError: where an elevation is asked about and leaving out the stations
+            of unknown height leaves nothing that can answer it
+
+    """
     utm_x, utm_y, _, _ = utm.from_latlon(latitude, longitude)
     settings = cast("Settings", request.settings)
     stations_dict, param_dict, dropped_for_height = request_stations(
@@ -70,7 +79,7 @@ def get_interpolated_df(
     df = calculate_interpolation(utm_x, utm_y, stations_dict, param_dict, settings.ts_geo_use_nearby_station_distance)
     # after the frame is built, not before: a parameter the exclusions left with three stations
     # holds columns and still interpolates to nothing, and only the frame knows that
-    report_height_exclusions(df, dropped_for_height, elevation)
+    report_height_exclusions(df, param_dict, dropped_for_height, elevation, stations_needed=STATIONS_NEEDED)
     return df
 
 
@@ -116,6 +125,9 @@ def request_stations(
     # so a multi-dataset request has several rows for one station, each with the coordinates and
     # distance its own dataset's meta index reported. `query()` yields one result per station, and
     # the row that answers for it is the closest one rather than whichever happened to sort last
+    # asked once: a provider that reports no height for any station has nothing for the walk to
+    # hold out for, and every one of FMI's, IPMA's and the Environment Agency's stations is such
+    heights_in_reach = df_stations_ranked.get_column("height").null_count() < df_stations_ranked.height
     stations_by_id = {
         station["station_id"]: station
         for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
@@ -133,7 +145,10 @@ def request_stations(
         station = stations_by_id[result.df.get_column("station_id")[0]]
         valid_station_groups_exists = has_valid_station_group(stations_dict, utm_x, utm_y)
         # check if all parameters found enough stations and the stations build a valid station group
-        if collection_is_done(param_dict, dropped_for_height) and valid_station_groups_exists:
+        if (
+            collection_is_done(param_dict, dropped_for_height, heights_in_reach=heights_in_reach)
+            and valid_station_groups_exists
+        ):
             break
         if result.df.drop_nulls("value").is_empty():
             continue

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -73,7 +73,7 @@ def get_interpolated_df(
     """
     utm_x, utm_y, _, _ = utm.from_latlon(latitude, longitude)
     settings = cast("Settings", request.settings)
-    stations_dict, param_dict, dropped_for_height = request_stations(
+    stations_dict, param_dict, dropped_for_height, unanswerable = request_stations(
         request,
         latitude,
         longitude,
@@ -91,6 +91,7 @@ def get_interpolated_df(
         elevation,
         stations_needed=STATIONS_NEEDED,
         nearby_station_distance=settings.ts_geo_use_nearby_station_distance,
+        unanswerable=unanswerable,
     )
     return df
 
@@ -102,7 +103,7 @@ def request_stations(
     utm_x: float,
     utm_y: float,
     elevation: float | None = None,
-) -> tuple[dict, dict, dict[tuple[str, str, str], DroppedForHeight]]:
+) -> tuple[dict, dict, dict[tuple[str, str, str], DroppedForHeight], set[tuple[str, str, str]]]:
     """Request the stations for the interpolation.
 
     Args:
@@ -114,8 +115,8 @@ def request_stations(
         elevation: elevation of the point in metres, to bring each station's readings to
 
     Returns:
-        the stations dict, the parameter dict, and how many stations each parameter lost for
-        having no height of its own
+        the stations dict, the parameter dict, how many stations each parameter lost for
+        having no height of its own, and the parameters the ranking proved unanswerable
 
     """
     param_dict = {}
@@ -193,7 +194,7 @@ def request_stations(
         if contributed:
             utm_x_station, utm_y_station = utm.from_latlon(station["latitude"], station["longitude"])[:2]
             stations_dict[station["station_id"]] = (utm_x_station, utm_y_station, station["distance"])
-    return stations_dict, param_dict, dropped_for_height
+    return stations_dict, param_dict, dropped_for_height, unanswerable
 
 
 def apply_station_values_per_parameter(

--- a/src/wetterdienst/core/interpolate.py
+++ b/src/wetterdienst/core/interpolate.py
@@ -131,7 +131,12 @@ def request_stations(
     # the row that answers for it is the closest one rather than whichever happened to sort last
     # counted once, off the ranking, before a single value is downloaded: what each parameter has
     # in its own radius, and how much of that reports a height
-    counts = count_stations_in_reach(df_stations_ranked, request.parameters, settings)
+    counts = count_stations_in_reach(
+        df_stations_ranked,
+        request.parameters,
+        settings,
+        request.interpolatable_parameters,
+    )
     unanswerable = unanswerable_at_height(counts, elevation, STATIONS_NEEDED)
     if unanswerable and unanswerable == set(counts):
         # every parameter asked for falls with height and not one station in reach reports one:

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -11,6 +11,7 @@ import polars as pl
 from tqdm import tqdm
 
 from wetterdienst.core.util import (
+    DroppedForHeight,
     can_answer_at_height,
     collection_is_done,
     count_stations_in_reach,
@@ -72,7 +73,7 @@ def request_stations(
     latitude: float,
     longitude: float,
     elevation: float | None = None,
-) -> tuple[dict, dict, dict[tuple[str, str, str], int]]:
+) -> tuple[dict, dict, dict[tuple[str, str, str], DroppedForHeight]]:
     """Request stations.
 
     A summary answers with one station's reading rather than a blend of several, so a height
@@ -81,7 +82,7 @@ def request_stations(
     """
     param_dict = {}
     stations_dict = {}
-    dropped_for_height: dict[tuple[str, str, str], int] = {}
+    dropped_for_height: dict[tuple[str, str, str], DroppedForHeight] = {}
     settings = cast("Settings", request.settings)
     # the widest radius any requested parameter may draw on, as in `interpolate.request_stations`.
     # `max(...values())` used to stand here, which is the widest radius of the *populated* keys --
@@ -156,7 +157,7 @@ def apply_station_values_per_parameter(
     station: dict,
     elevation: float | None = None,
     *,
-    dropped_for_height: dict[tuple[str, str, str], int],
+    dropped_for_height: dict[tuple[str, str, str], DroppedForHeight],
 ) -> bool:
     """Apply station values per parameter.
 
@@ -206,7 +207,11 @@ def apply_station_values_per_parameter(
             )
             # noted, not only logged: where this empties a parameter the caller is owed the
             # reason, and a log line is the one place a caller cannot read it from
-            dropped_for_height[param_key] = dropped_for_height.get(param_key, 0) + 1
+            lost = dropped_for_height.get(param_key)
+            dropped_for_height[param_key] = DroppedForHeight(
+                count=lost.count + 1 if lost else 1,
+                nearest=min(lost.nearest, station["distance"]) if lost else station["distance"],
+            )
             continue
         # cast, not parsed: the request declares its dates as `str | datetime | None` because
         # that is what a caller may hand it, and resolves them to datetimes in `__post_init__`

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -16,6 +16,7 @@ from wetterdienst.core.util import (
     count_stations_in_reach,
     extract_station_values,
     lapse_rate_for,
+    no_height_in_reach_error,
     open_parameter_data,
     parameters_still_in_reach,
     reduce_to_height,
@@ -106,9 +107,9 @@ def request_stations(
     counts = count_stations_in_reach(df_stations_ranked, request.parameters, settings)
     unanswerable = unanswerable_at_height(counts, elevation)
     if unanswerable and unanswerable == set(counts):
-        # no station in reach can be brought to the height asked about, and every parameter wants
-        # to be: there is nothing a download could add, so the report speaks for the whole request
-        return stations_dict, param_dict, {key: counts[key].total for key in unanswerable}
+        # every parameter asked for falls with height and not one station in reach reports one:
+        # true of the request whatever the stations hold, so it is said without downloading them
+        raise no_height_in_reach_error(unanswerable, elevation)
     stations_by_id = {
         station["station_id"]: station
         for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -62,9 +62,18 @@ def get_summarized_df(
             of unknown height leaves nothing that can answer it
 
     """
-    stations_dict, param_dict, dropped_for_height = request_stations(request, latitude, longitude, elevation)
+    stations_dict, param_dict, dropped_for_height, unanswerable = request_stations(
+        request, latitude, longitude, elevation
+    )
     df = calculate_summary(stations_dict, param_dict)
-    report_height_exclusions(df, param_dict, dropped_for_height, elevation, stations_needed=STATIONS_NEEDED)
+    report_height_exclusions(
+        df,
+        param_dict,
+        dropped_for_height,
+        elevation,
+        stations_needed=STATIONS_NEEDED,
+        unanswerable=unanswerable,
+    )
     return df
 
 
@@ -73,7 +82,7 @@ def request_stations(
     latitude: float,
     longitude: float,
     elevation: float | None = None,
-) -> tuple[dict, dict, dict[tuple[str, str, str], DroppedForHeight]]:
+) -> tuple[dict, dict, dict[tuple[str, str, str], DroppedForHeight], set[tuple[str, str, str]]]:
     """Request stations.
 
     A summary answers with one station's reading rather than a blend of several, so a height
@@ -147,7 +156,7 @@ def request_stations(
             dropped_for_height=dropped_for_height,
         ):
             stations_dict[station["station_id"]] = (station["longitude"], station["latitude"], station["distance"])
-    return stations_dict, param_dict, dropped_for_height
+    return stations_dict, param_dict, dropped_for_height, unanswerable
 
 
 def apply_station_values_per_parameter(

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -11,13 +11,16 @@ import polars as pl
 from tqdm import tqdm
 
 from wetterdienst.core.util import (
+    StationsInReach,
     can_answer_at_height,
     collection_is_done,
+    count_stations_in_reach,
     extract_station_values,
     lapse_rate_for,
     open_parameter_data,
     reduce_to_height,
     report_height_exclusions,
+    unanswerable_at_height,
 )
 from wetterdienst.model.metadata import ParameterModel
 from wetterdienst.util.logging import TqdmToLogger
@@ -57,9 +60,16 @@ def get_summarized_df(
             of unknown height leaves nothing that can answer it
 
     """
-    stations_dict, param_dict, dropped_for_height = request_stations(request, latitude, longitude, elevation)
+    stations_dict, param_dict, dropped_for_height, counts = request_stations(request, latitude, longitude, elevation)
     df = calculate_summary(stations_dict, param_dict)
-    report_height_exclusions(df, param_dict, dropped_for_height, elevation, stations_needed=STATIONS_NEEDED)
+    report_height_exclusions(
+        df,
+        param_dict,
+        dropped_for_height,
+        counts,
+        elevation,
+        stations_needed=STATIONS_NEEDED,
+    )
     return df
 
 
@@ -68,7 +78,7 @@ def request_stations(
     latitude: float,
     longitude: float,
     elevation: float | None = None,
-) -> tuple[dict, dict, set[tuple[str, str, str]]]:
+) -> tuple[dict, dict, set[tuple[str, str, str]], dict[tuple[str, str, str], StationsInReach]]:
     """Request stations.
 
     A summary answers with one station's reading rather than a blend of several, so a height
@@ -98,9 +108,14 @@ def request_stations(
     # so a multi-dataset request has several rows for one station, each with the coordinates and
     # distance its own dataset's meta index reported. `query()` yields one result per station, and
     # the row that answers for it is the closest one rather than whichever happened to sort last
-    # asked once, as in `interpolate.request_stations`: a provider that reports no height for any
-    # station has nothing for the walk to hold out for
-    heights_in_reach = df_stations_ranked.get_column("height").null_count() < df_stations_ranked.height
+    # counted once, off the ranking, before a single value is downloaded: what each parameter has
+    # in its own radius, and how much of that reports a height
+    counts = count_stations_in_reach(df_stations_ranked, request.parameters, settings)
+    unanswerable = unanswerable_at_height(counts, elevation)
+    if unanswerable and unanswerable == set(counts):
+        # no station in reach can be brought to the height asked about, and every parameter wants
+        # to be: there is nothing a download could add, so the report speaks for the whole request
+        return stations_dict, param_dict, unanswerable, counts
     stations_by_id = {
         station["station_id"]: station
         for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
@@ -117,7 +132,7 @@ def request_stations(
     ):
         station = stations_by_id[result.df.get_column("station_id")[0]]
         # check if all parameters found enough stations and the stations build a valid station group
-        if collection_is_done(param_dict, dropped_for_height, heights_in_reach=heights_in_reach):
+        if collection_is_done(param_dict, dropped_for_height - unanswerable):
             break
         if result.df.drop_nulls("value").is_empty():
             continue
@@ -130,7 +145,7 @@ def request_stations(
             dropped_for_height=dropped_for_height,
         ):
             stations_dict[station["station_id"]] = (station["longitude"], station["latitude"], station["distance"])
-    return stations_dict, param_dict, dropped_for_height
+    return stations_dict, param_dict, dropped_for_height, counts
 
 
 def apply_station_values_per_parameter(

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -11,13 +11,13 @@ import polars as pl
 from tqdm import tqdm
 
 from wetterdienst.core.util import (
-    StationsInReach,
     can_answer_at_height,
     collection_is_done,
     count_stations_in_reach,
     extract_station_values,
     lapse_rate_for,
     open_parameter_data,
+    parameters_still_in_reach,
     reduce_to_height,
     report_height_exclusions,
     unanswerable_at_height,
@@ -60,16 +60,9 @@ def get_summarized_df(
             of unknown height leaves nothing that can answer it
 
     """
-    stations_dict, param_dict, dropped_for_height, counts = request_stations(request, latitude, longitude, elevation)
+    stations_dict, param_dict, dropped_for_height = request_stations(request, latitude, longitude, elevation)
     df = calculate_summary(stations_dict, param_dict)
-    report_height_exclusions(
-        df,
-        param_dict,
-        dropped_for_height,
-        counts,
-        elevation,
-        stations_needed=STATIONS_NEEDED,
-    )
+    report_height_exclusions(df, param_dict, dropped_for_height, elevation, stations_needed=STATIONS_NEEDED)
     return df
 
 
@@ -78,7 +71,7 @@ def request_stations(
     latitude: float,
     longitude: float,
     elevation: float | None = None,
-) -> tuple[dict, dict, set[tuple[str, str, str]], dict[tuple[str, str, str], StationsInReach]]:
+) -> tuple[dict, dict, dict[tuple[str, str, str], int]]:
     """Request stations.
 
     A summary answers with one station's reading rather than a blend of several, so a height
@@ -87,7 +80,7 @@ def request_stations(
     """
     param_dict = {}
     stations_dict = {}
-    dropped_for_height: set[tuple[str, str, str]] = set()
+    dropped_for_height: dict[tuple[str, str, str], int] = {}
     settings = cast("Settings", request.settings)
     # the widest radius any requested parameter may draw on, as in `interpolate.request_stations`.
     # `max(...values())` used to stand here, which is the widest radius of the *populated* keys --
@@ -115,7 +108,7 @@ def request_stations(
     if unanswerable and unanswerable == set(counts):
         # no station in reach can be brought to the height asked about, and every parameter wants
         # to be: there is nothing a download could add, so the report speaks for the whole request
-        return stations_dict, param_dict, unanswerable, counts
+        return stations_dict, param_dict, {key: counts[key].total for key in unanswerable}
     stations_by_id = {
         station["station_id"]: station
         for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
@@ -132,7 +125,9 @@ def request_stations(
     ):
         station = stations_by_id[result.df.get_column("station_id")[0]]
         # check if all parameters found enough stations and the stations build a valid station group
-        if collection_is_done(param_dict, dropped_for_height - unanswerable):
+        if collection_is_done(
+            param_dict, dropped_for_height.keys() & parameters_still_in_reach(counts, station["distance"])
+        ):
             break
         if result.df.drop_nulls("value").is_empty():
             continue
@@ -145,7 +140,7 @@ def request_stations(
             dropped_for_height=dropped_for_height,
         ):
             stations_dict[station["station_id"]] = (station["longitude"], station["latitude"], station["distance"])
-    return stations_dict, param_dict, dropped_for_height, counts
+    return stations_dict, param_dict, dropped_for_height
 
 
 def apply_station_values_per_parameter(
@@ -155,7 +150,7 @@ def apply_station_values_per_parameter(
     station: dict,
     elevation: float | None = None,
     *,
-    dropped_for_height: set[tuple[str, str, str]],
+    dropped_for_height: dict[tuple[str, str, str], int],
 ) -> bool:
     """Apply station values per parameter.
 
@@ -205,7 +200,7 @@ def apply_station_values_per_parameter(
             )
             # noted, not only logged: where this empties a parameter the caller is owed the
             # reason, and a log line is the one place a caller cannot read it from
-            dropped_for_height.add(param_key)
+            dropped_for_height[param_key] = dropped_for_height.get(param_key, 0) + 1
             continue
         # cast, not parsed: the request declares its dates as `str | datetime | None` because
         # that is what a caller may hand it, and resolves them to datetimes in `__post_init__`

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -103,6 +103,12 @@ def request_stations(
     # so a multi-dataset request has several rows for one station, each with the coordinates and
     # distance its own dataset's meta index reported. `query()` yields one result per station, and
     # the row that answers for it is the closest one rather than whichever happened to sort last
+    stations_by_id = {
+        station["station_id"]: station
+        for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
+            named=True,
+        )
+    }
     # counted once, off the ranking, before a single value is downloaded: what each parameter has
     # in its own radius, and how much of that reports a height
     counts = count_stations_in_reach(
@@ -116,12 +122,6 @@ def request_stations(
         # every parameter asked for falls with height and not one station in reach reports one:
         # true of the request whatever the stations hold, so it is said without downloading them
         raise no_height_in_reach_error(unanswerable, elevation)
-    stations_by_id = {
-        station["station_id"]: station
-        for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
-            named=True,
-        )
-    }
     tqdm_out = TqdmToLogger(log, level=logging.INFO)
     for result in tqdm(
         stations_ranked.values.query(),

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -104,7 +104,12 @@ def request_stations(
     # the row that answers for it is the closest one rather than whichever happened to sort last
     # counted once, off the ranking, before a single value is downloaded: what each parameter has
     # in its own radius, and how much of that reports a height
-    counts = count_stations_in_reach(df_stations_ranked, request.parameters, settings)
+    counts = count_stations_in_reach(
+        df_stations_ranked,
+        request.parameters,
+        settings,
+        request.interpolatable_parameters,
+    )
     unanswerable = unanswerable_at_height(counts, elevation, STATIONS_NEEDED)
     if unanswerable and unanswerable == set(counts):
         # every parameter asked for falls with height and not one station in reach reports one:

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -31,6 +31,9 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+# a summary answers with one station's reading, so one is all it wants
+STATIONS_NEEDED = 1
+
 
 def get_summarized_df(
     request: TimeseriesRequest,
@@ -49,10 +52,14 @@ def get_summarized_df(
     Returns:
         Summarized DataFrame
 
+    Raises:
+        NoStationsWithHeightError: where an elevation is asked about and leaving out the stations
+            of unknown height leaves nothing that can answer it
+
     """
     stations_dict, param_dict, dropped_for_height = request_stations(request, latitude, longitude, elevation)
     df = calculate_summary(stations_dict, param_dict)
-    report_height_exclusions(df, dropped_for_height, elevation)
+    report_height_exclusions(df, param_dict, dropped_for_height, elevation, stations_needed=STATIONS_NEEDED)
     return df
 
 
@@ -91,6 +98,9 @@ def request_stations(
     # so a multi-dataset request has several rows for one station, each with the coordinates and
     # distance its own dataset's meta index reported. `query()` yields one result per station, and
     # the row that answers for it is the closest one rather than whichever happened to sort last
+    # asked once, as in `interpolate.request_stations`: a provider that reports no height for any
+    # station has nothing for the walk to hold out for
+    heights_in_reach = df_stations_ranked.get_column("height").null_count() < df_stations_ranked.height
     stations_by_id = {
         station["station_id"]: station
         for station in df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True).iter_rows(
@@ -107,7 +117,7 @@ def request_stations(
     ):
         station = stations_by_id[result.df.get_column("station_id")[0]]
         # check if all parameters found enough stations and the stations build a valid station group
-        if collection_is_done(param_dict, dropped_for_height):
+        if collection_is_done(param_dict, dropped_for_height, heights_in_reach=heights_in_reach):
             break
         if result.df.drop_nulls("value").is_empty():
             continue

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 from wetterdienst.core.util import (
     can_answer_at_height,
+    collection_is_done,
     extract_station_values,
     lapse_rate_for,
     open_parameter_data,
@@ -49,8 +50,10 @@ def get_summarized_df(
         Summarized DataFrame
 
     """
-    stations_dict, param_dict = request_stations(request, latitude, longitude, elevation)
-    return calculate_summary(stations_dict, param_dict)
+    stations_dict, param_dict, dropped_for_height = request_stations(request, latitude, longitude, elevation)
+    df = calculate_summary(stations_dict, param_dict)
+    report_height_exclusions(df, dropped_for_height, elevation)
+    return df
 
 
 def request_stations(
@@ -58,7 +61,7 @@ def request_stations(
     latitude: float,
     longitude: float,
     elevation: float | None = None,
-) -> tuple[dict, dict]:
+) -> tuple[dict, dict, set[tuple[str, str, str]]]:
     """Request stations.
 
     A summary answers with one station's reading rather than a blend of several, so a height
@@ -104,7 +107,7 @@ def request_stations(
     ):
         station = stations_by_id[result.df.get_column("station_id")[0]]
         # check if all parameters found enough stations and the stations build a valid station group
-        if len(param_dict) > 0 and all(param.finished for param in param_dict.values()):
+        if collection_is_done(param_dict, dropped_for_height):
             break
         if result.df.drop_nulls("value").is_empty():
             continue
@@ -117,8 +120,7 @@ def request_stations(
             dropped_for_height=dropped_for_height,
         ):
             stations_dict[station["station_id"]] = (station["longitude"], station["latitude"], station["distance"])
-    report_height_exclusions(param_dict, dropped_for_height, elevation)
-    return stations_dict, param_dict
+    return stations_dict, param_dict, dropped_for_height
 
 
 def apply_station_values_per_parameter(

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -16,6 +16,7 @@ from wetterdienst.core.util import (
     lapse_rate_for,
     open_parameter_data,
     reduce_to_height,
+    report_height_exclusions,
 )
 from wetterdienst.model.metadata import ParameterModel
 from wetterdienst.util.logging import TqdmToLogger
@@ -66,6 +67,7 @@ def request_stations(
     """
     param_dict = {}
     stations_dict = {}
+    dropped_for_height: set[tuple[str, str, str]] = set()
     settings = cast("Settings", request.settings)
     # the widest radius any requested parameter may draw on, as in `interpolate.request_stations`.
     # `max(...values())` used to stand here, which is the widest radius of the *populated* keys --
@@ -106,8 +108,16 @@ def request_stations(
             break
         if result.df.drop_nulls("value").is_empty():
             continue
-        if apply_station_values_per_parameter(result.df, stations_ranked, param_dict, station, elevation):
+        if apply_station_values_per_parameter(
+            result.df,
+            stations_ranked,
+            param_dict,
+            station,
+            elevation,
+            dropped_for_height=dropped_for_height,
+        ):
             stations_dict[station["station_id"]] = (station["longitude"], station["latitude"], station["distance"])
+    report_height_exclusions(param_dict, dropped_for_height, elevation)
     return stations_dict, param_dict
 
 
@@ -117,6 +127,8 @@ def apply_station_values_per_parameter(
     param_dict: dict,
     station: dict,
     elevation: float | None = None,
+    *,
+    dropped_for_height: set[tuple[str, str, str]],
 ) -> bool:
     """Apply station values per parameter.
 
@@ -164,6 +176,9 @@ def apply_station_values_per_parameter(
                 f"station {station['station_id']} has no height, so it says nothing about "
                 f"{parameter.name} at {elevation} m and is left out",
             )
+            # noted, not only logged: where this empties a parameter the caller is owed the
+            # reason, and a log line is the one place a caller cannot read it from
+            dropped_for_height.add(param_key)
             continue
         # cast, not parsed: the request declares its dates as `str | datetime | None` because
         # that is what a caller may hand it, and resolves them to datetimes in `__post_init__`

--- a/src/wetterdienst/core/summarize.py
+++ b/src/wetterdienst/core/summarize.py
@@ -105,7 +105,7 @@ def request_stations(
     # counted once, off the ranking, before a single value is downloaded: what each parameter has
     # in its own radius, and how much of that reports a height
     counts = count_stations_in_reach(df_stations_ranked, request.parameters, settings)
-    unanswerable = unanswerable_at_height(counts, elevation)
+    unanswerable = unanswerable_at_height(counts, elevation, STATIONS_NEEDED)
     if unanswerable and unanswerable == set(counts):
         # every parameter asked for falls with height and not one station in reach reports one:
         # true of the request whatever the stations hold, so it is said without downloading them

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -124,7 +124,12 @@ def can_answer_at_height(station_height: float | None, lapse_rate: float | None,
     return not (target_height is not None and lapse_rate and station_height is None)
 
 
-def collection_is_done(param_dict: dict, dropped_for_height: set[tuple[str, str, str]]) -> bool:
+def collection_is_done(
+    param_dict: dict,
+    dropped_for_height: set[tuple[str, str, str]],
+    *,
+    heights_in_reach: bool,
+) -> bool:
     """Whether every parameter has the stations it needs, so the walk down the ranking can stop.
 
     A parameter every station so far was turned away from for having no height never opened an
@@ -132,18 +137,26 @@ def collection_is_done(param_dict: dict, dropped_for_height: set[tuple[str, str,
     report it as unanswerable while a station further out, still inside the radius, has a height
     and could have answered it -- so a parameter that lost a station and has yet to take one keeps
     the walk going.
+
+    Unless no station in reach reports a height at all, which is what FMI, IPMA and the Environment
+    Agency publish: there is nothing to walk towards then, and holding the walk open would query
+    every station within the radius -- hundreds, for a provider that size -- to arrive at the same
+    answer the fourth station already gave.
     """
     return (
         bool(param_dict)
         and all(param_data.finished for param_data in param_dict.values())
-        and not dropped_for_height.difference(param_dict)
+        and (not heights_in_reach or not dropped_for_height.difference(param_dict))
     )
 
 
 def report_height_exclusions(
     df: pl.DataFrame,
+    param_dict: dict,
     dropped_for_height: set[tuple[str, str, str]],
     elevation: float | None,
+    *,
+    stations_needed: int,
 ) -> None:
     """Say what asking about a height cost, once the answer is in.
 
@@ -161,12 +174,18 @@ def report_height_exclusions(
     which is the silent empty result this is here to do away with.
 
     A parameter some other station answered is not reported at all: a station turned away where
-    the rest sufficed cost the answer nothing.
+    the rest sufficed cost the answer nothing. Nor is one the exclusions cannot be blamed for --
+    a parameter that kept the stations its calculation asks for and still came back null failed on
+    the geometry of where they stand or on the data they hold, and telling such a caller to ask
+    without an elevation would send them back for the same nulls under a wrong diagnosis.
 
     Args:
         df: the interpolated or summarized frame, before any nulls are dropped from it
+        param_dict: the parameters that were collected, each holding the columns it took
         dropped_for_height: the parameters that lost a station for having no height
         elevation: the height that was asked about
+        stations_needed: how many stations the calculation wants before it can answer -- four
+            surrounding the point for an interpolation, one for a summary
 
     Raises:
         NoStationsWithHeightError: where nothing was answered at all, there being no result for a
@@ -176,7 +195,12 @@ def report_height_exclusions(
     if not dropped_for_height:
         return
     answered = set(df.drop_nulls("value").select("resolution", "dataset", "parameter").unique().iter_rows())
-    emptied = sorted(dropped_for_height - answered)
+    emptied = sorted(
+        param_key
+        for param_key in dropped_for_height - answered
+        # minus the date column the values are laid on
+        if (param_dict[param_key].values.width - 1 if param_key in param_dict else 0) < stations_needed
+    )
     if not emptied:
         return
     listing = ", ".join("/".join(param_key) for param_key in emptied)

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -4,11 +4,13 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import polars as pl
 
+from wetterdienst.exceptions import NoStationsWithHeightError
 from wetterdienst.metadata.parameter_table import PARAMETERS
 from wetterdienst.metadata.resolution import Frequency
 
@@ -18,6 +20,8 @@ if TYPE_CHECKING:
     from wetterdienst.metadata.resolution import Resolution
     from wetterdienst.model.metadata import ParameterModel
     from wetterdienst.model.unit import UnitConverter
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -118,6 +122,56 @@ def can_answer_at_height(station_height: float | None, lapse_rate: float | None,
     it at its own altitude among neighbours moved to the caller's.
     """
     return not (target_height is not None and lapse_rate and station_height is None)
+
+
+def report_height_exclusions(
+    param_dict: dict,
+    dropped_for_height: set[tuple[str, str, str]],
+    elevation: float | None,
+) -> None:
+    """Say what asking about a height cost, once every station has been through.
+
+    A station whose own height is unknown is turned away from a quantity that falls with height,
+    and thirteen providers have such stations -- every one of FMI's, IPMA's and the Environment
+    Agency's among them. Where that empties a parameter, the answer is not "no data for those
+    dates": it is a question that cannot be answered as asked, and one the caller can fix by not
+    asking about a height. Left alone it comes back as an empty frame with the reason in a
+    server-side log, which is the one place the caller cannot look.
+
+    A parameter still answered by some other station is not reported at all: a station turned away
+    where three others were taken cost the answer nothing.
+
+    Args:
+        param_dict: the parameters that were collected, each holding the columns it took
+        dropped_for_height: the parameters that lost a station for having no height
+        elevation: the height that was asked about
+
+    Raises:
+        NoStationsWithHeightError: where nothing is left to answer with, there being no result for
+            a warning to be read against
+
+    """
+    emptied = sorted(
+        param_key
+        for param_key in dropped_for_height
+        # a parameter with a date grid and no station column is as empty as one that never opened
+        if param_key not in param_dict or param_dict[param_key].values.width < 2
+    )
+    if not emptied:
+        return
+    listing = ", ".join("/".join(param_key) for param_key in emptied)
+    if any(param_data.values.width > 1 for param_data in param_dict.values()):
+        log.warning(
+            f"no station of known height is in reach for {listing}, so it has no answer at "
+            f"{elevation} m; the rest of the result stands",
+        )
+        return
+    msg = (
+        f"no station of known height is in reach, so there is no answer at {elevation} m for "
+        f"{listing}. Ask without an elevation to take each station's readings as they came, or "
+        f"use a provider that publishes the heights of its stations."
+    )
+    raise NoStationsWithHeightError(msg)
 
 
 def reduce_to_height(

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -307,6 +307,7 @@ def report_height_exclusions(
     *,
     stations_needed: int,
     nearby_station_distance: float | None = None,
+    unanswerable: Collection[tuple[str, str, str]] = (),
 ) -> None:
     """Say what asking about a height cost, once the answer is in.
 
@@ -349,7 +350,9 @@ def report_height_exclusions(
         stations_needed: how many stations the calculation wants before it can answer -- four
             surrounding the point for an interpolation, one for a summary
         nearby_station_distance: how near a station has to stand to answer on its own, where the
-            calculation has such a shortcut, so that turning one away costs one station and not four
+            calculation has such a shortcut, so that losing one is the whole answer
+        unanswerable: the parameters the ranking already proved cannot be answered at this height,
+            no station inside their radius reporting one -- what they lost is beyond counting
 
     Raises:
         NoStationsWithHeightError: where nothing was answered at all and a parameter took not one
@@ -360,24 +363,27 @@ def report_height_exclusions(
         return
     answered = set(df.drop_nulls("value").select("resolution", "dataset", "parameter").unique().iter_rows())
 
-    def needed_for(dropped: DroppedForHeight) -> int:
+    def the_exclusions_cost_it(param_key: tuple[str, str, str], dropped: DroppedForHeight) -> bool:
+        """Whether giving the parameter back the stations it lost would have answered it."""
+        if param_key in unanswerable:
+            # the ranking said so before anything was downloaded: no station inside this
+            # parameter's radius reports a height, so every station that held it was turned away
+            return True
         # an interpolation answers from a single station standing near enough to the point, without
-        # the four a hull wants around it -- so where such a station was turned away for its height,
-        # one is what the exclusions cost and four would be the wrong bar to hold them to
-        # strictly nearer, as `calculate_interpolation` builds its nearby set: a station at
-        # exactly the distance is not one the interpolation would have answered from alone
+        # the four a hull wants around it, so losing such a station is the whole answer however
+        # many farther ones were kept -- a different question from how many were lost, not a
+        # smaller number of them. Strictly nearer, as `calculate_interpolation` takes its nearby
+        # set: a station at exactly the distance is not one it would have answered from alone
         if nearby_station_distance is not None and dropped.nearest < nearby_station_distance:
-            return 1
-        return stations_needed
+            return True
+        # minus the date column the values are laid on
+        kept = param_dict[param_key].values.width - 1 if param_key in param_dict else 0
+        return kept < stations_needed <= kept + dropped.count
 
     emptied = sorted(
         param_key
         for param_key, dropped in dropped_for_height.items()
-        # minus the date column the values are laid on
-        if param_key not in answered
-        and (kept := param_dict[param_key].values.width - 1 if param_key in param_dict else 0)
-        < needed_for(dropped)
-        <= kept + dropped.count
+        if param_key not in answered and the_exclusions_cost_it(param_key, dropped)
     )
     if not emptied:
         return

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, cast
 
 import polars as pl
 
@@ -127,10 +127,13 @@ def can_answer_at_height(station_height: float | None, lapse_rate: float | None,
 
 
 class StationsInReach(NamedTuple):
-    """How many stations a parameter has to draw on, and how many of those report a height."""
+    """What a parameter has inside its own radius, read off the ranking before any download."""
 
     total: int
     with_height: int
+    #: how far out the last station that reports a height stands, or None where there is none.
+    #: Stations are walked in this order, so once it is passed there is no height left to find
+    furthest_with_height: float | None
 
 
 def count_stations_in_reach(
@@ -145,10 +148,10 @@ def count_stations_in_reach(
     temperature at 20 km than for precipitation at 40 km, and one answer for the whole request
     would be the wrong one for at least one of them.
 
-    Two counts come out of it. The total says whether the exclusions can be blamed for an
-    unanswered parameter: where fewer stations were ever in reach than the calculation needs, the
-    heights are not what emptied it. The height count says whether walking further can help: where
-    no station in reach reports one, nothing this walk downloads will change that.
+    The height count says whether walking at all can help: where no station in reach reports one,
+    nothing this request downloads will change that. The distance says how long it can: the walk
+    goes outwards, so once it is past the furthest station that reports a height, no station left
+    to visit can answer a question about another height.
     """
     counts = {}
     for parameter in parameters:
@@ -156,10 +159,20 @@ def count_stations_in_reach(
             continue
         dataset = parameter.dataset
         radius = settings.ts_geo_station_distance_for(parameter.name, dataset.resolution.name)
-        in_reach = df_stations_ranked.filter(pl.col("distance").le(radius)).unique(subset=["station_id"])
+        # one row per station and the nearest of them, as the collection loop reads it: the
+        # ranking carries a row per station *and* dataset, and two dataset indexes can disagree
+        # about a station's height. Taking whichever row sorted last would answer "is there a
+        # height in reach" differently from the station the walk actually reads
+        in_reach = (
+            df_stations_ranked.filter(pl.col("distance").le(radius))
+            .unique(subset=["station_id"], keep="first", maintain_order=True)
+            .drop_nulls("height")
+        )
+        furthest = in_reach.get_column("distance").max()
         counts[(dataset.resolution.name, dataset.name, parameter.name)] = StationsInReach(
-            total=in_reach.height,
-            with_height=in_reach.drop_nulls("height").height,
+            total=df_stations_ranked.filter(pl.col("distance").le(radius)).n_unique("station_id"),
+            with_height=in_reach.height,
+            furthest_with_height=float(cast("float", furthest)) if furthest is not None else None,
         )
     return counts
 
@@ -181,6 +194,24 @@ def unanswerable_at_height(
         param_key
         for param_key, in_reach in counts.items()
         if not in_reach.with_height and PARAMETERS[param_key[2]].lapse_rate
+    }
+
+
+def parameters_still_in_reach(
+    counts: dict[tuple[str, str, str], StationsInReach],
+    station_distance: float,
+) -> set[tuple[str, str, str]]:
+    """Find the parameters a station this far out, or further, could still contribute to.
+
+    Only one that reports a height can, an elevation having been asked about, and the walk goes
+    outwards -- so a parameter whose furthest station of known height stands nearer than this has
+    nothing left coming. Waiting for it downloads the rest of the ranking to no end, which is what
+    happens when its one station of known height turns out to hold no data.
+    """
+    return {
+        param_key
+        for param_key, in_reach in counts.items()
+        if in_reach.furthest_with_height is not None and station_distance <= in_reach.furthest_with_height
     }
 
 
@@ -208,8 +239,7 @@ def collection_is_done(param_dict: dict, waiting_on: set[tuple[str, str, str]]) 
 def report_height_exclusions(
     df: pl.DataFrame,
     param_dict: dict,
-    dropped_for_height: set[tuple[str, str, str]],
-    counts: dict[tuple[str, str, str], StationsInReach],
+    dropped_for_height: dict[tuple[str, str, str], int],
     elevation: float | None,
     *,
     stations_needed: int,
@@ -234,15 +264,16 @@ def report_height_exclusions(
     a parameter that kept the stations its calculation asks for and still came back null failed on
     the geometry of where they stand or on the data they hold, and telling such a caller to ask
     without an elevation would send them back for the same nulls under a wrong diagnosis. Nor is a
-    parameter that never had enough stations in reach to answer with: keeping every one of them
-    would still have left it short, so the exclusions are not what emptied it.
+    parameter that would have been short of stations even with the ones it lost: the count is of
+    stations that held the parameter and were turned away, so keeping them is the answer the caller
+    is sent back for, and where that is still short of what the calculation needs it is not an
+    answer at all.
 
     Args:
         df: the interpolated or summarized frame, before any nulls are dropped from it
         param_dict: the parameters that were collected, each holding the columns it took
-        dropped_for_height: the parameters that lost a station for having no height
+        dropped_for_height: how many stations each parameter lost for having no height
         elevation: the height that was asked about
-        counts: how many stations each parameter had in reach, and how many reported a height
         stations_needed: how many stations the calculation wants before it can answer -- four
             surrounding the point for an interpolation, one for a summary
 
@@ -256,11 +287,12 @@ def report_height_exclusions(
     answered = set(df.drop_nulls("value").select("resolution", "dataset", "parameter").unique().iter_rows())
     emptied = sorted(
         param_key
-        for param_key in dropped_for_height - answered
+        for param_key, dropped in dropped_for_height.items()
         # minus the date column the values are laid on
-        if (param_dict[param_key].values.width - 1 if param_key in param_dict else 0)
+        if param_key not in answered
+        and (kept := param_dict[param_key].values.width - 1 if param_key in param_dict else 0)
         < stations_needed
-        <= counts[param_key].total
+        <= kept + dropped
     )
     if not emptied:
         return

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -189,6 +189,7 @@ def count_stations_in_reach(
 def unanswerable_at_height(
     counts: dict[tuple[str, str, str], StationsInReach],
     elevation: float | None,
+    stations_needed: int,
 ) -> set[tuple[str, str, str]]:
     """Find the parameters no station in reach can answer at the height asked about.
 
@@ -196,13 +197,19 @@ def unanswerable_at_height(
     another one. Where not one station inside its radius reports a height -- which is every station
     FMI, IPMA and the Environment Agency publish -- the parameter is unanswerable before anything
     is downloaded, and the walk down the ranking has nothing to look for.
+
+    Which is a claim about heights, so it is made only where there were heights to miss. A point
+    out at sea, or a mistyped coordinate, has no station in reach at all: the answer is empty for a
+    reason that has nothing to do with heights, and saying otherwise sends the caller off to drop
+    an elevation that was never the trouble. Too few stations to answer from is the same story --
+    keeping every one of them would still have left the calculation short.
     """
     if elevation is None:
         return set()
     return {
         param_key
         for param_key, in_reach in counts.items()
-        if not in_reach.with_height and PARAMETERS[param_key[2]].lapse_rate
+        if not in_reach.with_height and stations_needed <= in_reach.total and PARAMETERS[param_key[2]].lapse_rate
     }
 
 
@@ -298,11 +305,13 @@ def report_height_exclusions(
     is sent back for, and where that is still short of what the calculation needs it is not an
     answer at all.
 
-    Counting is as far as this goes, and it errs towards saying nothing. Four stations standing
-    together on one side of the point interpolate to nothing, so an exclusion that left the four
-    surrounding ones out really was the cause and goes unreported -- but telling that case apart
-    wants a hull test per parameter, and a wrong accusation sends the caller back for the same
-    nulls under a reason that is not theirs. Silence is the cheaper mistake of the two.
+    Counting is as far as this goes, and it cannot see where the stations stand. Four standing
+    together on one side of the point interpolate to nothing, so an exclusion that left the
+    surrounding ones out really was the cause and goes unreported; three kept and one lost may be
+    four that would never have surrounded it either. Telling those apart wants a hull test per
+    parameter. Until there is one, a parameter that kept nothing at all is refused and a parameter
+    that kept something is named in the log -- the count decides how loudly this speaks, not
+    whether the caller keeps their result.
 
     Args:
         df: the interpolated or summarized frame, before any nulls are dropped from it
@@ -313,8 +322,8 @@ def report_height_exclusions(
             surrounding the point for an interpolation, one for a summary
 
     Raises:
-        NoStationsWithHeightError: where nothing was answered at all, there being no result for a
-            warning to be read against
+        NoStationsWithHeightError: where nothing was answered at all and a parameter took not one
+            station, there being no result for a warning to be read against and no doubt about why
 
     """
     if not dropped_for_height:
@@ -332,12 +341,18 @@ def report_height_exclusions(
     if not emptied:
         return
     listing = ", ".join("/".join(param_key) for param_key in emptied)
-    if answered:
+    # a parameter that took not one station is the whole story: nothing to interpolate from and
+    # nothing left to wonder about. Where it kept some, the count is all the evidence there is --
+    # three kept and one lost may be four that would never have surrounded the point -- and
+    # refusing on that takes a frame away from a caller over a reason that may not be theirs
+    took_nothing = [param_key for param_key in emptied if param_key not in param_dict]
+    if answered or not took_nothing:
         log.warning(
             f"leaving out the stations of unknown height leaves nothing that can answer {listing} "
             f"at {elevation} m; the rest of the result stands",
         )
         return
+    listing = ", ".join("/".join(param_key) for param_key in took_nothing)
     msg = (
         f"leaving out the stations of unknown height leaves nothing that can answer {listing} at "
         f"{elevation} m. {_ASK_INSTEAD}"

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -25,6 +25,15 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
+#: what a caller can do about a height nothing in reach can be brought to. By coordinates,
+#: because a request named by a station id answers at that station's own height and so has no
+#: form that asks about no height at all
+_ASK_INSTEAD = (
+    "Ask by coordinates and without an elevation to take each station's readings as they came "
+    "-- naming a station id instead asks at that station's own height -- or use a provider that "
+    "publishes the heights of its stations."
+)
+
 
 @dataclass
 class _ParameterData:
@@ -215,6 +224,26 @@ def parameters_still_in_reach(
     }
 
 
+def no_height_in_reach_error(
+    unanswerable: set[tuple[str, str, str]],
+    elevation: float | None,
+) -> NoStationsWithHeightError:
+    """Refuse a request no station in reach reports a height for, before anything is downloaded.
+
+    A claim of its own, and one the ranking alone can make: not one station near the point says how
+    high it stands, so no reading can be brought to the height asked about, whatever those stations
+    hold. It is deliberately not the claim `report_height_exclusions` makes -- that one weighs how
+    many stations held the parameter, which is knowable only by downloading them, and downloading
+    every station in the radius to say what the ranking already said is what this avoids.
+    """
+    listing = ", ".join("/".join(param_key) for param_key in sorted(unanswerable))
+    msg = (
+        f"no station near the point reports a height of its own, so nothing can be brought to "
+        f"{elevation} m for {listing}. {_ASK_INSTEAD}"
+    )
+    return NoStationsWithHeightError(msg)
+
+
 def collection_is_done(param_dict: dict, waiting_on: set[tuple[str, str, str]]) -> bool:
     """Whether every parameter has the stations it needs, so the walk down the ranking can stop.
 
@@ -269,6 +298,12 @@ def report_height_exclusions(
     is sent back for, and where that is still short of what the calculation needs it is not an
     answer at all.
 
+    Counting is as far as this goes, and it errs towards saying nothing. Four stations standing
+    together on one side of the point interpolate to nothing, so an exclusion that left the four
+    surrounding ones out really was the cause and goes unreported -- but telling that case apart
+    wants a hull test per parameter, and a wrong accusation sends the caller back for the same
+    nulls under a reason that is not theirs. Silence is the cheaper mistake of the two.
+
     Args:
         df: the interpolated or summarized frame, before any nulls are dropped from it
         param_dict: the parameters that were collected, each holding the columns it took
@@ -305,9 +340,7 @@ def report_height_exclusions(
         return
     msg = (
         f"leaving out the stations of unknown height leaves nothing that can answer {listing} at "
-        f"{elevation} m. Ask by coordinates and without an elevation to take each station's "
-        f"readings as they came -- naming a station id instead asks at that station's own height "
-        f"-- or use a provider that publishes the heights of its stations."
+        f"{elevation} m. {_ASK_INSTEAD}"
     )
     raise NoStationsWithHeightError(msg)
 

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -135,6 +136,15 @@ def can_answer_at_height(station_height: float | None, lapse_rate: float | None,
     return not (target_height is not None and lapse_rate and station_height is None)
 
 
+class DroppedForHeight(NamedTuple):
+    """What a parameter lost to stations of unknown height, and how near the nearest of them was."""
+
+    count: int
+    #: distance of the nearest station turned away, in km. A station inside the nearby-station
+    #: distance answers on its own, so what it cost is not the four a hull wants but the one it was
+    nearest: float = math.inf
+
+
 class StationsInReach(NamedTuple):
     """What a parameter has inside its own radius, read off the ranking before any download."""
 
@@ -177,11 +187,14 @@ def count_stations_in_reach(
         # ranking carries a row per station *and* dataset, and two dataset indexes can disagree
         # about a station's height. Taking whichever row sorted last would answer "is there a
         # height in reach" differently from the station the walk actually reads
-        in_radius = df_stations_ranked.filter(pl.col("distance").le(radius)).unique(
-            subset=["station_id"],
-            keep="first",
-            maintain_order=True,
-        )
+        # by dataset as well as by distance: the ranking carries a row per station *and* dataset,
+        # so a station that stands in another dataset's index and reports a height there would
+        # otherwise count towards this parameter, which it can never answer
+        in_radius = df_stations_ranked.filter(
+            pl.col("resolution").eq(dataset.resolution.name),
+            pl.col("dataset").eq(dataset.name),
+            pl.col("distance").le(radius),
+        ).unique(subset=["station_id"], keep="first", maintain_order=True)
         with_height = in_radius.drop_nulls("height")
         furthest = with_height.get_column("distance").max()
         counts[(dataset.resolution.name, dataset.name, parameter.name)] = StationsInReach(
@@ -281,10 +294,11 @@ def collection_is_done(param_dict: dict, waiting_on: set[tuple[str, str, str]]) 
 def report_height_exclusions(
     df: pl.DataFrame,
     param_dict: dict,
-    dropped_for_height: dict[tuple[str, str, str], int],
+    dropped_for_height: dict[tuple[str, str, str], DroppedForHeight],
     elevation: float | None,
     *,
     stations_needed: int,
+    nearby_station_distance: float | None = None,
 ) -> None:
     """Say what asking about a height cost, once the answer is in.
 
@@ -326,6 +340,8 @@ def report_height_exclusions(
         elevation: the height that was asked about
         stations_needed: how many stations the calculation wants before it can answer -- four
             surrounding the point for an interpolation, one for a summary
+        nearby_station_distance: how near a station has to stand to answer on its own, where the
+            calculation has such a shortcut, so that turning one away costs one station and not four
 
     Raises:
         NoStationsWithHeightError: where nothing was answered at all and a parameter took not one
@@ -335,14 +351,23 @@ def report_height_exclusions(
     if not dropped_for_height:
         return
     answered = set(df.drop_nulls("value").select("resolution", "dataset", "parameter").unique().iter_rows())
+
+    def needed_for(dropped: DroppedForHeight) -> int:
+        # an interpolation answers from a single station standing near enough to the point, without
+        # the four a hull wants around it -- so where such a station was turned away for its height,
+        # one is what the exclusions cost and four would be the wrong bar to hold them to
+        if nearby_station_distance is not None and dropped.nearest <= nearby_station_distance:
+            return 1
+        return stations_needed
+
     emptied = sorted(
         param_key
         for param_key, dropped in dropped_for_height.items()
         # minus the date column the values are laid on
         if param_key not in answered
         and (kept := param_dict[param_key].values.width - 1 if param_key in param_dict else 0)
-        < stations_needed
-        <= kept + dropped
+        < needed_for(dropped)
+        <= kept + dropped.count
     )
     if not emptied:
         return
@@ -353,9 +378,11 @@ def report_height_exclusions(
     # refusing on that takes a frame away from a caller over a reason that may not be theirs
     took_nothing = [param_key for param_key in emptied if param_key not in param_dict]
     if answered or not took_nothing:
+        # only where something was answered is there a rest of the result to stand
+        stands = "; the rest of the result stands" if answered else ""
         log.warning(
             f"leaving out the stations of unknown height leaves nothing that can answer {listing} "
-            f"at {elevation} m; the rest of the result stands",
+            f"at {elevation} m{stands}",
         )
         return
     # the ones that kept a station are the same loss under a weaker light, and the exception speaks

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -124,52 +124,73 @@ def can_answer_at_height(station_height: float | None, lapse_rate: float | None,
     return not (target_height is not None and lapse_rate and station_height is None)
 
 
+def collection_is_done(param_dict: dict, dropped_for_height: set[tuple[str, str, str]]) -> bool:
+    """Whether every parameter has the stations it needs, so the walk down the ranking can stop.
+
+    A parameter every station so far was turned away from for having no height never opened an
+    entry of its own, so it cannot hold the walk open by being unfinished. Stopping there would
+    report it as unanswerable while a station further out, still inside the radius, has a height
+    and could have answered it -- so a parameter that lost a station and has yet to take one keeps
+    the walk going.
+    """
+    return (
+        bool(param_dict)
+        and all(param_data.finished for param_data in param_dict.values())
+        and not dropped_for_height.difference(param_dict)
+    )
+
+
 def report_height_exclusions(
-    param_dict: dict,
+    df: pl.DataFrame,
     dropped_for_height: set[tuple[str, str, str]],
     elevation: float | None,
 ) -> None:
-    """Say what asking about a height cost, once every station has been through.
+    """Say what asking about a height cost, once the answer is in.
 
     A station whose own height is unknown is turned away from a quantity that falls with height,
     and thirteen providers have such stations -- every one of FMI's, IPMA's and the Environment
-    Agency's among them. Where that empties a parameter, the answer is not "no data for those
-    dates": it is a question that cannot be answered as asked, and one the caller can fix by not
-    asking about a height. Left alone it comes back as an empty frame with the reason in a
-    server-side log, which is the one place the caller cannot look.
+    Agency's among them. Where that leaves a parameter unanswered, the result is not "no data for
+    those dates": it is a question that cannot be answered as asked, and one the caller can fix.
+    Left alone it comes back as an empty frame with the reason in a server-side log, which is the
+    one place the caller cannot look.
 
-    A parameter still answered by some other station is not reported at all: a station turned away
-    where three others were taken cost the answer nothing.
+    Whether a parameter was answered is read off the finished frame rather than off the columns
+    that were collected for it, because the two are not the same question. A summary answers from
+    one station, so a column is an answer; an interpolation wants four that surround the point, so
+    a parameter left with three by the exclusions holds columns and still comes back all null --
+    which is the silent empty result this is here to do away with.
+
+    A parameter some other station answered is not reported at all: a station turned away where
+    the rest sufficed cost the answer nothing.
 
     Args:
-        param_dict: the parameters that were collected, each holding the columns it took
+        df: the interpolated or summarized frame, before any nulls are dropped from it
         dropped_for_height: the parameters that lost a station for having no height
         elevation: the height that was asked about
 
     Raises:
-        NoStationsWithHeightError: where nothing is left to answer with, there being no result for
-            a warning to be read against
+        NoStationsWithHeightError: where nothing was answered at all, there being no result for a
+            warning to be read against
 
     """
-    emptied = sorted(
-        param_key
-        for param_key in dropped_for_height
-        # a parameter with a date grid and no station column is as empty as one that never opened
-        if param_key not in param_dict or param_dict[param_key].values.width < 2
-    )
+    if not dropped_for_height:
+        return
+    answered = set(df.drop_nulls("value").select("resolution", "dataset", "parameter").unique().iter_rows())
+    emptied = sorted(dropped_for_height - answered)
     if not emptied:
         return
     listing = ", ".join("/".join(param_key) for param_key in emptied)
-    if any(param_data.values.width > 1 for param_data in param_dict.values()):
+    if answered:
         log.warning(
-            f"no station of known height is in reach for {listing}, so it has no answer at "
-            f"{elevation} m; the rest of the result stands",
+            f"leaving out the stations of unknown height leaves nothing that can answer {listing} "
+            f"at {elevation} m; the rest of the result stands",
         )
         return
     msg = (
-        f"no station of known height is in reach, so there is no answer at {elevation} m for "
-        f"{listing}. Ask without an elevation to take each station's readings as they came, or "
-        f"use a provider that publishes the heights of its stations."
+        f"leaving out the stations of unknown height leaves nothing that can answer {listing} at "
+        f"{elevation} m. Ask by coordinates and without an elevation to take each station's "
+        f"readings as they came -- naming a station id instead asks at that station's own height "
+        f"-- or use a provider that publishes the heights of its stations."
     )
     raise NoStationsWithHeightError(msg)
 

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -6,20 +6,22 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import polars as pl
 
 from wetterdienst.exceptions import NoStationsWithHeightError
 from wetterdienst.metadata.parameter_table import PARAMETERS
 from wetterdienst.metadata.resolution import Frequency
+from wetterdienst.model.metadata import ParameterModel
 
 if TYPE_CHECKING:
     import datetime as dt
+    from collections.abc import Iterable
 
     from wetterdienst.metadata.resolution import Resolution
-    from wetterdienst.model.metadata import ParameterModel
     from wetterdienst.model.unit import UnitConverter
+    from wetterdienst.settings import Settings
 
 log = logging.getLogger(__name__)
 
@@ -124,12 +126,65 @@ def can_answer_at_height(station_height: float | None, lapse_rate: float | None,
     return not (target_height is not None and lapse_rate and station_height is None)
 
 
-def collection_is_done(
-    param_dict: dict,
-    dropped_for_height: set[tuple[str, str, str]],
-    *,
-    heights_in_reach: bool,
-) -> bool:
+class StationsInReach(NamedTuple):
+    """How many stations a parameter has to draw on, and how many of those report a height."""
+
+    total: int
+    with_height: int
+
+
+def count_stations_in_reach(
+    df_stations_ranked: pl.DataFrame,
+    parameters: Iterable[object],
+    settings: Settings,
+) -> dict[tuple[str, str, str], StationsInReach]:
+    """Count what each parameter has within its own radius, before a single value is downloaded.
+
+    Per parameter, because the radius is: a quantity that decorrelates fast in space is given a
+    narrower one, so "is there a station of known height in reach" has a different answer for
+    temperature at 20 km than for precipitation at 40 km, and one answer for the whole request
+    would be the wrong one for at least one of them.
+
+    Two counts come out of it. The total says whether the exclusions can be blamed for an
+    unanswered parameter: where fewer stations were ever in reach than the calculation needs, the
+    heights are not what emptied it. The height count says whether walking further can help: where
+    no station in reach reports one, nothing this walk downloads will change that.
+    """
+    counts = {}
+    for parameter in parameters:
+        if not isinstance(parameter, ParameterModel):
+            continue
+        dataset = parameter.dataset
+        radius = settings.ts_geo_station_distance_for(parameter.name, dataset.resolution.name)
+        in_reach = df_stations_ranked.filter(pl.col("distance").le(radius)).unique(subset=["station_id"])
+        counts[(dataset.resolution.name, dataset.name, parameter.name)] = StationsInReach(
+            total=in_reach.height,
+            with_height=in_reach.drop_nulls("height").height,
+        )
+    return counts
+
+
+def unanswerable_at_height(
+    counts: dict[tuple[str, str, str], StationsInReach],
+    elevation: float | None,
+) -> set[tuple[str, str, str]]:
+    """Find the parameters no station in reach can answer at the height asked about.
+
+    A quantity that falls with height needs a station whose own height is known to be brought to
+    another one. Where not one station inside its radius reports a height -- which is every station
+    FMI, IPMA and the Environment Agency publish -- the parameter is unanswerable before anything
+    is downloaded, and the walk down the ranking has nothing to look for.
+    """
+    if elevation is None:
+        return set()
+    return {
+        param_key
+        for param_key, in_reach in counts.items()
+        if not in_reach.with_height and PARAMETERS[param_key[2]].lapse_rate
+    }
+
+
+def collection_is_done(param_dict: dict, waiting_on: set[tuple[str, str, str]]) -> bool:
     """Whether every parameter has the stations it needs, so the walk down the ranking can stop.
 
     A parameter every station so far was turned away from for having no height never opened an
@@ -138,15 +193,15 @@ def collection_is_done(
     and could have answered it -- so a parameter that lost a station and has yet to take one keeps
     the walk going.
 
-    Unless no station in reach reports a height at all, which is what FMI, IPMA and the Environment
-    Agency publish: there is nothing to walk towards then, and holding the walk open would query
-    every station within the radius -- hundreds, for a provider that size -- to arrive at the same
-    answer the fourth station already gave.
+    `waiting_on` is those of them that a further station could still answer: a parameter with no
+    station of known height anywhere inside its radius is not among them, since holding the walk
+    open for it would download the rest of the ranking to arrive at the answer the fourth station
+    already gave.
     """
     return (
         bool(param_dict)
         and all(param_data.finished for param_data in param_dict.values())
-        and (not heights_in_reach or not dropped_for_height.difference(param_dict))
+        and not waiting_on.difference(param_dict)
     )
 
 
@@ -154,6 +209,7 @@ def report_height_exclusions(
     df: pl.DataFrame,
     param_dict: dict,
     dropped_for_height: set[tuple[str, str, str]],
+    counts: dict[tuple[str, str, str], StationsInReach],
     elevation: float | None,
     *,
     stations_needed: int,
@@ -177,13 +233,16 @@ def report_height_exclusions(
     the rest sufficed cost the answer nothing. Nor is one the exclusions cannot be blamed for --
     a parameter that kept the stations its calculation asks for and still came back null failed on
     the geometry of where they stand or on the data they hold, and telling such a caller to ask
-    without an elevation would send them back for the same nulls under a wrong diagnosis.
+    without an elevation would send them back for the same nulls under a wrong diagnosis. Nor is a
+    parameter that never had enough stations in reach to answer with: keeping every one of them
+    would still have left it short, so the exclusions are not what emptied it.
 
     Args:
         df: the interpolated or summarized frame, before any nulls are dropped from it
         param_dict: the parameters that were collected, each holding the columns it took
         dropped_for_height: the parameters that lost a station for having no height
         elevation: the height that was asked about
+        counts: how many stations each parameter had in reach, and how many reported a height
         stations_needed: how many stations the calculation wants before it can answer -- four
             surrounding the point for an interpolation, one for a summary
 
@@ -199,7 +258,9 @@ def report_height_exclusions(
         param_key
         for param_key in dropped_for_height - answered
         # minus the date column the values are laid on
-        if (param_dict[param_key].values.width - 1 if param_key in param_dict else 0) < stations_needed
+        if (param_dict[param_key].values.width - 1 if param_key in param_dict else 0)
+        < stations_needed
+        <= counts[param_key].total
     )
     if not emptied:
         return

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -17,7 +17,7 @@ from wetterdienst.model.metadata import ParameterModel
 
 if TYPE_CHECKING:
     import datetime as dt
-    from collections.abc import Iterable
+    from collections.abc import Collection, Iterable
 
     from wetterdienst.metadata.resolution import Resolution
     from wetterdienst.model.unit import UnitConverter
@@ -149,8 +149,13 @@ def count_stations_in_reach(
     df_stations_ranked: pl.DataFrame,
     parameters: Iterable[object],
     settings: Settings,
+    interpolatable: Collection[str],
 ) -> dict[tuple[str, str, str], StationsInReach]:
     """Count what each parameter has within its own radius, before a single value is downloaded.
+
+    Only the parameters the walk would collect: one it skips outright, for not being
+    interpolatable at all, is never unanswerable for want of a height, and counting it would keep
+    the refusal that costs no download from ever being reached.
 
     Per parameter, because the radius is: a quantity that decorrelates fast in space is given a
     narrower one, so "is there a station of known height in reach" has a different answer for
@@ -164,7 +169,7 @@ def count_stations_in_reach(
     """
     counts = {}
     for parameter in parameters:
-        if not isinstance(parameter, ParameterModel):
+        if not isinstance(parameter, ParameterModel) or parameter.name not in interpolatable:
             continue
         dataset = parameter.dataset
         radius = settings.ts_geo_station_distance_for(parameter.name, dataset.resolution.name)
@@ -172,15 +177,16 @@ def count_stations_in_reach(
         # ranking carries a row per station *and* dataset, and two dataset indexes can disagree
         # about a station's height. Taking whichever row sorted last would answer "is there a
         # height in reach" differently from the station the walk actually reads
-        in_reach = (
-            df_stations_ranked.filter(pl.col("distance").le(radius))
-            .unique(subset=["station_id"], keep="first", maintain_order=True)
-            .drop_nulls("height")
+        in_radius = df_stations_ranked.filter(pl.col("distance").le(radius)).unique(
+            subset=["station_id"],
+            keep="first",
+            maintain_order=True,
         )
-        furthest = in_reach.get_column("distance").max()
+        with_height = in_radius.drop_nulls("height")
+        furthest = with_height.get_column("distance").max()
         counts[(dataset.resolution.name, dataset.name, parameter.name)] = StationsInReach(
-            total=df_stations_ranked.filter(pl.col("distance").le(radius)).n_unique("station_id"),
-            with_height=in_reach.height,
+            total=in_radius.height,
+            with_height=with_height.height,
             furthest_with_height=float(cast("float", furthest)) if furthest is not None else None,
         )
     return counts
@@ -352,6 +358,14 @@ def report_height_exclusions(
             f"at {elevation} m; the rest of the result stands",
         )
         return
+    # the ones that kept a station are the same loss under a weaker light, and the exception speaks
+    # only for what is certain -- so they are said here rather than going unmentioned entirely
+    kept_some = [param_key for param_key in emptied if param_key in param_dict]
+    if kept_some:
+        listing = ", ".join("/".join(param_key) for param_key in kept_some)
+        log.warning(
+            f"leaving out the stations of unknown height leaves nothing that can answer {listing} at {elevation} m",
+        )
     listing = ", ".join("/".join(param_key) for param_key in took_nothing)
     msg = (
         f"leaving out the stations of unknown height leaves nothing that can answer {listing} at "

--- a/src/wetterdienst/core/util.py
+++ b/src/wetterdienst/core/util.py
@@ -178,23 +178,31 @@ def count_stations_in_reach(
     to visit can answer a question about another height.
     """
     counts = {}
+    # a station's height and its distance as the walk reads them: `stations_by_id` keeps one row
+    # per station, the nearest, over every dataset in the ranking. Two dataset indexes can disagree
+    # about a station's height, and reading a different row here than the walk does would refuse a
+    # request the walk would have answered
+    as_the_walk_reads_it = df_stations_ranked.unique(subset=["station_id"], keep="first", maintain_order=True)
     for parameter in parameters:
         if not isinstance(parameter, ParameterModel) or parameter.name not in interpolatable:
             continue
         dataset = parameter.dataset
         radius = settings.ts_geo_station_distance_for(parameter.name, dataset.resolution.name)
-        # one row per station and the nearest of them, as the collection loop reads it: the
-        # ranking carries a row per station *and* dataset, and two dataset indexes can disagree
-        # about a station's height. Taking whichever row sorted last would answer "is there a
-        # height in reach" differently from the station the walk actually reads
-        # by dataset as well as by distance: the ranking carries a row per station *and* dataset,
-        # so a station that stands in another dataset's index and reports a height there would
-        # otherwise count towards this parameter, which it can never answer
-        in_radius = df_stations_ranked.filter(
-            pl.col("resolution").eq(dataset.resolution.name),
-            pl.col("dataset").eq(dataset.name),
+        # which stations can answer this parameter is a different question from what they report:
+        # a station that stands only in another dataset's index holds none of this dataset's
+        # readings, so the walk passes over it however near it is, and counting it here would keep
+        # the walk open for a station it will always drop
+        holds_the_dataset = (
+            df_stations_ranked.filter(
+                pl.col("resolution").eq(dataset.resolution.name),
+                pl.col("dataset").eq(dataset.name),
+            )
+            .select("station_id")
+            .unique()
+        )
+        in_radius = as_the_walk_reads_it.join(holds_the_dataset, on="station_id", how="semi").filter(
             pl.col("distance").le(radius),
-        ).unique(subset=["station_id"], keep="first", maintain_order=True)
+        )
         with_height = in_radius.drop_nulls("height")
         furthest = with_height.get_column("distance").max()
         counts[(dataset.resolution.name, dataset.name, parameter.name)] = StationsInReach(
@@ -356,7 +364,9 @@ def report_height_exclusions(
         # an interpolation answers from a single station standing near enough to the point, without
         # the four a hull wants around it -- so where such a station was turned away for its height,
         # one is what the exclusions cost and four would be the wrong bar to hold them to
-        if nearby_station_distance is not None and dropped.nearest <= nearby_station_distance:
+        # strictly nearer, as `calculate_interpolation` builds its nearby set: a station at
+        # exactly the distance is not one the interpolation would have answered from alone
+        if nearby_station_distance is not None and dropped.nearest < nearby_station_distance:
             return 1
         return stations_needed
 

--- a/src/wetterdienst/exceptions.py
+++ b/src/wetterdienst/exceptions.py
@@ -49,3 +49,7 @@ class ApiNotFoundError(Exception):
 
 class NoInternetError(OSError):
     """Raised when no internet connection is available."""
+
+
+class NoStationsWithHeightError(ValueError):
+    """Raised when a height is asked about and no station in reach reports one of its own."""

--- a/src/wetterdienst/model/request.py
+++ b/src/wetterdienst/model/request.py
@@ -685,6 +685,11 @@ class TimeseriesRequest:
         Returns:
             InterpolatedValuesResult: Interpolated values.
 
+        Raises:
+            NoStationsWithHeightError: Where an elevation is asked about and leaving out the
+                stations whose height the provider does not report leaves nothing that can answer
+                it. A few providers report no height for any station.
+
         """
         from wetterdienst.core.interpolate import get_interpolated_df  # noqa: PLC0415
 
@@ -749,6 +754,13 @@ class TimeseriesRequest:
         names its height as well, and it is the one case where an interpolation knows the elevation
         of its target without being told. For the reading uncorrected, pass the station's
         coordinates to `interpolate` instead.
+
+        Raises:
+            NoStationsWithHeightError: Where leaving out the stations of unknown height leaves
+                nothing that can answer at this station's altitude. There is no elevation to omit
+                here, so the reading as it came is asked for by coordinates: pass the station's
+                own to `interpolate`.
+
         """
         latitude, longitude, station_height = self._get_position_by_station_id(station_id)
         return self.interpolate(
@@ -770,6 +782,11 @@ class TimeseriesRequest:
 
         Returns:
             SummarizedValuesResult: Summarized values.
+
+        Raises:
+            NoStationsWithHeightError: Where an elevation is asked about and leaving out the
+                stations whose height the provider does not report leaves nothing that can answer
+                it. A few providers report no height for any station.
 
         """
         from wetterdienst.core.summarize import get_summarized_df  # noqa: PLC0415
@@ -830,6 +847,13 @@ class TimeseriesRequest:
 
         Answers at the station's own altitude unless told another, as `interpolate_by_station_id`
         does.
+
+        Raises:
+            NoStationsWithHeightError: Where leaving out the stations of unknown height leaves
+                nothing that can answer at this station's altitude. There is no elevation to omit
+                here, so the reading as it came is asked for by coordinates: pass the station's
+                own to `summarize`.
+
         """
         latitude, longitude, station_height = self._get_position_by_station_id(station_id)
         return self.summarize(

--- a/src/wetterdienst/ui/cli.py
+++ b/src/wetterdienst/ui/cli.py
@@ -19,7 +19,7 @@ from cloup.constraints import AllSet, If, RequireExactly, accept_none
 from pydantic import BaseModel, ValidationError
 
 from wetterdienst import Settings, Wetterdienst, __appname__, __version__
-from wetterdienst.exceptions import ApiNotFoundError
+from wetterdienst.exceptions import ApiNotFoundError, NoStationsWithHeightError
 from wetterdienst.metadata.unit_type import UnitType
 from wetterdienst.ui.core import (
     HistoryRequest,
@@ -1565,6 +1565,11 @@ def interpolate(
             request=request,
             settings=settings,
         )
+    except NoStationsWithHeightError as e:
+        # an answerable request the caller phrased in a way this provider cannot serve:
+        # the message is the whole of it, and a traceback would only bury it
+        log.error(str(e))  # noqa: TRY400
+        sys.exit(1)
     except ValueError:
         log.exception("Error during interpolation")
         sys.exit(1)
@@ -1730,6 +1735,11 @@ def summarize(
             request=request,
             settings=settings,
         )
+    except NoStationsWithHeightError as e:
+        # an answerable request the caller phrased in a way this provider cannot serve:
+        # the message is the whole of it, and a traceback would only bury it
+        log.error(str(e))  # noqa: TRY400
+        sys.exit(1)
     except ValueError:
         log.exception("Error during summarize")
         sys.exit(1)

--- a/src/wetterdienst/ui/restapi.py
+++ b/src/wetterdienst/ui/restapi.py
@@ -7,14 +7,14 @@ from __future__ import annotations
 import json
 import logging
 from textwrap import dedent
-from typing import Annotated, Any, Literal, cast
+from typing import TYPE_CHECKING, Annotated, Any, Literal, cast
 
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
 from pydantic import ValidationError
 
 from wetterdienst import Author, Info, Settings, Wetterdienst, __version__
-from wetterdienst.exceptions import ApiNotFoundError, StartDateEndDateError
+from wetterdienst.exceptions import ApiNotFoundError, NoStationsWithHeightError, StartDateEndDateError
 
 # needed at runtime: FastAPI resolves this annotation to build the query parameter's enum
 from wetterdienst.metadata.unit_type import UnitType  # noqa: TC001
@@ -51,6 +51,12 @@ from wetterdienst.ui.core import (
 )
 from wetterdienst.util.cli import setup_logging
 from wetterdienst.util.ui import read_list
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from wetterdienst.model.request import TimeseriesRequest
+    from wetterdienst.model.result import InterpolatedValuesResult, SummarizedValuesResult
 
 info = Info()
 
@@ -603,6 +609,35 @@ def _geo_settings(
         raise HTTPException(status_code=400, detail=str(e)) from e
 
 
+def _geo_values(
+    get: Callable[..., InterpolatedValuesResult | SummarizedValuesResult],
+    api: type[TimeseriesRequest],
+    request: InterpolationRequest | SummaryRequest,
+    settings: Settings,
+    what: str,
+) -> InterpolatedValuesResult | SummarizedValuesResult:
+    """Run an interpolation or a summary, telling the caller which failures are theirs to fix.
+
+    Both endpoints answered every failure with a 404, which reads as "no such thing" for a request
+    that was understood and simply cannot be served as phrased -- an elevation no station in reach
+    can be placed against, or a window that ends before it starts. Those are 400s, and the same two
+    in both places, so they are decided here rather than twice over.
+    """
+    try:
+        return get(api=api, request=request, settings=settings)
+    except NoStationsWithHeightError as e:
+        # the message is the whole of it: which parameters lost their stations, and that asking
+        # without an elevation gets them back
+        log.info(f"Failed to {what}: {e}")
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except StartDateEndDateError as e:
+        log.exception(f"Failed to {what}")
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except Exception as e:
+        log.exception(f"Failed to {what}")
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
 # response models for the different formats are
 # - _InterpolatedValuesDict for json
 # - _InterpolatedValuesOgcFeatureCollection for geojson
@@ -641,21 +676,7 @@ def interpolate(
         request.interpolation_station_distance_heterogeneous,
     )
 
-    try:
-        values_ = get_interpolate(
-            api=api,
-            request=request,
-            settings=settings,
-        )
-    except StartDateEndDateError as e:
-        log.exception("Failed to interpolate")
-        raise HTTPException(
-            status_code=400,
-            detail=str(e),
-        ) from e
-    except Exception as e:
-        log.exception("Failed to interpolate")
-        raise HTTPException(status_code=404, detail=str(e)) from e
+    values_ = _geo_values(get_interpolate, api, request, settings, "interpolate")
 
     # build kwargs dynamically
     kwargs: dict[str, Any] = {
@@ -721,15 +742,7 @@ def summarize(
         request.summary_station_distance_heterogeneous,
     )
 
-    try:
-        values_ = get_summarize(
-            api=api,
-            request=request,
-            settings=settings,
-        )
-    except Exception as e:
-        log.exception("Failed to summarize")
-        raise HTTPException(status_code=404, detail=str(e)) from e
+    values_ = _geo_values(get_summarize, api, request, settings, "summarize")
 
     # build kwargs dynamically
     kwargs: dict[str, Any] = {

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -746,18 +746,21 @@ def test_interpolation_at_an_elevation(default_settings: Settings) -> None:
     assert lower < uncorrected.mean() < upper
 
 
-def _strip_station_heights(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Make a DWD request look like an FMI one: stations, readings, and no heights at all.
+def _blank_station_heights(monkeypatch: pytest.MonkeyPatch, keeps_its_height: pl.Expr) -> None:
+    """Make a DWD request look like a provider that reports heights for only some of its stations.
 
     FMI, IPMA and the Environment Agency publish no height for any station, and eleven more
     providers for some of theirs. Borrowing DWD's data and taking the heights away exercises the
-    same path without a second provider's outages deciding whether this test passes.
+    same path without a second provider's outages deciding whether this test passes. The frame is
+    ranked by distance, so the expression picks by how near the station is.
     """
     original = DwdObservationRequest.filter_by_distance
 
     def without_heights(self: DwdObservationRequest, *args: object, **kwargs: object) -> object:
         stations_ranked = original(self, *args, **kwargs)
-        stations_ranked.df = stations_ranked.df.with_columns(pl.lit(None, dtype=pl.Float64).alias("height"))
+        stations_ranked.df = stations_ranked.df.with_columns(
+            pl.when(keeps_its_height).then(pl.col("height")).otherwise(None).alias("height"),
+        )
         return stations_ranked
 
     monkeypatch.setattr(DwdObservationRequest, "filter_by_distance", without_heights)
@@ -780,10 +783,10 @@ def test_interpolation_at_an_elevation_none_of_the_stations_can_answer(
         end_date=dt.datetime(2022, 1, 5, tzinfo=ZoneInfo("UTC")),
         settings=default_settings,
     )
-    _strip_station_heights(monkeypatch)
+    _blank_station_heights(monkeypatch, pl.lit(value=False))
     with pytest.raises(
         NoStationsWithHeightError,
-        match=r"no answer at 200\.0 m for daily/climate_summary/temperature_air_mean_2m",
+        match=r"nothing that can answer daily/climate_summary/temperature_air_mean_2m at 200\.0 m",
     ):
         request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
     # and without an elevation the same stations answer as they always did
@@ -807,7 +810,7 @@ def test_interpolation_at_an_elevation_names_the_parameter_it_lost(
         end_date=dt.datetime(2022, 1, 5, tzinfo=ZoneInfo("UTC")),
         settings=default_settings,
     )
-    _strip_station_heights(monkeypatch)
+    _blank_station_heights(monkeypatch, pl.lit(value=False))
     with caplog.at_level(logging.WARNING):
         values = request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
     assert values.df.get_column("parameter").unique().to_list() == ["precipitation_height"]
@@ -821,3 +824,28 @@ def test_interpolation_error_no_start_date() -> None:
     )
     with pytest.raises(ValueError, match="start_date and end_date are required for interpolation"):
         request.interpolate(latlon=(52.8, 12.9))
+
+
+@pytest.mark.remote
+def test_interpolation_at_an_elevation_too_few_stations_left_to_interpolate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stations left over that cannot interpolate are as unanswered as no stations at all.
+
+    An interpolation wants four that surround the point, so two of known height among neighbours
+    of unknown height hold columns and still come back null. Read off the collected columns that
+    looks answered, and the caller gets a frame of nulls and no reason for them.
+    """
+    settings = Settings(ts_geo_use_nearby_station_distance=0.0)
+    request = DwdObservationRequest(
+        parameters=[("daily", "kl", "temperature_air_mean_2m")],
+        start_date=dt.datetime(2022, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(2022, 1, 5, tzinfo=ZoneInfo("UTC")),
+        settings=settings,
+    )
+    _blank_station_heights(monkeypatch, pl.int_range(pl.len()) < 2)
+    with pytest.raises(
+        NoStationsWithHeightError,
+        match=r"nothing that can answer daily/climate_summary/temperature_air_mean_2m at 200\.0 m",
+    ):
+        request.interpolate(latlon=(47.48, 11.06), elevation=200.0)

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -19,6 +19,7 @@ from wetterdienst.core.interpolate import (
 )
 from wetterdienst.exceptions import NoStationsWithHeightError, StationNotFoundError
 from wetterdienst.metadata.parameter_table import PARAMETERS
+from wetterdienst.model.values import TimeseriesValues
 from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
 from wetterdienst.provider.dwd.observation import (
     DwdObservationRequest,
@@ -784,12 +785,25 @@ def test_interpolation_at_an_elevation_none_of_the_stations_can_answer(
         settings=default_settings,
     )
     _blank_station_heights(monkeypatch, pl.lit(value=False))
+    downloads = 0
+    original_query = TimeseriesValues.query
+
+    def counting_query(self: TimeseriesValues) -> object:
+        nonlocal downloads
+        downloads += 1
+        return original_query(self)
+
+    monkeypatch.setattr(TimeseriesValues, "query", counting_query)
     with pytest.raises(
         NoStationsWithHeightError,
         match=r"nothing that can answer daily/climate_summary/temperature_air_mean_2m at 200\.0 m",
     ):
         request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
-    # and without an elevation the same stations answer as they always did
+    # and not one station's values were fetched to arrive at that: the ranking already said no
+    # station in reach reports a height, and every quantity asked for needs one
+    assert downloads == 0
+    # without an elevation the same stations answer as they always did
+    monkeypatch.setattr(TimeseriesValues, "query", original_query)
     assert not request.interpolate(latlon=(47.48, 11.06)).df.is_empty()
 
 

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -796,7 +796,7 @@ def test_interpolation_at_an_elevation_none_of_the_stations_can_answer(
     monkeypatch.setattr(TimeseriesValues, "query", counting_query)
     with pytest.raises(
         NoStationsWithHeightError,
-        match=r"nothing that can answer daily/climate_summary/temperature_air_mean_2m at 200\.0 m",
+        match=r"nothing can be brought to 200\.0 m for daily/climate_summary/temperature_air_mean_2m",
     ):
         request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
     # and not one station's values were fetched to arrive at that: the ranking already said no
@@ -827,7 +827,9 @@ def test_interpolation_at_an_elevation_names_the_parameter_it_lost(
     _blank_station_heights(monkeypatch, pl.lit(value=False))
     with caplog.at_level(logging.WARNING):
         values = request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
-    assert values.df.get_column("parameter").unique().to_list() == ["precipitation_height"]
+    # of the values that are there, not of the rows: a parameter with a station collected for it
+    # gets rows either way, so this is what says the other parameter really was answered
+    assert values.df.drop_nulls("value").get_column("parameter").unique().to_list() == ["precipitation_height"]
     assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
 
 

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -3,6 +3,7 @@
 """Tests for interpolation."""
 
 import datetime as dt
+import logging
 import random
 from queue import Queue
 from zoneinfo import ZoneInfo
@@ -16,7 +17,7 @@ from wetterdienst.core.interpolate import (
     apply_interpolation,
     get_valid_station_groups,
 )
-from wetterdienst.exceptions import StationNotFoundError
+from wetterdienst.exceptions import NoStationsWithHeightError, StationNotFoundError
 from wetterdienst.metadata.parameter_table import PARAMETERS
 from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
 from wetterdienst.provider.dwd.observation import (
@@ -743,6 +744,74 @@ def test_interpolation_at_an_elevation(default_settings: Settings) -> None:
     # stations themselves stand at
     lower, upper = min(valley.mean(), summit.mean()), max(valley.mean(), summit.mean())
     assert lower < uncorrected.mean() < upper
+
+
+def _strip_station_heights(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make a DWD request look like an FMI one: stations, readings, and no heights at all.
+
+    FMI, IPMA and the Environment Agency publish no height for any station, and eleven more
+    providers for some of theirs. Borrowing DWD's data and taking the heights away exercises the
+    same path without a second provider's outages deciding whether this test passes.
+    """
+    original = DwdObservationRequest.filter_by_distance
+
+    def without_heights(self: DwdObservationRequest, *args: object, **kwargs: object) -> object:
+        stations_ranked = original(self, *args, **kwargs)
+        stations_ranked.df = stations_ranked.df.with_columns(pl.lit(None, dtype=pl.Float64).alias("height"))
+        return stations_ranked
+
+    monkeypatch.setattr(DwdObservationRequest, "filter_by_distance", without_heights)
+
+
+@pytest.mark.remote
+def test_interpolation_at_an_elevation_none_of_the_stations_can_answer(
+    default_settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An elevation that empties the request says so instead of coming back empty.
+
+    A station of unknown height cannot be placed against the height asked about, and where that is
+    every station in reach there is nothing left to interpolate. That used to be an empty frame
+    with the reason in a server-side log -- the one place the caller cannot look.
+    """
+    request = DwdObservationRequest(
+        parameters=[("daily", "kl", "temperature_air_mean_2m")],
+        start_date=dt.datetime(2022, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(2022, 1, 5, tzinfo=ZoneInfo("UTC")),
+        settings=default_settings,
+    )
+    _strip_station_heights(monkeypatch)
+    with pytest.raises(
+        NoStationsWithHeightError,
+        match=r"no answer at 200\.0 m for daily/climate_summary/temperature_air_mean_2m",
+    ):
+        request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
+    # and without an elevation the same stations answer as they always did
+    assert not request.interpolate(latlon=(47.48, 11.06)).df.is_empty()
+
+
+@pytest.mark.remote
+def test_interpolation_at_an_elevation_names_the_parameter_it_lost(
+    default_settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parameter emptied beside one that answered is named, and the rest of the result stands.
+
+    Precipitation does not fall with height in the sense the correction means, so it keeps every
+    station a temperature loses.
+    """
+    request = DwdObservationRequest(
+        parameters=[("daily", "kl", "temperature_air_mean_2m"), ("daily", "kl", "precipitation_height")],
+        start_date=dt.datetime(2022, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(2022, 1, 5, tzinfo=ZoneInfo("UTC")),
+        settings=default_settings,
+    )
+    _strip_station_heights(monkeypatch)
+    with caplog.at_level(logging.WARNING):
+        values = request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
+    assert values.df.get_column("parameter").unique().to_list() == ["precipitation_height"]
+    assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
 
 
 def test_interpolation_error_no_start_date() -> None:

--- a/tests/core/test_interpolation.py
+++ b/tests/core/test_interpolation.py
@@ -844,13 +844,15 @@ def test_interpolation_error_no_start_date() -> None:
 
 @pytest.mark.remote
 def test_interpolation_at_an_elevation_too_few_stations_left_to_interpolate(
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Stations left over that cannot interpolate are as unanswered as no stations at all.
+    """Stations left over that cannot interpolate are named, the answer being null either way.
 
-    An interpolation wants four that surround the point, so two of known height among neighbours
-    of unknown height hold columns and still come back null. Read off the collected columns that
-    looks answered, and the caller gets a frame of nulls and no reason for them.
+    An interpolation wants four that surround the point, so two of known height among neighbours of
+    unknown height hold columns and still come back null. Whether keeping the other eight would
+    have helped is not something a count can say -- they may not have surrounded the point either
+    -- so it is said in the log rather than raised over the caller's result.
     """
     settings = Settings(ts_geo_use_nearby_station_distance=0.0)
     request = DwdObservationRequest(
@@ -860,8 +862,7 @@ def test_interpolation_at_an_elevation_too_few_stations_left_to_interpolate(
         settings=settings,
     )
     _blank_station_heights(monkeypatch, pl.int_range(pl.len()) < 2)
-    with pytest.raises(
-        NoStationsWithHeightError,
-        match=r"nothing that can answer daily/climate_summary/temperature_air_mean_2m at 200\.0 m",
-    ):
-        request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
+    with caplog.at_level(logging.WARNING):
+        values = request.interpolate(latlon=(47.48, 11.06), elevation=200.0)
+    assert values.df.drop_nulls("value").is_empty()
+    assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -10,6 +10,7 @@ import pytest
 from polars.testing import assert_frame_equal
 
 from wetterdienst import Settings
+from wetterdienst.exceptions import NoStationsWithHeightError
 from wetterdienst.provider.dwd.mosmix import DwdMosmixRequest
 from wetterdienst.provider.dwd.observation import (
     DwdObservationRequest,
@@ -139,3 +140,38 @@ def test_summary_error_no_start_date() -> None:
     )
     with pytest.raises(ValueError, match="start_date and end_date are required for summarization"):
         request.summarize(latlon=(52.8, 12.9))
+
+
+@pytest.mark.remote
+def test_summary_at_an_elevation_none_of_the_stations_can_answer(
+    default_settings: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A summary emptied by an elevation says so rather than coming back empty.
+
+    A summary answers with one station's reading rather than a blend, so a station it cannot place
+    against the height asked about is the whole answer gone, not a quarter of it. DWD's stations
+    stand in for FMI's here: same data, heights taken away, and no second provider's outages
+    deciding whether this passes.
+    """
+    request = DwdObservationRequest(
+        parameters=[("daily", "climate_summary", "temperature_air_mean_2m")],
+        start_date=dt.datetime(2022, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end_date=dt.datetime(2022, 1, 5, tzinfo=ZoneInfo("UTC")),
+        settings=default_settings,
+    )
+    original = DwdObservationRequest.filter_by_distance
+
+    def without_heights(self: DwdObservationRequest, *args: object, **kwargs: object) -> object:
+        stations_ranked = original(self, *args, **kwargs)
+        stations_ranked.df = stations_ranked.df.with_columns(pl.lit(None, dtype=pl.Float64).alias("height"))
+        return stations_ranked
+
+    monkeypatch.setattr(DwdObservationRequest, "filter_by_distance", without_heights)
+    with pytest.raises(
+        NoStationsWithHeightError,
+        match=r"no answer at 200\.0 m for daily/climate_summary/temperature_air_mean_2m",
+    ):
+        request.summarize(latlon=(47.48, 11.06), elevation=200.0)
+    # and without an elevation the same stations answer as they always did
+    assert not request.summarize(latlon=(47.48, 11.06)).df.is_empty()

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -170,7 +170,7 @@ def test_summary_at_an_elevation_none_of_the_stations_can_answer(
     monkeypatch.setattr(DwdObservationRequest, "filter_by_distance", without_heights)
     with pytest.raises(
         NoStationsWithHeightError,
-        match=r"nothing that can answer daily/climate_summary/temperature_air_mean_2m at 200\.0 m",
+        match=r"nothing can be brought to 200\.0 m for daily/climate_summary/temperature_air_mean_2m",
     ):
         request.summarize(latlon=(47.48, 11.06), elevation=200.0)
     # and without an elevation the same stations answer as they always did

--- a/tests/core/test_summary.py
+++ b/tests/core/test_summary.py
@@ -170,7 +170,7 @@ def test_summary_at_an_elevation_none_of_the_stations_can_answer(
     monkeypatch.setattr(DwdObservationRequest, "filter_by_distance", without_heights)
     with pytest.raises(
         NoStationsWithHeightError,
-        match=r"no answer at 200\.0 m for daily/climate_summary/temperature_air_mean_2m",
+        match=r"nothing that can answer daily/climate_summary/temperature_air_mean_2m at 200\.0 m",
     ):
         request.summarize(latlon=(47.48, 11.06), elevation=200.0)
     # and without an elevation the same stations answer as they always did

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -518,6 +518,10 @@ def test_report_height_exclusions_counts_a_station_near_enough_to_answer_alone()
     # the same station a kilometre further out answers nothing on its own, and four is the bar again
     lost_far = {TEMPERATURE: DroppedForHeight(count=1, nearest=8.0)}
     report_height_exclusions(df, {}, lost_far, 200.0, stations_needed=4, nearby_station_distance=1.0)
+    # nor one standing at exactly the distance: `calculate_interpolation` takes what is nearer than
+    # it, so a station on the line is not one it would have answered from alone either
+    lost_on_the_line = {TEMPERATURE: DroppedForHeight(count=1, nearest=1.0)}
+    report_height_exclusions(df, {}, lost_on_the_line, 200.0, stations_needed=4, nearby_station_distance=1.0)
     # nor where the shortcut is switched off
     report_height_exclusions(df, {}, lost_nearby, 200.0, stations_needed=4, nearby_station_distance=None)
 
@@ -578,3 +582,26 @@ def test_report_height_exclusions_claims_a_standing_result_only_where_there_is_o
             stations_needed=4,
         )
     assert "the rest of the result stands" in caplog.text
+
+
+def test_count_stations_in_reach_reads_the_height_the_walk_will_read() -> None:
+    """A station's height is the one the walk finds, whichever index it comes from.
+
+    The walk keeps one row per station, the nearest over every dataset in the ranking, and reads
+    the height off that. Two dataset indexes can disagree -- a height in one, none in the other --
+    and counting off the requested dataset's row alone would refuse, before downloading anything, a
+    request the walk would have answered from that station.
+    """
+    from wetterdienst.core.util import count_stations_in_reach  # noqa: PLC0415
+
+    daily = DwdObservationRequest.metadata["daily"]["climate_summary"]["temperature_air_mean_2m"]
+    df_stations_ranked = pl.concat(
+        [
+            # the nearer row, from another dataset's index, is the one the walk reads
+            _ranked("temperature_air", [{"station_id": "00001", "distance": 4.0, "height": 210.0}]),
+            _ranked("climate_summary", [{"station_id": "00001", "distance": 5.0, "height": None}]),
+        ],
+    )
+    counts = count_stations_in_reach(df_stations_ranked, [daily], Settings(), INTERPOLATABLE)
+    # the station holds the daily dataset, so it counts -- and it has a height, so nothing is refused
+    assert counts[("daily", "climate_summary", "temperature_air_mean_2m")] == (1, 1, 4.0)

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -3,8 +3,10 @@
 """Tests for shared interpolation and summary tools."""
 
 import datetime as dt
+import logging
 from zoneinfo import ZoneInfo
 
+import polars as pl
 import pytest
 
 from wetterdienst.core.util import build_date_grid
@@ -97,3 +99,53 @@ def test_build_date_grid_treats_subdaily_as_hourly() -> None:
     )
 
     assert df.height == 25  # hourly, both ends included
+
+
+def test_report_height_exclusions_raises_where_nothing_is_left() -> None:
+    """A request emptied by heights alone is a question that cannot be answered as asked.
+
+    Left to itself it comes back as an empty frame with the reason in a server-side log, which is
+    the one place the caller cannot look -- so it is raised, and the message says what to do about
+    it. Thirteen providers have stations without heights, FMI's, IPMA's and the Environment
+    Agency's being all of them.
+    """
+    from wetterdienst.core.util import report_height_exclusions  # noqa: PLC0415
+    from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
+
+    param_key = ("daily", "climate_summary", "temperature_air_mean_2m")
+    with pytest.raises(NoStationsWithHeightError, match=r"no answer at 200\.0 m for daily/climate_summary/temperature"):
+        report_height_exclusions({}, {param_key}, 200.0)
+
+
+def test_report_height_exclusions_warns_where_something_still_answers(caplog: pytest.LogCaptureFixture) -> None:
+    """A parameter emptied beside one that answered is named, not raised.
+
+    There is a result to read the warning against, and taking the whole request down over one of
+    its parameters would throw away readings the caller can use.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    answered = _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])))
+    param_dict = {("daily", "climate_summary", "precipitation_height"): answered}
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(param_dict, {("daily", "climate_summary", "temperature_air_mean_2m")}, 200.0)
+    assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
+    assert "the rest of the result stands" in caplog.text
+
+
+def test_report_height_exclusions_keeps_quiet_where_the_answer_stands() -> None:
+    """A station turned away where another was taken cost the answer nothing.
+
+    Nor is a request that lost no station to a height worth a word: the helper runs on every
+    interpolation and summary, elevation or not.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    param_key = ("daily", "climate_summary", "temperature_air_mean_2m")
+    answered = {param_key: _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])))}
+    # the parameter kept a station of its own, so the one turned away is not worth reporting
+    report_height_exclusions(answered, {param_key}, 200.0)
+    # and nothing was turned away at all
+    report_height_exclusions({}, set(), None)

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -12,6 +12,7 @@ import pytest
 from wetterdienst import Settings
 from wetterdienst.core.util import StationsInReach, build_date_grid
 from wetterdienst.metadata.resolution import Resolution, reading_interval
+from wetterdienst.provider.dwd.observation import DwdObservationRequest
 
 UTC = ZoneInfo("UTC")
 
@@ -111,6 +112,7 @@ def _answer(*rows: tuple[str, str, str, float | None]) -> pl.DataFrame:
     )
 
 
+INTERPOLATABLE = DwdObservationRequest.interpolatable_parameters
 TEMPERATURE = ("daily", "climate_summary", "temperature_air_mean_2m")
 PRECIPITATION = ("daily", "climate_summary", "precipitation_height")
 
@@ -293,7 +295,6 @@ def test_count_stations_in_reach_asks_per_parameter_radius() -> None:
     One answer for the whole request would be the wrong one for at least one of them.
     """
     from wetterdienst.core.util import count_stations_in_reach  # noqa: PLC0415
-    from wetterdienst.provider.dwd.observation import DwdObservationRequest  # noqa: PLC0415
 
     metadata = DwdObservationRequest.metadata["hourly"]
     parameters = [
@@ -310,7 +311,7 @@ def test_count_stations_in_reach_asks_per_parameter_radius() -> None:
         schema={"station_id": pl.String, "distance": pl.Float64, "height": pl.Float64},
         orient="row",
     )
-    counts = count_stations_in_reach(df_stations_ranked, parameters, Settings())
+    counts = count_stations_in_reach(df_stations_ranked, parameters, Settings(), INTERPOLATABLE)
     # 40 km for temperature: three stations, the furthest of them the only one with a height
     assert counts[("hourly", "temperature_air", "temperature_air_mean_2m")] == (3, 1, 35.0)
     # 20 km for precipitation: two stations, and the station that has a height is outside it
@@ -379,7 +380,6 @@ def test_count_stations_in_reach_reads_the_nearest_row_of_a_station() -> None:
     value is downloaded.
     """
     from wetterdienst.core.util import count_stations_in_reach  # noqa: PLC0415
-    from wetterdienst.provider.dwd.observation import DwdObservationRequest  # noqa: PLC0415
 
     parameters = [DwdObservationRequest.metadata["hourly"]["temperature_air"]["temperature_air_mean_2m"]]
     df_stations_ranked = pl.DataFrame(
@@ -390,7 +390,7 @@ def test_count_stations_in_reach_reads_the_nearest_row_of_a_station() -> None:
         schema={"station_id": pl.String, "distance": pl.Float64, "height": pl.Float64},
         orient="row",
     )
-    assert count_stations_in_reach(df_stations_ranked, parameters, Settings()) == {
+    assert count_stations_in_reach(df_stations_ranked, parameters, Settings(), INTERPOLATABLE) == {
         ("hourly", "temperature_air", "temperature_air_mean_2m"): (1, 1, 5.0),
     }
 
@@ -429,3 +429,55 @@ def test_no_height_in_reach_error_says_what_the_ranking_alone_can_say() -> None:
     assert "daily/climate_summary/precipitation_height, daily/climate_summary/temperature_air_mean_2m" in str(error)
     # and the remedy that applies to a request named by a station id as much as one by coordinates
     assert "naming a station id instead asks at that station's own height" in str(error)
+
+
+def test_count_stations_in_reach_passes_over_what_the_walk_would_not_collect() -> None:
+    """A parameter that cannot be interpolated at all is not counted.
+
+    It can never be unanswerable for want of a height, so counting it would leave the set of
+    unanswerable parameters short of the set of counted ones for ever -- and the refusal that costs
+    no download, which asks whether those two are the same, would never be reached. Every station
+    inside the radius would be fetched to arrive at the answer the station list already held.
+    """
+    from wetterdienst.core.util import count_stations_in_reach  # noqa: PLC0415
+
+    metadata = DwdObservationRequest.metadata["daily"]["climate_summary"]
+    # precipitation_form is the one member of daily/kl that is not interpolatable
+    parameters = [metadata["temperature_air_mean_2m"], metadata["precipitation_form"]]
+    df_stations_ranked = pl.DataFrame(
+        [{"station_id": "00001", "distance": 5.0, "height": None}],
+        schema={"station_id": pl.String, "distance": pl.Float64, "height": pl.Float64},
+        orient="row",
+    )
+    counts = count_stations_in_reach(df_stations_ranked, parameters, Settings(), INTERPOLATABLE)
+    assert set(counts) == {("daily", "climate_summary", "temperature_air_mean_2m")}
+
+
+def test_report_height_exclusions_names_the_uncertain_losses_beside_the_certain_one(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parameter that kept a station is still named when another is refused outright.
+
+    The exception speaks only for what is certain, so a parameter emptied under the weaker light
+    would otherwise go unmentioned altogether -- the warning branch having been passed over on the
+    way to the refusal.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+    from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
+
+    maximum = ("daily", "climate_summary", "temperature_air_max_2m")
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "ab")
+    df = _answer((*TEMPERATURE, None), (*maximum, None))
+    with (
+        caplog.at_level(logging.WARNING),
+        pytest.raises(NoStationsWithHeightError, match=r"temperature_air_mean_2m at 200\.0 m"),
+    ):
+        report_height_exclusions(
+            df,
+            {maximum: _ParameterData(kept)},
+            {TEMPERATURE: 5, maximum: 3},
+            200.0,
+            stations_needed=4,
+        )
+    assert "daily/climate_summary/temperature_air_max_2m" in caplog.text

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -113,9 +113,6 @@ def _answer(*rows: tuple[str, str, str, float | None]) -> pl.DataFrame:
 
 TEMPERATURE = ("daily", "climate_summary", "temperature_air_mean_2m")
 PRECIPITATION = ("daily", "climate_summary", "precipitation_height")
-# nine stations in reach, none of which reports a height: enough that the four an
-# interpolation wants were there to be had before the exclusions took them
-IN_REACH = {TEMPERATURE: StationsInReach(total=9, with_height=0)}
 
 
 def test_report_height_exclusions_raises_where_nothing_was_answered() -> None:
@@ -133,14 +130,13 @@ def test_report_height_exclusions_raises_where_nothing_was_answered() -> None:
         report_height_exclusions(
             _answer((*TEMPERATURE, None), (*TEMPERATURE, None)),
             {},
-            {TEMPERATURE},
-            {TEMPERATURE: StationsInReach(total=9, with_height=0)},
+            {TEMPERATURE: 9},
             200.0,
             stations_needed=4,
         )
     # and the same for a parameter that never opened a row at all
     with pytest.raises(NoStationsWithHeightError, match=r"at 200\.0 m"):
-        report_height_exclusions(_answer(), {}, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=4)
+        report_height_exclusions(_answer(), {}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
 
 
 def test_report_height_exclusions_warns_where_something_still_answers(caplog: pytest.LogCaptureFixture) -> None:
@@ -153,7 +149,7 @@ def test_report_height_exclusions_warns_where_something_still_answers(caplog: py
 
     df = _answer((*PRECIPITATION, 1.2), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(df, {}, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=4)
+        report_height_exclusions(df, {}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
     assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
     assert "the rest of the result stands" in caplog.text
 
@@ -172,7 +168,7 @@ def test_report_height_exclusions_counts_a_parameter_of_nulls_as_unanswered(
 
     df = _answer((*PRECIPITATION, None), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING), pytest.raises(NoStationsWithHeightError):
-        report_height_exclusions(df, {}, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=4)
+        report_height_exclusions(df, {}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
     assert not caplog.text
 
 
@@ -189,13 +185,12 @@ def test_report_height_exclusions_keeps_quiet_where_the_answer_stands(caplog: py
         report_height_exclusions(
             _answer((*TEMPERATURE, 3.4), (*TEMPERATURE, None)),
             {},
-            {TEMPERATURE},
-            IN_REACH,
+            {TEMPERATURE: 9},
             200.0,
             stations_needed=4,
         )
         # and nothing was turned away at all
-        report_height_exclusions(_answer(), {}, set(), IN_REACH, None, stations_needed=4)
+        report_height_exclusions(_answer(), {}, {}, None, stations_needed=4)
     assert not caplog.text
 
 
@@ -237,8 +232,7 @@ def test_report_height_exclusions_does_not_blame_the_heights_for_what_they_did_n
         report_height_exclusions(
             _answer((*TEMPERATURE, None)),
             {TEMPERATURE: _ParameterData(kept)},
-            {TEMPERATURE},
-            IN_REACH,
+            {TEMPERATURE: 9},
             200.0,
             stations_needed=4,
         )
@@ -261,13 +255,9 @@ def test_report_height_exclusions_blames_the_heights_for_leaving_too_few(
     kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "abc")
     param_dict = {TEMPERATURE: _ParameterData(kept)}
     with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
-        report_height_exclusions(
-            _answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=4
-        )
+        report_height_exclusions(_answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE: 9}, 200.0, stations_needed=4)
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(
-            _answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=1
-        )
+        report_height_exclusions(_answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE: 9}, 200.0, stations_needed=1)
     assert not caplog.text
 
 
@@ -285,32 +275,6 @@ def test_collection_is_done_does_not_wait_where_no_station_reports_a_height() ->
     assert collection_is_done({PRECIPITATION: finished}, set())
     # where some station does report one, the walk goes on until temperature has taken it
     assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE})
-
-
-def test_report_height_exclusions_does_not_blame_the_heights_for_a_thin_neighbourhood(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A parameter that never had four stations in reach was not emptied by the exclusions.
-
-    Three stations hold it in the whole radius and one of them reports no height, so two are left
-    and an interpolation wants four. Keeping all three would still have been one short, so asking
-    without an elevation returns the same nulls -- and a caller sent back for them under this
-    diagnosis is worse off than one who got the empty frame.
-    """
-    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
-
-    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
-    kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "ab")
-    with caplog.at_level(logging.WARNING):
-        report_height_exclusions(
-            _answer((*TEMPERATURE, None)),
-            {TEMPERATURE: _ParameterData(kept)},
-            {TEMPERATURE},
-            {TEMPERATURE: StationsInReach(total=3, with_height=2)},
-            200.0,
-            stations_needed=4,
-        )
-    assert not caplog.text
 
 
 def test_count_stations_in_reach_asks_per_parameter_radius() -> None:
@@ -341,9 +305,9 @@ def test_count_stations_in_reach_asks_per_parameter_radius() -> None:
     )
     counts = count_stations_in_reach(df_stations_ranked, parameters, Settings())
     # 40 km for temperature: three stations, the furthest of them the only one with a height
-    assert counts[("hourly", "temperature_air", "temperature_air_mean_2m")] == (3, 1)
+    assert counts[("hourly", "temperature_air", "temperature_air_mean_2m")] == (3, 1, 35.0)
     # 20 km for precipitation: two stations, and the station that has a height is outside it
-    assert counts[("hourly", "precipitation", "precipitation_height")] == (2, 0)
+    assert counts[("hourly", "precipitation", "precipitation_height")] == (2, 0, None)
 
 
 def test_unanswerable_at_height_names_what_no_walk_can_reach() -> None:
@@ -356,10 +320,78 @@ def test_unanswerable_at_height_names_what_no_walk_can_reach() -> None:
     from wetterdienst.core.util import unanswerable_at_height  # noqa: PLC0415
 
     counts = {
-        TEMPERATURE: StationsInReach(total=9, with_height=0),
-        PRECIPITATION: StationsInReach(total=9, with_height=0),
+        TEMPERATURE: StationsInReach(total=9, with_height=0, furthest_with_height=None),
+        PRECIPITATION: StationsInReach(total=9, with_height=0, furthest_with_height=None),
     }
     assert unanswerable_at_height(counts, 200.0) == {TEMPERATURE}
     # one station reporting a height is enough to be worth walking for
-    assert unanswerable_at_height({TEMPERATURE: StationsInReach(total=9, with_height=1)}, 200.0) == set()
+    assert (
+        unanswerable_at_height({TEMPERATURE: StationsInReach(total=9, with_height=1, furthest_with_height=12.0)}, 200.0)
+        == set()
+    )
     assert unanswerable_at_height(counts, None) == set()
+
+
+def test_report_height_exclusions_weighs_the_stations_that_held_the_parameter() -> None:
+    """What the exclusions took is stations that held the parameter, not stations in the radius.
+
+    Six stations stand within reach and two of them report the parameter in the window asked for,
+    one without a height. Counting the radius says four were there to be had and blames the
+    heights; counting what was turned away says two, which is short of the four an interpolation
+    wants either way. Sending that caller back to ask without an elevation returns the same nulls.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+    from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    kept = grid.with_columns(pl.Series("a", [None, None, None], dtype=pl.Float64))
+    param_dict = {TEMPERATURE: _ParameterData(kept)}
+    df = _answer((*TEMPERATURE, None))
+    # one taken and one turned away is two, and four are wanted: not the exclusions' doing
+    report_height_exclusions(df, param_dict, {TEMPERATURE: 1}, 200.0, stations_needed=4)
+    # three turned away would have made four, so they are
+    with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
+        report_height_exclusions(df, param_dict, {TEMPERATURE: 3}, 200.0, stations_needed=4)
+
+
+def test_count_stations_in_reach_reads_the_nearest_row_of_a_station() -> None:
+    """A station gets one row per dataset, and the walk reads the nearest of them.
+
+    The two indexes can disagree about a height, and whichever row happened to sort last would
+    answer "is there a station of known height in reach" differently from the station the
+    collection loop actually reads -- which decides whether the request is refused before a single
+    value is downloaded.
+    """
+    from wetterdienst.core.util import count_stations_in_reach  # noqa: PLC0415
+    from wetterdienst.provider.dwd.observation import DwdObservationRequest  # noqa: PLC0415
+
+    parameters = [DwdObservationRequest.metadata["hourly"]["temperature_air"]["temperature_air_mean_2m"]]
+    df_stations_ranked = pl.DataFrame(
+        [
+            {"station_id": "00001", "distance": 5.0, "height": 210.0},
+            {"station_id": "00001", "distance": 5.2, "height": None},
+        ],
+        schema={"station_id": pl.String, "distance": pl.Float64, "height": pl.Float64},
+        orient="row",
+    )
+    assert count_stations_in_reach(df_stations_ranked, parameters, Settings()) == {
+        ("hourly", "temperature_air", "temperature_air_mean_2m"): (1, 1, 5.0),
+    }
+
+
+def test_parameters_still_in_reach_stops_at_the_last_station_that_has_a_height() -> None:
+    """Past the furthest station of known height, no station left to visit can answer.
+
+    A parameter with one such station in reach that turns out to hold no data would otherwise hold
+    the walk open to the end of the ranking, downloading every station left to learn what the
+    ranking already said.
+    """
+    from wetterdienst.core.util import parameters_still_in_reach  # noqa: PLC0415
+
+    counts = {
+        TEMPERATURE: StationsInReach(total=9, with_height=1, furthest_with_height=12.0),
+        PRECIPITATION: StationsInReach(total=9, with_height=4, furthest_with_height=30.0),
+    }
+    assert parameters_still_in_reach(counts, 8.0) == {TEMPERATURE, PRECIPITATION}
+    assert parameters_still_in_reach(counts, 20.0) == {PRECIPITATION}
+    assert parameters_still_in_reach(counts, 31.0) == set()

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -395,3 +395,21 @@ def test_parameters_still_in_reach_stops_at_the_last_station_that_has_a_height()
     assert parameters_still_in_reach(counts, 8.0) == {TEMPERATURE, PRECIPITATION}
     assert parameters_still_in_reach(counts, 20.0) == {PRECIPITATION}
     assert parameters_still_in_reach(counts, 31.0) == set()
+
+
+def test_no_height_in_reach_error_says_what_the_ranking_alone_can_say() -> None:
+    """The refusal that costs no download claims only what the station list shows.
+
+    Not one station near the point says how high it stands, so no reading can be brought to the
+    height asked about -- true whether or not those stations hold the parameter, which is the
+    difference between this and the report that follows a walk.
+    """
+    from wetterdienst.core.util import no_height_in_reach_error  # noqa: PLC0415
+
+    error = no_height_in_reach_error({TEMPERATURE, PRECIPITATION}, 200.0)
+    assert "no station near the point reports a height of its own" in str(error)
+    assert "nothing can be brought to 200.0 m" in str(error)
+    # both parameters named, in a settled order
+    assert "daily/climate_summary/precipitation_height, daily/climate_summary/temperature_air_mean_2m" in str(error)
+    # and the remedy that applies to a request named by a station id as much as one by coordinates
+    assert "naming a station id instead asks at that station's own height" in str(error)

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -239,25 +239,32 @@ def test_report_height_exclusions_does_not_blame_the_heights_for_what_they_did_n
     assert not caplog.text
 
 
-def test_report_height_exclusions_blames_the_heights_for_leaving_too_few(
+def test_report_height_exclusions_refuses_only_where_a_parameter_took_nothing(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Stations left over that cannot interpolate are as unanswered as no stations at all.
+    """A parameter that took not one station is refused; one that took some is named in the log.
 
-    Three of known height among neighbours of unknown height hold columns and still come back null,
-    an interpolation wanting four that surround the point. A summary asks for one, so the same
-    three are three answers there and nothing is reported.
+    With nothing taken there is nothing to interpolate from and nothing to wonder about. With three
+    taken and one lost, the count is the whole of the evidence -- those four may be four that would
+    never have surrounded the point -- and refusing on that takes a frame away from a caller over a
+    reason that may not be theirs.
     """
     from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
     from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
 
     grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
     kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "abc")
-    param_dict = {TEMPERATURE: _ParameterData(kept)}
-    with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
-        report_height_exclusions(_answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE: 9}, 200.0, stations_needed=4)
+    df = _answer((*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(_answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE: 9}, 200.0, stations_needed=1)
+        report_height_exclusions(df, {TEMPERATURE: _ParameterData(kept)}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
+    assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
+    caplog.clear()
+    # nothing taken, and the stations that were turned away would have been enough
+    with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
+        report_height_exclusions(df, {}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
+    # a summary asks for one station, so the same three columns are three answers and go unmentioned
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(df, {TEMPERATURE: _ParameterData(kept)}, {TEMPERATURE: 9}, 200.0, stations_needed=1)
     assert not caplog.text
 
 
@@ -323,16 +330,23 @@ def test_unanswerable_at_height_names_what_no_walk_can_reach() -> None:
         TEMPERATURE: StationsInReach(total=9, with_height=0, furthest_with_height=None),
         PRECIPITATION: StationsInReach(total=9, with_height=0, furthest_with_height=None),
     }
-    assert unanswerable_at_height(counts, 200.0) == {TEMPERATURE}
+    assert unanswerable_at_height(counts, 200.0, 4) == {TEMPERATURE}
     # one station reporting a height is enough to be worth walking for
-    assert (
-        unanswerable_at_height({TEMPERATURE: StationsInReach(total=9, with_height=1, furthest_with_height=12.0)}, 200.0)
-        == set()
-    )
-    assert unanswerable_at_height(counts, None) == set()
+    with_one = {TEMPERATURE: StationsInReach(total=9, with_height=1, furthest_with_height=12.0)}
+    assert unanswerable_at_height(with_one, 200.0, 4) == set()
+    # a point with no station in reach at all -- out at sea, or a mistyped coordinate -- is empty
+    # for a reason that has nothing to do with heights
+    assert unanswerable_at_height({TEMPERATURE: StationsInReach(0, 0, None)}, 200.0, 4) == set()
+    # and neither has a neighbourhood too thin to have answered from in the first place
+    assert unanswerable_at_height({TEMPERATURE: StationsInReach(3, 0, None)}, 200.0, 4) == set()
+    # which a summary, asking for one station, is not
+    assert unanswerable_at_height({TEMPERATURE: StationsInReach(3, 0, None)}, 200.0, 1) == {TEMPERATURE}
+    assert unanswerable_at_height(counts, None, 4) == set()
 
 
-def test_report_height_exclusions_weighs_the_stations_that_held_the_parameter() -> None:
+def test_report_height_exclusions_weighs_the_stations_that_held_the_parameter(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """What the exclusions took is stations that held the parameter, not stations in the radius.
 
     Six stations stand within reach and two of them report the parameter in the window asked for,
@@ -341,17 +355,19 @@ def test_report_height_exclusions_weighs_the_stations_that_held_the_parameter() 
     wants either way. Sending that caller back to ask without an elevation returns the same nulls.
     """
     from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
-    from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
 
     grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
     kept = grid.with_columns(pl.Series("a", [None, None, None], dtype=pl.Float64))
     param_dict = {TEMPERATURE: _ParameterData(kept)}
     df = _answer((*TEMPERATURE, None))
-    # one taken and one turned away is two, and four are wanted: not the exclusions' doing
-    report_height_exclusions(df, param_dict, {TEMPERATURE: 1}, 200.0, stations_needed=4)
-    # three turned away would have made four, so they are
-    with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
+    with caplog.at_level(logging.WARNING):
+        # one taken and one turned away is two, and four are wanted: not the exclusions' doing
+        report_height_exclusions(df, param_dict, {TEMPERATURE: 1}, 200.0, stations_needed=4)
+    assert not caplog.text
+    with caplog.at_level(logging.WARNING):
+        # three turned away would have made four, so they are named
         report_height_exclusions(df, param_dict, {TEMPERATURE: 3}, 200.0, stations_needed=4)
+    assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
 
 
 def test_count_stations_in_reach_reads_the_nearest_row_of_a_station() -> None:

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -9,7 +9,8 @@ from zoneinfo import ZoneInfo
 import polars as pl
 import pytest
 
-from wetterdienst.core.util import build_date_grid
+from wetterdienst import Settings
+from wetterdienst.core.util import StationsInReach, build_date_grid
 from wetterdienst.metadata.resolution import Resolution, reading_interval
 
 UTC = ZoneInfo("UTC")
@@ -112,6 +113,9 @@ def _answer(*rows: tuple[str, str, str, float | None]) -> pl.DataFrame:
 
 TEMPERATURE = ("daily", "climate_summary", "temperature_air_mean_2m")
 PRECIPITATION = ("daily", "climate_summary", "precipitation_height")
+# nine stations in reach, none of which reports a height: enough that the four an
+# interpolation wants were there to be had before the exclusions took them
+IN_REACH = {TEMPERATURE: StationsInReach(total=9, with_height=0)}
 
 
 def test_report_height_exclusions_raises_where_nothing_was_answered() -> None:
@@ -130,12 +134,13 @@ def test_report_height_exclusions_raises_where_nothing_was_answered() -> None:
             _answer((*TEMPERATURE, None), (*TEMPERATURE, None)),
             {},
             {TEMPERATURE},
+            {TEMPERATURE: StationsInReach(total=9, with_height=0)},
             200.0,
             stations_needed=4,
         )
     # and the same for a parameter that never opened a row at all
     with pytest.raises(NoStationsWithHeightError, match=r"at 200\.0 m"):
-        report_height_exclusions(_answer(), {}, {TEMPERATURE}, 200.0, stations_needed=4)
+        report_height_exclusions(_answer(), {}, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=4)
 
 
 def test_report_height_exclusions_warns_where_something_still_answers(caplog: pytest.LogCaptureFixture) -> None:
@@ -148,7 +153,7 @@ def test_report_height_exclusions_warns_where_something_still_answers(caplog: py
 
     df = _answer((*PRECIPITATION, 1.2), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(df, {}, {TEMPERATURE}, 200.0, stations_needed=4)
+        report_height_exclusions(df, {}, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=4)
     assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
     assert "the rest of the result stands" in caplog.text
 
@@ -167,7 +172,7 @@ def test_report_height_exclusions_counts_a_parameter_of_nulls_as_unanswered(
 
     df = _answer((*PRECIPITATION, None), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING), pytest.raises(NoStationsWithHeightError):
-        report_height_exclusions(df, {}, {TEMPERATURE}, 200.0, stations_needed=4)
+        report_height_exclusions(df, {}, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=4)
     assert not caplog.text
 
 
@@ -185,11 +190,12 @@ def test_report_height_exclusions_keeps_quiet_where_the_answer_stands(caplog: py
             _answer((*TEMPERATURE, 3.4), (*TEMPERATURE, None)),
             {},
             {TEMPERATURE},
+            IN_REACH,
             200.0,
             stations_needed=4,
         )
         # and nothing was turned away at all
-        report_height_exclusions(_answer(), {}, set(), None, stations_needed=4)
+        report_height_exclusions(_answer(), {}, set(), IN_REACH, None, stations_needed=4)
     assert not caplog.text
 
 
@@ -204,13 +210,13 @@ def test_collection_is_done_waits_for_a_parameter_that_has_yet_to_take_a_station
 
     grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
     finished = _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])), finished=True)
-    assert collection_is_done({PRECIPITATION: finished}, set(), heights_in_reach=True)
+    assert collection_is_done({PRECIPITATION: finished}, set())
     # precipitation has what it needs, but every station so far said nothing about temperature
-    assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE}, heights_in_reach=True)
+    assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE})
     # once temperature has taken one, it speaks for itself again
-    assert collection_is_done({PRECIPITATION: finished, TEMPERATURE: finished}, {TEMPERATURE}, heights_in_reach=True)
+    assert collection_is_done({PRECIPITATION: finished, TEMPERATURE: finished}, {TEMPERATURE})
     # nothing collected at all is not done, whatever was turned away
-    assert not collection_is_done({}, set(), heights_in_reach=True)
+    assert not collection_is_done({}, set())
 
 
 def test_report_height_exclusions_does_not_blame_the_heights_for_what_they_did_not_do(
@@ -232,6 +238,7 @@ def test_report_height_exclusions_does_not_blame_the_heights_for_what_they_did_n
             _answer((*TEMPERATURE, None)),
             {TEMPERATURE: _ParameterData(kept)},
             {TEMPERATURE},
+            IN_REACH,
             200.0,
             stations_needed=4,
         )
@@ -254,9 +261,13 @@ def test_report_height_exclusions_blames_the_heights_for_leaving_too_few(
     kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "abc")
     param_dict = {TEMPERATURE: _ParameterData(kept)}
     with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
-        report_height_exclusions(_answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE}, 200.0, stations_needed=4)
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=4
+        )
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(_answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE}, 200.0, stations_needed=1)
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE}, IN_REACH, 200.0, stations_needed=1
+        )
     assert not caplog.text
 
 
@@ -271,6 +282,84 @@ def test_collection_is_done_does_not_wait_where_no_station_reports_a_height() ->
 
     grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
     finished = _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])), finished=True)
-    assert collection_is_done({PRECIPITATION: finished}, {TEMPERATURE}, heights_in_reach=False)
+    assert collection_is_done({PRECIPITATION: finished}, set())
     # where some station does report one, the walk goes on until temperature has taken it
-    assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE}, heights_in_reach=True)
+    assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE})
+
+
+def test_report_height_exclusions_does_not_blame_the_heights_for_a_thin_neighbourhood(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parameter that never had four stations in reach was not emptied by the exclusions.
+
+    Three stations hold it in the whole radius and one of them reports no height, so two are left
+    and an interpolation wants four. Keeping all three would still have been one short, so asking
+    without an elevation returns the same nulls -- and a caller sent back for them under this
+    diagnosis is worse off than one who got the empty frame.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "ab")
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None)),
+            {TEMPERATURE: _ParameterData(kept)},
+            {TEMPERATURE},
+            {TEMPERATURE: StationsInReach(total=3, with_height=2)},
+            200.0,
+            stations_needed=4,
+        )
+    assert not caplog.text
+
+
+def test_count_stations_in_reach_asks_per_parameter_radius() -> None:
+    """Each parameter is counted inside its own radius, not the widest of the request.
+
+    A quantity that decorrelates fast in space is given a narrower one: at hourly resolution
+    precipitation reaches 20 km where temperature reaches 40, so a station at 35 km with a height
+    on it answers the question "is there one in reach" for temperature and not for precipitation.
+    One answer for the whole request would be the wrong one for at least one of them.
+    """
+    from wetterdienst.core.util import count_stations_in_reach  # noqa: PLC0415
+    from wetterdienst.provider.dwd.observation import DwdObservationRequest  # noqa: PLC0415
+
+    metadata = DwdObservationRequest.metadata["hourly"]
+    parameters = [
+        metadata["temperature_air"]["temperature_air_mean_2m"],
+        metadata["precipitation"]["precipitation_height"],
+    ]
+    df_stations_ranked = pl.DataFrame(
+        [
+            {"station_id": "00001", "distance": 5.0, "height": None},
+            {"station_id": "00002", "distance": 15.0, "height": None},
+            {"station_id": "00003", "distance": 35.0, "height": 210.0},
+            {"station_id": "00004", "distance": 60.0, "height": 190.0},
+        ],
+        schema={"station_id": pl.String, "distance": pl.Float64, "height": pl.Float64},
+        orient="row",
+    )
+    counts = count_stations_in_reach(df_stations_ranked, parameters, Settings())
+    # 40 km for temperature: three stations, the furthest of them the only one with a height
+    assert counts[("hourly", "temperature_air", "temperature_air_mean_2m")] == (3, 1)
+    # 20 km for precipitation: two stations, and the station that has a height is outside it
+    assert counts[("hourly", "precipitation", "precipitation_height")] == (2, 0)
+
+
+def test_unanswerable_at_height_names_what_no_walk_can_reach() -> None:
+    """A quantity that falls with height and has no station of known height in reach is unanswerable.
+
+    Whatever the walk downloads, no reading can be brought to the height asked about. A quantity
+    that does not fall with height is answered by those same stations as it always was, and with no
+    elevation asked for nothing is unanswerable at all.
+    """
+    from wetterdienst.core.util import unanswerable_at_height  # noqa: PLC0415
+
+    counts = {
+        TEMPERATURE: StationsInReach(total=9, with_height=0),
+        PRECIPITATION: StationsInReach(total=9, with_height=0),
+    }
+    assert unanswerable_at_height(counts, 200.0) == {TEMPERATURE}
+    # one station reporting a height is enough to be worth walking for
+    assert unanswerable_at_height({TEMPERATURE: StationsInReach(total=9, with_height=1)}, 200.0) == set()
+    assert unanswerable_at_height(counts, None) == set()

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -101,51 +101,101 @@ def test_build_date_grid_treats_subdaily_as_hourly() -> None:
     assert df.height == 25  # hourly, both ends included
 
 
-def test_report_height_exclusions_raises_where_nothing_is_left() -> None:
-    """A request emptied by heights alone is a question that cannot be answered as asked.
+def _answer(*rows: tuple[str, str, str, float | None]) -> pl.DataFrame:
+    """Build a frame in the shape an interpolation or a summary returns."""
+    return pl.DataFrame(
+        [dict(zip(("resolution", "dataset", "parameter", "value"), row, strict=True)) for row in rows],
+        schema={"resolution": pl.String, "dataset": pl.String, "parameter": pl.String, "value": pl.Float64},
+        orient="row",
+    )
 
-    Left to itself it comes back as an empty frame with the reason in a server-side log, which is
-    the one place the caller cannot look -- so it is raised, and the message says what to do about
-    it. Thirteen providers have stations without heights, FMI's, IPMA's and the Environment
-    Agency's being all of them.
+
+TEMPERATURE = ("daily", "climate_summary", "temperature_air_mean_2m")
+PRECIPITATION = ("daily", "climate_summary", "precipitation_height")
+
+
+def test_report_height_exclusions_raises_where_nothing_was_answered() -> None:
+    """A request left unanswered by heights alone is a question that cannot be answered as asked.
+
+    Rows of nulls are as unanswered as no rows: an interpolation wants four stations that surround
+    the point, so a parameter the exclusions leave with three holds columns and still comes back
+    null. Judged on the columns collected rather than on the frame, that case reads as answered and
+    goes back to the caller silently, which is the whole thing this is here to do away with.
     """
     from wetterdienst.core.util import report_height_exclusions  # noqa: PLC0415
     from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
 
-    param_key = ("daily", "climate_summary", "temperature_air_mean_2m")
-    with pytest.raises(NoStationsWithHeightError, match=r"no answer at 200\.0 m for daily/climate_summary/temperature"):
-        report_height_exclusions({}, {param_key}, 200.0)
+    with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer daily/climate_summary/temperature"):
+        report_height_exclusions(_answer((*TEMPERATURE, None), (*TEMPERATURE, None)), {TEMPERATURE}, 200.0)
+    # and the same for a parameter that never opened a row at all
+    with pytest.raises(NoStationsWithHeightError, match=r"at 200\.0 m"):
+        report_height_exclusions(_answer(), {TEMPERATURE}, 200.0)
 
 
 def test_report_height_exclusions_warns_where_something_still_answers(caplog: pytest.LogCaptureFixture) -> None:
-    """A parameter emptied beside one that answered is named, not raised.
+    """A parameter left unanswered beside one that answered is named, not raised.
 
     There is a result to read the warning against, and taking the whole request down over one of
     its parameters would throw away readings the caller can use.
     """
-    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+    from wetterdienst.core.util import report_height_exclusions  # noqa: PLC0415
 
-    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
-    answered = _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])))
-    param_dict = {("daily", "climate_summary", "precipitation_height"): answered}
+    df = _answer((*PRECIPITATION, 1.2), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(param_dict, {("daily", "climate_summary", "temperature_air_mean_2m")}, 200.0)
+        report_height_exclusions(df, {TEMPERATURE}, 200.0)
     assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
     assert "the rest of the result stands" in caplog.text
 
 
-def test_report_height_exclusions_keeps_quiet_where_the_answer_stands() -> None:
-    """A station turned away where another was taken cost the answer nothing.
+def test_report_height_exclusions_counts_a_parameter_of_nulls_as_unanswered(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parameter that produced only nulls does not stand in for a result.
 
-    Nor is a request that lost no station to a height worth a word: the helper runs on every
+    It used to: any parameter holding a station column made this a warning rather than a refusal,
+    columns and answers not being the same thing, so a caller with nothing at all was told so in a
+    log line they could not read.
+    """
+    from wetterdienst.core.util import report_height_exclusions  # noqa: PLC0415
+    from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
+
+    df = _answer((*PRECIPITATION, None), (*TEMPERATURE, None))
+    with caplog.at_level(logging.WARNING), pytest.raises(NoStationsWithHeightError):
+        report_height_exclusions(df, {TEMPERATURE}, 200.0)
+    assert not caplog.text
+
+
+def test_report_height_exclusions_keeps_quiet_where_the_answer_stands(caplog: pytest.LogCaptureFixture) -> None:
+    """A station turned away where the rest sufficed cost the answer nothing.
+
+    Nor is a request that lost no station to a height worth a word: this runs on every
     interpolation and summary, elevation or not.
     """
-    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+    from wetterdienst.core.util import report_height_exclusions  # noqa: PLC0415
+
+    with caplog.at_level(logging.WARNING):
+        # the parameter was answered by the stations that kept their heights
+        report_height_exclusions(_answer((*TEMPERATURE, 3.4), (*TEMPERATURE, None)), {TEMPERATURE}, 200.0)
+        # and nothing was turned away at all
+        report_height_exclusions(_answer(), set(), None)
+    assert not caplog.text
+
+
+def test_collection_is_done_waits_for_a_parameter_that_has_yet_to_take_a_station() -> None:
+    """A parameter every station was turned away from cannot hold the walk open by itself.
+
+    It never opened an entry, so `all(finished)` passes over it, and the walk down the ranking
+    stops on the parameters that did open -- reporting it as unanswerable while a station further
+    out, still inside the radius, has a height and could have answered it.
+    """
+    from wetterdienst.core.util import _ParameterData, collection_is_done  # noqa: PLC0415
 
     grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
-    param_key = ("daily", "climate_summary", "temperature_air_mean_2m")
-    answered = {param_key: _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])))}
-    # the parameter kept a station of its own, so the one turned away is not worth reporting
-    report_height_exclusions(answered, {param_key}, 200.0)
-    # and nothing was turned away at all
-    report_height_exclusions({}, set(), None)
+    finished = _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])), finished=True)
+    assert collection_is_done({PRECIPITATION: finished}, set())
+    # precipitation has what it needs, but every station so far said nothing about temperature
+    assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE})
+    # once temperature has taken one, it speaks for itself again
+    assert collection_is_done({PRECIPITATION: finished, TEMPERATURE: finished}, {TEMPERATURE})
+    # nothing collected at all is not done, whatever was turned away
+    assert not collection_is_done({}, set())

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -605,3 +605,64 @@ def test_count_stations_in_reach_reads_the_height_the_walk_will_read() -> None:
     counts = count_stations_in_reach(df_stations_ranked, [daily], Settings(), INTERPOLATABLE)
     # the station holds the daily dataset, so it counts -- and it has a height, so nothing is refused
     assert counts[("daily", "climate_summary", "temperature_air_mean_2m")] == (1, 1, 4.0)
+
+
+def test_report_height_exclusions_names_a_nearby_station_lost_beside_others_kept(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Losing the station under the point is the whole answer, however many farther ones were kept.
+
+    An interpolation would have answered from that one alone; the three kept in its place cannot
+    close a hull around the point and come back null. Counting what was lost against what a hull
+    wants misses it entirely -- three kept is not fewer than the one the shortcut needed -- which
+    is how a case the shortcut exists for went unmentioned.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "abc")
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None)),
+            {TEMPERATURE: _ParameterData(kept)},
+            {TEMPERATURE: DroppedForHeight(count=1, nearest=0.5)},
+            200.0,
+            stations_needed=4,
+            nearby_station_distance=1.0,
+        )
+    assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
+
+
+def test_report_height_exclusions_says_what_the_ranking_already_proved(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parameter the ranking proved unanswerable is named however far the walk got.
+
+    No station inside its radius reports a height, so every station that held it was turned away --
+    and the walk, having nothing to wait for on its behalf, stops as soon as the other parameters
+    are done. Counting the few drops it managed against the four a hull wants would leave the
+    caller with a null column and no word about it.
+    """
+    from wetterdienst.core.util import report_height_exclusions  # noqa: PLC0415
+
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None), (*PRECIPITATION, 1.2)),
+            {},
+            {TEMPERATURE: DroppedForHeight(count=1)},
+            200.0,
+            stations_needed=4,
+            unanswerable={TEMPERATURE},
+        )
+    assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
+    caplog.clear()
+    # without that proof one drop is one station, and four are wanted: nothing to say
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None), (*PRECIPITATION, 1.2)),
+            {},
+            {TEMPERATURE: DroppedForHeight(count=1)},
+            200.0,
+            stations_needed=4,
+        )
+    assert not caplog.text

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -126,10 +126,16 @@ def test_report_height_exclusions_raises_where_nothing_was_answered() -> None:
     from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
 
     with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer daily/climate_summary/temperature"):
-        report_height_exclusions(_answer((*TEMPERATURE, None), (*TEMPERATURE, None)), {TEMPERATURE}, 200.0)
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None), (*TEMPERATURE, None)),
+            {},
+            {TEMPERATURE},
+            200.0,
+            stations_needed=4,
+        )
     # and the same for a parameter that never opened a row at all
     with pytest.raises(NoStationsWithHeightError, match=r"at 200\.0 m"):
-        report_height_exclusions(_answer(), {TEMPERATURE}, 200.0)
+        report_height_exclusions(_answer(), {}, {TEMPERATURE}, 200.0, stations_needed=4)
 
 
 def test_report_height_exclusions_warns_where_something_still_answers(caplog: pytest.LogCaptureFixture) -> None:
@@ -142,7 +148,7 @@ def test_report_height_exclusions_warns_where_something_still_answers(caplog: py
 
     df = _answer((*PRECIPITATION, 1.2), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(df, {TEMPERATURE}, 200.0)
+        report_height_exclusions(df, {}, {TEMPERATURE}, 200.0, stations_needed=4)
     assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
     assert "the rest of the result stands" in caplog.text
 
@@ -161,7 +167,7 @@ def test_report_height_exclusions_counts_a_parameter_of_nulls_as_unanswered(
 
     df = _answer((*PRECIPITATION, None), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING), pytest.raises(NoStationsWithHeightError):
-        report_height_exclusions(df, {TEMPERATURE}, 200.0)
+        report_height_exclusions(df, {}, {TEMPERATURE}, 200.0, stations_needed=4)
     assert not caplog.text
 
 
@@ -175,9 +181,15 @@ def test_report_height_exclusions_keeps_quiet_where_the_answer_stands(caplog: py
 
     with caplog.at_level(logging.WARNING):
         # the parameter was answered by the stations that kept their heights
-        report_height_exclusions(_answer((*TEMPERATURE, 3.4), (*TEMPERATURE, None)), {TEMPERATURE}, 200.0)
+        report_height_exclusions(
+            _answer((*TEMPERATURE, 3.4), (*TEMPERATURE, None)),
+            {},
+            {TEMPERATURE},
+            200.0,
+            stations_needed=4,
+        )
         # and nothing was turned away at all
-        report_height_exclusions(_answer(), set(), None)
+        report_height_exclusions(_answer(), {}, set(), None, stations_needed=4)
     assert not caplog.text
 
 
@@ -192,10 +204,73 @@ def test_collection_is_done_waits_for_a_parameter_that_has_yet_to_take_a_station
 
     grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
     finished = _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])), finished=True)
-    assert collection_is_done({PRECIPITATION: finished}, set())
+    assert collection_is_done({PRECIPITATION: finished}, set(), heights_in_reach=True)
     # precipitation has what it needs, but every station so far said nothing about temperature
-    assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE})
+    assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE}, heights_in_reach=True)
     # once temperature has taken one, it speaks for itself again
-    assert collection_is_done({PRECIPITATION: finished, TEMPERATURE: finished}, {TEMPERATURE})
+    assert collection_is_done({PRECIPITATION: finished, TEMPERATURE: finished}, {TEMPERATURE}, heights_in_reach=True)
     # nothing collected at all is not done, whatever was turned away
-    assert not collection_is_done({}, set())
+    assert not collection_is_done({}, set(), heights_in_reach=True)
+
+
+def test_report_height_exclusions_does_not_blame_the_heights_for_what_they_did_not_do(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A parameter that kept the stations it needs failed on something else.
+
+    One height-less station among six leaves five that can be brought to the target, and if the
+    answer is still null it is the geometry of where those five stand, or the data they hold. The
+    cure the message names -- ask without an elevation -- returns the same nulls, so naming the
+    heights here is a wrong diagnosis, and a hard error where there used to be a frame.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "abcde")
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None)),
+            {TEMPERATURE: _ParameterData(kept)},
+            {TEMPERATURE},
+            200.0,
+            stations_needed=4,
+        )
+    assert not caplog.text
+
+
+def test_report_height_exclusions_blames_the_heights_for_leaving_too_few(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Stations left over that cannot interpolate are as unanswered as no stations at all.
+
+    Three of known height among neighbours of unknown height hold columns and still come back null,
+    an interpolation wanting four that surround the point. A summary asks for one, so the same
+    three are three answers there and nothing is reported.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+    from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "abc")
+    param_dict = {TEMPERATURE: _ParameterData(kept)}
+    with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
+        report_height_exclusions(_answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE}, 200.0, stations_needed=4)
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(_answer((*TEMPERATURE, None)), param_dict, {TEMPERATURE}, 200.0, stations_needed=1)
+    assert not caplog.text
+
+
+def test_collection_is_done_does_not_wait_where_no_station_reports_a_height() -> None:
+    """A provider that publishes no heights has nothing for the walk to hold out for.
+
+    FMI has 441 stations and a height for none of them. Holding the walk open for a parameter that
+    can never take one would query every station inside the radius, one download each, to arrive at
+    the answer the fourth station already gave.
+    """
+    from wetterdienst.core.util import _ParameterData, collection_is_done  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    finished = _ParameterData(grid.with_columns(pl.Series("00011", [1.0, 2.0, 3.0])), finished=True)
+    assert collection_is_done({PRECIPITATION: finished}, {TEMPERATURE}, heights_in_reach=False)
+    # where some station does report one, the walk goes on until temperature has taken it
+    assert not collection_is_done({PRECIPITATION: finished}, {TEMPERATURE}, heights_in_reach=True)

--- a/tests/core/test_util.py
+++ b/tests/core/test_util.py
@@ -10,7 +10,7 @@ import polars as pl
 import pytest
 
 from wetterdienst import Settings
-from wetterdienst.core.util import StationsInReach, build_date_grid
+from wetterdienst.core.util import DroppedForHeight, StationsInReach, build_date_grid
 from wetterdienst.metadata.resolution import Resolution, reading_interval
 from wetterdienst.provider.dwd.observation import DwdObservationRequest
 
@@ -103,6 +103,22 @@ def test_build_date_grid_treats_subdaily_as_hourly() -> None:
     assert df.height == 25  # hourly, both ends included
 
 
+def _ranked(dataset: str, rows: list[dict]) -> pl.DataFrame:
+    """Build the shape `filter_by_distance` returns: a row per station and dataset, nearest first."""
+    resolution = "daily" if dataset == "climate_summary" else "hourly"
+    return pl.DataFrame(
+        [{"resolution": resolution, "dataset": dataset, **row} for row in rows],
+        schema={
+            "resolution": pl.String,
+            "dataset": pl.String,
+            "station_id": pl.String,
+            "distance": pl.Float64,
+            "height": pl.Float64,
+        },
+        orient="row",
+    )
+
+
 def _answer(*rows: tuple[str, str, str, float | None]) -> pl.DataFrame:
     """Build a frame in the shape an interpolation or a summary returns."""
     return pl.DataFrame(
@@ -132,13 +148,13 @@ def test_report_height_exclusions_raises_where_nothing_was_answered() -> None:
         report_height_exclusions(
             _answer((*TEMPERATURE, None), (*TEMPERATURE, None)),
             {},
-            {TEMPERATURE: 9},
+            {TEMPERATURE: DroppedForHeight(9)},
             200.0,
             stations_needed=4,
         )
     # and the same for a parameter that never opened a row at all
     with pytest.raises(NoStationsWithHeightError, match=r"at 200\.0 m"):
-        report_height_exclusions(_answer(), {}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
+        report_height_exclusions(_answer(), {}, {TEMPERATURE: DroppedForHeight(9)}, 200.0, stations_needed=4)
 
 
 def test_report_height_exclusions_warns_where_something_still_answers(caplog: pytest.LogCaptureFixture) -> None:
@@ -151,7 +167,7 @@ def test_report_height_exclusions_warns_where_something_still_answers(caplog: py
 
     df = _answer((*PRECIPITATION, 1.2), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(df, {}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
+        report_height_exclusions(df, {}, {TEMPERATURE: DroppedForHeight(9)}, 200.0, stations_needed=4)
     assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
     assert "the rest of the result stands" in caplog.text
 
@@ -170,7 +186,7 @@ def test_report_height_exclusions_counts_a_parameter_of_nulls_as_unanswered(
 
     df = _answer((*PRECIPITATION, None), (*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING), pytest.raises(NoStationsWithHeightError):
-        report_height_exclusions(df, {}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
+        report_height_exclusions(df, {}, {TEMPERATURE: DroppedForHeight(9)}, 200.0, stations_needed=4)
     assert not caplog.text
 
 
@@ -187,7 +203,7 @@ def test_report_height_exclusions_keeps_quiet_where_the_answer_stands(caplog: py
         report_height_exclusions(
             _answer((*TEMPERATURE, 3.4), (*TEMPERATURE, None)),
             {},
-            {TEMPERATURE: 9},
+            {TEMPERATURE: DroppedForHeight(9)},
             200.0,
             stations_needed=4,
         )
@@ -234,7 +250,7 @@ def test_report_height_exclusions_does_not_blame_the_heights_for_what_they_did_n
         report_height_exclusions(
             _answer((*TEMPERATURE, None)),
             {TEMPERATURE: _ParameterData(kept)},
-            {TEMPERATURE: 9},
+            {TEMPERATURE: DroppedForHeight(9)},
             200.0,
             stations_needed=4,
         )
@@ -258,15 +274,19 @@ def test_report_height_exclusions_refuses_only_where_a_parameter_took_nothing(
     kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "abc")
     df = _answer((*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(df, {TEMPERATURE: _ParameterData(kept)}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
+        report_height_exclusions(
+            df, {TEMPERATURE: _ParameterData(kept)}, {TEMPERATURE: DroppedForHeight(9)}, 200.0, stations_needed=4
+        )
     assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
     caplog.clear()
     # nothing taken, and the stations that were turned away would have been enough
     with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
-        report_height_exclusions(df, {}, {TEMPERATURE: 9}, 200.0, stations_needed=4)
+        report_height_exclusions(df, {}, {TEMPERATURE: DroppedForHeight(9)}, 200.0, stations_needed=4)
     # a summary asks for one station, so the same three columns are three answers and go unmentioned
     with caplog.at_level(logging.WARNING):
-        report_height_exclusions(df, {TEMPERATURE: _ParameterData(kept)}, {TEMPERATURE: 9}, 200.0, stations_needed=1)
+        report_height_exclusions(
+            df, {TEMPERATURE: _ParameterData(kept)}, {TEMPERATURE: DroppedForHeight(9)}, 200.0, stations_needed=1
+        )
     assert not caplog.text
 
 
@@ -301,15 +321,17 @@ def test_count_stations_in_reach_asks_per_parameter_radius() -> None:
         metadata["temperature_air"]["temperature_air_mean_2m"],
         metadata["precipitation"]["precipitation_height"],
     ]
-    df_stations_ranked = pl.DataFrame(
-        [
-            {"station_id": "00001", "distance": 5.0, "height": None},
-            {"station_id": "00002", "distance": 15.0, "height": None},
-            {"station_id": "00003", "distance": 35.0, "height": 210.0},
-            {"station_id": "00004", "distance": 60.0, "height": 190.0},
-        ],
-        schema={"station_id": pl.String, "distance": pl.Float64, "height": pl.Float64},
-        orient="row",
+    df_stations_ranked = pl.concat(
+        _ranked(dataset, rows)
+        for dataset in ("temperature_air", "precipitation")
+        for rows in [
+            [
+                {"station_id": "00001", "distance": 5.0, "height": None},
+                {"station_id": "00002", "distance": 15.0, "height": None},
+                {"station_id": "00003", "distance": 35.0, "height": 210.0},
+                {"station_id": "00004", "distance": 60.0, "height": 190.0},
+            ],
+        ]
     )
     counts = count_stations_in_reach(df_stations_ranked, parameters, Settings(), INTERPOLATABLE)
     # 40 km for temperature: three stations, the furthest of them the only one with a height
@@ -363,11 +385,11 @@ def test_report_height_exclusions_weighs_the_stations_that_held_the_parameter(
     df = _answer((*TEMPERATURE, None))
     with caplog.at_level(logging.WARNING):
         # one taken and one turned away is two, and four are wanted: not the exclusions' doing
-        report_height_exclusions(df, param_dict, {TEMPERATURE: 1}, 200.0, stations_needed=4)
+        report_height_exclusions(df, param_dict, {TEMPERATURE: DroppedForHeight(1)}, 200.0, stations_needed=4)
     assert not caplog.text
     with caplog.at_level(logging.WARNING):
         # three turned away would have made four, so they are named
-        report_height_exclusions(df, param_dict, {TEMPERATURE: 3}, 200.0, stations_needed=4)
+        report_height_exclusions(df, param_dict, {TEMPERATURE: DroppedForHeight(3)}, 200.0, stations_needed=4)
     assert "daily/climate_summary/temperature_air_mean_2m" in caplog.text
 
 
@@ -382,13 +404,12 @@ def test_count_stations_in_reach_reads_the_nearest_row_of_a_station() -> None:
     from wetterdienst.core.util import count_stations_in_reach  # noqa: PLC0415
 
     parameters = [DwdObservationRequest.metadata["hourly"]["temperature_air"]["temperature_air_mean_2m"]]
-    df_stations_ranked = pl.DataFrame(
+    df_stations_ranked = _ranked(
+        "temperature_air",
         [
             {"station_id": "00001", "distance": 5.0, "height": 210.0},
             {"station_id": "00001", "distance": 5.2, "height": None},
         ],
-        schema={"station_id": pl.String, "distance": pl.Float64, "height": pl.Float64},
-        orient="row",
     )
     assert count_stations_in_reach(df_stations_ranked, parameters, Settings(), INTERPOLATABLE) == {
         ("hourly", "temperature_air", "temperature_air_mean_2m"): (1, 1, 5.0),
@@ -444,11 +465,7 @@ def test_count_stations_in_reach_passes_over_what_the_walk_would_not_collect() -
     metadata = DwdObservationRequest.metadata["daily"]["climate_summary"]
     # precipitation_form is the one member of daily/kl that is not interpolatable
     parameters = [metadata["temperature_air_mean_2m"], metadata["precipitation_form"]]
-    df_stations_ranked = pl.DataFrame(
-        [{"station_id": "00001", "distance": 5.0, "height": None}],
-        schema={"station_id": pl.String, "distance": pl.Float64, "height": pl.Float64},
-        orient="row",
-    )
+    df_stations_ranked = _ranked("climate_summary", [{"station_id": "00001", "distance": 5.0, "height": None}])
     counts = count_stations_in_reach(df_stations_ranked, parameters, Settings(), INTERPOLATABLE)
     assert set(counts) == {("daily", "climate_summary", "temperature_air_mean_2m")}
 
@@ -476,8 +493,88 @@ def test_report_height_exclusions_names_the_uncertain_losses_beside_the_certain_
         report_height_exclusions(
             df,
             {maximum: _ParameterData(kept)},
-            {TEMPERATURE: 5, maximum: 3},
+            {TEMPERATURE: DroppedForHeight(5), maximum: DroppedForHeight(3)},
             200.0,
             stations_needed=4,
         )
     assert "daily/climate_summary/temperature_air_max_2m" in caplog.text
+
+
+def test_report_height_exclusions_counts_a_station_near_enough_to_answer_alone() -> None:
+    """A station turned away from under the point cost one station, not four.
+
+    An interpolation answers from a single station standing inside the nearby-station distance,
+    without the four a hull wants around the point. Hold the exclusions to four and the caller
+    standing on top of the one station in reach -- and it without a height -- is told nothing at
+    all, though that station is exactly what the elevation cost them.
+    """
+    from wetterdienst.core.util import report_height_exclusions  # noqa: PLC0415
+    from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
+
+    df = _answer((*TEMPERATURE, None))
+    lost_nearby = {TEMPERATURE: DroppedForHeight(count=1, nearest=0.5)}
+    with pytest.raises(NoStationsWithHeightError, match=r"nothing that can answer"):
+        report_height_exclusions(df, {}, lost_nearby, 200.0, stations_needed=4, nearby_station_distance=1.0)
+    # the same station a kilometre further out answers nothing on its own, and four is the bar again
+    lost_far = {TEMPERATURE: DroppedForHeight(count=1, nearest=8.0)}
+    report_height_exclusions(df, {}, lost_far, 200.0, stations_needed=4, nearby_station_distance=1.0)
+    # nor where the shortcut is switched off
+    report_height_exclusions(df, {}, lost_nearby, 200.0, stations_needed=4, nearby_station_distance=None)
+
+
+def test_count_stations_in_reach_counts_a_station_under_its_own_dataset() -> None:
+    """A station is counted for the dataset whose index it stands in.
+
+    The ranking carries a row per station and dataset, so a station that reports a height in the
+    hourly index would otherwise say there is a height in reach for a daily parameter it can never
+    answer -- holding the walk open to its distance, and suppressing the refusal that costs no
+    download.
+    """
+    from wetterdienst.core.util import count_stations_in_reach  # noqa: PLC0415
+
+    daily = DwdObservationRequest.metadata["daily"]["climate_summary"]["temperature_air_mean_2m"]
+    df_stations_ranked = pl.concat(
+        [
+            _ranked("climate_summary", [{"station_id": "00001", "distance": 5.0, "height": None}]),
+            _ranked("temperature_air", [{"station_id": "00002", "distance": 39.0, "height": 210.0}]),
+        ],
+    )
+    counts = count_stations_in_reach(df_stations_ranked, [daily], Settings(), INTERPOLATABLE)
+    # one station, no height, and nothing to walk out to 39 km for
+    assert counts[("daily", "climate_summary", "temperature_air_mean_2m")] == (1, 0, None)
+
+
+def test_report_height_exclusions_claims_a_standing_result_only_where_there_is_one(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Nothing answered is not "the rest of the result stands".
+
+    A parameter that kept a station or two and still answered nothing is named rather than raised,
+    and where it is the whole request the frame that comes back is null throughout -- so there is no
+    rest of it to stand.
+    """
+    from wetterdienst.core.util import _ParameterData, report_height_exclusions  # noqa: PLC0415
+
+    grid = build_date_grid(Resolution.DAILY, dt.datetime(2022, 1, 1, tzinfo=UTC), dt.datetime(2022, 1, 3, tzinfo=UTC))
+    kept = grid.with_columns(pl.Series(station_id, [None, None, None], dtype=pl.Float64) for station_id in "ab")
+    param_dict = {TEMPERATURE: _ParameterData(kept)}
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None)),
+            param_dict,
+            {TEMPERATURE: DroppedForHeight(9)},
+            200.0,
+            stations_needed=4,
+        )
+    assert "the rest of the result stands" not in caplog.text
+    caplog.clear()
+    # beside a parameter that did answer, there is
+    with caplog.at_level(logging.WARNING):
+        report_height_exclusions(
+            _answer((*TEMPERATURE, None), (*PRECIPITATION, 1.2)),
+            param_dict,
+            {TEMPERATURE: DroppedForHeight(9)},
+            200.0,
+            stations_needed=4,
+        )
+    assert "the rest of the result stands" in caplog.text

--- a/tests/ui/test_restapi.py
+++ b/tests/ui/test_restapi.py
@@ -2251,3 +2251,45 @@ def test_mcp_interpolate_tool_returns_data() -> None:
 
     data = asyncio.run(_call())
     assert data is not None
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "entry_point"),
+    [
+        ("/api/interpolate", "get_interpolate"),
+        ("/api/summarize", "get_summarize"),
+    ],
+)
+def test_geo_elevation_no_station_can_answer_is_a_400(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+    entry_point: str,
+) -> None:
+    """A request understood and unanswerable as phrased is the caller's to fix, so it is a 400.
+
+    Both endpoints used to answer every failure with a 404, which reads as "no such thing" for an
+    elevation no station in reach can be placed against -- and the detail carried the reason to a
+    caller who had no reason to read it.
+    """
+    from wetterdienst.exceptions import NoStationsWithHeightError  # noqa: PLC0415
+
+    msg = "no station of known height is in reach, so there is no answer at 200.0 m for daily/climate_summary/tas"
+
+    def unanswerable(**_kwargs: object) -> None:
+        raise NoStationsWithHeightError(msg)
+
+    monkeypatch.setattr(f"wetterdienst.ui.restapi.{entry_point}", unanswerable)
+    response = client.get(
+        endpoint,
+        params={
+            "provider": "dwd",
+            "network": "observation",
+            "parameters": "daily/kl/temperature_air_mean_2m",
+            "station": "00071",
+            "date": "1986-10-31",
+            "elevation": 200.0,
+        },
+    )
+    assert response.status_code == 400
+    assert response.json()["detail"] == msg


### PR DESCRIPTION
The limitation I flagged on #1899 and declined to paper over in the form.

## The hole

A station whose own height is unknown is turned away from a quantity that falls with height. Thirteen providers have such stations, and for three of them -- FMI, IPMA, the Environment Agency -- it is *every* station they publish. Asking FMI for an interpolated temperature at 50 m, on `main`:

```
FMI stations with a height: 0 of 441
rows: 0 | non-null values: 0
what the caller is told: nothing at all -- a 200 and an empty frame
```

The reason was there the whole time, in a `log.info` on the server. That is the one place the caller cannot look, and over the REST API "no rows" is indistinguishable from a quiet week at the station.

## What it says now

```
NoStationsWithHeightError: no station of known height is in reach, so there is no answer at
50.0 m for hourly/data/temperature_air_mean_2m. Ask without an elevation to take each station's
readings as they came, or use a provider that publishes the heights of its stations.
```

Raised only where nothing is left to answer with -- there being no result for a warning to be read against. Where another parameter still answered, the emptied one is named in a `log.warning` and the rest of the result stands: taking the whole request down over one of its parameters would throw away readings the caller can use. A station turned away where three others were taken says nothing at all, since it cost the answer nothing.

The parameters that lost their stations are collected as the stations go by (a set, not a per-station log line), and reported once at the end of `request_stations` -- the same code path for interpolation and summary.

## Where it surfaces

- **REST**: a **400** rather than the catch-all 404, which reads as "no such thing" for a request that was understood and simply cannot be served as phrased. Both geo endpoints decide that from one shared handler now, which also means `/api/summarize` answers a window that ends before it starts with a 400, as `/api/interpolate` already did. That is the one behaviour change against released code.
- **CLI**: the message, without a traceback -- `log.exception` on an expected user error buries the sentence that fixes it.
- **App**: nothing to change. `DataViewer.vue:222` already reads `err.data?.detail` into the error toast, so the message reaches the user in place of an empty chart.
- **MCP**: proxies the REST endpoints, so the detail comes back as the tool error.

## Tests

- `report_height_exclusions` on its own: raises where nothing answered, warns where something did, and keeps quiet both where the parameter kept a station of its own and where no station was turned away at all.
- End to end for both `interpolate` and `summarize`, by borrowing DWD's stations and taking the heights away -- same data, same code path, and no second provider's outages deciding whether the test passes.
- The REST mapping for both endpoints.

Both halves of the wiring were checked by putting them back wrong: dropping the report call, and then noting no parameter, each made 3 tests fail; restored, 7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011BMmz23eRedUH9VTYaMQzV
